### PR TITLE
Fix syntax highlighting for .ts files

### DIFF
--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -321,8 +321,7 @@ impl ViewerState {
                 // syntect defaults lack some common extensions — map them
                 // to a close-enough syntax so highlighting still works.
                 let fallback = match ext {
-                    "tsx" | "jsx" => "js",
-                    "mts" | "cts" => "ts",
+                    "ts" | "tsx" | "jsx" | "mts" | "cts" => "js",
                     _ => return None,
                 };
                 syntax_set.find_syntax_by_extension(fallback)


### PR DESCRIPTION
## Summary
- syntectのデフォルトSyntaxSetに TypeScript の定義が含まれておらず、`.ts` ファイルがプレーンテキスト扱いになっていた
- `.mts` / `.cts` のフォールバック先も `.ts` だったため同様にハイライト無効だった
- フォールバックマップを統合し、`ts` / `tsx` / `jsx` / `mts` / `cts` をすべて JavaScript シンタックスにフォールバックするよう修正

## Test plan
- [ ] `.ts` ファイルをViewerで開き、シンタックスハイライトが適用されることを確認
- [ ] `.tsx` / `.jsx` / `.mts` / `.cts` も同様に確認
- [ ] `.go` / `.rs` など既存のハイライトが壊れていないことを確認