### PR TITLE
Migrate hook injection to plugin distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Terminal-based Git workspace and code review TUI written in Rust. Manages multip
 
 ## Installation
 
+### 1. Install the binary
+
 ```sh
 git clone https://github.com/S-Nakamur-a/conductor.git
 cd conductor
@@ -29,6 +31,16 @@ make install
 ```
 
 `make install` installs the `conductor` binary to `~/.cargo/bin/` (`cargo install --path .`) and installs MCP server dependencies (`npm install`).
+
+### 2. Install the Claude Code plugin
+
+```sh
+claude plugin add github:S-Nakamur-a/conductor
+```
+
+This sets up:
+- **MCP server** — review comment DB integration
+- **Hooks** — waiting-state detection for Claude Code sessions
 
 ## Usage
 
@@ -67,14 +79,17 @@ Worktree | Explorer | Viewer | Terminal (Claude Code / Shell)
 
 Conductor includes an MCP server (`mcp/conductor-comment/`) that exposes the review database to Claude Code sessions running inside the terminal. This enables Claude Code to read and write review comments directly.
 
+The MCP server is automatically configured when you install the Claude Code plugin (see Installation step 2).
+
+For development:
+
 ```sh
 cd mcp/conductor-comment
 npm install
 npm run build  # compile TypeScript
 npm start      # run compiled JS
+# or: npm run dev (runs via tsx, no build step needed)
 ```
-
-For development: `npm run dev` (runs via tsx, no build step needed).
 
 ## Configuration
 

--- a/hooks/scripts/signal-active.sh
+++ b/hooks/scripts/signal-active.sh
@@ -7,6 +7,11 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
+# Guard: only fire in Conductor-managed repos
+if [ ! -d "$REPO_ROOT/.conductor" ]; then
+  exit 0
+fi
+
 WAITING_DIR="$REPO_ROOT/.conductor/cc-waiting"
 ENCODED_CWD=$(echo "$PWD" | sed 's|/|__|g')
 rm -f "$WAITING_DIR/$ENCODED_CWD"

--- a/hooks/scripts/signal-waiting.sh
+++ b/hooks/scripts/signal-waiting.sh
@@ -7,6 +7,11 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
+# Guard: only fire in Conductor-managed repos
+if [ ! -d "$REPO_ROOT/.conductor" ]; then
+  exit 0
+fi
+
 WAITING_DIR="$REPO_ROOT/.conductor/cc-waiting"
 mkdir -p "$WAITING_DIR"
 

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -15,7 +15,6 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -245,12 +244,7 @@ impl PtyManager {
             })
             .context("Failed to spawn PTY reader thread")?;
 
-        // 7. Inject Claude Code hooks for waiting-state detection.
-        if kind == SessionKind::ClaudeCode {
-            inject_cc_hooks(working_dir, repo_root);
-        }
-
-        // 8. Build the session struct.
+        // 7. Build the session struct.
         let session = PtySession {
             id: Uuid::new_v4().to_string(),
             label: label.to_string(),
@@ -832,109 +826,6 @@ impl PtyManager {
         if buf.len() > limit {
             let excess = buf.len() - limit;
             buf.drain(..excess);
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Claude Code hook injection
-// ---------------------------------------------------------------------------
-
-/// Inject Claude Code hooks into the worktree's `.claude/settings.local.json`
-/// so that the `Stop` event creates a marker file and `UserPromptSubmit` removes it.
-///
-/// The marker file lives at `<repo_root>/.conductor/cc-waiting/<sanitized_cwd>`,
-/// allowing the main app loop to detect waiting state without PTY heuristics.
-fn inject_cc_hooks(working_dir: &Path, repo_root: &Path) {
-    let signal_dir = repo_root.join(".conductor").join("cc-waiting");
-    let signal_dir_str = signal_dir.display().to_string();
-
-    // Marker identifier appended to commands so we can recognise our hooks.
-    const MARKER: &str = "# conductor-hook";
-
-    let stop_cmd = format!(
-        "mkdir -p '{signal_dir_str}' && touch '{signal_dir_str}/'$(echo \"$PWD\" | sed 's|/|__|g') {MARKER}"
-    );
-    let clear_cmd = format!(
-        "rm -f '{signal_dir_str}/'$(echo \"$PWD\" | sed 's|/|__|g') {MARKER}"
-    );
-
-    // Build the hooks JSON value.
-    let hooks_value = serde_json::json!({
-        "Stop": [
-            { "hooks": [{ "type": "command", "command": stop_cmd }] }
-        ],
-        "Notification": [
-            {
-                "matcher": "permission_prompt|elicitation_dialog|idle_prompt",
-                "hooks": [{ "type": "command", "command": stop_cmd }]
-            }
-        ],
-        "UserPromptSubmit": [
-            { "hooks": [{ "type": "command", "command": clear_cmd }] }
-        ]
-    });
-
-    // Read existing settings (if any) and merge.
-    let settings_dir = working_dir.join(".claude");
-    let settings_path = settings_dir.join("settings.local.json");
-
-    let mut root: serde_json::Map<String, JsonValue> = if settings_path.exists() {
-        match std::fs::read_to_string(&settings_path) {
-            Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
-            Err(_) => serde_json::Map::new(),
-        }
-    } else {
-        serde_json::Map::new()
-    };
-
-    // Merge hooks: preserve non-conductor hooks, replace conductor ones.
-    let new_hooks_map = hooks_value.as_object().unwrap();
-
-    let existing_hooks = root
-        .entry("hooks")
-        .or_insert_with(|| JsonValue::Object(serde_json::Map::new()));
-
-    if let Some(hooks_obj) = existing_hooks.as_object_mut() {
-        for (event_name, new_entries) in new_hooks_map {
-            // Remove any previous conductor-injected entries for this event.
-            let filtered: Vec<JsonValue> = hooks_obj
-                .get(event_name)
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter(|entry| {
-                            // Keep entries that don't contain our marker.
-                            let s = serde_json::to_string(entry).unwrap_or_default();
-                            !s.contains(MARKER)
-                        })
-                        .cloned()
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // Append our new entries.
-            let mut merged = filtered;
-            if let Some(new_arr) = new_entries.as_array() {
-                merged.extend(new_arr.iter().cloned());
-            }
-            hooks_obj.insert(event_name.clone(), JsonValue::Array(merged));
-        }
-    }
-
-    // Write back.
-    if let Err(e) = std::fs::create_dir_all(&settings_dir) {
-        log::warn!("failed to create .claude dir: {e}");
-        return;
-    }
-    match serde_json::to_string_pretty(&root) {
-        Ok(json_str) => {
-            if let Err(e) = std::fs::write(&settings_path, json_str) {
-                log::warn!("failed to write CC hooks to {}: {e}", settings_path.display());
-            }
-        }
-        Err(e) => {
-            log::warn!("failed to serialize CC hooks: {e}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove runtime `inject_cc_hooks()` from `pty_manager.rs` — hooks are now shipped declaratively via the Claude Code plugin (`hooks/hooks.json` + `hooks/scripts/`)
- Add `.conductor/` directory guard to hook scripts so they only fire in Conductor-managed repos
- Update README with plugin installation step (`claude plugin add`) and note that MCP server is auto-configured via plugin

## Test plan
- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all 30 tests pass
- [ ] Manual: verify hook scripts exit early in non-Conductor repos
- [ ] Manual: verify `claude plugin add github:S-Nakamur-a/conductor` installs hooks + MCP