### PR TITLE
Fix MCP server startup for marketplace plugin install

### DIFF
--- a/plugins/conductor/.mcp.json
+++ b/plugins/conductor/.mcp.json
@@ -1,8 +1,11 @@
 {
   "mcpServers": {
     "conductor": {
-      "command": "npx",
-      "args": ["tsx", "${CLAUDE_PLUGIN_ROOT}/mcp/conductor-comment/src/index.ts"]
+      "command": "sh",
+      "args": [
+        "-c",
+        "(cd \"${CLAUDE_PLUGIN_ROOT}/mcp/conductor-comment\" && npm install --silent 2>/dev/null) && npx --yes tsx \"${CLAUDE_PLUGIN_ROOT}/mcp/conductor-comment/src/index.ts\""
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- MCP server failed to start when plugin was installed via marketplace (`/plugin install conductor@conductor-marketplace`)
- Root cause: `npx tsx` requires `node_modules/` which is gitignored and not present in the cached plugin directory
- Fix: use `sh -c` to auto-run `npm install` before launching, matching the pattern used by other working plugins

## Test plan
- [ ] `/plugin install conductor@conductor-marketplace` で再インストール
- [ ] MCP ツール (`get_pending_comments` 等) が正常に動作することを確認