### PR TITLE
Show dot files in Explorer by default

### DIFF
--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -514,6 +514,7 @@ impl ViewerState {
     /// tend to contain a very large number of files and are rarely useful to
     /// browse interactively.
     const SKIP_DIRS: &[&str] = &[
+        ".git",
         "node_modules",
         "target",
         "vendor",
@@ -598,10 +599,6 @@ impl ViewerState {
         for child in &children {
             let name = child.file_name().to_string_lossy().to_string();
 
-            if name.starts_with('.') {
-                continue;
-            }
-
             let child_path = child.path();
             let is_dir = child_path.is_dir();
 
@@ -661,11 +658,6 @@ impl ViewerState {
 
         for child in &children {
             let name = child.file_name().to_string_lossy().to_string();
-
-            // Skip hidden directories like .git
-            if name.starts_with('.') {
-                continue;
-            }
 
             let child_path = child.path();
             let is_dir = child_path.is_dir();


### PR DESCRIPTION
## Summary
- Explorerパネルでドットファイル（`.gitignore`, `.env`, `.github/` など）がデフォルトで表示されるように変更
- `walk_dir()` と `read_dir_entries()` の `name.starts_with('.')` フィルタを削除
- `.git` ディレクトリは `SKIP_DIRS` に追加して引き続き非表示

## Test plan
- [ ] `cargo check` / `cargo build` が通ること
- [ ] Conductor起動後、Explorerにドットファイル（`.gitignore` 等）が表示されること
- [ ] `.git` ディレクトリが表示されないこと
- [ ] ディレクトリ展開時（遅延読み込み）でもドットファイルが表示されること