### PR TITLE
Fix MCP plugin install and update package-lock.json

### DIFF
--- a/plugins/conductor/mcp/conductor-comment/package-lock.json
+++ b/plugins/conductor/mcp/conductor-comment/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "better-sqlite3": "^11.8.1"
+        "better-sqlite3": "^11.8.1",
+        "zod": "^3.0.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -2135,9 +2136,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary
- Fix MCP server startup when plugin is installed via marketplace (`npm install` before `npx tsx`)
- Update package-lock.json to reflect the added `zod` direct dependency

## Test plan
- [ ] Install plugin via `/plugin marketplace add` + `/plugin install`
- [ ] Verify MCP server connects successfully (`/mcp`)