### PR TITLE
Fix command palette keybinding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Worktree | Explorer | Viewer | Terminal (Claude Code / Shell)
 
 ### Command Palette
 
-**Alt+;** (any panel, including terminal) or **:** (Worktree panel) to open the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
+**Ctrl+.** (any panel, including terminal) or **:** (non-terminal panels) to open the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
 
 ## MCP Server
 


### PR DESCRIPTION
## Summary
- READMEのコマンドパレット起動キーが実際のコードと一致していなかったのを修正
  - `Alt+;` → `Ctrl+.` (実装: `KeyModifiers::CONTROL` + `KeyCode::Char('.')`)
  - `Worktree panel` → `non-terminal panels` (`:` はターミナル以外の全パネルで有効)

## Test plan
- [ ] README の記述が `src/event.rs` のキーバインド実装と一致していることを確認