### PR TITLE
Move ccusage toggle from env var to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terminal-based Git workspace and code review TUI written in Rust. Manages multip
 
 | Dependency | Purpose | How to enable |
 |---|---|---|
-| **ccusage** (via npx) | Token usage / cost display in title bar | Set env var `CONDUCTOR_CCUSAGE=1` |
+| **ccusage** (via npx) | Token usage / cost display in title bar | Set `ccusage.enabled = true` in config |
 | **terminal-notifier** | macOS notifications when Claude Code is waiting for input | `brew install terminal-notifier` + set `notification.cc_waiting = true` in config |
 
 ## Installation
@@ -119,6 +119,10 @@ theme = "catppuccin-mocha"     # catppuccin-mocha | dracula | nord | solarized-d
 
 [notification]
 # cc_waiting = false
+
+[ccusage]
+# enabled = false
+# poll_interval_secs = 120
 ```
 
 ## Data Paths

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     pub keybinds: KeybindsConfig,
     /// `[notification]` -- OS notification settings.
     pub notification: NotificationConfig,
+    /// `[ccusage]` -- Claude Code token usage display.
+    pub ccusage: CcusageConfig,
 }
 
 
@@ -232,6 +234,25 @@ pub struct NotificationConfig {
     pub cc_waiting: bool,
 }
 
+/// `[ccusage]` section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CcusageConfig {
+    /// Enable Claude Code token usage display in the title bar.
+    pub enabled: bool,
+    /// Polling interval in seconds.
+    pub poll_interval_secs: u64,
+}
+
+impl Default for CcusageConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            poll_interval_secs: 120,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -295,6 +316,8 @@ mod tests {
         assert!(cfg2.diff.word_diff);
         assert_eq!(cfg2.review.prompt_action, PromptAction::Clipboard);
         assert!(!cfg2.notification.cc_waiting);
+        assert!(!cfg2.ccusage.enabled);
+        assert_eq!(cfg2.ccusage.poll_interval_secs, 120);
     }
 
     #[test]
@@ -323,6 +346,16 @@ mod tests {
         let p = PathBuf::from("~/dev/project");
         let expanded = expand_tilde(&p);
         assert!(!expanded.to_string_lossy().starts_with('~'));
+    }
+
+    #[test]
+    fn ccusage_config_parse() {
+        let cfg: CcusageConfig =
+            toml::from_str(r#"enabled = true
+poll_interval_secs = 60"#)
+                .expect("parse");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.poll_interval_secs, 60);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,11 +135,10 @@ fn run_loop(
     const STATS_REFRESH_POLL: Duration = Duration::from_secs(30);
     let mut last_stats_refresh = Instant::now();
 
-    // ── ccusage polling (opt-in via CONDUCTOR_CCUSAGE=1) ────────
-    const CCUSAGE_POLL: Duration = Duration::from_secs(120);
-    let ccusage_enabled =
-        std::env::var("CONDUCTOR_CCUSAGE").map(|v| v == "1").unwrap_or(false);
-    let mut last_ccusage_poll = Instant::now() - CCUSAGE_POLL; // trigger immediately
+    // ── ccusage polling (opt-in via [ccusage] enabled = true) ─────
+    let ccusage_poll = Duration::from_secs(app.config.ccusage.poll_interval_secs);
+    let ccusage_enabled = app.config.ccusage.enabled;
+    let mut last_ccusage_poll = Instant::now() - ccusage_poll; // trigger immediately
     let ccusage_result: Arc<Mutex<Option<crate::app::CcusageInfo>>> =
         Arc::new(Mutex::new(None));
 
@@ -264,7 +263,7 @@ fn run_loop(
         }
 
         // ── ccusage background fetch ────────────────────────────────
-        if ccusage_enabled && last_ccusage_poll.elapsed() >= CCUSAGE_POLL {
+        if ccusage_enabled && last_ccusage_poll.elapsed() >= ccusage_poll {
             last_ccusage_poll = Instant::now();
             let result_handle = Arc::clone(&ccusage_result);
             std::thread::spawn(move || {


### PR DESCRIPTION
## Summary
- `CONDUCTOR_CCUSAGE=1` 環境変数を廃止し、`[ccusage]` config セクションに移行
- ポーリング間隔も `poll_interval_secs` で設定可能に

```toml
[ccusage]
enabled = true
# poll_interval_secs = 120
```

## Test plan
- [x] `cargo test config` — 全テストパス
- [ ] `config.toml` に `[ccusage] enabled = true` を設定してタイトルバーにトークン使用量が表示されることを確認
- [ ] 未設定時にデフォルト(無効)で動作することを確認