### PR TITLE
Fix title bar stats to show today's activity with per-item colors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -253,8 +253,8 @@ pub struct App {
     // ── Gamification (session stats + streak) ────────────────────
     /// ID of the current stats session (for gamification tracking).
     pub stats_session_id: Option<String>,
-    /// Cached streak info (refreshed periodically).
-    pub streak_info: Option<review_store::StreakInfo>,
+    /// Cached today's activity stats (refreshed periodically).
+    pub today_stats: Option<review_store::DailyStats>,
     /// HEAD oid per worktree branch (for commit detection).
     pub worktree_heads: HashMap<String, String>,
 
@@ -335,7 +335,7 @@ impl App {
         if let Some(store) = &review_store {
             let _ = store.increment_daily_stat("sessions_used");
         }
-        let streak_info = review_store.as_ref().and_then(|store| store.calculate_streak().ok());
+        let today_stats = review_store.as_ref().and_then(|store| store.get_today_stats().ok());
 
         let theme = Theme::from_name(&config.viewer.theme);
 
@@ -409,7 +409,7 @@ impl App {
             terminal_scroll_claude: 0,
             terminal_scroll_shell: 0,
             stats_session_id,
-            streak_info,
+            today_stats,
             worktree_heads: HashMap::new(),
             ccusage_info: None,
             bg_branch_rx: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ fn run_loop(
         if last_stats_refresh.elapsed() >= STATS_REFRESH_POLL {
             last_stats_refresh = Instant::now();
             if let Some(store) = &app.review_store {
-                app.streak_info = store.calculate_streak().ok();
+                app.today_stats = store.get_today_stats().ok();
             }
         }
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -153,41 +153,56 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
     // ── Right-aligned items (accumulated right_offset) ──────────
     let mut right_offset: u16 = 0;
 
-    // ── Stats display (streak + ccusage, unified) ─────────────
+    // ── Stats display (today's activity + ccusage) ────────────
     {
-        let mut parts: Vec<String> = Vec::new();
-        if let Some(ref streak) = app.streak_info {
-            if streak.consecutive_days > 0 {
-                parts.push(format!(
-                    "{} days",
-                    streak.consecutive_days,
-                ));
-            }
-            if streak.today_activity_count > 0 {
-                parts.push(format!(
-                    "{} PRs",
-                    streak.today_activity_count,
-                ));
-            }
+        let sep = Span::styled(" | ", Style::default().fg(Color::DarkGray).bg(Color::DarkGray));
+        let mut spans: Vec<Span> = Vec::new();
+
+        if let Some(ref stats) = app.today_stats {
+            spans.push(Span::styled(
+                format!("{} branches", stats.branches_created),
+                Style::default().fg(Color::Cyan).bg(Color::DarkGray),
+            ));
+            spans.push(sep.clone());
+            spans.push(Span::styled(
+                format!("{} commits", stats.commits_made),
+                Style::default().fg(Color::Green).bg(Color::DarkGray),
+            ));
+            spans.push(sep.clone());
+            spans.push(Span::styled(
+                format!("{} reviews", stats.reviews_created),
+                Style::default().fg(Color::Magenta).bg(Color::DarkGray),
+            ));
         }
         if let Some(ref info) = app.ccusage_info {
-            parts.push(format!("{} tokens", format_tokens(info.total_tokens)));
-            parts.push(format!("${:.2}", info.total_cost));
+            if !spans.is_empty() {
+                spans.push(sep.clone());
+            }
+            spans.push(Span::styled(
+                format!("{} tokens", format_tokens(info.total_tokens)),
+                Style::default().fg(Color::Yellow).bg(Color::DarkGray),
+            ));
+            spans.push(sep.clone());
+            spans.push(Span::styled(
+                format!("${:.2}", info.total_cost),
+                Style::default().fg(Color::LightGreen).bg(Color::DarkGray),
+            ));
         }
-        if !parts.is_empty() {
-            let stats_text = format!(" {} ", parts.join(" | "));
-            let stats_w = UnicodeWidthStr::width(stats_text.as_str()) as u16;
+
+        if !spans.is_empty() {
+            // Add padding spaces
+            spans.insert(0, Span::styled(" ", Style::default().bg(Color::DarkGray)));
+            spans.push(Span::styled(" ", Style::default().bg(Color::DarkGray)));
+
+            let stats_line = Line::from(spans);
+            let stats_w = stats_line.width() as u16;
             if stats_w + 2 < area.width {
-                let stats_style = Style::default()
-                    .fg(Color::Green)
-                    .bg(Color::DarkGray);
                 let stats_area = Rect::new(
                     area.x + area.width - stats_w - right_offset,
                     area.y,
                     stats_w,
                     1,
                 );
-                let stats_line = Line::from(Span::styled(&stats_text, stats_style));
                 frame.render_widget(Paragraph::new(stats_line), stats_area);
                 right_offset += stats_w + 1;
             }


### PR DESCRIPTION
## Summary

- タイトルバー右上の stats 表示を `streak_info`（days/PRs）から `today_stats` に変更し、今日の実際のアクティビティ（branches, commits, reviews）を個別表示
- 各項目に個別の色を割り当て（Cyan, Green, Magenta, Yellow, LightGreen）で視認性を向上
- ccusage の tokens/cost 表示はそのまま維持

## Test plan

- [x] `cargo build` コンパイル確認
- [x] `cargo test` 全31テスト通過
- [x] `cargo clippy` 警告なし