### PR TITLE
Switch worktree selection from double-click to single-click

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -166,8 +166,6 @@ pub struct App {
     pub active_claude_session: Option<usize>,
     /// Index of the active Shell session for the current worktree (into pty_manager.sessions).
     pub active_shell_session: Option<usize>,
-    /// Timestamp and row of the last mouse click in the Worktree panel (for double-click detection).
-    pub last_worktree_click: (std::time::Instant, u16),
     /// Timestamp and row of the last mouse click in the Explorer/Diff area (for double-click detection).
     pub last_explorer_click: (std::time::Instant, u16),
     /// Timestamp of the last mouse click in a terminal panel (for double-click detection).
@@ -392,7 +390,6 @@ impl App {
             needs_clear: false,
             active_claude_session: None,
             active_shell_session: None,
-            last_worktree_click: (std::time::Instant::now(), 0),
             last_explorer_click: (std::time::Instant::now(), 0),
             last_terminal_click: std::time::Instant::now(),
             worktree_pending_branch: String::new(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -1850,14 +1850,7 @@ pub fn handle_mouse_event(
                 if col < left_end {
                     app.focus = Focus::Worktree;
 
-                    // Double-click detection.
-                    let now = std::time::Instant::now();
-                    let (prev_time, prev_row) = app.last_worktree_click;
-                    let is_double = now.duration_since(prev_time).as_millis() < 400
-                        && prev_row == row;
-                    app.last_worktree_click = (now, row);
-
-                    // Click selects a worktree.
+                    // Click selects and switches to the worktree.
                     let relative_row = (row - main_area.y) as usize;
                     let item_row = relative_row.saturating_sub(1);
                     if !app.worktrees.is_empty() {
@@ -1865,11 +1858,8 @@ pub fn handle_mouse_event(
                             item_row.min(app.worktrees.len().saturating_sub(1));
                     }
 
-                    // Double-click switches to the selected worktree.
-                    if is_double {
-                        app.on_worktree_changed();
-                        app.set_focus(Focus::Explorer);
-                    }
+                    app.on_worktree_changed();
+                    app.set_focus(Focus::Explorer);
                 } else if col < explorer_end {
                     // Explorer column.
                     app.focus = Focus::Explorer;


### PR DESCRIPTION
## Summary
- Worktreeパネルでシングルクリックで即座にworktreeを選択・切り替えるように変更（従来はダブルクリックが必要だった）
- Enterキーによる選択動作は変更なし
- 不要になったダブルクリック検出用フィールド `last_worktree_click` を削除

## Test plan
- [ ] Worktreeパネルでシングルクリックでworktreeが切り替わることを確認
- [ ] Enterキーでworktreeが切り替わることを確認
- [ ] Explorer/Diff/Terminalパネルのクリック動作に影響がないことを確認