### PR TITLE
Add filtered branch picker for base branch selection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -176,6 +176,12 @@ pub struct App {
     // ── Create worktree 2-step flow ─────────────────────────────
     /// Branch name entered in step 1, held while step 2 (base branch) is active.
     pub worktree_pending_branch: String,
+    /// Full list of branches available as base for worktree creation.
+    pub base_branch_list: Vec<String>,
+    /// Currently selected index in the base branch picker.
+    pub base_branch_selected: usize,
+    /// Filter string for narrowing the base branch list.
+    pub base_branch_filter: String,
 
     // ── Switch (remote branch checkout) ─────────────────────────
     /// Whether the switch-branch overlay is active.
@@ -396,6 +402,9 @@ impl App {
             last_explorer_click: (std::time::Instant::now(), 0),
             last_terminal_click: std::time::Instant::now(),
             worktree_pending_branch: String::new(),
+            base_branch_list: Vec::new(),
+            base_branch_selected: 0,
+            base_branch_filter: String::new(),
             switch_branch_active: false,
             switch_branch_list: Vec::new(),
             switch_branch_selected: 0,
@@ -1789,6 +1798,48 @@ impl App {
         } else {
             let filter_lower = self.switch_branch_filter.to_lowercase();
             self.switch_branch_list
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| b.to_lowercase().contains(&filter_lower))
+                .collect()
+        }
+    }
+
+    /// Load branches available as base for worktree creation.
+    /// Lists remote branches and pre-selects `origin/<main_branch>`.
+    pub fn load_base_branches(&mut self) {
+        match git_engine::GitEngine::open(&self.repo_path) {
+            Ok(engine) => {
+                match engine.list_remote_branches() {
+                    Ok(branches) => {
+                        self.base_branch_list = branches;
+                        self.base_branch_selected = 0;
+                        self.base_branch_filter.clear();
+                        // Pre-select origin/<main_branch> if it exists.
+                        let default_base = format!("origin/{}", self.config.general.main_branch);
+                        if let Some(pos) = self.base_branch_list.iter().position(|b| b == &default_base) {
+                            self.base_branch_selected = pos;
+                        }
+                    }
+                    Err(e) => {
+                        self.set_status(format!("Error listing branches: {e}"), StatusLevel::Error);
+                        self.base_branch_list.clear();
+                    }
+                }
+            }
+            Err(e) => {
+                self.set_status(format!("Error: {e}"), StatusLevel::Error);
+            }
+        }
+    }
+
+    /// Return the filtered list of base branches based on the current filter.
+    pub fn filtered_base_branches(&self) -> Vec<(usize, &String)> {
+        if self.base_branch_filter.is_empty() {
+            self.base_branch_list.iter().enumerate().collect()
+        } else {
+            let filter_lower = self.base_branch_filter.to_lowercase();
+            self.base_branch_list
                 .iter()
                 .enumerate()
                 .filter(|(_, b)| b.to_lowercase().contains(&filter_lower))

--- a/src/event.rs
+++ b/src/event.rs
@@ -932,14 +932,12 @@ fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
                     app.worktree_input_buffer.clear();
                     app.set_status("Cancelled (empty name).".to_string(), StatusLevel::Warning);
                 } else {
-                    // Move to step 2: base branch input.
+                    // Move to step 2: base branch picker.
                     app.worktree_pending_branch = name;
                     app.worktree_input_buffer.clear();
                     app.worktree_input_mode = WorktreeInputMode::CreatingWorktreeBase;
-                    app.set_status(
-                        "Base branch (Enter for origin/main, Esc to cancel):".to_string(),
-                        StatusLevel::Info,
-                    );
+                    app.load_base_branches();
+                    app.status_message = None;
                 }
             }
             KeyCode::Backspace => {
@@ -950,29 +948,54 @@ fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         },
-        WorktreeInputMode::CreatingWorktreeBase => match key.code {
-            KeyCode::Esc => {
-                app.worktree_input_mode = WorktreeInputMode::Normal;
-                app.worktree_input_buffer.clear();
-                app.worktree_pending_branch.clear();
-                app.set_status("Cancelled.".to_string(), StatusLevel::Warning);
+        WorktreeInputMode::CreatingWorktreeBase => {
+            let filtered = app.filtered_base_branches();
+            let count = filtered.len();
+
+            match key.code {
+                KeyCode::Esc => {
+                    app.worktree_input_mode = WorktreeInputMode::Normal;
+                    app.base_branch_filter.clear();
+                    app.worktree_pending_branch.clear();
+                    app.set_status("Cancelled.".to_string(), StatusLevel::Warning);
+                }
+                KeyCode::Down => {
+                    if count > 0 && app.base_branch_selected + 1 < count {
+                        app.base_branch_selected += 1;
+                    }
+                }
+                KeyCode::Up => {
+                    if app.base_branch_selected > 0 {
+                        app.base_branch_selected -= 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    let filtered = app.filtered_base_branches();
+                    let base_ref = if let Some(&(original_idx, _)) = filtered.get(app.base_branch_selected) {
+                        app.base_branch_list.get(original_idx).cloned().unwrap_or_default()
+                    } else if !app.base_branch_filter.is_empty() {
+                        // No match — use the filter text as a raw ref.
+                        app.base_branch_filter.clone()
+                    } else {
+                        String::new() // Will default to origin/main
+                    };
+                    let branch_name = app.worktree_pending_branch.clone();
+                    app.worktree_input_mode = WorktreeInputMode::Normal;
+                    app.base_branch_filter.clear();
+                    app.worktree_pending_branch.clear();
+                    app.create_worktree_from_base(&branch_name, &base_ref);
+                }
+                KeyCode::Backspace => {
+                    app.base_branch_filter.pop();
+                    app.base_branch_selected = 0;
+                }
+                KeyCode::Char(c) if key.modifiers.is_empty() => {
+                    app.base_branch_filter.push(c);
+                    app.base_branch_selected = 0;
+                }
+                _ => {}
             }
-            KeyCode::Enter => {
-                let base_ref = app.worktree_input_buffer.clone();
-                let branch_name = app.worktree_pending_branch.clone();
-                app.worktree_input_mode = WorktreeInputMode::Normal;
-                app.worktree_input_buffer.clear();
-                app.worktree_pending_branch.clear();
-                app.create_worktree_from_base(&branch_name, &base_ref);
-            }
-            KeyCode::Backspace => {
-                app.worktree_input_buffer.pop();
-            }
-            KeyCode::Char(c) => {
-                app.worktree_input_buffer.push(c);
-            }
-            _ => {}
-        },
+        }
         WorktreeInputMode::ConfirmingDelete => match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 // Save branch name before deleting worktree.

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -518,38 +518,89 @@ pub fn render_prune_overlay(frame: &mut Frame, area: Rect, app: &App) {
 
 /// Render the base branch input overlay (step 2 of worktree creation).
 pub fn render_worktree_base_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
-    let popup_height = 5_u16;
-    let popup_width = area.width.saturating_sub(8).min(60);
+    let popup_width = 70_u16.min(area.width.saturating_sub(4));
+    let popup_height = 22_u16.min(area.height.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
-    let y = area.y + area.height.saturating_sub(popup_height + 2);
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
 
     frame.render_widget(ratatui::widgets::Clear, popup_area);
 
+    // Split into filter bar + list.
+    let chunks = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(3),
+    ])
+    .split(popup_area);
+
+    // Filter bar.
     let title = format!(
-        " Base Branch for '{}' (default: origin/main) ",
+        " Base Branch for '{}' (type to filter, Enter: select, Esc: cancel) ",
         app.worktree_pending_branch,
     );
-    let block = Block::default()
+    let filter_block = Block::default()
         .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow));
 
-    let inner = block.inner(popup_area);
-    frame.render_widget(block, popup_area);
+    let filter_inner = filter_block.inner(chunks[0]);
+    frame.render_widget(filter_block, chunks[0]);
 
-    let hint_line = Line::from(Span::styled(
-        "Enter a base ref (e.g. origin/main, origin/develop) or press Enter for default",
-        Style::default().fg(Color::DarkGray),
-    ));
-    let input_text = format!("{}\u{2588}", app.worktree_input_buffer);
-    let input_line = Line::from(Span::styled(
-        input_text,
+    let filter_text = format!("{}\u{2588}", app.base_branch_filter);
+    let filter_para = Paragraph::new(Span::styled(
+        filter_text,
         Style::default().fg(Color::White),
     ));
+    frame.render_widget(filter_para, filter_inner);
 
-    let paragraph = Paragraph::new(vec![hint_line, input_line]);
-    frame.render_widget(paragraph, inner);
+    // Branch list.
+    let list_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let list_inner = list_block.inner(chunks[1]);
+    frame.render_widget(list_block, chunks[1]);
+
+    let filtered = app.filtered_base_branches();
+    if filtered.is_empty() {
+        let hint = if app.base_branch_filter.is_empty() {
+            "  No branches found.".to_string()
+        } else {
+            format!("  No matches. Enter will use '{}' as base ref.", app.base_branch_filter)
+        };
+        let paragraph = Paragraph::new(hint)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(paragraph, list_inner);
+        return;
+    }
+
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .enumerate()
+        .map(|(vis_idx, (_orig_idx, branch))| {
+            let style = if vis_idx == app.base_branch_selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!("  {branch}"),
+                style,
+            )))
+        })
+        .collect();
+
+    let list = List::new(items).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let mut state = ListState::default();
+    state.select(Some(app.base_branch_selected));
+    frame.render_stateful_widget(list, list_inner, &mut state);
 }
 
 /// Render the branch deletion confirmation overlay.


### PR DESCRIPTION
## Summary
- Worktree新規作成時のbase branch選択（ステップ2）を、テキスト入力からSwitch Branchと同様のフィルタ付きリストピッカーに変更
- `origin/main`（configの`main_branch`に基づく）がデフォルトでハイライト選択済み → そのままEnterで従来通りの挙動
- 文字入力でインクリメンタルフィルタリング、Up/Downで選択移動
- フィルタにマッチするブランチがない場合、入力テキストをそのままraw ref（タグ、コミットハッシュ等）として使用可能

## Test plan
- [ ] Worktree作成でステップ2に進んだ時にブランチリストが表示される
- [ ] `origin/main` がデフォルトで選択されており、そのままEnterで従来通り動作する
- [ ] 文字入力でリストがフィルタリングされる
- [ ] Up/Downキーで選択を移動できる
- [ ] Escでキャンセルできる
- [ ] マッチなしの状態でEnterするとフィルタ文字列がraw refとして使われる