### PR TITLE
Add orange notification bar for CC waiting state

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -247,9 +247,9 @@ pub struct App {
     /// Frame counter for UI animations (e.g. waiting-state pulse).
     pub ui_tick: u64,
 
-    /// Title bar badge positions: (start_col, end_col, branch_name).
+    /// Notification bar badge positions: (start_col, end_col, branch_name).
     /// Populated during rendering for click-to-jump.
-    pub title_bar_badges: Vec<(u16, u16, String)>,
+    pub notification_bar_badges: Vec<(u16, u16, String)>,
 
     /// Scrollback offset for the Claude Code terminal (0 = live view at bottom).
     pub terminal_scroll_claude: usize,
@@ -426,7 +426,7 @@ impl App {
             command_palette_filter: String::new(),
             command_palette_selected: 0,
             ui_tick: 0,
-            title_bar_badges: Vec::new(),
+            notification_bar_badges: Vec::new(),
             terminal_scroll_claude: 0,
             terminal_scroll_shell: 0,
             stats_session_id,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1802,13 +1802,16 @@ pub fn handle_mouse_event(
     use ratatui::layout::{Constraint, Layout};
 
     // Compute layout regions — must match render_ui in main.rs.
+    let notif_height: u16 = if !app.cc_waiting_worktrees.is_empty() { 1 } else { 0 };
     let outer = Layout::vertical([
         Constraint::Length(1), // title bar
+        Constraint::Length(notif_height), // notification bar
         Constraint::Min(0),
         Constraint::Length(1), // status bar
     ])
     .split(frame_area);
-    let main_area = outer[1];
+    let notif_area = outer[1];
+    let main_area = outer[2];
 
     let (left_w, explorer_w, viewer_w) = crate::accordion_widths(app.terminal_expanded, main_area.width);
 
@@ -1851,9 +1854,9 @@ pub fn handle_mouse_event(
             }
         }
         MouseEventKind::Down(MouseButton::Left) => {
-            // Title bar click — check for badge clicks.
-            if row < main_area.y {
-                for (start_col, end_col, branch) in &app.title_bar_badges {
+            // Notification bar click — check for badge clicks.
+            if notif_height > 0 && row == notif_area.y {
+                for (start_col, end_col, branch) in &app.notification_bar_badges {
                     if col >= *start_col && col < *end_col {
                         if let Some(wt_idx) =
                             app.worktrees.iter().position(|w| w.branch == *branch)
@@ -1865,6 +1868,11 @@ pub fn handle_mouse_event(
                         return;
                     }
                 }
+                return;
+            }
+
+            // Title bar click — ignore.
+            if row < main_area.y {
                 return;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,14 +182,16 @@ fn run_loop(
         // Compute PTY sizes for Claude and Shell panels.
         {
             let area = last_frame_area;
-            // Must match render_ui layout: title bar (1) + main + status bar (1).
+            // Must match render_ui layout: title bar (1) + notification bar (0 or 1) + main + status bar (1).
+            let notif_height: u16 = if !app.cc_waiting_worktrees.is_empty() { 1 } else { 0 };
             let outer = Layout::vertical([
                 Constraint::Length(1),
+                Constraint::Length(notif_height),
                 Constraint::Min(0),
                 Constraint::Length(1),
             ])
             .split(area);
-            let main_area = outer[1];
+            let main_area = outer[2];
 
             let (left_w, explorer_w, viewer_w) = accordion_widths(app.terminal_expanded, main_area.width);
             let right_w = main_area.width.saturating_sub(left_w + explorer_w + viewer_w);
@@ -351,20 +353,30 @@ pub fn accordion_widths(terminal_expanded: bool, total_width: u16) -> (u16, u16,
 fn render_ui(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
-    // Outer: title bar (1 row) + main content + status bar (1 row).
+    let has_notifications = !app.cc_waiting_worktrees.is_empty();
+    let notif_height: u16 = if has_notifications { 1 } else { 0 };
+
+    // Outer: title bar (1 row) + notification bar (0 or 1 row) + main content + status bar (1 row).
     let outer = Layout::vertical([
         Constraint::Length(1),
+        Constraint::Length(notif_height),
         Constraint::Min(0),
         Constraint::Length(1),
     ])
     .split(area);
 
     let title_area = outer[0];
-    let main_area = outer[1];
-    let status_area = outer[2];
+    let notif_area = outer[1];
+    let main_area = outer[2];
+    let status_area = outer[3];
 
     // ── Title bar ───────────────────────────────────────────────────
     ui::common::render_title_bar(frame, title_area, app);
+
+    // ── Notification bar (CC waiting) ───────────────────────────────
+    if has_notifications {
+        ui::common::render_notification_bar(frame, notif_area, app);
+    }
 
     // ── Accordion column widths ─────────────────────────────────────
     let (left_w, explorer_w, viewer_w) = accordion_widths(app.terminal_expanded, main_area.width);

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -147,8 +147,6 @@ fn name_to_color(name: &str) -> (Color, Color) {
 }
 
 /// Render the title bar at the top showing worktree name and working directory.
-/// Also renders CC waiting badges on the right side and records their positions
-/// in `app.title_bar_badges` for click handling.
 pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App) {
     let wt_name = app
         .worktrees
@@ -161,27 +159,11 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
         .map(|w| w.path.display().to_string())
         .unwrap_or_else(|| app.repo_path.display().to_string());
 
-    let has_waiting = !app.cc_waiting_worktrees.is_empty();
-
     let (badge_bg, branch_fg) = name_to_color(&app.main_repo_name);
 
-    // When CC sessions are waiting, pulse the title bar by varying lightness.
-    let (bar_bg, conductor_bg, conductor_fg) = if has_waiting {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        app.main_repo_name.hash(&mut hasher);
-        let hue = (hasher.finish() % 360) as f64;
-        let phase = (app.ui_tick / 20) % 3;
-        let (l_badge, l_bar) = match phase {
-            0 => (0.55, 0.20),   // brighter pulse
-            1 => (0.40, 0.15),   // slightly darker
-            _ => (0.45, 0.12),   // normal
-        };
-        let (br, bg_c, bb) = hsl_to_rgb(hue, 0.6, l_badge);
-        let (bar_r, bar_g, bar_b) = hsl_to_rgb(hue, 0.3, l_bar);
-        (Color::Rgb(bar_r, bar_g, bar_b), Color::Rgb(br, bg_c, bb), Color::Black)
-    } else {
-        (Color::DarkGray, badge_bg, Color::Black)
-    };
+    let bar_bg = Color::DarkGray;
+    let conductor_bg = badge_bg;
+    let conductor_fg = Color::Black;
 
     let badge_text = format!(" {} ", app.main_repo_name);
     let line = Line::from(vec![
@@ -197,10 +179,7 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
     let paragraph = Paragraph::new(line).style(Style::default().bg(bar_bg));
     frame.render_widget(paragraph, area);
 
-    // ── Right-aligned items (accumulated right_offset) ──────────
-    let mut right_offset: u16 = 0;
-
-    // ── Stats display (today's activity + ccusage) ────────────
+    // ── Right-aligned stats display (today's activity + ccusage) ──────────
     {
         let sep = Span::styled(" | ", Style::default().fg(Color::DarkGray).bg(Color::DarkGray));
         let mut spans: Vec<Span> = Vec::new();
@@ -245,25 +224,52 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
             let stats_w = stats_line.width() as u16;
             if stats_w + 2 < area.width {
                 let stats_area = Rect::new(
-                    area.x + area.width - stats_w - right_offset,
+                    area.x + area.width - stats_w,
                     area.y,
                     stats_w,
                     1,
                 );
                 frame.render_widget(Paragraph::new(stats_line), stats_area);
-                right_offset += stats_w + 1;
             }
         }
     }
+}
 
-    // ── CC waiting badges (right-aligned) ────────────────────────
-    app.title_bar_badges.clear();
+/// Render the notification bar showing CC waiting badges.
+/// Returns the height consumed (0 if no notifications, 1 if shown).
+/// Records badge positions in `app.notification_bar_badges` for click handling.
+pub fn render_notification_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App) -> u16 {
+    app.notification_bar_badges.clear();
 
     if app.cc_waiting_worktrees.is_empty() {
-        return;
+        return 0;
     }
 
-    // Sort for stable ordering (by display name).
+    // Orange-tinted background for the notification bar.
+    let pulse_on = (app.ui_tick / 20) % 2 == 0;
+    let bar_bg = if pulse_on {
+        Color::Rgb(50, 30, 0)  // warm dark orange
+    } else {
+        Color::Rgb(35, 20, 0)  // darker pulse
+    };
+
+    // Fill background.
+    let bg_line = Line::from(Span::styled(
+        " ".repeat(area.width as usize),
+        Style::default().bg(bar_bg),
+    ));
+    frame.render_widget(Paragraph::new(bg_line), area);
+
+    // Leading indicator.
+    let prefix = " ⏳ ";
+    let prefix_style = Style::default()
+        .fg(Color::Rgb(255, 180, 50))
+        .bg(bar_bg)
+        .add_modifier(Modifier::BOLD);
+    let prefix_area = Rect::new(area.x, area.y, prefix.len() as u16, 1);
+    frame.render_widget(Paragraph::new(Span::styled(prefix, prefix_style)), prefix_area);
+
+    // Collect waiting worktrees sorted by branch name.
     let mut waiting: Vec<(&PathBuf, String)> = app.cc_waiting_worktrees.iter().map(|p| {
         let name = app.worktrees.iter()
             .find(|w| &w.path == p)
@@ -273,45 +279,57 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
     }).collect();
     waiting.sort_by(|a, b| a.1.cmp(&b.1));
 
-    // Build badge strings: "[branch ⏳]"
-    let badges: Vec<String> = waiting.iter().map(|(_, name)| format!("[{name} ⏳]")).collect();
-    let total_badge_width: u16 = badges
-        .iter()
-        .map(|b| UnicodeWidthStr::width(b.as_str()) as u16 + 1) // +1 for space separator
-        .sum::<u16>()
-        .saturating_sub(1); // no trailing space
-
-    if total_badge_width + right_offset + 2 > area.width {
-        return; // not enough room
-    }
-
-    // Pulse animation: alternate lightness based on ui_tick using hash-derived hue.
-    let pulse_color = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        app.main_repo_name.hash(&mut hasher);
-        let hue = (hasher.finish() % 360) as f64;
-        let l = if (app.ui_tick / 15) % 2 == 0 { 0.55 } else { 0.65 };
-        let (r, g, b) = hsl_to_rgb(hue, 0.7, l);
-        Color::Rgb(r, g, b)
+    // Badge colors: orange pulse.
+    let badge_bg = if pulse_on {
+        Color::Rgb(200, 120, 0) // bright orange
+    } else {
+        Color::Rgb(180, 100, 0) // slightly dimmer
     };
     let badge_style = Style::default()
         .fg(Color::Black)
-        .bg(pulse_color)
+        .bg(badge_bg)
         .add_modifier(Modifier::BOLD);
 
-    let mut x = area.x + area.width - total_badge_width - right_offset;
-    for (i, badge_str) in badges.iter().enumerate() {
+    let sep_style = Style::default()
+        .fg(Color::Rgb(180, 120, 40))
+        .bg(bar_bg);
+
+    let mut x = area.x + UnicodeWidthStr::width(prefix) as u16;
+
+    for (i, (_path, name)) in waiting.iter().enumerate() {
+        if i > 0 {
+            // Separator between badges.
+            let sep_area = Rect::new(x, area.y, 1, 1);
+            frame.render_widget(Paragraph::new(Span::styled(" ", sep_style)), sep_area);
+            x += 1;
+        }
+
+        let badge_str = format!(" {name} ⏳ ");
         let w = UnicodeWidthStr::width(badge_str.as_str()) as u16;
+
+        if x + w > area.x + area.width {
+            break; // not enough room
+        }
+
         let badge_area = Rect::new(x, area.y, w, 1);
-        let badge_line = Line::from(Span::styled(badge_str, badge_style));
-        frame.render_widget(Paragraph::new(badge_line), badge_area);
+        frame.render_widget(Paragraph::new(Span::styled(&badge_str, badge_style)), badge_area);
 
-        // Record position for click handling (store branch name).
-        app.title_bar_badges
-            .push((x, x + w, waiting[i].1.clone()));
+        // Record position for click handling.
+        app.notification_bar_badges.push((x, x + w, name.clone()));
 
-        x += w + 1; // +1 for separator space
+        x += w;
     }
+
+    // Trailing hint text.
+    let hint = " (click to jump)";
+    let hint_w = UnicodeWidthStr::width(hint) as u16;
+    if x + hint_w < area.x + area.width {
+        let hint_area = Rect::new(x + 1, area.y, hint_w, 1);
+        let hint_style = Style::default().fg(Color::Rgb(120, 90, 40)).bg(bar_bg);
+        frame.render_widget(Paragraph::new(Span::styled(hint, hint_style)), hint_area);
+    }
+
+    1
 }
 
 /// Render a status bar at the bottom of the screen.

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -50,7 +50,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             let pulse_on = (app.ui_tick / 30) % 2 == 0;
             let label_style = if is_waiting {
                 Style::default()
-                    .fg(if pulse_on { Color::Yellow } else { Color::Cyan })
+                    .fg(if pulse_on { Color::Rgb(255, 165, 0) } else { Color::Rgb(200, 120, 0) })
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -41,7 +41,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
             let marker_style = if is_waiting {
                 Style::default()
-                    .fg(if pulse_on { Color::Yellow } else { Color::Cyan })
+                    .fg(if pulse_on { Color::Rgb(255, 165, 0) } else { Color::Rgb(200, 120, 0) })
                     .add_modifier(Modifier::BOLD)
             } else if i == app.selected_worktree {
                 Style::default()
@@ -80,7 +80,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 spans.push(Span::styled(
                     indicator,
                     Style::default()
-                        .fg(if pulse_on { Color::Yellow } else { Color::Cyan })
+                        .fg(if pulse_on { Color::Rgb(255, 165, 0) } else { Color::Rgb(200, 120, 0) })
                         .add_modifier(Modifier::BOLD),
                 ));
             }
@@ -99,9 +99,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             // Apply background highlight to the entire row when waiting.
             if is_waiting {
                 let bg = if pulse_on {
-                    Color::Rgb(0, 50, 65)
+                    Color::Rgb(60, 35, 0)   // warm orange tint
                 } else {
-                    Color::Rgb(0, 30, 40)
+                    Color::Rgb(40, 22, 0)   // darker orange pulse
                 };
                 item.style(Style::default().bg(bg))
             } else {


### PR DESCRIPTION
## Summary
- CC待ち検知時のハイライト色をYellow/CyanからオレンジRGB系に変更し、視認性を向上
- title barに重ねていたCC waitingバッジを専用のnotification barに分離（通知がある時のみ1行表示）
- 複数ワークツリーが同時に待ち状態でもバッジが横並びで綺麗に表示される
- バッジクリックでワークツリー切り替え+TerminalClaude focusは従来通り動作

## Test plan
- [ ] CC待ち状態でworktreeパネルのマーカー・ダイヤモンド・背景がオレンジ系で光ること
- [ ] CC待ち状態でterminal claudeタブがオレンジで光ること
- [ ] title barがCC待ち時にパルスしなくなっていること
- [ ] notification barがCC待ち時のみ表示され、通知がない時はスペースを消費しないこと
- [ ] notification barのバッジクリックでワークツリー切り替え+terminal focusが動くこと
- [ ] 複数ワークツリー同時待ちで複数バッジが並んで表示されること