### PR TITLE
Remove auto-detect session label feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -310,18 +310,6 @@ fn run_loop(
         // Scan Claude Code PTY output for file-change patterns.
         app.check_cc_output();
 
-        // Try to auto-detect session labels for Claude Code sessions.
-        for i in 0..app.pty_manager.sessions().len() {
-            let session = &app.pty_manager.sessions()[i];
-            if session.kind == crate::pty_manager::SessionKind::ClaudeCode
-                && session.label.starts_with("CC:")
-            {
-                if let Some(new_label) = app.pty_manager.auto_detect_label(i) {
-                    app.pty_manager.set_label(i, &new_label);
-                }
-            }
-        }
-
         if app.should_quit {
             return Ok(());
         }

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -448,55 +448,6 @@ impl PtyManager {
             .unwrap_or(false)
     }
 
-    /// Try to auto-detect a session label from the PTY output.
-    ///
-    /// Looks for patterns like "I'll " or "Let me " at the start of Claude's output
-    /// and extracts the first sentence as a label.
-    pub fn auto_detect_label(&mut self, idx: usize) -> Option<String> {
-        let output = self.get_output(idx);
-
-        // Look through the first 20 lines for Claude's response.
-        for line in output.iter().take(20) {
-            // Strip ANSI escape sequences before matching.
-            let clean = strip_ansi(line);
-            let trimmed = clean.trim();
-
-            // Skip empty lines, prompts, and commands.
-            if trimmed.is_empty() || trimmed.starts_with('$') || trimmed.starts_with('>') {
-                continue;
-            }
-
-            // Look for typical Claude opening patterns.
-            let patterns = [
-                "I'll ", "I will ", "Let me ", "I'm going to ",
-                "I can ", "Sure, ", "OK, ", "Alright, ",
-            ];
-
-            for pattern in &patterns {
-                if trimmed.starts_with(pattern) || trimmed.contains(pattern) {
-                    // Extract up to the first period or 60 chars.
-                    let text = if let Some(dot_pos) = trimmed.find('.') {
-                        &trimmed[..dot_pos]
-                    } else if trimmed.len() > 60 {
-                        &trimmed[..60]
-                    } else {
-                        trimmed
-                    };
-                    return Some(text.to_string());
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Update the label for a session at the given index.
-    pub fn set_label(&mut self, idx: usize, label: &str) {
-        if let Some(session) = self.sessions.get_mut(idx) {
-            session.label = label.to_string();
-        }
-    }
-
     // -- Input waiting detection ---------------------------------------------
 
     /// Check whether the Claude Code session at `idx` appears to be waiting


### PR DESCRIPTION
## Summary
- 毎フレーム(60fps)全セッションのPTY出力バッファをロック+スキャンしていたラベル自動検出を削除
- セッションラベルは初期値の `CC:<n>` のまま維持
- `auto_detect_label` / `set_label` メソッドも未使用のため削除

## Test plan
- [ ] `cargo check` / `cargo clippy` パス済み
- [ ] Conductor起動後、Claude Codeセッションのラベルが `CC:` で表示されることを確認
- [ ] Shell PTYの反応速度に悪影響がないことを確認