### PR TITLE
新規worktree作成時に自動でフォーカスを切り替える

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1561,6 +1561,14 @@ impl App {
 
     // ── Worktree create / delete helpers ──────────────────────────
 
+    /// Select a worktree by its path and trigger UI updates.
+    fn select_worktree_by_path(&mut self, path: &std::path::Path) {
+        if let Some(idx) = self.worktrees.iter().position(|w| w.path == path) {
+            self.selected_worktree = idx;
+            self.on_worktree_changed();
+        }
+    }
+
     /// Create a worktree from a base ref (2-step flow).
     pub fn create_worktree_from_base(&mut self, branch_name: &str, base_ref: &str) {
         let base = if base_ref.is_empty() { "origin/main" } else { base_ref };
@@ -1569,11 +1577,12 @@ impl App {
             Ok(engine) => {
                 match engine.create_worktree_from_base(branch_name, base, wt_dir.as_deref()) {
                     Ok(path) => {
+                        self.record_stat("branches_created");
+                        self.refresh_worktrees();
+                        self.select_worktree_by_path(&path);
                         self.set_status(format!(
                             "Created worktree: {} (from {})", path.display(), base
                         ), StatusLevel::Success);
-                        self.record_stat("branches_created");
-                        self.refresh_worktrees();
                     }
                     Err(e) => {
                         self.set_status(format!("Error: {e}"), StatusLevel::Error);
@@ -1593,11 +1602,12 @@ impl App {
             Ok(engine) => {
                 match engine.create_worktree_from_remote(remote_branch, wt_dir.as_deref()) {
                     Ok(path) => {
+                        self.record_stat("branches_created");
+                        self.refresh_worktrees();
+                        self.select_worktree_by_path(&path);
                         self.set_status(format!(
                             "Created tracking worktree: {}", path.display()
                         ), StatusLevel::Success);
-                        self.record_stat("branches_created");
-                        self.refresh_worktrees();
                     }
                     Err(e) => {
                         self.set_status(format!("Error: {e}"), StatusLevel::Error);


### PR DESCRIPTION
## 概要

新規にworktreeを作成した際、以前は作成前に選択していたworktreeにフォーカスが戻っていたが、新しく作成したworktreeが自動的に選択されるように修正。

## 変更内容

- `select_worktree_by_path` ヘルパーメソッドを追加し、パスからworktreeを特定して選択・UI更新を行う
- `create_worktree_from_base` / `create_worktree_from_remote` で、worktree作成後に `select_worktree_by_path` を呼び出して新しいworktreeにフォーカスを移す
- `on_worktree_changed()` が呼ばれるため、Explorer・Diff・Review・PTYセッション等のUI状態も正しく切り替わる

## テスト計画

- [ ] worktreeをbase refから新規作成し、作成後に新しいworktreeが選択されていることを確認
- [ ] remote branchからworktreeを作成し、同様に新しいworktreeが選択されることを確認
- [ ] 既存のworktree切り替え操作に影響がないことを確認