### PR TITLE
Add expand button to all panels

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -233,8 +233,9 @@ pub struct App {
     /// Which panel's help to display (captured at the moment `?` was pressed).
     pub help_context: Focus,
 
-    /// Whether the terminal column is manually expanded (via the [<=>] button).
-    pub terminal_expanded: bool,
+    /// Which panel is currently expanded to 100% (via the [<=>] button).
+    /// `None` means no panel is expanded (default layout).
+    pub expanded_panel: Option<Focus>,
 
     // ── Command palette overlay ─────────────────────────────────
     /// Whether the command palette is open.
@@ -421,7 +422,7 @@ impl App {
             syntect_theme,
             help_active: false,
             help_context: Focus::Worktree,
-            terminal_expanded: false,
+            expanded_panel: None,
             command_palette_active: false,
             command_palette_filter: String::new(),
             command_palette_selected: 0,
@@ -667,8 +668,12 @@ impl App {
             CommandId::FocusViewer => self.set_focus(Focus::Viewer),
             CommandId::FocusTerminalClaude => self.set_focus(Focus::TerminalClaude),
             CommandId::FocusTerminalShell => self.set_focus(Focus::TerminalShell),
-            CommandId::ToggleTerminalExpand => {
-                self.terminal_expanded = !self.terminal_expanded;
+            CommandId::TogglePanelExpand => {
+                if self.expanded_panel == Some(self.focus) {
+                    self.expanded_panel = None;
+                } else {
+                    self.expanded_panel = Some(self.focus);
+                }
             }
             CommandId::CreateWorktree => {
                 self.worktree_input_mode = WorktreeInputMode::CreatingWorktree;

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -11,7 +11,7 @@ pub enum CommandId {
     FocusViewer,
     FocusTerminalClaude,
     FocusTerminalShell,
-    ToggleTerminalExpand,
+    TogglePanelExpand,
 
     // Worktree
     CreateWorktree,
@@ -96,8 +96,8 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Navigation, keybinding: Some("Tab"), keywords: "terminal claude" },
     PaletteCommand { id: CommandId::FocusTerminalShell, label: "Focus: Shell Terminal",
         category: CommandCategory::Navigation, keybinding: Some("Tab"), keywords: "terminal shell" },
-    PaletteCommand { id: CommandId::ToggleTerminalExpand, label: "Toggle Terminal Expand",
-        category: CommandCategory::Navigation, keybinding: None, keywords: "resize maximize" },
+    PaletteCommand { id: CommandId::TogglePanelExpand, label: "Toggle Panel Expand",
+        category: CommandCategory::Navigation, keybinding: None, keywords: "resize maximize fullscreen" },
 
     // Worktree
     PaletteCommand { id: CommandId::CreateWorktree, label: "Worktree: Create New",

--- a/src/event.rs
+++ b/src/event.rs
@@ -1856,7 +1856,12 @@ fn handle_terminal_tab_click(app: &mut App, click_col: u16, tab_area_x: u16, is_
 
     // Check [<=>] toggle.
     if relative_x >= x && relative_x < x + 5 {
-        app.terminal_expanded = !app.terminal_expanded;
+        let target = if is_claude { Focus::TerminalClaude } else { Focus::TerminalShell };
+        if app.expanded_panel.is_some() {
+            app.expanded_panel = None;
+        } else {
+            app.expanded_panel = Some(target);
+        }
     }
 }
 
@@ -1880,7 +1885,7 @@ pub fn handle_mouse_event(
     let notif_area = outer[1];
     let main_area = outer[2];
 
-    let (left_w, explorer_w, viewer_w) = crate::accordion_widths(app.terminal_expanded, main_area.width);
+    let (left_w, explorer_w, viewer_w) = crate::accordion_widths(app.expanded_panel, main_area.width);
 
     let left_end = main_area.x + left_w;
     let explorer_end = left_end + explorer_w;
@@ -1945,6 +1950,33 @@ pub fn handle_mouse_event(
 
             // Only handle clicks in the main area.
             if row >= main_area.y && row < main_area.y + main_area.height {
+                // Check for [<=>] expand button clicks on the top border row.
+                if row == main_area.y {
+                    let expand_btn_target = if col < left_end && left_w >= 7 {
+                        let btn_start = main_area.x + left_w - 6;
+                        let btn_end = main_area.x + left_w - 1;
+                        if col >= btn_start && col < btn_end { Some(Focus::Worktree) } else { None }
+                    } else if col >= left_end && col < explorer_end && explorer_w >= 7 {
+                        let btn_start = left_end + explorer_w - 6;
+                        let btn_end = left_end + explorer_w - 1;
+                        if col >= btn_start && col < btn_end { Some(Focus::Explorer) } else { None }
+                    } else if col >= explorer_end && col < viewer_end && viewer_w >= 7 {
+                        let btn_start = explorer_end + viewer_w - 6;
+                        let btn_end = explorer_end + viewer_w - 1;
+                        if col >= btn_start && col < btn_end { Some(Focus::Viewer) } else { None }
+                    } else {
+                        None
+                    };
+                    if let Some(target) = expand_btn_target {
+                        if app.expanded_panel == Some(target) {
+                            app.expanded_panel = None;
+                        } else {
+                            app.expanded_panel = Some(target);
+                        }
+                        return;
+                    }
+                }
+
                 if col < left_end {
                     // Click selects and switches to the worktree.
                     let relative_row = (row - main_area.y) as usize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn run_loop(
             .split(area);
             let main_area = outer[2];
 
-            let (left_w, explorer_w, viewer_w) = accordion_widths(app.terminal_expanded, main_area.width);
+            let (left_w, explorer_w, viewer_w) = accordion_widths(app.expanded_panel, main_area.width);
             let right_w = main_area.width.saturating_sub(left_w + explorer_w + viewer_w);
 
             if right_w > 2 {
@@ -322,24 +322,25 @@ fn run_loop(
     }
 }
 
-/// Calculate accordion panel widths based on terminal expansion state.
+/// Calculate accordion panel widths based on panel expansion state.
 ///
 /// Returns `(left_width, explorer_width, viewer_width)`. The right panel gets whatever remains.
-pub fn accordion_widths(terminal_expanded: bool, total_width: u16) -> (u16, u16, u16) {
-    let min_col = 3_u16;
+pub fn accordion_widths(expanded_panel: Option<crate::app::Focus>, total_width: u16) -> (u16, u16, u16) {
+    use crate::app::Focus;
 
-    if terminal_expanded {
-        // When terminal is expanded, shrink left panels to give more width.
-        let left = min_col;
-        let explorer = (total_width * 8 / 100).max(min_col);
-        let viewer = (total_width * 12 / 100).max(min_col);
-        (left, explorer, viewer)
-    } else {
-        // Default proportions.
-        let left = (total_width * 15 / 100).max(min_col);
-        let explorer = (total_width * 20 / 100).max(min_col);
-        let viewer = (total_width * 30 / 100).max(min_col);
-        (left, explorer, viewer)
+    match expanded_panel {
+        Some(Focus::Worktree) => (total_width, 0, 0),
+        Some(Focus::Explorer) => (0, total_width, 0),
+        Some(Focus::Viewer) => (0, 0, total_width),
+        Some(Focus::TerminalClaude | Focus::TerminalShell) => (0, 0, 0),
+        None => {
+            // Default proportions.
+            let min_col = 3_u16;
+            let left = (total_width * 15 / 100).max(min_col);
+            let explorer = (total_width * 20 / 100).max(min_col);
+            let viewer = (total_width * 30 / 100).max(min_col);
+            (left, explorer, viewer)
+        }
     }
 }
 
@@ -373,7 +374,7 @@ fn render_ui(frame: &mut Frame, app: &mut App) {
     }
 
     // ── Accordion column widths ─────────────────────────────────────
-    let (left_w, explorer_w, viewer_w) = accordion_widths(app.terminal_expanded, main_area.width);
+    let (left_w, explorer_w, viewer_w) = accordion_widths(app.expanded_panel, main_area.width);
     let right_w = main_area.width.saturating_sub(left_w + explorer_w + viewer_w);
 
     let columns = Layout::horizontal([

--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -4,9 +4,9 @@
 //! and a list of changed (diff) files in the bottom half. Enter on a file
 //! opens it in the Viewer panel.
 
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::Span;
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Frame;
 
@@ -127,8 +127,16 @@ fn render_file_tree(frame: &mut Frame, area: Rect, app: &App, panel_focused: boo
         " Explorer ".to_string()
     };
 
+    let is_expanded = app.expanded_panel == Some(Focus::Explorer);
+    let (expand_label, expand_color) = if is_expanded {
+        ("[>=<]", Color::Yellow)
+    } else {
+        ("[<=>]", Color::DarkGray)
+    };
+
     let block = Block::default()
         .title(title)
+        .title_top(Line::from(Span::styled(expand_label, Style::default().fg(expand_color))).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -71,7 +71,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Add [+] and [<=>] tabs.
     let mut titles = tab_titles;
     titles.push(Line::from(Span::styled("[+]", Style::default().fg(Color::Green))));
-    let (expand_label, expand_color) = if app.terminal_expanded {
+    let is_expanded = matches!(app.expanded_panel, Some(crate::app::Focus::TerminalClaude | crate::app::Focus::TerminalShell));
+    let (expand_label, expand_color) = if is_expanded {
         ("[>=<]", Color::Yellow)
     } else {
         ("[<=>]", Color::DarkGray)

--- a/src/ui/terminal_shell.rs
+++ b/src/ui/terminal_shell.rs
@@ -62,7 +62,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Add [+] and [<=>] tabs.
     let mut titles = tab_titles;
     titles.push(Line::from(Span::styled("[+]", Style::default().fg(Color::Green))));
-    let (expand_label, expand_color) = if app.terminal_expanded {
+    let is_expanded = matches!(app.expanded_panel, Some(crate::app::Focus::TerminalClaude | crate::app::Focus::TerminalShell));
+    let (expand_label, expand_color) = if is_expanded {
         ("[>=<]", Color::Yellow)
     } else {
         ("[<=>]", Color::DarkGray)

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -4,7 +4,7 @@
 //! have been modified (according to diff_state) are highlighted inline.
 //! Review comments are shown as inline badges.
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
@@ -45,8 +45,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         None => " (no file selected) ".to_string(),
     };
 
+    let is_expanded = app.expanded_panel == Some(Focus::Viewer);
+    let (expand_label, expand_color) = if is_expanded {
+        ("[>=<]", Color::Yellow)
+    } else {
+        ("[<=>]", Color::DarkGray)
+    };
+
     let block = Block::default()
         .title(title)
+        .title_top(Line::from(Span::styled(expand_label, Style::default().fg(expand_color))).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -3,7 +3,7 @@
 //! Displays the list of worktrees with selection, status indicators,
 //! and creation/deletion UI overlays.
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
@@ -16,8 +16,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let focused = app.focus == Focus::Worktree;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };
 
+    let is_expanded = app.expanded_panel == Some(Focus::Worktree);
+    let (expand_label, expand_color) = if is_expanded {
+        ("[>=<]", Color::Yellow)
+    } else {
+        ("[<=>]", Color::DarkGray)
+    };
+
     let block = Block::default()
         .title(" Worktrees ")
+        .title_top(Line::from(Span::styled(expand_label, Style::default().fg(expand_color))).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 


### PR DESCRIPTION
## Summary
- Replace `terminal_expanded: bool` with `expanded_panel: Option<Focus>` to support expanding any panel
- Add `[<=>]` button to Worktree, Explorer, and Viewer panel titles (right-aligned)
- Clicking `[<=>]` on any panel expands it to 100% width, hiding all other panels
- Clicking `[>=<]` (or clicking on any other panel's button) restores the default layout
- Update command palette: `ToggleTerminalExpand` → `TogglePanelExpand` (expands the currently focused panel)

## Test plan
- [x] `cargo check` — no errors, no new warnings
- [x] `cargo test` — all 31 tests pass
- [ ] Manual: click `[<=>]` on Worktree panel → it fills 100% width
- [ ] Manual: click `[<=>]` on Explorer panel → it fills 100% width
- [ ] Manual: click `[<=>]` on Viewer panel → it fills 100% width
- [ ] Manual: click `[<=>]` on Terminal panel → it fills 100% width (same as before)
- [ ] Manual: click `[>=<]` to collapse back to default layout
- [ ] Manual: command palette "Toggle Panel Expand" works for the focused panel