### PR TITLE
fix: prevent panic when selecting worktree in full-panel mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -612,6 +612,18 @@ impl App {
 
     /// Set focus to a panel, lazily loading data when first needed.
     pub fn set_focus(&mut self, focus: Focus) {
+        // Collapse expanded panel when focus moves to a panel that would have zero width.
+        if let Some(expanded) = self.expanded_panel {
+            let dominated = match expanded {
+                Focus::TerminalClaude | Focus::TerminalShell => {
+                    matches!(focus, Focus::TerminalClaude | Focus::TerminalShell)
+                }
+                other => other == focus,
+            };
+            if !dominated {
+                self.expanded_panel = None;
+            }
+        }
         match focus {
             Focus::Explorer | Focus::Viewer => {
                 if self.viewer_state.file_tree.is_empty() {
@@ -830,24 +842,26 @@ impl App {
 
     /// Cycle focus forward: Worktree → Explorer → Viewer → TerminalClaude → TerminalShell → Worktree
     pub fn cycle_focus_forward(&mut self) {
-        self.focus = match self.focus {
+        let next = match self.focus {
             Focus::Worktree => Focus::Explorer,
             Focus::Explorer => Focus::Viewer,
             Focus::Viewer => Focus::TerminalClaude,
             Focus::TerminalClaude => Focus::TerminalShell,
             Focus::TerminalShell => Focus::Worktree,
         };
+        self.set_focus(next);
     }
 
     /// Cycle focus backward.
     pub fn cycle_focus_backward(&mut self) {
-        self.focus = match self.focus {
+        let prev = match self.focus {
             Focus::Worktree => Focus::TerminalShell,
             Focus::Explorer => Focus::Worktree,
             Focus::Viewer => Focus::Explorer,
             Focus::TerminalClaude => Focus::Viewer,
             Focus::TerminalShell => Focus::TerminalClaude,
         };
+        self.set_focus(prev);
     }
 
     // ── Terminal / PTY helpers ────────────────────────────────────────

--- a/src/event.rs
+++ b/src/event.rs
@@ -86,7 +86,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
 
     if app.focus == Focus::TerminalClaude || app.focus == Focus::TerminalShell {
         if key.code == KeyCode::Esc && key.modifiers.contains(KeyModifiers::CONTROL) {
-            app.focus = Focus::Explorer;
+            app.set_focus(Focus::Explorer);
             return;
         }
 
@@ -1994,7 +1994,7 @@ pub fn handle_mouse_event(
                     }
                 } else if col < explorer_end {
                     // Explorer column.
-                    app.focus = Focus::Explorer;
+                    app.set_focus(Focus::Explorer);
 
                     // Determine if click is in top half (file tree) or bottom half (diff list).
                     if row >= explorer_mid_y {
@@ -2066,7 +2066,7 @@ pub fn handle_mouse_event(
                     }
                 } else if col < viewer_end {
                     // Viewer column.
-                    app.focus = Focus::Viewer;
+                    app.set_focus(Focus::Viewer);
 
                     // Detect clicks on the gutter (line number area) for line selection.
                     let panel_x = explorer_end;
@@ -2129,7 +2129,7 @@ pub fn handle_mouse_event(
                     let terminal_x = viewer_end;
 
                     if row < terminal_split_y {
-                        app.focus = Focus::TerminalClaude;
+                        app.set_focus(Focus::TerminalClaude);
                         // Click on tab bar (first row of Claude panel).
                         if row == main_area.y {
                             handle_terminal_tab_click(app, col, terminal_x, true);
@@ -2138,7 +2138,7 @@ pub fn handle_mouse_event(
                             spawn_terminal_session(app);
                         }
                     } else {
-                        app.focus = Focus::TerminalShell;
+                        app.set_focus(Focus::TerminalShell);
                         // Click on tab bar (first row of Shell panel).
                         if row == terminal_split_y {
                             handle_terminal_tab_click(app, col, terminal_x, false);

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -27,9 +27,19 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let focused = app.focus == Focus::Viewer;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };
 
+    let is_expanded = app.expanded_panel == Some(Focus::Viewer);
+    let (expand_label, expand_color) = if is_expanded {
+        ("[>=<]", Color::Yellow)
+    } else {
+        ("[<=>]", Color::DarkGray)
+    };
+
+    // Truncate title so it doesn't overlap with the [<=>] button on the right.
+    // Reserve: 2 (borders) + expand_label width + 1 (gap).
+    let max_title_len = (area.width as usize).saturating_sub(2 + expand_label.len() + 1);
     let title = match &vs.current_file {
         Some(path) => {
-            if !vs.search_matches.is_empty() {
+            let raw = if !vs.search_matches.is_empty() {
                 format!(
                     " {} [{}/{}] ",
                     path,
@@ -40,16 +50,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 format!(" {path} [no matches] ")
             } else {
                 format!(" {path} ")
+            };
+            if raw.len() > max_title_len && max_title_len > 4 {
+                // Truncate with ellipsis: " …<tail> "
+                let inner_max = max_title_len.saturating_sub(2); // leading/trailing spaces
+                let tail: String = raw.trim().chars().rev().take(inner_max.saturating_sub(1)).collect::<Vec<_>>().into_iter().rev().collect();
+                format!(" \u{2026}{tail} ")
+            } else {
+                raw
             }
         }
         None => " (no file selected) ".to_string(),
-    };
-
-    let is_expanded = app.expanded_panel == Some(Focus::Viewer);
-    let (expand_label, expand_color) = if is_expanded {
-        ("[>=<]", Color::Yellow)
-    } else {
-        ("[<=>]", Color::DarkGray)
     };
 
     let block = Block::default()


### PR DESCRIPTION
## Summary
- パネルをフル展開（[<=>]）した状態でフォーカスが別パネルに移動すると、移動先パネルの幅が0になりpanicする問題を修正
- `set_focus()` に展開パネルの自動折りたたみロジックを追加し、全てのフォーカス変更（Tab/BackTab、Enter、マウスクリック、Ctrl+Esc）を `set_focus()` 経由に統一
- Viewerパネルのタイトルが長いファイル名で [<=>] ボタンと重なる問題を修正（省略記号で切り詰め）

## Changes
- **`app.rs`**: `set_focus()` でフォーカス先が展開パネルの外なら `expanded_panel` をリセット。`cycle_focus_forward/backward` を `set_focus()` 経由に変更
- **`event.rs`**: `app.focus = Focus::*` の直接代入5箇所を `app.set_focus()` に統一
- **`ui/viewer_panel.rs`**: ファイル名タイトルを `[<=>]` ボタン分だけ切り詰め、末尾を優先表示（`…path/to/file.rs`）

## Test plan
- [x] `cargo test` 全31テスト通過
- [ ] Worktreeパネルを [<=>] でフル展開 → Enter で選択 → panicしないことを確認
- [ ] 各パネルをフル展開 → Tab/マウスで別パネルに移動 → 展開が解除されることを確認
- [ ] Terminal(Claude/Shell)間の切り替えでは展開が維持されることを確認
- [ ] 長いファイル名を開いた状態で Viewer の [<=>] ボタンが見えることを確認