### PR TITLE
fix: prevent panic when expanding panels to full width

### DIFF
--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -76,6 +76,9 @@ fn file_icon(name: &str) -> &'static str {
 
 /// Render the explorer (file tree) panel into the given area.
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
     let focused = app.focus == Focus::Explorer;
 
     // Split into top (file tree) and bottom (diff list).

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -12,6 +12,9 @@ use crate::app::{App, Focus};
 
 /// Render the Claude Code terminal panel into the given area.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
     let focused = app.focus == Focus::TerminalClaude;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };
 

--- a/src/ui/terminal_shell.rs
+++ b/src/ui/terminal_shell.rs
@@ -12,6 +12,9 @@ use crate::app::{App, Focus};
 
 /// Render the Shell terminal panel into the given area.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
     let focused = app.focus == Focus::TerminalShell;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };
 

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -23,6 +23,9 @@ struct DiffAnnotation {
 
 /// Render the viewer (file content) panel into the given area.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
     let vs = &app.viewer_state;
     let focused = app.focus == Focus::Viewer;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -13,6 +13,9 @@ use crate::app::{App, Focus};
 
 /// Render the worktree panel into the given area.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
     let focused = app.focus == Focus::Worktree;
     let border_color = if focused { Color::Yellow } else { Color::DarkGray };
 


### PR DESCRIPTION
## Summary
- Viewerパネルを全幅に展開すると、Explorerパネルの幅が0になりratauiのScrollbarウィジェットが`Scrollbar area is empty`でパニックする問題を修正
- 全パネル（worktree, explorer, viewer, terminal_claude, terminal_shell）のrender関数に`area.width == 0 || area.height == 0`のガードを追加

## Test plan
- [ ] Viewerパネルで`<=>`をクリックして全幅に展開しても、パニックしないことを確認
- [ ] Explorer, Worktreeパネルでも同様に全幅展開してパニックしないことを確認
- [ ] Terminal展開時にも問題ないことを確認
- [ ] 通常のパネルレイアウトが変わらないことを確認