### PR TITLE
feat: worktreeパネル空白ダブルクリックで新規worktree作成

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -120,6 +120,8 @@ pub struct App {
     pub worktree_input_mode: WorktreeInputMode,
     /// Text buffer for worktree name input.
     pub worktree_input_buffer: String,
+    /// Timestamp of the last click on worktree blank space (for double-click detection).
+    pub worktree_blank_last_click: std::time::Instant,
     /// Status message (flash message) shown in the status bar.
     pub status_message: Option<StatusMessage>,
     /// Last known HEAD oid for the selected worktree (for change-detection polling).
@@ -372,6 +374,7 @@ impl App {
             pty_manager: pty_manager::PtyManager::new(),
             worktree_input_mode: WorktreeInputMode::Normal,
             worktree_input_buffer: String::new(),
+            worktree_blank_last_click: std::time::Instant::now(),
             status_message: None,
             last_poll_head_oid: None,
             last_poll_status: None,

--- a/src/event.rs
+++ b/src/event.rs
@@ -2030,8 +2030,20 @@ pub fn handle_mouse_event(
                         app.on_worktree_changed();
                         app.set_focus(Focus::Explorer);
                     } else {
-                        // Clicked on blank space below worktree items — just focus.
-                        app.set_focus(Focus::Worktree);
+                        // Clicked on blank space below worktree items.
+                        let now = std::time::Instant::now();
+                        let elapsed = now.duration_since(app.worktree_blank_last_click);
+                        app.worktree_blank_last_click = now;
+
+                        if elapsed.as_millis() < 400 {
+                            // Double-click → open worktree creation dialog.
+                            app.worktree_input_mode =
+                                crate::app::WorktreeInputMode::CreatingWorktree;
+                            app.worktree_input_buffer.clear();
+                        } else {
+                            // Single click → just focus.
+                            app.set_focus(Focus::Worktree);
+                        }
                     }
                 } else if col < explorer_end {
                     // Explorer column.


### PR DESCRIPTION
## Summary
- Worktreeパネルのアイテム下の空白エリアをダブルクリックすると、新規worktree作成ダイアログが開くように
- シングルクリックは従来通りフォーカス切り替えのみ
- 既存のviewer行番号ダブルクリックと同じ400ms閾値で検出

## Test plan
- [ ] worktreeパネルの空白エリアをシングルクリック → フォーカスのみ変わることを確認
- [ ] 空白エリアをダブルクリック → worktree作成ダイアログが表示されることを確認
- [ ] ダイアログからEscでキャンセルできることを確認
- [ ] ダイアログからworktree名を入力して作成できることを確認