### PR TITLE
feat: sync 対象を常に main ブランチに限定

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -720,7 +720,7 @@ impl App {
                 } else {
                     self.load_sync_branches();
                     if self.sync_branches.is_empty() {
-                        self.set_status_info("No other worktree branches to sync.".to_string());
+                        self.set_status_info("No non-main worktrees to sync.".to_string());
                     } else {
                         self.sync_active = true;
                     }
@@ -1938,12 +1938,13 @@ impl App {
         }
     }
 
-    /// Load sync branch candidates (other local worktree branches).
+    /// Load sync branch candidates (non-main worktree branches).
+    /// Sync always merges main into a target worktree, so candidates are all
+    /// worktrees except the main one.
     pub fn load_sync_branches(&mut self) {
-        let current_branch = self.selected_worktree_branch();
         self.sync_branches = self.worktrees
             .iter()
-            .filter(|w| w.branch != current_branch)
+            .filter(|w| !w.is_main)
             .map(|w| w.branch.clone())
             .collect();
         self.sync_selected = 0;

--- a/src/event.rs
+++ b/src/event.rs
@@ -338,7 +338,7 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 // First sync: show branch picker.
                 app.load_sync_branches();
                 if app.sync_branches.is_empty() {
-                    app.set_status("No other worktree branches to sync.".to_string(), StatusLevel::Warning);
+                    app.set_status("No non-main worktrees to sync.".to_string(), StatusLevel::Warning);
                 } else {
                     app.sync_active = true;
                 }
@@ -1539,9 +1539,14 @@ fn handle_sync_key(app: &mut App, key: KeyEvent) {
             }
         }
         KeyCode::Enter => {
-            if let Some(branch) = app.sync_branches.get(app.sync_selected).cloned() {
+            if let Some(target_branch) = app.sync_branches.get(app.sync_selected).cloned() {
                 app.sync_active = false;
-                app.execute_sync(&branch);
+                // Switch selected worktree to the target, then sync main into it.
+                if let Some(idx) = app.worktrees.iter().position(|w| w.branch == target_branch) {
+                    app.selected_worktree = idx;
+                }
+                let main_branch = app.config.general.main_branch.clone();
+                app.execute_sync(&main_branch);
             }
         }
         KeyCode::Esc => {

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -434,7 +434,7 @@ pub fn render_sync_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(ratatui::widgets::Clear, popup_area);
 
     let block = Block::default()
-        .title(" Sync Branch (Enter: merge, Esc: cancel) ")
+        .title(" Sync main into… (Enter: merge, Esc: cancel) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green));
 


### PR DESCRIPTION
## Summary
- sync オーバーレイの候補を「選択中以外のワークツリー」から「main 以外のワークツリー」に変更
- 選択したワークツリーに対して常に main ブランチを merge するように修正
- UI タイトルを「Sync main into…」に変更して意味を明確化

## Test plan
- [ ] main ワークツリー選択時に y を押して、main 以外のワークツリーが候補に出ることを確認
- [ ] 非 main ワークツリー選択時に y を押しても、同じ候補リストが出ることを確認
- [ ] 候補を選択して Enter すると、そのワークツリーに main が merge されることを確認
- [ ] resync (既に sync 済みで y) が引き続き動作することを確認