### PR TITLE
feat: propagate コマンドの追加

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -789,6 +789,9 @@ impl App {
                     self.set_status_info("No other worktree branches available.".to_string());
                 }
             }
+            CommandId::PropagateSyncedChanges => {
+                self.execute_propagate();
+            }
             CommandId::NewClaudeCode => {
                 if let Err(e) = self.spawn_claude_code() {
                     self.set_status(format!("Failed to start Claude Code: {e}"), StatusLevel::Error);
@@ -1769,6 +1772,90 @@ impl App {
                     }
                     Err(e) => {
                         self.set_status(format!("Unsync error: {e}"), StatusLevel::Error);
+                    }
+                }
+            }
+            Err(e) => {
+                self.set_status(format!("Error: {e}"), StatusLevel::Error);
+            }
+        }
+    }
+
+    /// Propagate uncommitted changes from the synced source branch into the
+    /// current worktree. Auto-commits on the source, then re-syncs.
+    pub fn execute_propagate(&mut self) {
+        // 1. Get the synced branch for current worktree.
+        let (wt_path, synced_branch) = match self.worktrees.get(self.selected_worktree) {
+            Some(wt) => {
+                if let Some(b) = self.synced_branch.get(&wt.path) {
+                    (wt.path.clone(), b.clone())
+                } else {
+                    self.set_status(
+                        "Not synced — propagate requires an active sync.".to_string(),
+                        StatusLevel::Warning,
+                    );
+                    return;
+                }
+            }
+            None => {
+                self.set_status("No worktree selected.".to_string(), StatusLevel::Error);
+                return;
+            }
+        };
+
+        // 2. Find the worktree that owns the synced branch.
+        let source_path = match self.worktrees.iter().find(|w| w.branch == synced_branch) {
+            Some(w) => w.path.clone(),
+            None => {
+                self.set_status(
+                    format!("Source worktree for '{synced_branch}' not found."),
+                    StatusLevel::Error,
+                );
+                return;
+            }
+        };
+
+        // 3. Auto-commit on source, then resync.
+        match git_engine::GitEngine::open(&self.repo_path) {
+            Ok(engine) => {
+                match engine.auto_commit_worktree(&source_path) {
+                    Ok(Some(_oid)) => {
+                        // Unsync (reset --hard HEAD).
+                        if let Err(e) = engine.unsync_reset(&wt_path) {
+                            self.set_status(
+                                format!("Propagate failed during reset: {e}"),
+                                StatusLevel::Error,
+                            );
+                            return;
+                        }
+                        // Re-sync with the source branch.
+                        match engine.sync_merge(&wt_path, &synced_branch) {
+                            Ok(msg) => {
+                                self.set_status(
+                                    format!("Propagated: {msg}"),
+                                    StatusLevel::Success,
+                                );
+                                self.refresh_worktrees();
+                            }
+                            Err(e) => {
+                                self.set_status(
+                                    format!("Propagate sync error: {e}"),
+                                    StatusLevel::Error,
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        self.set_status(
+                            format!("Source '{synced_branch}' is clean — nothing to propagate."),
+                            StatusLevel::Info,
+                        );
+                    }
+                    Err(e) => {
+                        self.set_status(
+                            format!("Auto-commit error: {e}"),
+                            StatusLevel::Error,
+                        );
                     }
                 }
             }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -23,6 +23,7 @@ pub enum CommandId {
     RefreshWorktrees,
     ResetMainToOrigin,
     CherryPick,
+    PropagateSyncedChanges,
 
     // Terminal
     NewClaudeCode,
@@ -118,6 +119,8 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Worktree, keybinding: Some("R"), keywords: "reset origin" },
     PaletteCommand { id: CommandId::CherryPick, label: "Worktree: Cherry-pick",
         category: CommandCategory::Worktree, keybinding: Some("p"), keywords: "cherry pick commit" },
+    PaletteCommand { id: CommandId::PropagateSyncedChanges, label: "Worktree: Propagate",
+        category: CommandCategory::Worktree, keybinding: Some("S"), keywords: "propagate sync commit send push" },
 
     // Terminal
     PaletteCommand { id: CommandId::NewClaudeCode, label: "Terminal: New Claude Code",

--- a/src/event.rs
+++ b/src/event.rs
@@ -424,6 +424,9 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 }
             }
         }
+        KeyCode::Char('S') => {
+            app.execute_propagate();
+        }
         KeyCode::Char('p') => {
             let current_branch = app
                 .worktrees

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -452,6 +452,59 @@ impl GitEngine {
         Ok("Unsynced — reset to HEAD. Press y to sync again.".to_string())
     }
 
+    // ── Propagate (auto-commit source worktree) ───────────────────
+
+    /// Stage all changes and create an auto-commit in the given worktree.
+    /// Returns `Ok(Some(oid_string))` if a commit was created, or `Ok(None)`
+    /// if the worktree is clean (nothing to commit).
+    pub fn auto_commit_worktree(&self, worktree_path: &Path) -> Result<Option<String>> {
+        let repo = Repository::open(worktree_path)
+            .with_context(|| format!(
+                "Cannot open worktree at {}",
+                worktree_path.display()
+            ))?;
+
+        // Check if there are any changes to commit.
+        let statuses = repo.statuses(Some(
+            StatusOptions::new()
+                .include_untracked(true)
+                .show(StatusShow::IndexAndWorkdir),
+        ))?;
+
+        if statuses.is_empty() {
+            return Ok(None);
+        }
+
+        // Stage all changes (equivalent to `git add -A`).
+        let mut index = repo.index()?;
+        index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+        index.update_all(["*"].iter(), None)?;
+        index.write()?;
+
+        // Create the commit.
+        let tree_oid = index.write_tree()?;
+        let tree = repo.find_tree(tree_oid)?;
+        let head_commit = repo.head()?.peel_to_commit()?;
+
+        let sig = repo.signature()
+            .or_else(|_| git2::Signature::now("Conductor", "conductor@localhost"))
+            .context("cannot create git signature")?;
+
+        let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S");
+        let message = format!("propagate: auto-commit {timestamp}");
+
+        let oid = repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &message,
+            &tree,
+            &[&head_commit],
+        )?;
+
+        Ok(Some(oid.to_string()))
+    }
+
     // ── Fetch ────────────────────────────────────────────────────
 
     /// Run `git fetch --prune origin` by shelling out to the `git` CLI.

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -960,6 +960,7 @@ fn help_lines_for(focus: crate::app::Focus) -> Vec<Line<'static>> {
             help_key(&mut lines, "s", "Switch (checkout remote branch)");
             help_key(&mut lines, "y", "Sync (merge other branch in)");
             help_key(&mut lines, "Y", "Unsync (reset --hard HEAD)");
+            help_key(&mut lines, "S", "Propagate (commit source & resync)");
             help_key(&mut lines, "p", "Cherry-pick from other branch");
             help_key(&mut lines, "P", "Prune stale worktrees");
             help_key(&mut lines, "m", "Merge branch into main");


### PR DESCRIPTION
## Summary
- sync中のworktreeで `S` キーを押すと、sync元の未コミット変更を自動コミット→resyncで取り込む「propagate」機能を追加
- コマンドパレットからも `Worktree: Propagate` で実行可能
- sync元がcleanな場合は何もせず通知

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy` 警告なし（既存のみ）
- [x] `cargo test` 全31テストパス