### PR TITLE
fix: sync のマージ方向を修正（feature → main）

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1678,22 +1678,28 @@ impl App {
         }
     }
 
-    /// Execute sync merge on the current worktree.
-    pub fn execute_sync(&mut self, source_branch: &str) {
-        let wt_path = match self.worktrees.get(self.selected_worktree) {
+    /// Execute sync: merge feature branch into the main worktree (no commit).
+    pub fn execute_sync(&mut self, feature_branch: &str) {
+        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
             Some(wt) => wt.path.clone(),
             None => {
-                self.set_status("No worktree selected.".to_string(), StatusLevel::Error);
+                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
                 return;
             }
         };
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
-                match engine.sync_merge(&wt_path, source_branch) {
-                    Ok(msg) => {
-                        self.synced_branch.insert(wt_path, source_branch.to_string());
+                match engine.sync_merge(&main_path, feature_branch) {
+                    Ok(git_engine::SyncResult::Merged(msg)) => {
+                        self.synced_branch.insert(main_path, feature_branch.to_string());
                         self.set_status(msg, StatusLevel::Success);
                         self.refresh_worktrees();
+                    }
+                    Ok(git_engine::SyncResult::UpToDate) => {
+                        self.set_status(
+                            format!("Already up-to-date with '{feature_branch}'. No changes to merge."),
+                            StatusLevel::Info,
+                        );
                     }
                     Err(e) => {
                         self.set_status(format!("Sync error: {e}"), StatusLevel::Error);
@@ -1706,33 +1712,41 @@ impl App {
         }
     }
 
-    /// Execute resync: unsync then sync again with the previously synced branch.
+    /// Execute resync: unsync main then sync again with the previously synced branch.
     pub fn execute_resync(&mut self) {
-        let (wt_path, branch) = match self.worktrees.get(self.selected_worktree) {
-            Some(wt) => {
-                if let Some(b) = self.synced_branch.get(&wt.path) {
-                    (wt.path.clone(), b.clone())
-                } else {
-                    self.set_status("No previous sync to repeat.".to_string(), StatusLevel::Warning);
-                    return;
-                }
-            }
+        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
+            Some(wt) => wt.path.clone(),
             None => {
-                self.set_status("No worktree selected.".to_string(), StatusLevel::Error);
+                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
+                return;
+            }
+        };
+        let branch = match self.synced_branch.get(&main_path) {
+            Some(b) => b.clone(),
+            None => {
+                self.set_status("No previous sync to repeat.".to_string(), StatusLevel::Warning);
                 return;
             }
         };
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
                 // First unsync (reset --hard HEAD).
-                if let Err(e) = engine.unsync_reset(&wt_path) {
+                if let Err(e) = engine.unsync_reset(&main_path) {
                     self.set_status(format!("Resync failed during reset: {e}"), StatusLevel::Error);
                     return;
                 }
                 // Then sync again.
-                match engine.sync_merge(&wt_path, &branch) {
-                    Ok(msg) => {
+                match engine.sync_merge(&main_path, &branch) {
+                    Ok(git_engine::SyncResult::Merged(msg)) => {
                         self.set_status(format!("Resynced: {msg}"), StatusLevel::Success);
+                        self.refresh_worktrees();
+                    }
+                    Ok(git_engine::SyncResult::UpToDate) => {
+                        self.synced_branch.remove(&main_path);
+                        self.set_status(
+                            format!("'{branch}' is now up-to-date with main. Sync cleared."),
+                            StatusLevel::Info,
+                        );
                         self.refresh_worktrees();
                     }
                     Err(e) => {
@@ -1746,27 +1760,28 @@ impl App {
         }
     }
 
-    /// Returns the synced branch for the currently selected worktree, if any.
+    /// Returns the synced feature branch for the main worktree, if any.
     pub fn current_synced_branch(&self) -> Option<&str> {
-        self.worktrees.get(self.selected_worktree)
+        self.worktrees.iter()
+            .find(|w| w.is_main)
             .and_then(|wt| self.synced_branch.get(&wt.path))
             .map(|s| s.as_str())
     }
 
-    /// Execute unsync (reset --hard HEAD) on the current worktree.
+    /// Execute unsync (reset --hard HEAD) on the main worktree.
     pub fn execute_unsync(&mut self) {
-        let wt_path = match self.worktrees.get(self.selected_worktree) {
+        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
             Some(wt) => wt.path.clone(),
             None => {
-                self.set_status("No worktree selected.".to_string(), StatusLevel::Error);
+                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
                 return;
             }
         };
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
-                match engine.unsync_reset(&wt_path) {
+                match engine.unsync_reset(&main_path) {
                     Ok(msg) => {
-                        self.synced_branch.remove(&wt_path);
+                        self.synced_branch.remove(&main_path);
                         self.set_status(msg, StatusLevel::Success);
                         self.refresh_worktrees();
                     }
@@ -1781,29 +1796,29 @@ impl App {
         }
     }
 
-    /// Propagate uncommitted changes from the synced source branch into the
-    /// current worktree. Auto-commits on the source, then re-syncs.
+    /// Propagate uncommitted changes from the synced feature branch into main.
+    /// Auto-commits on the feature worktree, then re-syncs into main.
     pub fn execute_propagate(&mut self) {
-        // 1. Get the synced branch for current worktree.
-        let (wt_path, synced_branch) = match self.worktrees.get(self.selected_worktree) {
-            Some(wt) => {
-                if let Some(b) = self.synced_branch.get(&wt.path) {
-                    (wt.path.clone(), b.clone())
-                } else {
-                    self.set_status(
-                        "Not synced — propagate requires an active sync.".to_string(),
-                        StatusLevel::Warning,
-                    );
-                    return;
-                }
-            }
+        // 1. Get the synced feature branch for the main worktree.
+        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
+            Some(wt) => wt.path.clone(),
             None => {
-                self.set_status("No worktree selected.".to_string(), StatusLevel::Error);
+                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
+                return;
+            }
+        };
+        let synced_branch = match self.synced_branch.get(&main_path) {
+            Some(b) => b.clone(),
+            None => {
+                self.set_status(
+                    "Not synced — propagate requires an active sync.".to_string(),
+                    StatusLevel::Warning,
+                );
                 return;
             }
         };
 
-        // 2. Find the worktree that owns the synced branch.
+        // 2. Find the worktree that owns the synced feature branch.
         let source_path = match self.worktrees.iter().find(|w| w.branch == synced_branch) {
             Some(w) => w.path.clone(),
             None => {
@@ -1815,26 +1830,34 @@ impl App {
             }
         };
 
-        // 3. Auto-commit on source, then resync.
+        // 3. Auto-commit on source, then resync into main.
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
                 match engine.auto_commit_worktree(&source_path) {
                     Ok(Some(_oid)) => {
-                        // Unsync (reset --hard HEAD).
-                        if let Err(e) = engine.unsync_reset(&wt_path) {
+                        // Unsync main (reset --hard HEAD).
+                        if let Err(e) = engine.unsync_reset(&main_path) {
                             self.set_status(
                                 format!("Propagate failed during reset: {e}"),
                                 StatusLevel::Error,
                             );
                             return;
                         }
-                        // Re-sync with the source branch.
-                        match engine.sync_merge(&wt_path, &synced_branch) {
-                            Ok(msg) => {
+                        // Re-sync feature branch into main.
+                        match engine.sync_merge(&main_path, &synced_branch) {
+                            Ok(git_engine::SyncResult::Merged(msg)) => {
                                 self.set_status(
                                     format!("Propagated: {msg}"),
                                     StatusLevel::Success,
                                 );
+                                self.refresh_worktrees();
+                            }
+                            Ok(git_engine::SyncResult::UpToDate) => {
+                                self.set_status(
+                                    format!("Propagated (commit applied, now up-to-date)."),
+                                    StatusLevel::Success,
+                                );
+                                self.synced_branch.remove(&main_path);
                                 self.refresh_worktrees();
                             }
                             Err(e) => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1548,14 +1548,10 @@ fn handle_sync_key(app: &mut App, key: KeyEvent) {
             }
         }
         KeyCode::Enter => {
-            if let Some(target_branch) = app.sync_branches.get(app.sync_selected).cloned() {
+            if let Some(feature_branch) = app.sync_branches.get(app.sync_selected).cloned() {
                 app.sync_active = false;
-                // Switch selected worktree to the target, then sync main into it.
-                if let Some(idx) = app.worktrees.iter().position(|w| w.branch == target_branch) {
-                    app.selected_worktree = idx;
-                }
-                let main_branch = app.config.general.main_branch.clone();
-                app.execute_sync(&main_branch);
+                // Merge the selected feature branch into main worktree.
+                app.execute_sync(&feature_branch);
             }
         }
         KeyCode::Esc => {

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -9,6 +9,15 @@ use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use git2::{Repository, StatusOptions, StatusShow};
 
+/// Result of a sync merge operation.
+#[derive(Debug)]
+pub enum SyncResult {
+    /// The merge was performed successfully.
+    Merged(String),
+    /// The target is already up-to-date with the source branch.
+    UpToDate,
+}
+
 /// Info about a single worktree.
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -361,9 +370,9 @@ impl GitEngine {
     // ── Sync / Unsync (wt sync, unsync) ─────────────────────────
 
     /// Merge `branch_name` into the worktree at `worktree_path` without
-    /// committing (--no-commit equivalent). If conflicts occur, aborts
-    /// and resets.
-    pub fn sync_merge(&self, worktree_path: &Path, branch_name: &str) -> Result<String> {
+    /// committing (--no-commit --no-ff equivalent). If conflicts occur,
+    /// aborts and resets.
+    pub fn sync_merge(&self, worktree_path: &Path, branch_name: &str) -> Result<SyncResult> {
         let repo = Repository::open(worktree_path)
             .with_context(|| format!(
                 "Cannot open worktree at {}. Is the path valid?",
@@ -371,14 +380,10 @@ impl GitEngine {
             ))?;
 
         // Find the branch to merge.
-        let branch_ref = match repo.find_branch(branch_name, git2::BranchType::Local) {
-            Ok(b) => b,
-            Err(_) => {
-                return Ok(format!(
-                    "Branch '{branch_name}' not found locally. Was it deleted or renamed?"
-                ));
-            }
-        };
+        let branch_ref = repo.find_branch(branch_name, git2::BranchType::Local)
+            .with_context(|| format!(
+                "Branch '{branch_name}' not found locally. Was it deleted or renamed?"
+            ))?;
         let branch_commit_oid = branch_ref.get().peel_to_commit()
             .context("Failed to resolve branch commit. The branch ref may be corrupt.")?
             .id();
@@ -389,27 +394,22 @@ impl GitEngine {
         let (analysis, _preference) = repo.merge_analysis(&[&branch_annotated])?;
 
         if analysis.is_up_to_date() {
-            return Ok(format!(
-                "Already up-to-date with '{branch_name}'. No changes to merge."
-            ));
+            return Ok(SyncResult::UpToDate);
         }
 
-        if analysis.is_fast_forward() || analysis.is_normal() {
-            // Proceed with merge.
-        } else {
-            return Ok(format!(
+        if !analysis.is_fast_forward() && !analysis.is_normal() {
+            anyhow::bail!(
                 "Cannot merge '{branch_name}': unrelated histories. \
                  Ensure both branches share a common ancestor."
-            ));
+            );
         }
 
         // Perform the merge (this updates the index and workdir but does NOT commit).
-        if let Err(e) = repo.merge(&[&branch_annotated], None, None) {
-            return Ok(format!(
-                "Merge of '{branch_name}' failed: {e}. \
+        repo.merge(&[&branch_annotated], None, None)
+            .with_context(|| format!(
+                "Merge of '{branch_name}' failed. \
                  Try committing or stashing local changes first."
-            ));
-        }
+            ))?;
 
         // Check for conflicts.
         let index = repo.index()?;
@@ -432,15 +432,15 @@ impl GitEngine {
             let head_commit = repo.head()?.peel_to_commit()?;
             repo.reset(head_commit.as_object(), git2::ResetType::Hard, None)?;
             repo.cleanup_state()?;
-            return Ok(format!(
+            anyhow::bail!(
                 "Conflicts with '{branch_name}' in: {conflict_list}. \
                  Sync aborted, worktree restored. Resolve conflicts in the source branch first."
-            ));
+            );
         }
 
-        Ok(format!(
-            "Synced '{branch_name}' (uncommitted). Press y to resync, Y to unsync."
-        ))
+        Ok(SyncResult::Merged(format!(
+            "Synced '{branch_name}' → main (uncommitted). Press y to resync, Y to unsync."
+        )))
     }
 
     /// Reset worktree to HEAD (undo sync). Equivalent to `git reset --hard HEAD`.

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -434,7 +434,7 @@ pub fn render_sync_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(ratatui::widgets::Clear, popup_area);
 
     let block = Block::default()
-        .title(" Sync main into… (Enter: merge, Esc: cancel) ")
+        .title(" Sync → main (Enter: merge, Esc: cancel) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green));
 


### PR DESCRIPTION
## Summary
- sync が main → feature の方向にマージしていたため、ファイルが変わらないのに `[synced]` と表示されるバグを修正
- `SyncResult` enum を導入し、実際にマージされた場合のみ synced 状態にするよう変更
- `execute_sync/resync/unsync/propagate` を全て main worktree 基準に統一

## Root Cause
`sync_merge` が feature worktree を開いて main をマージしていた（main → feature）。正しくは `wt sync` と同様に feature branch を main worktree にマージする必要があった（feature → main）。

また `sync_merge` が branch not found / conflicts / already up-to-date 等の soft failure を全て `Ok(String)` で返しており、`execute_sync` が全て成功扱いにしていた。

## Test plan
- [x] `cargo check` pass
- [x] `cargo test` 31 tests pass
- [ ] 手動確認: worktree を sync して main にファイル変更が反映されること
- [ ] 手動確認: already up-to-date の場合 synced 状態にならないこと
- [ ] 手動確認: resync / unsync / propagate が正しく動作すること