### PR TITLE
feat: sync機能をgrab機能に置き換え

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -84,8 +84,17 @@ pub enum WorktreeInputMode {
     ConfirmingDelete,
     /// Confirming branch deletion after worktree removal (y/n/f).
     ConfirmingDeleteBranch,
-    /// Confirming unsync / reset (y/n).
-    ConfirmingUnsync,
+    /// Confirming ungrab (y/n).
+    ConfirmingUngrab,
+}
+
+/// Info about a grabbed branch (branch checkout swap with main).
+#[derive(Debug, Clone)]
+pub struct GrabbedBranch {
+    /// The original branch name (e.g., "feature-x").
+    pub branch: String,
+    /// Path of the worktree that originally had this branch.
+    pub source_worktree: PathBuf,
 }
 
 /// Top-level application state shared across all UI panels.
@@ -191,15 +200,15 @@ pub struct App {
     /// Filter string for narrowing the switch branch list.
     pub switch_branch_filter: String,
 
-    // ── Sync (merge branch for testing) ─────────────────────────
-    /// Whether the sync overlay is active.
-    pub sync_active: bool,
-    /// List of local branch names available for sync.
-    pub sync_branches: Vec<String>,
-    /// Currently selected index in the sync list.
-    pub sync_selected: usize,
-    /// Tracks which branch was last synced per worktree path (for resync).
-    pub synced_branch: HashMap<PathBuf, String>,
+    // ── Grab (checkout branch on main) ─────────────────────────
+    /// Whether the grab branch picker overlay is active.
+    pub grab_active: bool,
+    /// List of local branch names available for grab.
+    pub grab_branches: Vec<String>,
+    /// Currently selected index in the grab list.
+    pub grab_selected: usize,
+    /// Currently grabbed branch info (branch name + source worktree path).
+    pub grabbed_branch: Option<GrabbedBranch>,
 
     // ── Prune ───────────────────────────────────────────────────
     /// Whether the prune overlay is active.
@@ -409,10 +418,10 @@ impl App {
             switch_branch_list: Vec::new(),
             switch_branch_selected: 0,
             switch_branch_filter: String::new(),
-            sync_active: false,
-            sync_branches: Vec::new(),
-            sync_selected: 0,
-            synced_branch: HashMap::new(),
+            grab_active: false,
+            grab_branches: Vec::new(),
+            grab_selected: 0,
+            grabbed_branch: None,
             prune_active: false,
             prune_stale: Vec::new(),
             worktree_pending_delete_branch: String::new(),
@@ -655,7 +664,7 @@ impl App {
     /// Return a help text string describing the keybindings for the current focus.
     pub fn status_bar_text(&self) -> &'static str {
         match self.focus {
-            Focus::Worktree => "Alt+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | y: sync/resync | Y: unsync | P: prune",
+            Focus::Worktree => "Alt+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune",
             Focus::Explorer => "Alt+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list",
             Focus::Viewer => "Alt+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment",
             Focus::TerminalClaude => "Alt+1-5: jump | Ctrl+n: new CC | Ctrl+p: palette | Ctrl+w: worktree | keys → PTY",
@@ -714,15 +723,15 @@ impl App {
                     self.status_message = None;
                 }
             }
-            CommandId::SyncBranch => {
-                if self.current_synced_branch().is_some() {
-                    self.execute_resync();
+            CommandId::GrabBranch => {
+                if self.grabbed_branch.is_some() {
+                    self.set_status("Already grabbing a branch. Ungrab first (Y).".to_string(), StatusLevel::Warning);
                 } else {
-                    self.load_sync_branches();
-                    if self.sync_branches.is_empty() {
-                        self.set_status_info("No non-main worktrees to sync.".to_string());
+                    self.load_grab_branches();
+                    if self.grab_branches.is_empty() {
+                        self.set_status_info("No non-main worktrees to grab.".to_string());
                     } else {
-                        self.sync_active = true;
+                        self.grab_active = true;
                     }
                 }
             }
@@ -788,9 +797,6 @@ impl App {
                 } else {
                     self.set_status_info("No other worktree branches available.".to_string());
                 }
-            }
-            CommandId::PropagateSyncedChanges => {
-                self.execute_propagate();
             }
             CommandId::NewClaudeCode => {
                 if let Err(e) = self.spawn_claude_code() {
@@ -1678,8 +1684,8 @@ impl App {
         }
     }
 
-    /// Execute sync: merge feature branch into the main worktree (no commit).
-    pub fn execute_sync(&mut self, feature_branch: &str) {
+    /// Execute grab: checkout main to the selected worktree's branch.
+    pub fn execute_grab(&mut self, branch_name: &str) {
         let main_path = match self.worktrees.iter().find(|w| w.is_main) {
             Some(wt) => wt.path.clone(),
             None => {
@@ -1687,198 +1693,77 @@ impl App {
                 return;
             }
         };
-        match git_engine::GitEngine::open(&self.repo_path) {
-            Ok(engine) => {
-                match engine.sync_merge(&main_path, feature_branch) {
-                    Ok(git_engine::SyncResult::Merged(msg)) => {
-                        self.synced_branch.insert(main_path, feature_branch.to_string());
-                        self.set_status(msg, StatusLevel::Success);
-                        self.refresh_worktrees();
-                    }
-                    Ok(git_engine::SyncResult::UpToDate) => {
-                        self.set_status(
-                            format!("Already up-to-date with '{feature_branch}'. No changes to merge."),
-                            StatusLevel::Info,
-                        );
-                    }
-                    Err(e) => {
-                        self.set_status(format!("Sync error: {e}"), StatusLevel::Error);
-                    }
-                }
-            }
-            Err(e) => {
-                self.set_status(format!("Error: {e}"), StatusLevel::Error);
-            }
-        }
-    }
-
-    /// Execute resync: unsync main then sync again with the previously synced branch.
-    pub fn execute_resync(&mut self) {
-        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
-            Some(wt) => wt.path.clone(),
-            None => {
-                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
-                return;
-            }
-        };
-        let branch = match self.synced_branch.get(&main_path) {
-            Some(b) => b.clone(),
-            None => {
-                self.set_status("No previous sync to repeat.".to_string(), StatusLevel::Warning);
-                return;
-            }
-        };
-        match git_engine::GitEngine::open(&self.repo_path) {
-            Ok(engine) => {
-                // First unsync (reset --hard HEAD).
-                if let Err(e) = engine.unsync_reset(&main_path) {
-                    self.set_status(format!("Resync failed during reset: {e}"), StatusLevel::Error);
-                    return;
-                }
-                // Then sync again.
-                match engine.sync_merge(&main_path, &branch) {
-                    Ok(git_engine::SyncResult::Merged(msg)) => {
-                        self.set_status(format!("Resynced: {msg}"), StatusLevel::Success);
-                        self.refresh_worktrees();
-                    }
-                    Ok(git_engine::SyncResult::UpToDate) => {
-                        self.synced_branch.remove(&main_path);
-                        self.set_status(
-                            format!("'{branch}' is now up-to-date with main. Sync cleared."),
-                            StatusLevel::Info,
-                        );
-                        self.refresh_worktrees();
-                    }
-                    Err(e) => {
-                        self.set_status(format!("Resync error: {e}"), StatusLevel::Error);
-                    }
-                }
-            }
-            Err(e) => {
-                self.set_status(format!("Error: {e}"), StatusLevel::Error);
-            }
-        }
-    }
-
-    /// Returns the synced feature branch for the main worktree, if any.
-    pub fn current_synced_branch(&self) -> Option<&str> {
-        self.worktrees.iter()
-            .find(|w| w.is_main)
-            .and_then(|wt| self.synced_branch.get(&wt.path))
-            .map(|s| s.as_str())
-    }
-
-    /// Execute unsync (reset --hard HEAD) on the main worktree.
-    pub fn execute_unsync(&mut self) {
-        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
-            Some(wt) => wt.path.clone(),
-            None => {
-                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
-                return;
-            }
-        };
-        match git_engine::GitEngine::open(&self.repo_path) {
-            Ok(engine) => {
-                match engine.unsync_reset(&main_path) {
-                    Ok(msg) => {
-                        self.synced_branch.remove(&main_path);
-                        self.set_status(msg, StatusLevel::Success);
-                        self.refresh_worktrees();
-                    }
-                    Err(e) => {
-                        self.set_status(format!("Unsync error: {e}"), StatusLevel::Error);
-                    }
-                }
-            }
-            Err(e) => {
-                self.set_status(format!("Error: {e}"), StatusLevel::Error);
-            }
-        }
-    }
-
-    /// Propagate uncommitted changes from the synced feature branch into main.
-    /// Auto-commits on the feature worktree, then re-syncs into main.
-    pub fn execute_propagate(&mut self) {
-        // 1. Get the synced feature branch for the main worktree.
-        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
-            Some(wt) => wt.path.clone(),
-            None => {
-                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
-                return;
-            }
-        };
-        let synced_branch = match self.synced_branch.get(&main_path) {
-            Some(b) => b.clone(),
-            None => {
-                self.set_status(
-                    "Not synced — propagate requires an active sync.".to_string(),
-                    StatusLevel::Warning,
-                );
-                return;
-            }
-        };
-
-        // 2. Find the worktree that owns the synced feature branch.
-        let source_path = match self.worktrees.iter().find(|w| w.branch == synced_branch) {
+        let source_path = match self.worktrees.iter().find(|w| w.branch == branch_name) {
             Some(w) => w.path.clone(),
             None => {
                 self.set_status(
-                    format!("Source worktree for '{synced_branch}' not found."),
+                    format!("Worktree for '{branch_name}' not found."),
                     StatusLevel::Error,
                 );
                 return;
             }
         };
-
-        // 3. Auto-commit on source, then resync into main.
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
-                match engine.auto_commit_worktree(&source_path) {
-                    Ok(Some(_oid)) => {
-                        // Unsync main (reset --hard HEAD).
-                        if let Err(e) = engine.unsync_reset(&main_path) {
-                            self.set_status(
-                                format!("Propagate failed during reset: {e}"),
-                                StatusLevel::Error,
-                            );
-                            return;
-                        }
-                        // Re-sync feature branch into main.
-                        match engine.sync_merge(&main_path, &synced_branch) {
-                            Ok(git_engine::SyncResult::Merged(msg)) => {
-                                self.set_status(
-                                    format!("Propagated: {msg}"),
-                                    StatusLevel::Success,
-                                );
-                                self.refresh_worktrees();
-                            }
-                            Ok(git_engine::SyncResult::UpToDate) => {
-                                self.set_status(
-                                    format!("Propagated (commit applied, now up-to-date)."),
-                                    StatusLevel::Success,
-                                );
-                                self.synced_branch.remove(&main_path);
-                                self.refresh_worktrees();
-                            }
-                            Err(e) => {
-                                self.set_status(
-                                    format!("Propagate sync error: {e}"),
-                                    StatusLevel::Error,
-                                );
-                            }
-                        }
-                    }
-                    Ok(None) => {
+                match engine.grab_branch(&main_path, &source_path, branch_name) {
+                    Ok(()) => {
+                        self.grabbed_branch = Some(GrabbedBranch {
+                            branch: branch_name.to_string(),
+                            source_worktree: source_path,
+                        });
                         self.set_status(
-                            format!("Source '{synced_branch}' is clean — nothing to propagate."),
-                            StatusLevel::Info,
+                            format!("Grabbed '{branch_name}' — main is now on this branch. Press Y to ungrab."),
+                            StatusLevel::Success,
                         );
+                        self.refresh_worktrees();
                     }
                     Err(e) => {
+                        self.set_status(format!("Grab error: {e}"), StatusLevel::Error);
+                    }
+                }
+            }
+            Err(e) => {
+                self.set_status(format!("Error: {e}"), StatusLevel::Error);
+            }
+        }
+    }
+
+    /// Execute ungrab: return main to main branch, restore worktree to original branch.
+    pub fn execute_ungrab(&mut self) {
+        let grabbed = match self.grabbed_branch.clone() {
+            Some(g) => g,
+            None => {
+                self.set_status("Not grabbing any branch.".to_string(), StatusLevel::Warning);
+                return;
+            }
+        };
+        let main_path = match self.worktrees.iter().find(|w| w.is_main) {
+            Some(wt) => wt.path.clone(),
+            None => {
+                self.set_status("Main worktree not found.".to_string(), StatusLevel::Error);
+                return;
+            }
+        };
+        let main_branch = self.config.general.main_branch.clone();
+        match git_engine::GitEngine::open(&self.repo_path) {
+            Ok(engine) => {
+                match engine.ungrab_branch(
+                    &main_path,
+                    &grabbed.source_worktree,
+                    &grabbed.branch,
+                    &main_branch,
+                ) {
+                    Ok(()) => {
+                        let branch = grabbed.branch.clone();
+                        self.grabbed_branch = None;
                         self.set_status(
-                            format!("Auto-commit error: {e}"),
-                            StatusLevel::Error,
+                            format!("Ungrabbed '{branch}' — main restored."),
+                            StatusLevel::Success,
                         );
+                        self.refresh_worktrees();
+                    }
+                    Err(e) => {
+                        self.set_status(format!("Ungrab error: {e}"), StatusLevel::Error);
                     }
                 }
             }
@@ -2048,16 +1933,14 @@ impl App {
         }
     }
 
-    /// Load sync branch candidates (non-main worktree branches).
-    /// Sync always merges main into a target worktree, so candidates are all
-    /// worktrees except the main one.
-    pub fn load_sync_branches(&mut self) {
-        self.sync_branches = self.worktrees
+    /// Load grab branch candidates (non-main worktree branches).
+    pub fn load_grab_branches(&mut self) {
+        self.grab_branches = self.worktrees
             .iter()
             .filter(|w| !w.is_main)
             .map(|w| w.branch.clone())
             .collect();
-        self.sync_selected = 0;
+        self.grab_selected = 0;
     }
 
     pub fn delete_selected_worktree(&mut self) {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -17,13 +17,12 @@ pub enum CommandId {
     CreateWorktree,
     DeleteWorktree,
     SwitchBranch,
-    SyncBranch,
+    GrabBranch,
     PruneWorktrees,
     MergeToMain,
     RefreshWorktrees,
     ResetMainToOrigin,
     CherryPick,
-    PropagateSyncedChanges,
 
     // Terminal
     NewClaudeCode,
@@ -107,8 +106,8 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Worktree, keybinding: Some("X"), keywords: "remove branch" },
     PaletteCommand { id: CommandId::SwitchBranch, label: "Worktree: Switch Branch (Remote)",
         category: CommandCategory::Worktree, keybinding: Some("s"), keywords: "checkout remote" },
-    PaletteCommand { id: CommandId::SyncBranch, label: "Worktree: Sync / Resync",
-        category: CommandCategory::Worktree, keybinding: Some("y"), keywords: "merge integrate resync" },
+    PaletteCommand { id: CommandId::GrabBranch, label: "Worktree: Grab Branch",
+        category: CommandCategory::Worktree, keybinding: Some("g"), keywords: "grab checkout branch" },
     PaletteCommand { id: CommandId::PruneWorktrees, label: "Worktree: Prune Stale",
         category: CommandCategory::Worktree, keybinding: Some("P"), keywords: "clean stale" },
     PaletteCommand { id: CommandId::MergeToMain, label: "Worktree: Merge into Main",
@@ -119,8 +118,6 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Worktree, keybinding: Some("R"), keywords: "reset origin" },
     PaletteCommand { id: CommandId::CherryPick, label: "Worktree: Cherry-pick",
         category: CommandCategory::Worktree, keybinding: Some("p"), keywords: "cherry pick commit" },
-    PaletteCommand { id: CommandId::PropagateSyncedChanges, label: "Worktree: Propagate",
-        category: CommandCategory::Worktree, keybinding: Some("S"), keywords: "propagate sync commit send push" },
 
     // Terminal
     PaletteCommand { id: CommandId::NewClaudeCode, label: "Terminal: New Claude Code",

--- a/src/event.rs
+++ b/src/event.rs
@@ -33,8 +33,8 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         handle_switch_branch_key(app, key);
         return;
     }
-    if app.sync_active {
-        handle_sync_key(app, key);
+    if app.grab_active {
+        handle_grab_key(app, key);
         return;
     }
     if app.prune_active {
@@ -330,27 +330,24 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 app.set_status("No remote branches found.".to_string(), StatusLevel::Warning);
             }
         }
-        KeyCode::Char('y') => {
-            if app.current_synced_branch().is_some() {
-                // Resync: unsync then sync again with the same branch.
-                app.execute_resync();
+        KeyCode::Char('g') => {
+            if app.grabbed_branch.is_some() {
+                app.set_status("Already grabbing a branch. Ungrab first (G).".to_string(), StatusLevel::Warning);
             } else {
-                // First sync: show branch picker.
-                app.load_sync_branches();
-                if app.sync_branches.is_empty() {
-                    app.set_status("No non-main worktrees to sync.".to_string(), StatusLevel::Warning);
+                app.load_grab_branches();
+                if app.grab_branches.is_empty() {
+                    app.set_status("No non-main worktrees to grab.".to_string(), StatusLevel::Warning);
                 } else {
-                    app.sync_active = true;
+                    app.grab_active = true;
                 }
             }
         }
-        KeyCode::Char('Y') => {
-            if app.current_synced_branch().is_none() {
-                app.set_status("Not synced — nothing to unsync.".to_string(), StatusLevel::Warning);
+        KeyCode::Char('G') => {
+            if app.grabbed_branch.is_none() {
+                app.set_status("Not grabbing — nothing to ungrab.".to_string(), StatusLevel::Warning);
             } else {
-                // Unsync: confirm reset --hard HEAD.
-                app.worktree_input_mode = crate::app::WorktreeInputMode::ConfirmingUnsync;
-                app.set_status("Unsync (reset --hard HEAD)? All uncommitted changes will be lost. (y/n)".to_string(), StatusLevel::Warning);
+                app.worktree_input_mode = crate::app::WorktreeInputMode::ConfirmingUngrab;
+                app.set_status("Ungrab? Main will return to main branch. (y/n)".to_string(), StatusLevel::Warning);
             }
         }
         KeyCode::Char('P') => {
@@ -423,9 +420,6 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                     app.set_status(format!("Error: {e}"), StatusLevel::Error);
                 }
             }
-        }
-        KeyCode::Char('S') => {
-            app.execute_propagate();
         }
         KeyCode::Char('p') => {
             let current_branch = app
@@ -1060,14 +1054,14 @@ fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
                 app.set_status("Branch kept.".to_string(), StatusLevel::Warning);
             }
         },
-        WorktreeInputMode::ConfirmingUnsync => match key.code {
+        WorktreeInputMode::ConfirmingUngrab => match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 app.worktree_input_mode = WorktreeInputMode::Normal;
-                app.execute_unsync();
+                app.execute_ungrab();
             }
             _ => {
                 app.worktree_input_mode = WorktreeInputMode::Normal;
-                app.set_status("Unsync cancelled.".to_string(), StatusLevel::Warning);
+                app.set_status("Ungrab cancelled.".to_string(), StatusLevel::Warning);
             }
         },
         WorktreeInputMode::Normal => unreachable!(),
@@ -1531,31 +1525,30 @@ fn handle_switch_branch_key(app: &mut App, key: KeyEvent) {
     }
 }
 
-// ── Overlay: sync ───────────────────────────────────────────────────────
+// ── Overlay: grab ───────────────────────────────────────────────────────
 
-fn handle_sync_key(app: &mut App, key: KeyEvent) {
-    let count = app.sync_branches.len();
+fn handle_grab_key(app: &mut App, key: KeyEvent) {
+    let count = app.grab_branches.len();
 
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
-            if count > 0 && app.sync_selected + 1 < count {
-                app.sync_selected += 1;
+            if count > 0 && app.grab_selected + 1 < count {
+                app.grab_selected += 1;
             }
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            if app.sync_selected > 0 {
-                app.sync_selected -= 1;
+            if app.grab_selected > 0 {
+                app.grab_selected -= 1;
             }
         }
         KeyCode::Enter => {
-            if let Some(feature_branch) = app.sync_branches.get(app.sync_selected).cloned() {
-                app.sync_active = false;
-                // Merge the selected feature branch into main worktree.
-                app.execute_sync(&feature_branch);
+            if let Some(branch) = app.grab_branches.get(app.grab_selected).cloned() {
+                app.grab_active = false;
+                app.execute_grab(&branch);
             }
         }
         KeyCode::Esc => {
-            app.sync_active = false;
+            app.grab_active = false;
         }
         _ => {}
     }

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -9,15 +9,6 @@ use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use git2::{Repository, StatusOptions, StatusShow};
 
-/// Result of a sync merge operation.
-#[derive(Debug)]
-pub enum SyncResult {
-    /// The merge was performed successfully.
-    Merged(String),
-    /// The target is already up-to-date with the source branch.
-    UpToDate,
-}
-
 /// Info about a single worktree.
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -367,146 +358,108 @@ impl GitEngine {
         }
     }
 
-    // ── Sync / Unsync (wt sync, unsync) ─────────────────────────
+    // ── Grab / Ungrab ──────────────────────────────────────────────
 
-    /// Merge `branch_name` into the worktree at `worktree_path` without
-    /// committing (--no-commit --no-ff equivalent). If conflicts occur,
-    /// aborts and resets.
-    pub fn sync_merge(&self, worktree_path: &Path, branch_name: &str) -> Result<SyncResult> {
-        let repo = Repository::open(worktree_path)
-            .with_context(|| format!(
-                "Cannot open worktree at {}. Is the path valid?",
-                worktree_path.display()
-            ))?;
-
-        // Find the branch to merge.
-        let branch_ref = repo.find_branch(branch_name, git2::BranchType::Local)
-            .with_context(|| format!(
-                "Branch '{branch_name}' not found locally. Was it deleted or renamed?"
-            ))?;
-        let branch_commit_oid = branch_ref.get().peel_to_commit()
-            .context("Failed to resolve branch commit. The branch ref may be corrupt.")?
-            .id();
-        let branch_annotated = repo.find_annotated_commit(branch_commit_oid)
-            .context("Failed to find annotated commit for branch.")?;
-
-        // Perform merge analysis.
-        let (analysis, _preference) = repo.merge_analysis(&[&branch_annotated])?;
-
-        if analysis.is_up_to_date() {
-            return Ok(SyncResult::UpToDate);
-        }
-
-        if !analysis.is_fast_forward() && !analysis.is_normal() {
-            anyhow::bail!(
-                "Cannot merge '{branch_name}': unrelated histories. \
-                 Ensure both branches share a common ancestor."
-            );
-        }
-
-        // Perform the merge (this updates the index and workdir but does NOT commit).
-        repo.merge(&[&branch_annotated], None, None)
-            .with_context(|| format!(
-                "Merge of '{branch_name}' failed. \
-                 Try committing or stashing local changes first."
-            ))?;
-
-        // Check for conflicts.
-        let index = repo.index()?;
-        if index.has_conflicts() {
-            // Collect conflicting file paths for a helpful message.
-            let conflict_paths: Vec<String> = index.conflicts()?
-                .filter_map(|c| c.ok())
-                .filter_map(|c| {
-                    c.our.or(c.their).or(c.ancestor)
-                        .and_then(|e| String::from_utf8(e.path).ok())
-                })
-                .collect();
-            let conflict_list = if conflict_paths.len() <= 3 {
-                conflict_paths.join(", ")
-            } else {
-                format!("{} (+{} more)", conflict_paths[..3].join(", "), conflict_paths.len() - 3)
-            };
-
-            // Abort: reset to HEAD.
-            let head_commit = repo.head()?.peel_to_commit()?;
-            repo.reset(head_commit.as_object(), git2::ResetType::Hard, None)?;
-            repo.cleanup_state()?;
-            anyhow::bail!(
-                "Conflicts with '{branch_name}' in: {conflict_list}. \
-                 Sync aborted, worktree restored. Resolve conflicts in the source branch first."
-            );
-        }
-
-        Ok(SyncResult::Merged(format!(
-            "Synced '{branch_name}' → main (uncommitted). Press y to resync, Y to unsync."
-        )))
-    }
-
-    /// Reset worktree to HEAD (undo sync). Equivalent to `git reset --hard HEAD`.
-    pub fn unsync_reset(&self, worktree_path: &Path) -> Result<String> {
+    /// Check whether a worktree has uncommitted changes to tracked files.
+    pub fn has_tracked_changes(&self, worktree_path: &Path) -> Result<bool> {
         let repo = Repository::open(worktree_path)
             .with_context(|| format!("cannot open worktree at {}", worktree_path.display()))?;
-
-        let head_commit = repo.head()?.peel_to_commit()?;
-        repo.reset(head_commit.as_object(), git2::ResetType::Hard, None)
-            .context("failed to reset --hard HEAD")?;
-        repo.cleanup_state().ok(); // best-effort cleanup of MERGE_HEAD etc.
-
-        Ok("Unsynced — reset to HEAD. Press y to sync again.".to_string())
-    }
-
-    // ── Propagate (auto-commit source worktree) ───────────────────
-
-    /// Stage all changes and create an auto-commit in the given worktree.
-    /// Returns `Ok(Some(oid_string))` if a commit was created, or `Ok(None)`
-    /// if the worktree is clean (nothing to commit).
-    pub fn auto_commit_worktree(&self, worktree_path: &Path) -> Result<Option<String>> {
-        let repo = Repository::open(worktree_path)
-            .with_context(|| format!(
-                "Cannot open worktree at {}",
-                worktree_path.display()
-            ))?;
-
-        // Check if there are any changes to commit.
         let statuses = repo.statuses(Some(
             StatusOptions::new()
-                .include_untracked(true)
+                .include_untracked(false)
                 .show(StatusShow::IndexAndWorkdir),
         ))?;
+        Ok(!statuses.is_empty())
+    }
 
-        if statuses.is_empty() {
-            return Ok(None);
+    /// Grab a branch: move the source worktree to a temporary `__grab`
+    /// branch, then checkout main to the original branch.
+    ///
+    /// Requires both worktrees to have no uncommitted tracked changes.
+    pub fn grab_branch(
+        &self,
+        main_path: &Path,
+        source_worktree_path: &Path,
+        branch_name: &str,
+    ) -> Result<()> {
+        if self.has_tracked_changes(main_path)? {
+            anyhow::bail!("Main worktree has uncommitted tracked changes. Commit or stash first.");
+        }
+        if self.has_tracked_changes(source_worktree_path)? {
+            anyhow::bail!(
+                "Worktree '{branch_name}' has uncommitted tracked changes. Commit or stash first."
+            );
         }
 
-        // Stage all changes (equivalent to `git add -A`).
-        let mut index = repo.index()?;
-        index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
-        index.update_all(["*"].iter(), None)?;
-        index.write()?;
+        let grab_branch_name = format!("{branch_name}__grab");
 
-        // Create the commit.
-        let tree_oid = index.write_tree()?;
-        let tree = repo.find_tree(tree_oid)?;
-        let head_commit = repo.head()?.peel_to_commit()?;
+        // Create __grab branch on source worktree and checkout it.
+        let source_repo = Repository::open(source_worktree_path)
+            .with_context(|| format!("cannot open worktree at {}", source_worktree_path.display()))?;
+        let head_commit = source_repo.head()?.peel_to_commit()?;
+        source_repo.branch(&grab_branch_name, &head_commit, false)
+            .with_context(|| format!("failed to create branch '{grab_branch_name}'"))?;
+        source_repo.set_head(&format!("refs/heads/{grab_branch_name}"))
+            .with_context(|| format!("failed to set HEAD to '{grab_branch_name}'"))?;
+        source_repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .context("failed to checkout __grab branch")?;
 
-        let sig = repo.signature()
-            .or_else(|_| git2::Signature::now("Conductor", "conductor@localhost"))
-            .context("cannot create git signature")?;
+        // Checkout main worktree to the original branch.
+        let main_repo = Repository::open(main_path)
+            .with_context(|| format!("cannot open main worktree at {}", main_path.display()))?;
+        main_repo.set_head(&format!("refs/heads/{branch_name}"))
+            .with_context(|| format!("failed to set main HEAD to '{branch_name}'"))?;
+        main_repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .with_context(|| format!("failed to checkout '{branch_name}' in main worktree"))?;
 
-        let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S");
-        let message = format!("propagate: auto-commit {timestamp}");
+        Ok(())
+    }
 
-        let oid = repo.commit(
-            Some("HEAD"),
-            &sig,
-            &sig,
-            &message,
-            &tree,
-            &[&head_commit],
-        )?;
+    /// Ungrab: return main to main branch, restore source worktree to
+    /// original branch, and delete the temporary `__grab` branch.
+    ///
+    /// Requires both worktrees to have no uncommitted tracked changes.
+    pub fn ungrab_branch(
+        &self,
+        main_path: &Path,
+        source_worktree_path: &Path,
+        branch_name: &str,
+        main_branch: &str,
+    ) -> Result<()> {
+        if self.has_tracked_changes(main_path)? {
+            anyhow::bail!("Main worktree has uncommitted tracked changes. Commit or stash first.");
+        }
+        if self.has_tracked_changes(source_worktree_path)? {
+            anyhow::bail!(
+                "Worktree (on __grab) has uncommitted tracked changes. Commit or stash first."
+            );
+        }
 
-        Ok(Some(oid.to_string()))
+        // Checkout main worktree back to main branch.
+        let main_repo = Repository::open(main_path)
+            .with_context(|| format!("cannot open main worktree at {}", main_path.display()))?;
+        main_repo.set_head(&format!("refs/heads/{main_branch}"))
+            .with_context(|| format!("failed to set main HEAD to '{main_branch}'"))?;
+        main_repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .with_context(|| format!("failed to checkout '{main_branch}' in main worktree"))?;
+
+        // Checkout source worktree back to original branch.
+        let source_repo = Repository::open(source_worktree_path)
+            .with_context(|| format!("cannot open worktree at {}", source_worktree_path.display()))?;
+        source_repo.set_head(&format!("refs/heads/{branch_name}"))
+            .with_context(|| format!("failed to set HEAD to '{branch_name}'"))?;
+        source_repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .with_context(|| format!("failed to checkout '{branch_name}'"))?;
+
+        // Delete the temporary __grab branch.
+        let grab_branch_name = format!("{branch_name}__grab");
+        let mut grab_branch = source_repo
+            .find_branch(&grab_branch_name, git2::BranchType::Local)
+            .with_context(|| format!("branch '{grab_branch_name}' not found"))?;
+        grab_branch.delete()
+            .with_context(|| format!("failed to delete branch '{grab_branch_name}'"))?;
+
+        Ok(())
     }
 
     // ── Fetch ────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,8 +419,8 @@ fn render_ui(frame: &mut Frame, app: &mut App) {
     if app.worktree_input_mode == crate::app::WorktreeInputMode::ConfirmingDeleteBranch {
         ui::dashboard::render_delete_branch_confirm_overlay(frame, main_area, app);
     }
-    if app.worktree_input_mode == crate::app::WorktreeInputMode::ConfirmingUnsync {
-        render_confirm_overlay(frame, main_area, app, " Confirm Unsync ", ratatui::style::Color::Yellow);
+    if app.worktree_input_mode == crate::app::WorktreeInputMode::ConfirmingUngrab {
+        render_confirm_overlay(frame, main_area, app, " Confirm Ungrab ", ratatui::style::Color::Yellow);
     }
     if app.cherry_pick_active {
         ui::dashboard::render_cherry_pick_overlay(frame, main_area, app);
@@ -428,8 +428,8 @@ fn render_ui(frame: &mut Frame, app: &mut App) {
     if app.switch_branch_active {
         ui::dashboard::render_switch_branch_overlay(frame, main_area, app);
     }
-    if app.sync_active {
-        ui::dashboard::render_sync_overlay(frame, main_area, app);
+    if app.grab_active {
+        ui::dashboard::render_grab_overlay(frame, main_area, app);
     }
     if app.prune_active {
         ui::dashboard::render_prune_overlay(frame, main_area, app);

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -422,10 +422,10 @@ pub fn render_switch_branch_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_stateful_widget(list, list_inner, &mut state);
 }
 
-/// Render the sync branch picker overlay.
-pub fn render_sync_overlay(frame: &mut Frame, area: Rect, app: &App) {
+/// Render the grab branch picker overlay.
+pub fn render_grab_overlay(frame: &mut Frame, area: Rect, app: &App) {
     let popup_width = 50_u16.min(area.width.saturating_sub(4));
-    let content_lines = app.sync_branches.len() as u16;
+    let content_lines = app.grab_branches.len() as u16;
     let popup_height = (content_lines + 2).min(14).min(area.height.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
@@ -434,26 +434,26 @@ pub fn render_sync_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(ratatui::widgets::Clear, popup_area);
 
     let block = Block::default()
-        .title(" Sync → main (Enter: merge, Esc: cancel) ")
+        .title(" Grab → main (Enter: grab, Esc: cancel) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green));
 
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    if app.sync_branches.is_empty() {
-        let paragraph = Paragraph::new("  No branches to sync.")
+    if app.grab_branches.is_empty() {
+        let paragraph = Paragraph::new("  No branches to grab.")
             .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(paragraph, inner);
         return;
     }
 
     let items: Vec<ListItem> = app
-        .sync_branches
+        .grab_branches
         .iter()
         .enumerate()
         .map(|(i, branch)| {
-            let style = if i == app.sync_selected {
+            let style = if i == app.grab_selected {
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD)
@@ -474,7 +474,7 @@ pub fn render_sync_overlay(frame: &mut Frame, area: Rect, app: &App) {
     );
 
     let mut state = ListState::default();
-    state.select(Some(app.sync_selected));
+    state.select(Some(app.grab_selected));
     frame.render_stateful_widget(list, inner, &mut state);
 }
 
@@ -958,9 +958,8 @@ fn help_lines_for(focus: crate::app::Focus) -> Vec<Line<'static>> {
             help_key(&mut lines, "w", "Create new worktree");
             help_key(&mut lines, "X", "Delete selected worktree");
             help_key(&mut lines, "s", "Switch (checkout remote branch)");
-            help_key(&mut lines, "y", "Sync (merge other branch in)");
-            help_key(&mut lines, "Y", "Unsync (reset --hard HEAD)");
-            help_key(&mut lines, "S", "Propagate (commit source & resync)");
+            help_key(&mut lines, "g", "Grab (checkout branch on main)");
+            help_key(&mut lines, "G", "Ungrab (restore main branch)");
             help_key(&mut lines, "p", "Cherry-pick from other branch");
             help_key(&mut lines, "P", "Prune stale worktrees");
             help_key(&mut lines, "m", "Merge branch into main");

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -26,8 +26,19 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         ("[<=>]", Color::DarkGray)
     };
 
+    let title = if app.grabbed_branch.is_some() {
+        " Worktrees [GRABBED] "
+    } else {
+        " Worktrees "
+    };
+    let title_style = if app.grabbed_branch.is_some() {
+        Style::default().fg(Color::Rgb(255, 165, 0)).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+
     let block = Block::default()
-        .title(" Worktrees ")
+        .title(Span::styled(title, title_style))
         .title_top(Line::from(Span::styled(expand_label, Style::default().fg(expand_color))).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
@@ -35,22 +46,32 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Pulse phase: ~1s cycle at 60fps (30 frames on, 30 frames off).
     let pulse_on = (app.ui_tick / 30) % 2 == 0;
 
+    // Check if this worktree is on a __grab branch (should be greyed out).
+    let is_grab_branch = |wt: &crate::git_engine::WorktreeInfo| -> bool {
+        wt.branch.ends_with("__grab")
+    };
+
     let items: Vec<ListItem> = app
         .worktrees
         .iter()
         .enumerate()
         .map(|(i, wt)| {
             let is_waiting = app.cc_waiting_worktrees.contains(&wt.path);
+            let is_grabbed = is_grab_branch(wt);
 
             let marker = if wt.is_main {
                 "\u{25cf}" // ●
+            } else if is_grabbed {
+                "\u{1f512}" // 🔒
             } else if i == app.selected_worktree {
                 "\u{25c9}" // ◉
             } else {
                 "\u{25cb}" // ○
             };
 
-            let marker_style = if is_waiting {
+            let marker_style = if is_grabbed {
+                Style::default().fg(Color::DarkGray)
+            } else if is_waiting {
                 Style::default()
                     .fg(if pulse_on { Color::Rgb(255, 165, 0) } else { Color::Rgb(200, 120, 0) })
                     .add_modifier(Modifier::BOLD)
@@ -68,7 +89,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 format!("+{} ~{} -{}", wt.added, wt.modified, wt.deleted)
             };
 
-            let branch_style = if is_waiting {
+            let branch_style = if is_grabbed {
+                Style::default().fg(Color::DarkGray)
+            } else if is_waiting {
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD)
@@ -85,8 +108,24 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 Span::styled(wt.branch.clone(), branch_style),
             ];
 
+            // Grabbed indicator on __grab worktree.
+            if is_grabbed {
+                spans.push(Span::styled(
+                    " (grabbed)",
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+
+            // Tag main worktree when holding a grabbed branch.
+            if wt.is_main && app.grabbed_branch.is_some() {
+                spans.push(Span::styled(
+                    " \u{2190}grabbed",
+                    Style::default().fg(Color::Rgb(255, 165, 0)).add_modifier(Modifier::BOLD),
+                ));
+            }
+
             // Prominent waiting indicator with pulse animation.
-            if is_waiting {
+            if is_waiting && !is_grabbed {
                 let indicator = if pulse_on { " \u{25c6}" } else { " \u{25c7}" }; // ◆ / ◇
                 spans.push(Span::styled(
                     indicator,
@@ -98,7 +137,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
             spans.push(Span::styled(
                 format!(" {status_text}"),
-                if wt.is_clean {
+                if is_grabbed {
+                    Style::default().fg(Color::DarkGray)
+                } else if wt.is_clean {
                     Style::default().fg(Color::DarkGray)
                 } else {
                     Style::default().fg(Color::Magenta)
@@ -106,33 +147,35 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             ));
 
             // Remote sync indicator (ahead/behind upstream).
-            match (wt.ahead, wt.behind) {
-                (Some(0), Some(0)) => {
-                    // Synced with remote
-                    spans.push(Span::styled(" ≡", Style::default().fg(Color::DarkGray)));
-                }
-                (Some(ahead), Some(behind)) => {
-                    let mut parts = Vec::new();
-                    if ahead > 0 {
-                        parts.push(format!("↑{ahead}"));
+            if !is_grabbed {
+                match (wt.ahead, wt.behind) {
+                    (Some(0), Some(0)) => {
+                        // Synced with remote
+                        spans.push(Span::styled(" ≡", Style::default().fg(Color::DarkGray)));
                     }
-                    if behind > 0 {
-                        parts.push(format!("↓{behind}"));
+                    (Some(ahead), Some(behind)) => {
+                        let mut parts = Vec::new();
+                        if ahead > 0 {
+                            parts.push(format!("↑{ahead}"));
+                        }
+                        if behind > 0 {
+                            parts.push(format!("↓{behind}"));
+                        }
+                        spans.push(Span::styled(
+                            format!(" {}", parts.join("")),
+                            Style::default().fg(Color::Cyan),
+                        ));
                     }
-                    spans.push(Span::styled(
-                        format!(" {}", parts.join("")),
-                        Style::default().fg(Color::Cyan),
-                    ));
-                }
-                _ => {
-                    // No upstream tracking
+                    _ => {
+                        // No upstream tracking
+                    }
                 }
             }
 
             let item = ListItem::new(Line::from(spans));
 
             // Apply background highlight to the entire row when waiting.
-            if is_waiting {
+            if is_waiting && !is_grabbed {
                 let bg = if pulse_on {
                     Color::Rgb(60, 35, 0)   // warm orange tint
                 } else {


### PR DESCRIPTION
## Summary
- sync（--no-commit merge）を廃止し、grab（ブランチcheckout swap）方式に変更
- grab: worktreeを`__grab`ブランチに退避→mainを元ブランチにcheckout
- ungrab: mainをmainブランチに復帰→worktreeを元ブランチに復帰→`__grab`削除
- tracked fileの未コミット変更チェックでcheckout可否を判定
- `__grab`ブランチのworktreeは🔒アイコン+グレーアウトで誤操作防止
- キーバインド: `g`=grab, `G`=ungrab
- resync/propagate機能を削除（grab方式では不要）

## Test plan
- [x] `cargo build` 成功
- [x] `cargo test` 31テスト全パス