### PR TITLE
fix: grab precheck を zsh の wt grab に合わせて修正

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1686,6 +1686,18 @@ impl App {
 
     /// Execute grab: checkout main to the selected worktree's branch.
     pub fn execute_grab(&mut self, branch_name: &str) {
+        // Pre-check: already grabbing another branch
+        if let Some(ref grabbed) = self.grabbed_branch {
+            self.set_status(
+                format!(
+                    "Already grabbed: {}. Ungrab first (Y).",
+                    grabbed.branch
+                ),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+
         let main_path = match self.worktrees.iter().find(|w| w.is_main) {
             Some(wt) => wt.path.clone(),
             None => {

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -361,15 +361,25 @@ impl GitEngine {
     // ── Grab / Ungrab ──────────────────────────────────────────────
 
     /// Check whether a worktree has uncommitted changes to tracked files.
+    ///
+    /// Uses `git diff --quiet HEAD` (shell-out) to match the behaviour of the
+    /// `wt grab` zsh helper exactly.  libgit2's status API can report extra
+    /// entries (renames, type-changes, ignored-file edge-cases) that
+    /// `git diff HEAD` does not, causing false positives.
     pub fn has_tracked_changes(&self, worktree_path: &Path) -> Result<bool> {
-        let repo = Repository::open(worktree_path)
-            .with_context(|| format!("cannot open worktree at {}", worktree_path.display()))?;
-        let statuses = repo.statuses(Some(
-            StatusOptions::new()
-                .include_untracked(false)
-                .show(StatusShow::IndexAndWorkdir),
-        ))?;
-        Ok(!statuses.is_empty())
+        use std::process::{Command, Stdio};
+
+        let status = Command::new("git")
+            .args(["diff", "--quiet", "HEAD"])
+            .current_dir(worktree_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .context("failed to run `git diff --quiet HEAD`")?;
+
+        // exit 0 = clean, exit 1 = dirty
+        Ok(!status.success())
     }
 
     /// Grab a branch: move the source worktree to a temporary `__grab`


### PR DESCRIPTION
## Summary
- `has_tracked_changes` を libgit2 status API から `git diff --quiet HEAD` シェルアウトに変更（zsh の `wt grab` と同じ挙動に統一。libgit2 が false positive を返して grab できない問題を修正）
- `execute_grab` に既にgrab中かのプリチェックを追加

## Test plan
- [ ] 未コミット変更がない状態で grab できることを確認
- [ ] 既にgrab中に再度grabしようとすると警告が出ることを確認