### PR TITLE
feat: 複数行テキストのペースト分割問題を修正

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -933,6 +933,48 @@ fn forward_key_to_pty(app: &mut App, session_idx: usize, key: KeyEvent) {
     }
 }
 
+// ── Paste event handling ────────────────────────────────────────────────
+
+/// Handle a bracketed paste event. When the terminal panel is focused,
+/// forward the entire pasted text to the PTY in one write, wrapped with
+/// bracketed-paste escape sequences so the shell/application treats it as
+/// a single paste rather than individual keystrokes.
+pub fn handle_paste_event(app: &mut App, data: String) {
+    if app.focus != Focus::TerminalClaude && app.focus != Focus::TerminalShell {
+        // For non-terminal panels, insert the first line into whichever input
+        // buffer is active (e.g. worktree input, search, etc.).
+        // For now, only handle terminal paste — overlay paste is not common.
+        return;
+    }
+
+    let session_idx = match app.focus {
+        Focus::TerminalClaude => app.active_claude_session,
+        Focus::TerminalShell => app.active_shell_session,
+        _ => None,
+    };
+
+    if let Some(idx) = session_idx {
+        // Wrap the paste data with bracketed-paste escape sequences so
+        // that the child process (shell, editor, claude-code) knows this
+        // is pasted text and will not execute each line individually.
+        let mut buf = Vec::with_capacity(data.len() + 12);
+        buf.extend_from_slice(b"\x1b[200~");
+        buf.extend_from_slice(data.as_bytes());
+        buf.extend_from_slice(b"\x1b[201~");
+
+        if let Err(e) = app.pty_manager.write_to_session(idx, &buf) {
+            log::warn!("failed to write paste data to PTY session: {e}");
+        } else {
+            match app.focus {
+                Focus::TerminalClaude => app.terminal_scroll_claude = 0,
+                Focus::TerminalShell => app.terminal_scroll_shell = 0,
+                _ => {}
+            }
+            app.clear_cc_waiting_signal(idx);
+        }
+    }
+}
+
 // ── Overlay: worktree input ─────────────────────────────────────────────
 
 fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 
 use crate::app::App;
-use crate::event::{handle_key_event, handle_mouse_event};
+use crate::event::{handle_key_event, handle_mouse_event, handle_paste_event};
 
 /// Tick rate when terminal panels are focused (~120fps for responsive PTY).
 const TICK_RATE_TERMINAL: Duration = Duration::from_millis(8);
@@ -50,6 +50,7 @@ fn main() -> Result<()> {
         stdout,
         EnterAlternateScreen,
         crossterm::event::EnableMouseCapture,
+        crossterm::event::EnableBracketedPaste,
     )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
@@ -73,6 +74,7 @@ fn main() -> Result<()> {
         terminal.backend_mut(),
         LeaveAlternateScreen,
         crossterm::event::DisableMouseCapture,
+        crossterm::event::DisableBracketedPaste,
     )?;
     terminal.show_cursor()?;
 
@@ -227,6 +229,7 @@ fn run_loop(
             match crossterm_read()? {
                 Event::Key(key) => handle_key_event(app, key),
                 Event::Mouse(mouse) => handle_mouse_event(app, mouse, last_frame_area),
+                Event::Paste(data) => handle_paste_event(app, data),
                 Event::Resize(_, _) => {}
                 _ => {}
             }


### PR DESCRIPTION
## Summary
- crossterm の `EnableBracketedPaste` を有効化し、ペーストイベントを個別キーではなく `Event::Paste` として受信
- `handle_paste_event` を追加し、ペーストデータをブラケットペーストエスケープシーケンス (`\x1b[200~` ... `\x1b[201~`) で囲んでPTYに一括書き込み
- ターミナル終了時に `DisableBracketedPaste` でクリーンアップ

## Test plan
- [ ] Conductor 起動 → Terminal パネルにフォーカス → 複数行テキストをペースト → 分割されず一塊として入力されることを確認