### PR TITLE
feat: command palette に不足コマンドを追加

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -846,6 +846,129 @@ impl App {
                     self.repo_selector_selected = self.repo_list_index;
                 }
             }
+            CommandId::UngrabBranch => {
+                if self.grabbed_branch.is_none() {
+                    self.set_status("Not grabbing — nothing to ungrab.".to_string(), StatusLevel::Warning);
+                } else {
+                    self.worktree_input_mode = WorktreeInputMode::ConfirmingUngrab;
+                    self.set_status("Ungrab? Main will return to main branch. (y/n)".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::ShowDiffList => {
+                self.viewer_state.explorer_show_comments = false;
+                self.viewer_state.explorer_focus_on_diff_list = true;
+                self.set_focus(Focus::Explorer);
+            }
+            CommandId::ShowCommentList => {
+                self.viewer_state.explorer_show_comments = true;
+                self.viewer_state.explorer_focus_on_diff_list = true;
+                self.set_focus(Focus::Explorer);
+            }
+            CommandId::AddReviewComment => {
+                if let Some(file_path) = self.viewer_state.current_file.clone() {
+                    let location = if let Some((start, end)) = self.viewer_state.selected_range() {
+                        if start == end {
+                            format!("{file_path}:{start} ")
+                        } else {
+                            format!("{file_path}:{start}-{end} ")
+                        }
+                    } else {
+                        let line = self.viewer_state.file_scroll + 1;
+                        format!("{file_path}:{line} ")
+                    };
+                    self.viewer_state.clear_selection();
+                    self.review_state.input_buffer = location;
+                    self.review_state.input_kind = crate::review_store::CommentKind::Suggest;
+                    self.review_state.input_mode = crate::review_state::ReviewInputMode::AddingComment;
+                    self.review_state.status_message =
+                        Some("Add comment: [s:|q:]file:line body".to_string());
+                    self.set_focus(Focus::Viewer);
+                } else {
+                    self.set_status("No file open in viewer.".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::ViewCommentDetail => {
+                // Try viewer context first (current line), then comment list context.
+                if self.viewer_state.current_file.is_some() {
+                    let cursor_line = if let Some((start, _)) = self.viewer_state.selected_range() {
+                        start
+                    } else {
+                        self.viewer_state.file_scroll + 1
+                    };
+                    if let Some(comments) = self.review_state.file_comments.get(&cursor_line) {
+                        if !comments.is_empty() {
+                            let target_id = &comments[0].id;
+                            if let Some(idx) = self.review_state.comments.iter().position(|c| c.id == *target_id) {
+                                let cid = target_id.clone();
+                                if !self.review_state.cached_replies.contains_key(&cid) {
+                                    if let Some(store) = self.review_store.as_ref() {
+                                        if let Ok(replies) = store.get_replies(&cid) {
+                                            self.review_state.cached_replies.insert(cid, replies);
+                                        }
+                                    }
+                                }
+                                self.review_state.comment_detail_idx = idx;
+                                self.review_state.comment_detail_scroll = 0;
+                                self.review_state.comment_detail_active = true;
+                                self.set_focus(Focus::Viewer);
+                                return;
+                            }
+                        }
+                    }
+                }
+                self.set_status("No comment on current line.".to_string(), StatusLevel::Warning);
+            }
+            CommandId::DeleteComment => {
+                if self.viewer_state.explorer_show_comments
+                    && self.viewer_state.explorer_focus_on_diff_list
+                    && !self.review_state.comment_list_rows.is_empty()
+                {
+                    self.delete_selected_review_comment();
+                } else {
+                    self.set_status("No comment selected.".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::ToggleCommentResolve => {
+                if self.viewer_state.explorer_show_comments
+                    && self.viewer_state.explorer_focus_on_diff_list
+                    && !self.review_state.comment_list_rows.is_empty()
+                {
+                    self.toggle_selected_review_status();
+                } else {
+                    self.set_status("No comment selected.".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::EditComment => {
+                let comment_idx = self
+                    .review_state
+                    .selected_comment_idx(self.viewer_state.comment_list_selected);
+                if let Some(comment) = comment_idx.and_then(|idx| self.review_state.comments.get(idx)) {
+                    self.review_state.input_buffer = comment.body.clone();
+                    self.review_state.input_mode = crate::review_state::ReviewInputMode::EditingComment;
+                    self.review_state.selected = comment_idx.unwrap();
+                    self.review_state.status_message =
+                        Some("Edit comment (Enter to save, Esc to cancel)".to_string());
+                } else {
+                    self.set_status("No comment selected.".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::ReplyToComment => {
+                let comment_idx = self
+                    .review_state
+                    .selected_comment_idx(self.viewer_state.comment_list_selected);
+                if let Some(idx) = comment_idx {
+                    self.review_state.input_buffer.clear();
+                    self.review_state.input_mode = crate::review_state::ReviewInputMode::ReplyingToComment;
+                    self.review_state.selected = idx;
+                    self.review_state.status_message =
+                        Some("Reply to comment (Enter to send, Esc to cancel)".to_string());
+                } else {
+                    self.set_status("No comment selected.".to_string(), StatusLevel::Warning);
+                }
+            }
+            CommandId::SaveSessionHistory => {
+                self.save_current_session_history();
+            }
             CommandId::Quit => self.should_quit = true,
         }
     }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -45,6 +45,26 @@ pub enum CommandId {
     OpenRepo,
     SwitchRepo,
 
+    // Worktree (additional)
+    UngrabBranch,
+
+    // Explorer
+    ShowDiffList,
+    ShowCommentList,
+
+    // Viewer / Review
+    AddReviewComment,
+    ViewCommentDetail,
+
+    // Comment actions
+    DeleteComment,
+    ToggleCommentResolve,
+    EditComment,
+    ReplyToComment,
+
+    // Session
+    SaveSessionHistory,
+
     // App
     Quit,
 }
@@ -119,6 +139,10 @@ pub const COMMANDS: &[PaletteCommand] = &[
     PaletteCommand { id: CommandId::CherryPick, label: "Worktree: Cherry-pick",
         category: CommandCategory::Worktree, keybinding: Some("p"), keywords: "cherry pick commit" },
 
+    // Worktree (additional)
+    PaletteCommand { id: CommandId::UngrabBranch, label: "Worktree: Ungrab Branch",
+        category: CommandCategory::Worktree, keybinding: Some("G"), keywords: "ungrab release branch" },
+
     // Terminal
     PaletteCommand { id: CommandId::NewClaudeCode, label: "Terminal: New Claude Code",
         category: CommandCategory::Terminal, keybinding: Some("Ctrl+n"), keywords: "spawn ai" },
@@ -136,6 +160,10 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::View, keybinding: Some("/"), keywords: "find grep" },
     PaletteCommand { id: CommandId::ToggleHelp, label: "Show Help",
         category: CommandCategory::View, keybinding: Some("?"), keywords: "keybindings shortcuts" },
+    PaletteCommand { id: CommandId::ShowDiffList, label: "Explorer: Show Diff List",
+        category: CommandCategory::View, keybinding: Some("d"), keywords: "diff changed files" },
+    PaletteCommand { id: CommandId::ShowCommentList, label: "Explorer: Show Comment List",
+        category: CommandCategory::View, keybinding: Some("c"), keywords: "comment review list" },
 
     // Review
     PaletteCommand { id: CommandId::ShowReviewComments, label: "Review: Show Comments",
@@ -144,6 +172,20 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Review, keybinding: None, keywords: "template prompt" },
     PaletteCommand { id: CommandId::SessionHistory, label: "Review: Session History",
         category: CommandCategory::Review, keybinding: Some("H"), keywords: "history log" },
+    PaletteCommand { id: CommandId::AddReviewComment, label: "Review: Add Comment",
+        category: CommandCategory::Review, keybinding: Some("c"), keywords: "new comment add write" },
+    PaletteCommand { id: CommandId::ViewCommentDetail, label: "Review: View Comment Detail",
+        category: CommandCategory::Review, keybinding: Some("Space"), keywords: "detail preview" },
+    PaletteCommand { id: CommandId::DeleteComment, label: "Review: Delete Comment",
+        category: CommandCategory::Review, keybinding: Some("x"), keywords: "remove delete" },
+    PaletteCommand { id: CommandId::ToggleCommentResolve, label: "Review: Toggle Resolve",
+        category: CommandCategory::Review, keybinding: Some("r"), keywords: "resolve unresolve status" },
+    PaletteCommand { id: CommandId::EditComment, label: "Review: Edit Comment",
+        category: CommandCategory::Review, keybinding: Some("e"), keywords: "edit modify update" },
+    PaletteCommand { id: CommandId::ReplyToComment, label: "Review: Reply to Comment",
+        category: CommandCategory::Review, keybinding: Some("R"), keywords: "reply respond" },
+    PaletteCommand { id: CommandId::SaveSessionHistory, label: "Session: Save History",
+        category: CommandCategory::Review, keybinding: Some("s"), keywords: "save record session" },
 
     // Repository
     PaletteCommand { id: CommandId::OpenRepo, label: "Repository: Open by Path",


### PR DESCRIPTION
## Summary
- Command palette に不足していた11コマンドを追加 (26 → 37コマンド)
- Review系操作(コメント追加/編集/削除/返信/resolve toggle)
- Explorer操作(diff list / comment list 切替)
- Worktree: Ungrab Branch
- Session: Save History

## Test plan
- [x] `cargo check` 通過