### PR TITLE
feat: Alt+1-5 パネルジャンプ実装 & macOS で Opt 表記に修正

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -663,12 +663,25 @@ impl App {
 
     /// Return a help text string describing the keybindings for the current focus.
     pub fn status_bar_text(&self) -> &'static str {
-        match self.focus {
-            Focus::Worktree => "Alt+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune",
-            Focus::Explorer => "Alt+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list",
-            Focus::Viewer => "Alt+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment",
-            Focus::TerminalClaude => "Alt+1-5: jump | Ctrl+n: new CC | Ctrl+p: palette | Ctrl+w: worktree | keys → PTY",
-            Focus::TerminalShell => "Alt+1-5: jump | Ctrl+t: new shell | keys → PTY",
+        #[cfg(target_os = "macos")]
+        {
+            match self.focus {
+                Focus::Worktree => "Opt+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune",
+                Focus::Explorer => "Opt+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list",
+                Focus::Viewer => "Opt+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment",
+                Focus::TerminalClaude => "Opt+1-5: jump | Ctrl+n: new CC | Ctrl+p: palette | Ctrl+w: worktree | keys → PTY",
+                Focus::TerminalShell => "Opt+1-5: jump | Ctrl+t: new shell | keys → PTY",
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            match self.focus {
+                Focus::Worktree => "Alt+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune",
+                Focus::Explorer => "Alt+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list",
+                Focus::Viewer => "Alt+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment",
+                Focus::TerminalClaude => "Alt+1-5: jump | Ctrl+n: new CC | Ctrl+p: palette | Ctrl+w: worktree | keys → PTY",
+                Focus::TerminalShell => "Alt+1-5: jump | Ctrl+t: new shell | keys → PTY",
+            }
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -82,6 +82,19 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // ── 1b. Alt+1-5 — panel jump (intercepted globally, even from terminals) ─
+
+    if key.modifiers.contains(KeyModifiers::ALT) {
+        match key.code {
+            KeyCode::Char('1') => { app.set_focus(Focus::Worktree); return; }
+            KeyCode::Char('2') => { app.set_focus(Focus::Explorer); return; }
+            KeyCode::Char('3') => { app.set_focus(Focus::Viewer); return; }
+            KeyCode::Char('4') => { app.set_focus(Focus::TerminalClaude); return; }
+            KeyCode::Char('5') => { app.set_focus(Focus::TerminalShell); return; }
+            _ => {}
+        }
+    }
+
     // ── 2. Terminal focus — Ctrl+Esc leaves terminal, everything else → PTY ─
 
     if app.focus == Focus::TerminalClaude || app.focus == Focus::TerminalShell {

--- a/src/ui/review.rs
+++ b/src/ui/review.rs
@@ -49,10 +49,26 @@ pub fn render_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
                 CommentKind::Question => "Question",
             };
             let icon = kind_icon(app.review_state.input_kind);
-            format!(" {icon} New {kind_label} (Tab: toggle | Alt+Enter: newline) ")
+            if cfg!(target_os = "macos") {
+                format!(" {icon} New {kind_label} (Tab: toggle | Opt+Enter: newline) ")
+            } else {
+                format!(" {icon} New {kind_label} (Tab: toggle | Alt+Enter: newline) ")
+            }
         }
-        ReviewInputMode::EditingComment => " Edit Comment (Alt+Enter: newline) ".to_string(),
-        ReviewInputMode::ReplyingToComment => " Reply to Comment (Alt+Enter: newline) ".to_string(),
+        ReviewInputMode::EditingComment => {
+            if cfg!(target_os = "macos") {
+                " Edit Comment (Opt+Enter: newline) ".to_string()
+            } else {
+                " Edit Comment (Alt+Enter: newline) ".to_string()
+            }
+        }
+        ReviewInputMode::ReplyingToComment => {
+            if cfg!(target_os = "macos") {
+                " Reply to Comment (Opt+Enter: newline) ".to_string()
+            } else {
+                " Reply to Comment (Alt+Enter: newline) ".to_string()
+            }
+        }
         ReviewInputMode::Normal => unreachable!(),
     };
 


### PR DESCRIPTION
## Summary
- Alt(Option)+1-5 でパネル間を直接ジャンプするキーバインドを実装（表記のみで未実装だった）
- ターミナルパネルからでもイベントを奪って動作するようにした
- macOS ビルドではステータスバー・レビュー入力の "Alt" 表記を "Opt" に変更（`#[cfg(target_os = "macos")]`）

## Test plan
- [x] `cargo check` 通過
- [x] `cargo test` 全31テスト通過