### PR TITLE
fix: worktree パネルのシングルクリックでフォーカスを維持

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -2062,7 +2062,7 @@ pub fn handle_mouse_event(
                         // Clicked on an actual worktree item.
                         app.selected_worktree = item_row;
                         app.on_worktree_changed();
-                        app.set_focus(Focus::Explorer);
+                        app.set_focus(Focus::Worktree);
                     } else {
                         // Clicked on blank space below worktree items.
                         let now = std::time::Instant::now();


### PR DESCRIPTION
## Summary
- worktree パネルでワークツリーをシングルクリックした際、フォーカスが Explorer に移動していたのを Worktree パネルに留まるよう修正
- Explorer/Viewer の内容更新はそのまま維持

## Test plan
- [ ] worktree パネルでワークツリーをクリックし、フォーカスが worktree パネルに留まることを確認
- [ ] クリック後に Explorer/Viewer の内容が正しく更新されることを確認