### PR TITLE
fix: MCP server の npm audit 脆弱性を修正

### DIFF
--- a/plugins/conductor/mcp/conductor-comment/package-lock.json
+++ b/plugins/conductor/mcp/conductor-comment/package-lock.json
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary
- `hono` 4.12.0 → 4.12.3 にアップデート（`npm audit fix`）
- AWS Lambda ALB conninfo での IP Spoofing による認証バイパスの脆弱性 (GHSA-xh87-mx6m-69f3) を解消

## Test plan
- [x] `npm audit` で脆弱性が 0 件であることを確認済み