### PR TITLE
feat: GitHub風 Unified Diff View を実装

### DIFF
--- a/src/diff_state.rs
+++ b/src/diff_state.rs
@@ -104,6 +104,8 @@ pub struct DiffLine {
     pub new_line_no: Option<usize>,
     /// Intra-line change segments. Empty vec = fallback to whole-line rendering.
     pub inline_segments: Vec<InlineSegment>,
+    /// The text content of this line (tab-expanded).
+    pub content: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -347,6 +349,30 @@ impl DiffState {
         }
     }
 
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    /// Expand tab characters to spaces, matching the viewer's tab expansion.
+    pub fn expand_tabs(line: &str, tab_width: usize) -> String {
+        if !line.contains('\t') {
+            return line.to_string();
+        }
+        let mut result = String::with_capacity(line.len());
+        let mut col = 0;
+        for ch in line.chars() {
+            if ch == '\t' {
+                let spaces = tab_width - (col % tab_width);
+                for _ in 0..spaces {
+                    result.push(' ');
+                }
+                col += spaces;
+            } else {
+                result.push(ch);
+                col += 1;
+            }
+        }
+        result
+    }
+
     // ── Private helpers ─────────────────────────────────────────────────
 
     /// Use `git2` + `similar` to compute file-level diffs for a given range.
@@ -471,6 +497,13 @@ impl DiffState {
                                 })
                                 .collect();
 
+                            // Build content by joining segment texts.
+                            let content: String = segments.iter()
+                                .map(|s| s.text.trim_end_matches('\n').trim_end_matches('\r'))
+                                .collect::<Vec<_>>()
+                                .join("");
+                            let content = Self::expand_tabs(&content, 4);
+
                             let has_emphasis = segments.iter().any(|s| s.emphasized);
                             let inline_segments =
                                 if has_emphasis { segments } else { Vec::new() };
@@ -480,6 +513,7 @@ impl DiffState {
                                 old_line_no,
                                 new_line_no,
                                 inline_segments,
+                                content,
                             });
                         }
                     } else {
@@ -499,11 +533,15 @@ impl DiffState {
                             let old_line_no = change.old_index().map(|i| i + 1);
                             let new_line_no = change.new_index().map(|i| i + 1);
 
+                            let raw = change.value().trim_end_matches('\n').trim_end_matches('\r');
+                            let content = Self::expand_tabs(raw, 4);
+
                             hunk_lines.push(DiffLine {
                                 tag,
                                 old_line_no,
                                 new_line_no,
                                 inline_segments: Vec::new(),
+                                content,
                             });
                         }
                     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -611,21 +611,27 @@ fn handle_explorer_diff_list_key(app: &mut App, key: KeyEvent) {
                     app.viewer_state.diff_list_selected = new_count - 1;
                 }
             } else if let Some((file_diff, _section)) = app.diff_state.resolve_file(selected) {
-                // Open the selected diff file in the Viewer and scroll to first change.
+                // Open the selected diff file in the Viewer and enter unified diff mode.
                 let file_path = file_diff.path.clone();
-                let first_change_line = file_diff.hunks.iter()
-                    .flat_map(|h| h.lines.iter())
-                    .find(|l| l.tag != crate::diff_state::DiffLineTag::Equal)
-                    .and_then(|l| l.new_line_no.or(l.old_line_no));
+                let file_diff_clone = file_diff.clone();
                 if let Some(wt) = app.worktrees.get(app.selected_worktree) {
                     let wt_path = wt.path.clone();
                     app.viewer_state.open_file(&wt_path, &file_path);
-                    if let Some(line) = first_change_line {
-                        app.viewer_state.file_scroll = line.saturating_sub(4);
-                    }
                     app.viewer_state.reveal_file_in_tree(&file_path, &wt_path);
                     app.rehighlight_viewer();
                     app.review_state.build_file_comment_cache(&file_path);
+
+                    // Build unified diff view from the file's hunks.
+                    app.viewer_state.build_unified_diff_view(&file_diff_clone);
+
+                    // Scroll to the first changed line in the diff view.
+                    if let Some(pos) = app.viewer_state.diff_view_lines.iter().position(|e| {
+                        matches!(e, crate::viewer_state::UnifiedDiffEntry::Line { tag, .. }
+                            if *tag != crate::diff_state::DiffLineTag::Equal)
+                    }) {
+                        app.viewer_state.diff_view_scroll = pos.saturating_sub(3);
+                    }
+
                     app.set_focus(Focus::Viewer);
                 }
             }
@@ -832,6 +838,12 @@ fn handle_viewer_key(app: &mut App, key: KeyEvent) {
     // Clear comment preview on any key input.
     app.viewer_state.comment_preview_line = None;
 
+    // Unified diff mode has its own navigation.
+    if app.viewer_state.diff_mode {
+        handle_viewer_diff_mode_key(app, key);
+        return;
+    }
+
     let total = app.viewer_state.file_content.len();
 
     // Esc goes back to Explorer.
@@ -897,6 +909,77 @@ fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         }
         KeyCode::Char(' ') => {
             // Open comment detail modal for comments on the current line.
+            open_viewer_comment_detail(app);
+        }
+        _ => {}
+    }
+}
+
+/// Key handling for the viewer panel in unified diff mode.
+fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
+    let total = app.viewer_state.diff_view_lines.len();
+
+    // Esc exits diff mode and goes back to Explorer.
+    if key.code == KeyCode::Esc {
+        app.viewer_state.clear_selection();
+        app.viewer_state.exit_diff_mode();
+        app.set_focus(Focus::Explorer);
+        return;
+    }
+
+    if total == 0 {
+        return;
+    }
+
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if app.viewer_state.diff_view_scroll + 1 < total {
+                app.viewer_state.diff_view_scroll += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.viewer_state.diff_view_scroll =
+                app.viewer_state.diff_view_scroll.saturating_sub(1);
+        }
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.viewer_state.diff_view_scroll =
+                (app.viewer_state.diff_view_scroll + 15).min(total.saturating_sub(1));
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.viewer_state.diff_view_scroll =
+                app.viewer_state.diff_view_scroll.saturating_sub(15);
+        }
+        KeyCode::Char('g') => {
+            app.viewer_state.diff_view_scroll = 0;
+        }
+        KeyCode::Char('G') => {
+            app.viewer_state.diff_view_scroll = total.saturating_sub(1);
+        }
+        KeyCode::Char('h') | KeyCode::Left => {
+            app.viewer_state.h_scroll = app.viewer_state.h_scroll.saturating_sub(4);
+        }
+        KeyCode::Char('l') | KeyCode::Right => {
+            app.viewer_state.h_scroll += 4;
+        }
+        KeyCode::Char('0') => {
+            app.viewer_state.h_scroll = 0;
+        }
+        KeyCode::Char('c') => {
+            // Comment: only allowed on lines with new_line_no (Equal/Insert).
+            if let Some(entry) = app.viewer_state.diff_view_lines.get(app.viewer_state.diff_view_scroll) {
+                match entry {
+                    crate::viewer_state::UnifiedDiffEntry::Line { tag, new_line_no: Some(_), .. }
+                        if *tag != crate::diff_state::DiffLineTag::Delete =>
+                    {
+                        open_viewer_comment(app);
+                    }
+                    _ => {
+                        app.status_message = Some("Cannot comment on deleted lines".to_string().into());
+                    }
+                }
+            }
+        }
+        KeyCode::Char(' ') => {
             open_viewer_comment_detail(app);
         }
         _ => {}
@@ -2148,28 +2231,27 @@ pub fn handle_mouse_event(
                                         app.diff_state.resolve_file(idx)
                                     {
                                         let file_path = file_diff.path.clone();
-                                        let first_change_line = file_diff
-                                            .hunks
-                                            .iter()
-                                            .flat_map(|h| h.lines.iter())
-                                            .find(|l| {
-                                                l.tag != crate::diff_state::DiffLineTag::Equal
-                                            })
-                                            .and_then(|l| l.new_line_no.or(l.old_line_no));
+                                        let file_diff_clone = file_diff.clone();
                                         if let Some(wt) =
                                             app.worktrees.get(app.selected_worktree)
                                         {
                                             let wt_path = wt.path.clone();
                                             app.viewer_state.open_file(&wt_path, &file_path);
-                                            if let Some(line) = first_change_line {
-                                                app.viewer_state.file_scroll =
-                                                    line.saturating_sub(4);
-                                            }
                                             app.viewer_state
                                                 .reveal_file_in_tree(&file_path, &wt_path);
                                             app.rehighlight_viewer();
                                             app.review_state
                                                 .build_file_comment_cache(&file_path);
+
+                                            // Build unified diff view.
+                                            app.viewer_state.build_unified_diff_view(&file_diff_clone);
+                                            if let Some(pos) = app.viewer_state.diff_view_lines.iter().position(|e| {
+                                                matches!(e, crate::viewer_state::UnifiedDiffEntry::Line { tag, .. }
+                                                    if *tag != crate::diff_state::DiffLineTag::Equal)
+                                            }) {
+                                                app.viewer_state.diff_view_scroll = pos.saturating_sub(3);
+                                            }
+
                                             app.set_focus(Focus::Viewer);
                                         }
                                     }
@@ -2216,6 +2298,44 @@ pub fn handle_mouse_event(
                     let inner_x = panel_x + 1; // inside border
                     let inner_y = main_area.y + 1; // inside border
 
+                    if app.viewer_state.diff_mode {
+                        // Diff mode: resolve line number from diff_view_lines.
+                        let diff_total = app.viewer_state.diff_view_lines.len();
+                        if diff_total > 0 && row >= inner_y {
+                            let line_offset = (row - inner_y) as usize;
+                            let idx = app.viewer_state.diff_view_scroll + line_offset;
+                            if let Some(crate::viewer_state::UnifiedDiffEntry::Line { new_line_no: Some(line_1), tag, .. }) = app.viewer_state.diff_view_lines.get(idx) {
+                                if *tag != crate::diff_state::DiffLineTag::Delete {
+                                    let line_1 = *line_1;
+                                    let has_comment = app.review_state.file_comments.contains_key(&line_1);
+                                    if has_comment {
+                                        let now = std::time::Instant::now();
+                                        let elapsed = now.duration_since(app.viewer_state.last_line_click_time);
+                                        let is_double = elapsed.as_millis() < 400
+                                            && app.viewer_state.last_line_click_line == line_1;
+                                        app.viewer_state.last_line_click_time = now;
+                                        app.viewer_state.last_line_click_line = line_1;
+
+                                        if is_double {
+                                            app.viewer_state.selected_line_start = Some(line_1);
+                                            app.viewer_state.selected_line_end = None;
+                                            app.viewer_state.comment_preview_line = None;
+                                            open_viewer_comment(app);
+                                        } else {
+                                            app.viewer_state.clear_selection();
+                                            app.viewer_state.comment_preview_line = Some(line_1);
+                                        }
+                                    } else {
+                                        app.viewer_state.comment_preview_line = None;
+                                        let is_double = app.viewer_state.click_line_number(line_1);
+                                        if is_double {
+                                            open_viewer_comment(app);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
                     let total_lines = app.viewer_state.file_content.len();
                     if total_lines > 0 && row >= inner_y {
                         let gutter_width = {
@@ -2265,6 +2385,7 @@ pub fn handle_mouse_event(
                             }
                         }
                     }
+                    } // end non-diff-mode
                 } else {
                     // Right column: top 80% = Claude, bottom 20% = Shell.
                     let terminal_split_y =

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -14,6 +14,7 @@ use crate::app::{App, Focus};
 use crate::diff_state::{DiffLineTag, InlineSegment};
 use crate::review_state::ReviewInputMode;
 use crate::review_store::ReviewComment;
+use crate::viewer_state::UnifiedDiffEntry;
 
 /// Annotation for a diff line, carrying the tag and optional inline segments.
 struct DiffAnnotation {
@@ -71,6 +72,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         .title_top(Line::from(Span::styled(expand_label, Style::default().fg(expand_color))).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
+
+    // Unified diff mode: delegate to dedicated renderer.
+    if vs.diff_mode && !vs.diff_view_lines.is_empty() {
+        render_diff_view(frame, area, app, block);
+        return;
+    }
 
     if vs.file_content.is_empty() {
         let placeholder = Paragraph::new("Select a file to view its contents.")
@@ -260,6 +267,230 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     }
 }
 
+/// Render the unified diff view (GitHub-style).
+fn render_diff_view(frame: &mut Frame, area: Rect, app: &App, block: Block<'_>) {
+    let vs = &app.viewer_state;
+    let inner_height = area.height.saturating_sub(2) as usize;
+
+    // Compute max line number for gutter width.
+    let max_line_no = vs.diff_view_lines.iter().filter_map(|entry| {
+        match entry {
+            UnifiedDiffEntry::Line { new_line_no, .. } => *new_line_no,
+            _ => None,
+        }
+    }).max().unwrap_or(0);
+    let gutter_width = digit_count(max_line_no);
+
+    // Collect line numbers that have review comments.
+    let comment_lines: std::collections::HashSet<usize> =
+        app.review_state.file_comments.keys().copied().collect();
+
+    let lines: Vec<Line> = vs
+        .diff_view_lines
+        .iter()
+        .skip(vs.diff_view_scroll)
+        .take(inner_height)
+        .map(|entry| {
+            match entry {
+                UnifiedDiffEntry::HunkSeparator => {
+                    // Thin grey separator line.
+                    let sep = format!(
+                        "{:─<width$}",
+                        " ··· ",
+                        width = area.width.saturating_sub(2) as usize,
+                    );
+                    Line::from(Span::styled(
+                        sep,
+                        Style::default().fg(Color::DarkGray),
+                    ))
+                }
+                UnifiedDiffEntry::Line {
+                    tag,
+                    new_line_no,
+                    old_line_no: _,
+                    content,
+                    inline_segments,
+                } => {
+                    let is_selected = new_line_no
+                        .map(|n| vs.is_line_selected(n))
+                        .unwrap_or(false);
+
+                    // Gutter marker.
+                    let (gutter_prefix, diff_bg, emphasis_bg) = match tag {
+                        DiffLineTag::Insert => ("+", Some(app.theme.diff_add_bg), Some(app.theme.diff_add_bg_emphasis)),
+                        DiffLineTag::Delete => ("-", Some(app.theme.diff_del_bg), Some(app.theme.diff_del_bg_emphasis)),
+                        DiffLineTag::Equal => (" ", None, None),
+                    };
+
+                    // Line number (blank for Delete lines).
+                    let line_num_str = match new_line_no {
+                        Some(n) => format!("{n:>gutter_width$}"),
+                        None => " ".repeat(gutter_width),
+                    };
+
+                    let num = format!("{gutter_prefix}{line_num_str} \u{2502} ");
+                    let gutter_style = if is_selected {
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::LightBlue)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        match tag {
+                            DiffLineTag::Insert => Style::default().fg(Color::Green),
+                            DiffLineTag::Delete => Style::default().fg(Color::Red),
+                            DiffLineTag::Equal => Style::default().fg(Color::DarkGray),
+                        }
+                    };
+                    let gutter_span = Span::styled(num, gutter_style);
+
+                    // Comment badge (only for lines with new_line_no).
+                    let badge = if new_line_no.is_some_and(|n| comment_lines.contains(&n)) {
+                        Span::styled("\u{25c6} ", Style::default().fg(Color::Yellow))
+                    } else {
+                        Span::raw("  ")
+                    };
+
+                    // Content styling.
+                    let content_spans: Vec<Span> = if is_selected {
+                        vec![Span::styled(
+                            content.clone(),
+                            Style::default().bg(Color::DarkGray).fg(Color::White),
+                        )]
+                    } else if !inline_segments.is_empty() {
+                        match tag {
+                            DiffLineTag::Insert => {
+                                // Try syntax highlighting + word-diff merge.
+                                if let Some(line_no) = new_line_no {
+                                    let idx = line_no - 1;
+                                    vs.highlighted_lines.get(idx)
+                                        .filter(|t| !t.is_empty())
+                                        .and_then(|tokens| merge_syntax_with_inline(
+                                            inline_segments, tokens,
+                                            diff_bg.unwrap_or(Color::Reset),
+                                            emphasis_bg.unwrap_or(Color::Reset),
+                                        ))
+                                        .unwrap_or_else(|| render_inline_diff_spans(
+                                            inline_segments,
+                                            diff_bg.unwrap_or(Color::Reset),
+                                            emphasis_bg.unwrap_or(Color::Reset),
+                                        ))
+                                } else {
+                                    render_inline_diff_spans(
+                                        inline_segments,
+                                        diff_bg.unwrap_or(Color::Reset),
+                                        emphasis_bg.unwrap_or(Color::Reset),
+                                    )
+                                }
+                            }
+                            DiffLineTag::Delete => {
+                                render_inline_diff_spans(
+                                    inline_segments,
+                                    diff_bg.unwrap_or(Color::Reset),
+                                    emphasis_bg.unwrap_or(Color::Reset),
+                                )
+                            }
+                            DiffLineTag::Equal => {
+                                if let Some(line_no) = new_line_no {
+                                    syntax_spans_for_line(vs, line_no - 1, None)
+                                } else {
+                                    vec![Span::styled(content.clone(), Style::default().fg(Color::White))]
+                                }
+                            }
+                        }
+                    } else {
+                        // No inline segments — use syntax highlighting or plain.
+                        match tag {
+                            DiffLineTag::Insert => {
+                                if let Some(line_no) = new_line_no {
+                                    syntax_spans_for_line(vs, line_no - 1, diff_bg)
+                                } else {
+                                    vec![Span::styled(
+                                        content.clone(),
+                                        Style::default().fg(Color::White).bg(diff_bg.unwrap_or(Color::Reset)),
+                                    )]
+                                }
+                            }
+                            DiffLineTag::Delete => {
+                                vec![Span::styled(
+                                    content.clone(),
+                                    Style::default().fg(Color::White).bg(diff_bg.unwrap_or(Color::Reset)),
+                                )]
+                            }
+                            DiffLineTag::Equal => {
+                                if let Some(line_no) = new_line_no {
+                                    syntax_spans_for_line(vs, line_no - 1, None)
+                                } else {
+                                    vec![Span::styled(content.clone(), Style::default().fg(Color::White))]
+                                }
+                            }
+                        }
+                    };
+
+                    // Apply horizontal scroll.
+                    let content_spans = h_scroll_spans(content_spans, vs.h_scroll);
+
+                    let mut spans = vec![gutter_span, badge];
+                    spans.extend(content_spans);
+                    Line::from(spans)
+                }
+            }
+        })
+        .collect();
+
+    frame.render_widget(ratatui::widgets::Clear, area);
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+
+    // Show selection hint overlay.
+    if let Some((start, end)) = vs.selected_range() {
+        let hint = if start == end {
+            format!(" L{start} selected \u{2502} c: comment  Esc: clear ")
+        } else {
+            format!(" L{start}-L{end} selected \u{2502} c: comment  Esc: clear ")
+        };
+        let hint_width = hint.len().min(area.width.saturating_sub(2) as usize) as u16;
+        let y = area.y + area.height.saturating_sub(2);
+        let hint_area = Rect::new(area.x + 1, y, hint_width, 1);
+        frame.render_widget(ratatui::widgets::Clear, hint_area);
+        let hint_widget = Paragraph::new(Span::styled(
+            hint,
+            Style::default().fg(Color::Black).bg(Color::LightBlue),
+        ));
+        frame.render_widget(hint_widget, hint_area);
+    }
+
+    // Show comment preview overlay.
+    if !vs.search_active && app.review_state.input_mode == ReviewInputMode::Normal {
+        let cursor_line = if let Some(line) = vs.comment_preview_line {
+            line
+        } else if let Some((start, _)) = vs.selected_range() {
+            start
+        } else {
+            // Determine current line from diff_view_scroll position.
+            vs.diff_view_lines.get(vs.diff_view_scroll)
+                .and_then(|e| match e {
+                    UnifiedDiffEntry::Line { new_line_no, .. } => *new_line_no,
+                    _ => None,
+                })
+                .unwrap_or(0)
+        };
+        if cursor_line > 0 {
+            if let Some(comments) = app.review_state.file_comments.get(&cursor_line) {
+                let has_selection = vs.selected_range().is_some();
+                render_comment_preview(
+                    frame,
+                    area,
+                    comments,
+                    cursor_line,
+                    has_selection,
+                    &app.review_state.reply_counts,
+                );
+            }
+        }
+    }
+}
+
 /// Render a comment preview overlay at the bottom of the viewer area.
 fn render_comment_preview(
     frame: &mut Frame,
@@ -389,24 +620,17 @@ fn build_diff_annotations(app: &App) -> std::collections::HashMap<usize, DiffAnn
     let insert_annotations = |file_diff: &FileDiff, map: &mut std::collections::HashMap<usize, DiffAnnotation>| {
         for hunk in &file_diff.hunks {
             for line in &hunk.lines {
-                match line.tag {
-                    DiffLineTag::Insert => {
-                        if let Some(n) = line.new_line_no {
-                            map.entry(n).or_insert_with(|| DiffAnnotation {
-                                tag: DiffLineTag::Insert,
-                                inline_segments: line.inline_segments.clone(),
-                            });
-                        }
+                // The viewer displays the NEW file content, so only Insert
+                // lines (keyed by new_line_no) can be meaningfully annotated.
+                // Delete lines use old_line_no which refers to the old file
+                // and would collide with Insert entries, hiding additions.
+                if line.tag == DiffLineTag::Insert {
+                    if let Some(n) = line.new_line_no {
+                        map.entry(n).or_insert_with(|| DiffAnnotation {
+                            tag: DiffLineTag::Insert,
+                            inline_segments: line.inline_segments.clone(),
+                        });
                     }
-                    DiffLineTag::Delete => {
-                        if let Some(n) = line.old_line_no {
-                            map.entry(n).or_insert_with(|| DiffAnnotation {
-                                tag: DiffLineTag::Delete,
-                                inline_segments: line.inline_segments.clone(),
-                            });
-                        }
-                    }
-                    DiffLineTag::Equal => {}
                 }
             }
         }

--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -12,6 +12,8 @@ use syntect::highlighting::Theme as SyntectTheme;
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+use crate::diff_state::{DiffLineTag, FileDiff, InlineSegment};
+
 /// A single entry in the flattened file tree.
 #[derive(Debug, Clone)]
 pub struct FileTreeEntry {
@@ -29,6 +31,25 @@ pub struct FileTreeEntry {
     /// Always `false` for files. Directories start as `false` and are set to
     /// `true` after their children are read from the filesystem.
     pub children_loaded: bool,
+}
+
+/// An entry in the unified diff view.
+#[derive(Debug, Clone)]
+pub enum UnifiedDiffEntry {
+    /// A separator between hunks.
+    HunkSeparator,
+    /// A single line (context, addition, or deletion).
+    Line {
+        tag: DiffLineTag,
+        /// Line number in the new file. `Some` for Equal/Insert, `None` for Delete.
+        new_line_no: Option<usize>,
+        /// Line number in the old file. `Some` for Equal/Delete, `None` for Insert.
+        old_line_no: Option<usize>,
+        /// The text content of this line.
+        content: String,
+        /// Intra-line change segments (word diff).
+        inline_segments: Vec<InlineSegment>,
+    },
 }
 
 /// All state owned by the Viewer mode.
@@ -88,6 +109,12 @@ pub struct ViewerState {
     pub last_comment_click_time: std::time::Instant,
     /// The index that was last clicked in the comment list.
     pub last_comment_click_idx: usize,
+    /// Whether the viewer is in unified diff mode.
+    pub diff_mode: bool,
+    /// Unified diff view entries (populated when entering diff mode).
+    pub diff_view_lines: Vec<UnifiedDiffEntry>,
+    /// Vertical scroll offset for the diff view.
+    pub diff_view_scroll: usize,
 }
 
 impl Default for ViewerState {
@@ -120,6 +147,9 @@ impl Default for ViewerState {
             comment_preview_line: None,
             last_comment_click_time: std::time::Instant::now(),
             last_comment_click_idx: usize::MAX,
+            diff_mode: false,
+            diff_view_lines: Vec::new(),
+            diff_view_scroll: 0,
         }
     }
 }
@@ -177,6 +207,7 @@ impl ViewerState {
 
     /// Open (read) a file and store its lines in `file_content`.
     pub fn open_file(&mut self, worktree_path: &Path, relative_path: &str) {
+        self.exit_diff_mode();
         self.highlighted_lines.clear();
         let full = worktree_path.join(relative_path);
         match fs::read_to_string(&full) {
@@ -436,6 +467,42 @@ impl ViewerState {
         }
 
         false
+    }
+
+    // ── Unified diff view ─────────────────────────────────────────────────
+
+    /// Build the unified diff view entries from a `FileDiff`.
+    pub fn build_unified_diff_view(&mut self, file_diff: &FileDiff) {
+        self.diff_view_lines.clear();
+
+        for (hunk_idx, hunk) in file_diff.hunks.iter().enumerate() {
+            // Add hunk separator between hunks (not before the first one).
+            if hunk_idx > 0 {
+                self.diff_view_lines.push(UnifiedDiffEntry::HunkSeparator);
+            }
+
+            for line in &hunk.lines {
+                self.diff_view_lines.push(UnifiedDiffEntry::Line {
+                    tag: line.tag,
+                    new_line_no: line.new_line_no,
+                    old_line_no: line.old_line_no,
+                    content: line.content.clone(),
+                    inline_segments: line.inline_segments.clone(),
+                });
+            }
+        }
+
+        if !self.diff_view_lines.is_empty() {
+            self.diff_mode = true;
+            self.diff_view_scroll = 0;
+        }
+    }
+
+    /// Exit unified diff mode and reset related state.
+    pub fn exit_diff_mode(&mut self) {
+        self.diff_mode = false;
+        self.diff_view_lines.clear();
+        self.diff_view_scroll = 0;
     }
 
     // ── Tree reveal ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- diff listからファイルを開いた際に、GitHub unified diff形式で削除行(赤)・追加行(緑)・context行を表示するビューを追加
- `DiffLine`に`content`フィールドを追加し、削除行のテキストを保持可能に
- `UnifiedDiffEntry`モデルでhunk separator・各行の表示データを構成し、`render_diff_view()`で描画
- diff modeではDelete行へのコメントを禁止し、Escで通常ファイル表示に復帰

## Test plan
- [x] `cargo check` + `cargo test` 通過確認
- [ ] TUI起動 → worktree選択 → `d` → diff list表示 → Enterでファイルを開く → 削除行(赤)・追加行(緑)・context行が表示される
- [ ] Delete行で `c` → コメントできない（ステータスメッセージ表示）
- [ ] Insert/Equal行で `c` → コメント作成可能
- [ ] Esc → Explorer に戻り、ファイルツリーからファイルを開く → 通常表示に復帰