### PR TITLE
fix: diff view のインラインセグメントでタブ展開を修正

### DIFF
--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -666,8 +666,12 @@ fn render_inline_diff_spans(
         .iter()
         .map(|seg| {
             let bg = if seg.emphasized { emphasis_bg } else { diff_bg };
+            let text = expand_tabs(
+                seg.text.trim_end_matches('\n').trim_end_matches('\r'),
+                4,
+            );
             Span::styled(
-                seg.text.clone(),
+                text,
                 Style::default().fg(Color::White).bg(bg),
             )
         })


### PR DESCRIPTION
## Summary
- `render_inline_diff_spans` が生のタブ文字(`\t`)をそのまま Span に渡していたため、Delete 行のインデントが Equal/Insert 行と不一致になっていた
- `merge_syntax_with_inline` と同様に `expand_tabs()` を適用し、全行で統一的なタブ展開(4スペース)を実現

## Test plan
- [x] `cargo check` — コンパイル成功
- [x] `cargo test` — 全35テスト通過
- [ ] Go コード等タブインデントのファイルで diff view を確認し、Delete/Insert/Equal 行のインデントが揃うことを確認