### PR TITLE
fix: diff view のスクロールと状態保持を修正

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -2498,17 +2498,34 @@ fn handle_mouse_scroll(
         }
     } else if col < viewer_end {
         // Viewer scroll.
-        let total = app.viewer_state.file_content.len();
-        if total > 0 {
-            if delta > 0 {
-                app.viewer_state.file_scroll = (app.viewer_state.file_scroll
-                    + delta.unsigned_abs() as usize)
-                    .min(total.saturating_sub(1));
-            } else {
-                app.viewer_state.file_scroll = app
-                    .viewer_state
-                    .file_scroll
-                    .saturating_sub(delta.unsigned_abs() as usize);
+        if app.viewer_state.diff_mode {
+            // Unified diff view scroll.
+            let total = app.viewer_state.diff_view_lines.len();
+            if total > 0 {
+                if delta > 0 {
+                    app.viewer_state.diff_view_scroll = (app.viewer_state.diff_view_scroll
+                        + delta.unsigned_abs() as usize)
+                        .min(total.saturating_sub(1));
+                } else {
+                    app.viewer_state.diff_view_scroll = app
+                        .viewer_state
+                        .diff_view_scroll
+                        .saturating_sub(delta.unsigned_abs() as usize);
+                }
+            }
+        } else {
+            let total = app.viewer_state.file_content.len();
+            if total > 0 {
+                if delta > 0 {
+                    app.viewer_state.file_scroll = (app.viewer_state.file_scroll
+                        + delta.unsigned_abs() as usize)
+                        .min(total.saturating_sub(1));
+                } else {
+                    app.viewer_state.file_scroll = app
+                        .viewer_state
+                        .file_scroll
+                        .saturating_sub(delta.unsigned_abs() as usize);
+                }
             }
         }
     } else {

--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -192,9 +192,26 @@ impl ViewerState {
         if let Some(ref rel_path) = prev_file {
             let full = worktree_path.join(rel_path);
             if full.is_file() {
+                // Preserve diff mode state across tree refreshes so that
+                // file-watcher / periodic refreshes don't kick the user
+                // out of the unified diff view.
+                let was_diff_mode = self.diff_mode;
+                let prev_diff_lines = if was_diff_mode {
+                    std::mem::take(&mut self.diff_view_lines)
+                } else {
+                    Vec::new()
+                };
+                let prev_diff_scroll = self.diff_view_scroll;
+
                 self.open_file(worktree_path, rel_path);
                 self.file_scroll = prev_file_scroll;
                 self.h_scroll = prev_h_scroll;
+
+                if was_diff_mode {
+                    self.diff_mode = true;
+                    self.diff_view_lines = prev_diff_lines;
+                    self.diff_view_scroll = prev_diff_scroll;
+                }
 
                 // Try to restore tree_selected to point at the file entry.
                 if let Some(idx) = self.file_tree.iter().position(|e| e.path == *rel_path) {


### PR DESCRIPTION
## Summary
- diff view でマウスホイールによる上下スクロールが効かない問題を修正
- ファイルウォッチャーや定期リフレッシュで diff_mode が解除されてしまう問題を修正

## Changes
- `event.rs`: Viewer パネルのマウススクロール処理で `diff_mode` 判定を追加し、`diff_view_scroll` を操作するよう分岐
- `viewer_state.rs`: `load_file_tree` で diff_mode の状態（フラグ・行データ・スクロール位置）を保存・復元

## Test plan
- [ ] diff view でマウスホイールによる上下スクロールが動作すること
- [ ] diff view 中にファイル変更が発生しても diff view が維持されること
- [ ] コメント入力(c)→キャンセル(Esc)後も diff view に留まること