### PR TITLE
feat: diff hunk セパレーターに関数コンテキストヘッダーを表示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "open",
  "portable-pty",
  "ratatui",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ notify = "7"
 unicode-width = "0.2"
 vt100 = "0.15"
 open = "5"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/diff_state.rs
+++ b/src/diff_state.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use git2::Repository;
+use regex::Regex;
 use similar::{ChangeTag, TextDiff};
 
 use crate::config::DiffView;
@@ -117,6 +118,8 @@ pub struct DiffLine {
 pub struct DiffHunk {
     /// The lines that make up this hunk.
     pub lines: Vec<DiffLine>,
+    /// Function context header (e.g. "fn some_function()"), if detected.
+    pub func_header: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -375,6 +378,58 @@ impl DiffState {
 
     // ── Private helpers ─────────────────────────────────────────────────
 
+    /// Return a regex pattern for detecting function/class/struct headers
+    /// based on the file extension. Returns `None` for unsupported extensions.
+    fn func_pattern_for_ext(ext: &str) -> Option<Regex> {
+        let pattern = match ext {
+            // Rust
+            "rs" => r"^\s*(pub\s+)?(async\s+)?(fn|impl|struct|enum|trait|mod|macro_rules!)\b",
+            // TypeScript / JavaScript
+            "ts" | "tsx" | "js" | "jsx" | "mjs" | "mts" | "cjs" | "cts" => {
+                r"^\s*(export\s+)?(default\s+)?(async\s+)?(function\*?|class)\b|^\s*(export\s+)?(const|let|var)\s+\w+\s*="
+            }
+            // Python
+            "py" => r"^\s*(async\s+)?(def|class)\b",
+            // Go
+            "go" => r"^(func|type)\b",
+            // Java / C# / Kotlin
+            "java" | "cs" | "kt" | "kts" => {
+                r"^\s*(public|private|protected|internal|static|abstract|override|final|suspend)?\s*(public|private|protected|internal|static|abstract|override|final|suspend)?\s*(class|interface|enum|record|fun|void|int|long|string|bool|boolean|var|val|object)\b"
+            }
+            // C / C++
+            "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hxx" => {
+                r"^[a-zA-Z_][\w:*&<> ]*\s+\*?\w+\s*\(|^\s*(class|struct|enum|namespace|template)\b"
+            }
+            // Ruby
+            "rb" => r"^\s*(def|class|module)\b",
+            // PHP
+            "php" => r"^\s*(public|private|protected|static)?\s*(function|class|interface|trait)\b",
+            // Shell
+            "sh" | "bash" | "zsh" => r"^\s*(\w+\s*\(\)|function\s+\w+)",
+            _ => return None,
+        };
+        Regex::new(pattern).ok()
+    }
+
+    /// Scan upward from `start_line` (0-indexed) to find the nearest function
+    /// header in the old file content.
+    fn find_func_header(old_lines: &[&str], start_line: usize, pattern: &Regex) -> Option<String> {
+        for i in (0..=start_line).rev() {
+            let line = old_lines[i].trim_end();
+            if pattern.is_match(line) {
+                // Truncate very long headers for display.
+                let trimmed = line.trim();
+                let header = if trimmed.len() > 80 {
+                    format!("{}…", &trimmed[..80])
+                } else {
+                    trimmed.to_string()
+                };
+                return Some(header);
+            }
+        }
+        None
+    }
+
     /// Use `git2` + `similar` to compute file-level diffs for a given range.
     fn compute_diff_range(
         worktree_path: &Path,
@@ -463,6 +518,14 @@ impl DiffState {
             // Use `similar` to compute line-level diff with context.
             let text_diff = TextDiff::from_lines(&old_content, &new_content);
 
+            // Prepare function context extraction.
+            let ext = Path::new(&path)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            let func_pattern = Self::func_pattern_for_ext(ext);
+            let old_lines: Vec<&str> = old_content.lines().collect();
+
             let context_radius = 3;
             let mut hunks = Vec::new();
             let mut total_added = 0usize;
@@ -547,8 +610,23 @@ impl DiffState {
                     }
                 }
 
+                // Extract function context header for this hunk.
+                let func_header = func_pattern.as_ref().and_then(|pat| {
+                    // Find the first line number in the hunk (old side).
+                    let first_old_line = hunk_lines.iter().find_map(|l| l.old_line_no);
+                    let first_new_line = hunk_lines.iter().find_map(|l| l.new_line_no);
+                    let start = first_old_line.or(first_new_line).unwrap_or(1);
+                    if start > 0 && !old_lines.is_empty() {
+                        let search_from = (start - 1).min(old_lines.len() - 1);
+                        Self::find_func_header(&old_lines, search_from, pat)
+                    } else {
+                        None
+                    }
+                });
+
                 hunks.push(DiffHunk {
                     lines: hunk_lines,
+                    func_header,
                 });
             }
 

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -295,17 +295,40 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &App, block: Block<'_>) 
         .take(inner_height)
         .map(|entry| {
             match entry {
-                UnifiedDiffEntry::HunkSeparator => {
-                    // Thin grey separator line.
-                    let sep = format!(
-                        "{:─<width$}",
-                        " ··· ",
-                        width = area.width.saturating_sub(2) as usize,
-                    );
-                    Line::from(Span::styled(
-                        sep,
-                        Style::default().fg(Color::DarkGray),
-                    ))
+                UnifiedDiffEntry::HunkSeparator { func_header } => {
+                    let width = area.width.saturating_sub(2) as usize;
+                    match func_header {
+                        Some(header) => {
+                            let prefix = " ··· ";
+                            let suffix = " ───";
+                            // Fill the rest with ─
+                            let header_display = format!("{prefix}{header}{suffix}");
+                            let fill_len = width.saturating_sub(header_display.chars().count());
+                            let fill: String = "─".repeat(fill_len);
+                            Line::from(vec![
+                                Span::styled(prefix, Style::default().fg(Color::DarkGray)),
+                                Span::styled(
+                                    header.clone(),
+                                    Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                                ),
+                                Span::styled(
+                                    format!("{suffix}{fill}"),
+                                    Style::default().fg(Color::DarkGray),
+                                ),
+                            ])
+                        }
+                        None => {
+                            let sep = format!(
+                                "{:─<width$}",
+                                " ··· ",
+                                width = width,
+                            );
+                            Line::from(Span::styled(
+                                sep,
+                                Style::default().fg(Color::DarkGray),
+                            ))
+                        }
+                    }
                 }
                 UnifiedDiffEntry::Line {
                     tag,

--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -37,7 +37,9 @@ pub struct FileTreeEntry {
 #[derive(Debug, Clone)]
 pub enum UnifiedDiffEntry {
     /// A separator between hunks.
-    HunkSeparator,
+    HunkSeparator {
+        func_header: Option<String>,
+    },
     /// A single line (context, addition, or deletion).
     Line {
         tag: DiffLineTag,
@@ -495,7 +497,9 @@ impl ViewerState {
         for (hunk_idx, hunk) in file_diff.hunks.iter().enumerate() {
             // Add hunk separator between hunks (not before the first one).
             if hunk_idx > 0 {
-                self.diff_view_lines.push(UnifiedDiffEntry::HunkSeparator);
+                self.diff_view_lines.push(UnifiedDiffEntry::HunkSeparator {
+                    func_header: hunk.func_header.clone(),
+                });
             }
 
             for line in &hunk.lines {


### PR DESCRIPTION
## Summary
- diff view の各 hunk セパレーターに、その hunk が属する関数/構造体/impl の名前を表示
- hunk の開始行から上方向に走査し、言語別の正規表現にマッチする最初の行を関数ヘッダーとして使用（git 本体と同じアルゴリズム）
- 対応言語: Rust, TypeScript/JavaScript, Python, Go, Java/C#/Kotlin, C/C++, Ruby, PHP, Shell

## 変更内容
- `DiffHunk` に `func_header: Option<String>` フィールドを追加
- `func_pattern_for_ext()` で言語別の正規表現パターンを定義
- `compute_diff_range()` で hunk 作成時に関数コンテキストを抽出
- `UnifiedDiffEntry::HunkSeparator` にヘッダー情報を追加
- セパレーターのレンダリングでヘッダーをイタリック表示

## Test plan
- [x] `cargo check` コンパイル通過
- [x] `cargo test` 全35テスト通過
- [x] `cargo clippy` 新規警告なし