### PR TITLE
fix: 関数ヘッダー切り詰め時のマルチバイト文字境界 panic を修正

### DIFF
--- a/src/diff_state.rs
+++ b/src/diff_state.rs
@@ -420,7 +420,12 @@ impl DiffState {
                 // Truncate very long headers for display.
                 let trimmed = line.trim();
                 let header = if trimmed.len() > 80 {
-                    format!("{}…", &trimmed[..80])
+                    // Find the last char boundary at or before byte 80.
+                    let mut end = 80;
+                    while !trimmed.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    format!("{}…", &trimmed[..end])
                 } else {
                     trimmed.to_string()
                 };


### PR DESCRIPTION
## Summary
- diff hunk セパレーターの関数ヘッダーを80バイトで切り詰める際、マルチバイト文字（日本語等）の途中でスライスして panic する問題を修正
- `is_char_boundary()` で安全な文字境界を探してからスライスするよう変更

## Test plan
- 日本語を含む長い関数ヘッダーがある diff を表示して panic しないことを確認