### PR TITLE
feat: Explorer ファイル名 fuzzy search

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -45,6 +45,10 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         handle_cherry_pick_key(app, key);
         return;
     }
+    if app.viewer_state.filename_search_active {
+        handle_filename_search_key(app, key);
+        return;
+    }
     if app.viewer_state.search_active {
         handle_viewer_search_key(app, key);
         return;
@@ -559,6 +563,13 @@ fn handle_explorer_key(app: &mut App, key: KeyEvent) {
             if let Some(&last) = visible.last() {
                 app.viewer_state.tree_selected = last;
             }
+        }
+        KeyCode::Char('/') => {
+            app.viewer_state.filename_search_active = true;
+            app.viewer_state.filename_search_query.clear();
+            app.viewer_state.filename_search_results.clear();
+            app.viewer_state.filename_search_selected = 0;
+            app.viewer_state.execute_filename_search();
         }
         _ => {}
     }
@@ -1482,6 +1493,74 @@ fn handle_help_key(app: &mut App, key: KeyEvent) {
         KeyCode::Char('2') => app.help_context = Focus::Explorer,
         KeyCode::Char('3') => app.help_context = Focus::Viewer,
         KeyCode::Char('4') => app.help_context = Focus::TerminalClaude,
+        _ => {}
+    }
+}
+
+// ── Overlay: filename search ────────────────────────────────────────────
+
+fn handle_filename_search_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc => {
+            app.viewer_state.filename_search_active = false;
+            app.viewer_state.filename_search_query.clear();
+            app.viewer_state.filename_search_results.clear();
+            app.viewer_state.filename_search_selected = 0;
+        }
+        KeyCode::Enter => {
+            if let Some(result) = app
+                .viewer_state
+                .filename_search_results
+                .get(app.viewer_state.filename_search_selected)
+                .cloned()
+            {
+                app.viewer_state.filename_search_active = false;
+
+                // Reveal and open the selected file (keep Focus on Explorer).
+                if let Some(wt) = app.worktrees.get(app.selected_worktree) {
+                    let wt_path = wt.path.clone();
+                    app.viewer_state.reveal_file_in_tree(&result.path, &wt_path);
+                    app.viewer_state.open_file(&wt_path, &result.path);
+                    app.rehighlight_viewer();
+                    app.review_state.build_file_comment_cache(&result.path);
+                }
+            }
+            app.viewer_state.filename_search_query.clear();
+            app.viewer_state.filename_search_results.clear();
+            app.viewer_state.filename_search_selected = 0;
+        }
+        KeyCode::Backspace => {
+            app.viewer_state.filename_search_query.pop();
+            app.viewer_state.filename_search_selected = 0;
+            app.viewer_state.execute_filename_search();
+        }
+        KeyCode::Down => {
+            let count = app.viewer_state.filename_search_results.len();
+            if count > 0 && app.viewer_state.filename_search_selected + 1 < count {
+                app.viewer_state.filename_search_selected += 1;
+            }
+        }
+        KeyCode::Up => {
+            if app.viewer_state.filename_search_selected > 0 {
+                app.viewer_state.filename_search_selected -= 1;
+            }
+        }
+        KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            let count = app.viewer_state.filename_search_results.len();
+            if count > 0 && app.viewer_state.filename_search_selected + 1 < count {
+                app.viewer_state.filename_search_selected += 1;
+            }
+        }
+        KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            if app.viewer_state.filename_search_selected > 0 {
+                app.viewer_state.filename_search_selected -= 1;
+            }
+        }
+        KeyCode::Char(c) => {
+            app.viewer_state.filename_search_query.push(c);
+            app.viewer_state.filename_search_selected = 0;
+            app.viewer_state.execute_filename_search();
+        }
         _ => {}
     }
 }

--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -102,6 +102,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     if app.viewer_state.search_active {
         render_search_box(frame, area, &app.viewer_state.search_query);
     }
+
+    // Show filename search overlay.
+    if app.viewer_state.filename_search_active {
+        render_filename_search_overlay(frame, chunks[0], app);
+    }
 }
 
 /// Render the file tree (top half).
@@ -488,4 +493,93 @@ fn render_search_box(frame: &mut Frame, area: Rect, query: &str) {
         Style::default().fg(Color::Yellow),
     ));
     frame.render_widget(paragraph, search_area);
+}
+
+/// Render the filename search overlay on top of the file tree area.
+fn render_filename_search_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let vs = &app.viewer_state;
+    let inner_width = area.width.saturating_sub(2);
+    let inner_height = area.height.saturating_sub(2) as usize;
+
+    if inner_width == 0 || inner_height == 0 {
+        return;
+    }
+
+    // Input box at the top of the panel (inside the border).
+    let input_y = area.y + 1;
+    let input_area = Rect::new(area.x + 1, input_y, inner_width, 1);
+    frame.render_widget(ratatui::widgets::Clear, input_area);
+
+    let total_files = vs.file_tree.iter().filter(|e| !e.is_dir).count();
+    let match_count = vs.filename_search_results.len();
+    let counter = format!(" {match_count}/{total_files}");
+    let query_width = inner_width.saturating_sub(counter.len() as u16 + 1) as usize;
+
+    let query_display = &vs.filename_search_query;
+    let query_text = format!("/{query_display}\u{2588}");
+    // Truncate display if needed.
+    let query_truncated: String = query_text.chars().take(query_width).collect();
+
+    let input_line = Line::from(vec![
+        Span::styled(query_truncated, Style::default().fg(Color::Yellow)),
+        Span::styled(counter, Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(ratatui::widgets::Paragraph::new(input_line), input_area);
+
+    // Results list below the input.
+    let results_start_y = input_y + 1;
+    let results_height = (area.y + area.height).saturating_sub(results_start_y + 1) as usize;
+
+    if results_height == 0 {
+        return;
+    }
+
+    // Scroll the results if selected is beyond visible range.
+    let scroll = if vs.filename_search_selected >= results_height {
+        vs.filename_search_selected - results_height + 1
+    } else {
+        0
+    };
+
+    if vs.filename_search_results.is_empty() && !vs.filename_search_query.is_empty() {
+        let no_match_area = Rect::new(area.x + 1, results_start_y, inner_width, 1);
+        frame.render_widget(ratatui::widgets::Clear, no_match_area);
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(Span::styled(
+                "No matches",
+                Style::default().fg(Color::DarkGray),
+            )),
+            no_match_area,
+        );
+        return;
+    }
+
+    for (vi, result) in vs
+        .filename_search_results
+        .iter()
+        .skip(scroll)
+        .take(results_height)
+        .enumerate()
+    {
+        let y = results_start_y + vi as u16;
+        let row_area = Rect::new(area.x + 1, y, inner_width, 1);
+        frame.render_widget(ratatui::widgets::Clear, row_area);
+
+        let is_selected = scroll + vi == vs.filename_search_selected;
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        // Truncate path to fit.
+        let display: String = result.path.chars().take(inner_width as usize).collect();
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(Span::styled(display, style)),
+            row_area,
+        );
+    }
 }

--- a/src/viewer_state.rs
+++ b/src/viewer_state.rs
@@ -14,6 +14,17 @@ use syntect::util::LinesWithEndings;
 
 use crate::diff_state::{DiffLineTag, FileDiff, InlineSegment};
 
+/// A file matched by filename fuzzy search, with its score.
+#[derive(Debug, Clone)]
+pub struct ScoredFile {
+    /// Index in `file_tree`.
+    pub tree_index: usize,
+    /// Relative path of the file.
+    pub path: String,
+    /// Fuzzy match score (higher = better).
+    pub score: i32,
+}
+
 /// A single entry in the flattened file tree.
 #[derive(Debug, Clone)]
 pub struct FileTreeEntry {
@@ -117,6 +128,14 @@ pub struct ViewerState {
     pub diff_view_lines: Vec<UnifiedDiffEntry>,
     /// Vertical scroll offset for the diff view.
     pub diff_view_scroll: usize,
+    /// Whether the filename search overlay is active.
+    pub filename_search_active: bool,
+    /// Current filename search query.
+    pub filename_search_query: String,
+    /// Scored and sorted fuzzy search results.
+    pub filename_search_results: Vec<ScoredFile>,
+    /// Selected index within the search results list.
+    pub filename_search_selected: usize,
 }
 
 impl Default for ViewerState {
@@ -152,6 +171,10 @@ impl Default for ViewerState {
             diff_mode: false,
             diff_view_lines: Vec::new(),
             diff_view_scroll: 0,
+            filename_search_active: false,
+            filename_search_query: String::new(),
+            filename_search_results: Vec::new(),
+            filename_search_selected: 0,
         }
     }
 }
@@ -353,6 +376,149 @@ impl ViewerState {
             self.search_match_idx - 1
         };
         self.file_scroll = self.search_matches[self.search_match_idx];
+    }
+
+    // ── Filename fuzzy search ─────────────────────────────────────────────
+
+    /// Run fuzzy filename search over the file tree and populate results.
+    pub fn execute_filename_search(&mut self) {
+        self.filename_search_results.clear();
+
+        let query = self.filename_search_query.to_lowercase();
+
+        for (idx, entry) in self.file_tree.iter().enumerate() {
+            if entry.is_dir {
+                continue;
+            }
+
+            let path_lower = entry.path.to_lowercase();
+            let name_lower = entry.name.to_lowercase();
+
+            // If query is empty, include all files with score 0.
+            if query.is_empty() {
+                self.filename_search_results.push(ScoredFile {
+                    tree_index: idx,
+                    path: entry.path.clone(),
+                    score: 0,
+                });
+                continue;
+            }
+
+            // Check fuzzy subsequence match first — skip non-matching files.
+            if !Self::is_fuzzy_match(&query, &path_lower) {
+                continue;
+            }
+
+            let mut score: i32 = 10; // Base score for fuzzy match.
+
+            // Bonus: consecutive character matches.
+            score += Self::consecutive_bonus(&query, &path_lower);
+
+            // Bonus: filename exact prefix.
+            if name_lower.starts_with(&query) {
+                score += 100;
+            }
+
+            // Bonus: path substring match.
+            if path_lower.contains(&query) {
+                score += 50;
+            }
+
+            // Bonus: filename substring match.
+            if name_lower.contains(&query) {
+                score += 30;
+            }
+
+            // Bonus: word boundary match (char after '/', '_', '-', '.').
+            if Self::has_word_boundary_match(&query, &path_lower) {
+                score += 20;
+            }
+
+            self.filename_search_results.push(ScoredFile {
+                tree_index: idx,
+                path: entry.path.clone(),
+                score,
+            });
+        }
+
+        // Sort by score descending, then path ascending for stability.
+        self.filename_search_results.sort_by(|a, b| {
+            b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path))
+        });
+    }
+
+    /// Check if all characters of `query` appear in `haystack` in order.
+    fn is_fuzzy_match(query: &str, haystack: &str) -> bool {
+        let mut haystack_chars = haystack.chars();
+        for qc in query.chars() {
+            if !haystack_chars.any(|hc| hc == qc) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Award bonus points for consecutive matching characters.
+    fn consecutive_bonus(query: &str, haystack: &str) -> i32 {
+        let mut bonus = 0i32;
+        let mut consecutive = 0;
+        let mut hay_iter = haystack.chars().peekable();
+
+        for qc in query.chars() {
+            let mut found = false;
+            for hc in hay_iter.by_ref() {
+                if hc == qc {
+                    consecutive += 1;
+                    if consecutive > 1 {
+                        bonus += consecutive;
+                    }
+                    found = true;
+                    break;
+                }
+                consecutive = 0;
+            }
+            if !found {
+                break;
+            }
+        }
+        bonus
+    }
+
+    /// Check if query characters match at word boundaries in the haystack
+    /// (after '/', '_', '-', '.', or at position 0).
+    fn has_word_boundary_match(query: &str, haystack: &str) -> bool {
+        let boundary_chars: Vec<char> = haystack
+            .char_indices()
+            .filter(|&(i, _)| {
+                if i == 0 {
+                    return true;
+                }
+                let prev = haystack.as_bytes().get(i - 1).copied().unwrap_or(0);
+                matches!(prev, b'/' | b'_' | b'-' | b'.')
+            })
+            .map(|(_, c)| c)
+            .collect();
+
+        if boundary_chars.len() < query.len() {
+            return false;
+        }
+
+        let mut bi = 0;
+        for qc in query.chars() {
+            let mut found = false;
+            while bi < boundary_chars.len() {
+                if boundary_chars[bi] == qc {
+                    bi += 1;
+                    found = true;
+                    break;
+                }
+                bi += 1;
+            }
+            if !found {
+                return false;
+            }
+        }
+        true
     }
 
     /// Run syntect highlighting on `file_content` and cache the result.


### PR DESCRIPTION
## Summary
- Explorer パネルで `/` キーを押すとファイル名 fuzzy search オーバーレイを起動
- クエリ入力でリアルタイムにマッチ結果を絞り込み（fuzzy subsequence + スコアリング）
- Enter で選択ファイルへツリーカーソル移動＋Viewer でオープン（Focus は Explorer 維持）
- Up/Down/Ctrl+n/Ctrl+p で結果間移動、Esc でキャンセル

## Test plan
- [x] `cargo check` 通過
- [x] `cargo clippy` 新規警告なし
- [x] `cargo build` 成功
- [x] `cargo test` 全35テスト通過
- [ ] `cargo run` で Explorer パネルの `/` キーによるファイル名検索を手動確認