### PR TITLE
feat: Smart Worktree — タスク説明からブランチ名+プロンプトを自動生成

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,19 @@ pub enum WorktreeInputMode {
     ConfirmingDeleteBranch,
     /// Confirming ungrab (y/n).
     ConfirmingUngrab,
+    /// Smart Worktree: typing a multi-line task description.
+    SmartDescription,
+    /// Smart Worktree: waiting for LLM to generate branch name + prompt.
+    SmartGenerating,
+    /// Smart Worktree: confirming/editing the generated branch name.
+    SmartConfirmBranch,
+}
+
+/// Result from the smart worktree LLM generation.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SmartGenResult {
+    pub branch: String,
+    pub prompt: String,
 }
 
 /// Info about a grabbed branch (branch checkout swap with main).
@@ -288,6 +301,18 @@ pub struct App {
     // ── Background fetch for switch-branch overlay ──────────────
     /// Receiver for branch lists fetched in the background.
     pub bg_branch_rx: Option<mpsc::Receiver<Vec<String>>>,
+
+    // ── Smart Worktree ──────────────────────────────────────────
+    /// Multi-line task description buffer for smart worktree creation.
+    pub smart_description_buffer: String,
+    /// Receiver for the background LLM generation result.
+    pub smart_gen_rx: Option<mpsc::Receiver<Result<SmartGenResult, String>>>,
+    /// Generated branch name (editable in SmartConfirmBranch state).
+    pub smart_branch_name: String,
+    /// Generated prompt to pre-type into Claude Code.
+    pub smart_prompt: String,
+    /// When true, auto-spawn Claude Code after worktree creation and pre-type the prompt.
+    pub smart_auto_spawn: bool,
 }
 
 /// Aggregated token usage and cost from ccusage.
@@ -454,6 +479,11 @@ impl App {
             worktree_heads: HashMap::new(),
             ccusage_info: None,
             bg_branch_rx: None,
+            smart_description_buffer: String::new(),
+            smart_gen_rx: None,
+            smart_branch_name: String::new(),
+            smart_prompt: String::new(),
+            smart_auto_spawn: false,
         };
         app.refresh_worktrees();
         app.refresh_reviews();
@@ -722,7 +752,7 @@ impl App {
             CommandId::CreateWorktree => {
                 self.worktree_input_mode = WorktreeInputMode::CreatingWorktree;
                 self.worktree_input_buffer.clear();
-                self.set_status_info("New branch name (Enter to continue, Esc to cancel):".to_string());
+                self.set_status_info("New branch name (Tab: Smart Mode, Enter to continue, Esc to cancel):".to_string());
             }
             CommandId::DeleteWorktree => {
                 if let Some(wt) = self.worktrees.get(self.selected_worktree) {
@@ -1773,8 +1803,26 @@ impl App {
                         self.set_status(format!(
                             "Created worktree: {} (from {})", path.display(), base
                         ), StatusLevel::Success);
+
+                        // Smart Worktree: auto-spawn Claude Code and pre-type prompt.
+                        if self.smart_auto_spawn {
+                            let prompt = std::mem::take(&mut self.smart_prompt);
+                            self.smart_auto_spawn = false;
+                            match self.spawn_claude_code() {
+                                Ok(idx) => {
+                                    if !prompt.is_empty() {
+                                        let _ = self.pty_manager.write_to_session(idx, prompt.as_bytes());
+                                    }
+                                    self.set_focus(Focus::TerminalClaude);
+                                }
+                                Err(e) => {
+                                    log::warn!("Failed to auto-spawn Claude Code: {e}");
+                                }
+                            }
+                        }
                     }
                     Err(e) => {
+                        self.smart_auto_spawn = false;
                         self.set_status(format!("Error: {e}"), StatusLevel::Error);
                     }
                 }
@@ -2031,6 +2079,106 @@ impl App {
             Err(mpsc::TryRecvError::Empty) => { /* still fetching */ }
             Err(mpsc::TryRecvError::Disconnected) => {
                 self.bg_branch_rx = None;
+            }
+        }
+    }
+
+    // ── Smart Worktree generation ──────────────────────────────────────
+
+    /// Spawn a background thread to generate a branch name and prompt via `claude --print`.
+    pub fn start_smart_generation(&mut self, description: &str) {
+        let (tx, rx) = mpsc::channel();
+        self.smart_gen_rx = Some(rx);
+
+        let desc = description.to_string();
+        std::thread::spawn(move || {
+            let system_prompt = r#"You are a helper that generates a git branch name and a Claude Code prompt from a task description.
+Output ONLY a JSON object with two fields:
+- "branch": a kebab-case branch name in English, 3-5 words, prefixed with "feature/", "fix/", or "refactor/" as appropriate.
+- "prompt": a detailed, actionable prompt for Claude Code to implement the task. Write the prompt in the same language as the input description.
+No markdown fences, no explanation, just the JSON object."#;
+
+            let result = std::process::Command::new("claude")
+                .args(["--print", "-p", system_prompt])
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn();
+
+            let result = match result {
+                Ok(mut child) => {
+                    if let Some(mut stdin) = child.stdin.take() {
+                        use std::io::Write;
+                        let _ = stdin.write_all(desc.as_bytes());
+                    }
+                    match child.wait_with_output() {
+                        Ok(output) => {
+                            if !output.status.success() {
+                                let stderr = String::from_utf8_lossy(&output.stderr);
+                                Err(format!("claude exited with {}: {}", output.status, stderr))
+                            } else {
+                                let stdout = String::from_utf8_lossy(&output.stdout);
+                                // Strip markdown fences if present.
+                                let json_str = stdout
+                                    .trim()
+                                    .strip_prefix("```json")
+                                    .or_else(|| stdout.trim().strip_prefix("```"))
+                                    .unwrap_or(stdout.trim());
+                                let json_str = json_str
+                                    .strip_suffix("```")
+                                    .unwrap_or(json_str)
+                                    .trim();
+                                serde_json::from_str::<SmartGenResult>(json_str)
+                                    .map_err(|e| format!("JSON parse error: {e}\nRaw output: {stdout}"))
+                            }
+                        }
+                        Err(e) => Err(format!("Failed to wait for claude: {e}")),
+                    }
+                }
+                Err(e) => Err(format!("Failed to spawn claude: {e}")),
+            };
+
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Poll the smart generation background task. Non-blocking.
+    pub fn poll_smart_generation(&mut self) {
+        let rx = match self.smart_gen_rx.as_ref() {
+            Some(rx) => rx,
+            None => return,
+        };
+        match rx.try_recv() {
+            Ok(Ok(result)) => {
+                self.smart_branch_name = result.branch;
+                self.smart_prompt = result.prompt;
+                self.worktree_input_mode = WorktreeInputMode::SmartConfirmBranch;
+                self.smart_gen_rx = None;
+                self.set_status(
+                    "Branch name generated. Edit if needed, Enter to continue.".to_string(),
+                    StatusLevel::Success,
+                );
+            }
+            Ok(Err(e)) => {
+                log::warn!("Smart generation failed: {e}");
+                // Fallback to manual mode.
+                self.worktree_input_mode = WorktreeInputMode::CreatingWorktree;
+                self.worktree_input_buffer.clear();
+                self.smart_gen_rx = None;
+                self.set_status(
+                    format!("Smart generation failed, enter branch name manually: {e}"),
+                    StatusLevel::Error,
+                );
+            }
+            Err(mpsc::TryRecvError::Empty) => { /* still generating */ }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.worktree_input_mode = WorktreeInputMode::CreatingWorktree;
+                self.worktree_input_buffer.clear();
+                self.smart_gen_rx = None;
+                self.set_status(
+                    "Smart generation thread disconnected, enter branch name manually.".to_string(),
+                    StatusLevel::Error,
+                );
             }
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -324,7 +324,7 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
             // Step 1: enter branch name for new worktree.
             app.worktree_input_mode = crate::app::WorktreeInputMode::CreatingWorktree;
             app.worktree_input_buffer.clear();
-            app.set_status("New branch name (Enter to continue, Esc to cancel):".to_string(), StatusLevel::Info);
+            app.set_status("New branch name (Tab: Smart Mode, Enter to continue, Esc to cancel):".to_string(), StatusLevel::Info);
         }
         KeyCode::Char('X') => {
             if let Some(wt) = app.worktrees.get(app.selected_worktree) {
@@ -1095,6 +1095,15 @@ fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
                 app.worktree_input_buffer.clear();
                 app.status_message = None;
             }
+            KeyCode::Tab => {
+                // Switch to Smart Mode.
+                app.smart_description_buffer = std::mem::take(&mut app.worktree_input_buffer);
+                app.worktree_input_mode = WorktreeInputMode::SmartDescription;
+                app.set_status(
+                    "Describe your task (Alt+Enter: newline, Enter: generate, Tab: manual mode, Esc: cancel)".to_string(),
+                    StatusLevel::Info,
+                );
+            }
             KeyCode::Enter => {
                 let name = app.worktree_input_buffer.clone();
                 if name.is_empty() {
@@ -1213,6 +1222,85 @@ fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
                 app.worktree_input_mode = WorktreeInputMode::Normal;
                 app.set_status("Ungrab cancelled.".to_string(), StatusLevel::Warning);
             }
+        },
+        WorktreeInputMode::SmartDescription => {
+            // Alt+Enter inserts a newline (multi-line editing).
+            if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::ALT) {
+                app.smart_description_buffer.push('\n');
+                return;
+            }
+            match key.code {
+                KeyCode::Esc => {
+                    app.worktree_input_mode = WorktreeInputMode::Normal;
+                    app.smart_description_buffer.clear();
+                    app.status_message = None;
+                }
+                KeyCode::Tab => {
+                    // Switch back to manual mode.
+                    app.worktree_input_buffer = std::mem::take(&mut app.smart_description_buffer);
+                    app.worktree_input_mode = WorktreeInputMode::CreatingWorktree;
+                    app.set_status(
+                        "New branch name (Tab: Smart Mode, Enter to continue, Esc to cancel):".to_string(),
+                        StatusLevel::Info,
+                    );
+                }
+                KeyCode::Enter => {
+                    let desc = app.smart_description_buffer.trim().to_string();
+                    if desc.is_empty() {
+                        app.set_status("Description is empty.".to_string(), StatusLevel::Warning);
+                    } else {
+                        app.worktree_input_mode = WorktreeInputMode::SmartGenerating;
+                        app.start_smart_generation(&desc);
+                        app.set_status("Generating branch name and prompt...".to_string(), StatusLevel::Info);
+                    }
+                }
+                KeyCode::Backspace => {
+                    app.smart_description_buffer.pop();
+                }
+                KeyCode::Char(c) => {
+                    app.smart_description_buffer.push(c);
+                }
+                _ => {}
+            }
+        }
+        WorktreeInputMode::SmartGenerating => {
+            // Only Esc is accepted during generation.
+            if key.code == KeyCode::Esc {
+                app.worktree_input_mode = WorktreeInputMode::Normal;
+                app.smart_description_buffer.clear();
+                app.smart_gen_rx = None;
+                app.set_status("Smart generation cancelled.".to_string(), StatusLevel::Warning);
+            }
+        }
+        WorktreeInputMode::SmartConfirmBranch => match key.code {
+            KeyCode::Esc => {
+                app.worktree_input_mode = WorktreeInputMode::Normal;
+                app.smart_branch_name.clear();
+                app.smart_prompt.clear();
+                app.smart_description_buffer.clear();
+                app.set_status("Smart worktree cancelled.".to_string(), StatusLevel::Warning);
+            }
+            KeyCode::Enter => {
+                let branch = app.smart_branch_name.trim().to_string();
+                if branch.is_empty() {
+                    app.set_status("Branch name is empty.".to_string(), StatusLevel::Warning);
+                } else {
+                    app.worktree_pending_branch = branch;
+                    app.smart_branch_name.clear();
+                    app.smart_description_buffer.clear();
+                    app.smart_auto_spawn = true;
+                    app.worktree_input_mode = WorktreeInputMode::CreatingWorktreeBase;
+                    app.load_base_branches();
+                    app.status_message = None;
+                }
+            }
+            KeyCode::Backspace => {
+                app.smart_branch_name.pop();
+            }
+            KeyCode::Char(c) => {
+                app.smart_branch_name.push(c);
+            }
+            _ => {}
         },
         WorktreeInputMode::Normal => unreachable!(),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,9 @@ fn run_loop(
         // Check if a background fetch for the switch-branch overlay has finished.
         app.poll_bg_branches();
 
+        // Check if smart worktree generation has finished.
+        app.poll_smart_generation();
+
         // Periodically refresh the worktree list to pick up external changes
         // (e.g. `git worktree add` run inside a terminal panel).
         if last_worktree_poll.elapsed() >= WORKTREE_POLL {
@@ -472,6 +475,15 @@ fn render_ui(frame: &mut Frame, app: &mut App) {
     }
     if app.worktree_input_mode == crate::app::WorktreeInputMode::ConfirmingUngrab {
         render_confirm_overlay(frame, main_area, app, " Confirm Ungrab ", ratatui::style::Color::Yellow);
+    }
+    if app.worktree_input_mode == crate::app::WorktreeInputMode::SmartDescription {
+        ui::dashboard::render_smart_description_overlay(frame, main_area, app);
+    }
+    if app.worktree_input_mode == crate::app::WorktreeInputMode::SmartGenerating {
+        ui::dashboard::render_smart_generating_overlay(frame, main_area, app);
+    }
+    if app.worktree_input_mode == crate::app::WorktreeInputMode::SmartConfirmBranch {
+        ui::dashboard::render_smart_confirm_branch_overlay(frame, main_area, app);
     }
     if app.cherry_pick_active {
         ui::dashboard::render_cherry_pick_overlay(frame, main_area, app);

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -147,7 +147,7 @@ pub fn render_worktree_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(ratatui::widgets::Clear, popup_area);
 
     let block = Block::default()
-        .title(" New Worktree Name ")
+        .title(" New Worktree Name (Tab: Smart Mode) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme.border_focused));
 
@@ -1040,4 +1040,165 @@ fn help_lines_for(focus: crate::app::Focus, theme: &Theme) -> Vec<Line<'static>>
     }
 
     lines
+}
+
+// ── Smart Worktree overlays ──────────────────────────────────────────
+
+/// Render the Smart Worktree description input overlay (multi-line).
+pub fn render_smart_description_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let popup_width = 80_u16.min(area.width.saturating_sub(4));
+    let popup_height = 14_u16.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Smart Worktree — Describe your task ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.info));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    // Split: text area + help hint
+    let chunks = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    // Render multi-line text with block cursor.
+    let display = format!("{}\u{2588}", app.smart_description_buffer);
+    let paragraph = Paragraph::new(display)
+        .style(Style::default().fg(theme.fg))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(paragraph, chunks[0]);
+
+    // Help hint.
+    let hint = Line::from(vec![
+        Span::styled("Alt+Enter", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": newline  ", Style::default().fg(theme.muted)),
+        Span::styled("Enter", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": generate  ", Style::default().fg(theme.muted)),
+        Span::styled("Tab", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": manual  ", Style::default().fg(theme.muted)),
+        Span::styled("Esc", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": cancel", Style::default().fg(theme.muted)),
+    ]);
+    frame.render_widget(Paragraph::new(hint), chunks[1]);
+}
+
+/// Render the Smart Worktree generating/loading overlay.
+pub fn render_smart_generating_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let popup_width = 60_u16.min(area.width.saturating_sub(4));
+    let popup_height = 5_u16;
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Smart Worktree ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.info));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    // Braille spinner animation using ui_tick.
+    let braille = ['\u{2801}', '\u{2802}', '\u{2804}', '\u{2840}', '\u{2880}', '\u{2820}', '\u{2810}', '\u{2808}'];
+    let idx = (app.ui_tick / 4) as usize % braille.len();
+    let spinner = braille[idx];
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled(format!(" {spinner} "), Style::default().fg(theme.accent)),
+            Span::styled(
+                "Generating branch name and prompt...",
+                Style::default().fg(theme.fg),
+            ),
+        ]),
+        Line::from(Span::styled(
+            " Press Esc to cancel",
+            Style::default().fg(theme.muted),
+        )),
+    ];
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+/// Render the Smart Worktree branch confirmation/edit overlay.
+pub fn render_smart_confirm_branch_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let popup_width = 70_u16.min(area.width.saturating_sub(4));
+    let popup_height = 9_u16.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Smart Worktree — Confirm Branch Name ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.info));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    // Label
+    frame.render_widget(
+        Paragraph::new(Span::styled(" Branch name:", Style::default().fg(theme.muted))),
+        chunks[0],
+    );
+
+    // Editable branch name with cursor
+    let branch_display = format!(" {}\u{2588}", app.smart_branch_name);
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            branch_display,
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        )),
+        chunks[1],
+    );
+
+    // Blank line
+    // chunks[2] is blank separator
+
+    // Prompt preview (truncated)
+    let max_preview = (popup_width as usize).saturating_sub(4);
+    let preview = if app.smart_prompt.len() > max_preview {
+        format!(" {}...", &app.smart_prompt[..max_preview.saturating_sub(3)])
+    } else {
+        format!(" {}", &app.smart_prompt)
+    };
+    // Replace newlines with spaces for single-line preview.
+    let preview = preview.replace('\n', " ");
+    frame.render_widget(
+        Paragraph::new(Span::styled(preview, Style::default().fg(theme.muted))),
+        chunks[3],
+    );
+
+    // Help hint
+    let hint = Line::from(vec![
+        Span::styled("Enter", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": continue  ", Style::default().fg(theme.muted)),
+        Span::styled("Esc", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(": cancel", Style::default().fg(theme.muted)),
+    ]);
+    frame.render_widget(Paragraph::new(hint), chunks[4]);
 }


### PR DESCRIPTION
## Summary
- worktree 作成時に `Tab` で Smart Mode に切替、自然言語タスク説明 → `claude --print` でブランチ名+プロンプト自動生成 → worktree 作成 → Claude Code 自動起動+プロンプト事前入力を一気通貫で実行
- 生成失敗時はマニュアルモードにフォールバックし、既存フローを維持
- 3つの新オーバーレイ UI（説明入力 / ローディングスピナー / ブランチ確認・編集）

## Changes
- `src/app.rs`: `WorktreeInputMode` に3バリアント追加、`SmartGenResult` 構造体、`start_smart_generation()` / `poll_smart_generation()`、`create_worktree_from_base()` 拡張
- `src/event.rs`: Smart Mode 3状態のキーハンドラ、Tab 切替、Alt+Enter 改行
- `src/ui/dashboard.rs`: 3つの新オーバーレイ描画関数
- `src/main.rs`: メインループ配線（ポーリング+レンダリング）

## Test plan
- [ ] `w` → Tab → Smart Mode モーダル表示確認
- [ ] タスク説明入力 → Enter → ローディングスピナー表示
- [ ] 生成完了 → ブランチ名確認・編集 → Enter → ベースブランチ選択
- [ ] worktree 作成 → Claude Code 自動起動+プロンプト事前入力
- [ ] 各段階の Esc キャンセル正常動作
- [ ] claude CLI 不在時のフォールバック