### PR TITLE
fix: smart modeプレビューのマルチバイト文字panicを修正

### DIFF
--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1181,8 +1181,9 @@ pub fn render_smart_confirm_branch_overlay(frame: &mut Frame, area: Rect, app: &
 
     // Prompt preview (truncated)
     let max_preview = (popup_width as usize).saturating_sub(4);
-    let preview = if app.smart_prompt.len() > max_preview {
-        format!(" {}...", &app.smart_prompt[..max_preview.saturating_sub(3)])
+    let truncated: String = app.smart_prompt.chars().take(max_preview.saturating_sub(3)).collect();
+    let preview = if truncated.len() < app.smart_prompt.len() {
+        format!(" {}...", truncated)
     } else {
         format!(" {}", &app.smart_prompt)
     };


### PR DESCRIPTION
## Summary
- smart modeのブランチ確認オーバーレイで、日本語を含むプロンプトのプレビュー表示時にバイトインデックスでスライスしていたため、マルチバイト文字の途中で切断されてpanicしていた
- `&str[..n]` を `chars().take(n).collect()` に変更し、文字境界を正しく扱うようにした

## Test plan
- [x] `cargo check` 通過
- [ ] 日本語を含むタスク説明でsmart modeを開いてpanicしないことを確認