### PR TITLE
fix: 水族館パネルの高さ上限20%化とアニメーションFPS安定化

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -319,6 +319,10 @@ pub struct App {
     pub local_branches: Vec<String>,
     /// Aquarium animation state for the decoration zone.
     pub aquarium_state: crate::ui::decoration::AquariumState,
+    /// Separate tick counter for aquarium animation (time-based, not frame-based).
+    pub aquarium_tick: u64,
+    /// Last time the aquarium was ticked (for fixed-rate animation).
+    pub last_aquarium_time: std::time::Instant,
 }
 
 /// Aggregated token usage and cost from ccusage.
@@ -492,6 +496,8 @@ impl App {
             smart_auto_spawn: false,
             local_branches: Vec::new(),
             aquarium_state: Default::default(),
+            aquarium_tick: 0,
+            last_aquarium_time: std::time::Instant::now(),
         };
         app.refresh_worktrees();
         app.refresh_reviews();
@@ -648,13 +654,14 @@ impl App {
         }
     }
 
-    /// Advance the aquarium animation by one tick.
+    /// Advance the aquarium animation by one tick (called at a fixed interval).
     pub fn tick_aquarium(&mut self, width: u16, height: u16) {
         use crate::ui::decoration::{AquariumActivity, DecorationMode};
         let mode = DecorationMode::from_str(&self.config.general.decoration);
         if mode != DecorationMode::Aquarium {
             return;
         }
+        self.aquarium_tick = self.aquarium_tick.wrapping_add(1);
         let activity = if self.cc_waiting_worktrees.is_empty() {
             AquariumActivity::Calm
         } else {
@@ -662,7 +669,7 @@ impl App {
         };
         crate::ui::decoration::tick_aquarium(
             &mut self.aquarium_state,
-            self.ui_tick,
+            self.aquarium_tick,
             width,
             height,
             activity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ const TICK_RATE_ACTIVE: Duration = Duration::from_millis(16);
 const TICK_RATE_IDLE: Duration = Duration::from_millis(500);
 /// How long to keep using the active tick rate after the last input event.
 const ACTIVITY_TIMEOUT: Duration = Duration::from_millis(500);
+/// Fixed interval for aquarium animation ticks (~20fps, independent of redraw rate).
+const AQUARIUM_TICK_INTERVAL: Duration = Duration::from_millis(50);
 
 fn main() -> Result<()> {
     // ── Panic hook: write backtrace to ~/.config/conductor/panic.log ──
@@ -212,17 +214,6 @@ fn run_loop(
                 }
             }
 
-            // Tick the aquarium animation using last-known worktree panel width.
-            {
-                let (left_w, _, _) = accordion_widths(app.expanded_panel, last_frame_area.width);
-                // Estimate decoration zone height: subtract list + detail from panel height.
-                let panel_h = last_frame_area.height.saturating_sub(3); // title+notif+status
-                let list_h = (app.worktrees.len() as u16 + 2).max(5);
-                let detail_h = (1 + app.local_branches.len() as u16 + 2).min(8);
-                let deco_h = panel_h.saturating_sub(list_h + detail_h);
-                app.tick_aquarium(left_w.saturating_sub(2), deco_h);
-            }
-
             // Draw the current frame.
             terminal.draw(|frame| {
                 last_frame_area = frame.area();
@@ -269,12 +260,27 @@ fn run_loop(
             }
         }
 
+        // Tick the aquarium animation at a fixed rate, independent of redraw rate.
+        if app.last_aquarium_time.elapsed() >= AQUARIUM_TICK_INTERVAL {
+            app.last_aquarium_time = std::time::Instant::now();
+            let (left_w, _, _) = accordion_widths(app.expanded_panel, last_frame_area.width);
+            let panel_h = last_frame_area.height.saturating_sub(3);
+            let list_h = (app.worktrees.len() as u16 + 2).max(5);
+            let detail_h = (1 + app.local_branches.len() as u16 + 2).min(8);
+            let deco_h = panel_h.saturating_sub(list_h + detail_h);
+            app.tick_aquarium(left_w.saturating_sub(2), deco_h);
+            needs_redraw = true;
+        }
+
         // Wait for an event. Use a fast tick rate shortly after user input
         // so that scrolling and navigation feel responsive, then fall back to
         // an idle rate to save CPU.
+        let has_aquarium = crate::ui::decoration::DecorationMode::from_str(&app.config.general.decoration)
+            == crate::ui::decoration::DecorationMode::Aquarium;
         let tick = match app.focus {
             crate::app::Focus::TerminalClaude | crate::app::Focus::TerminalShell => TICK_RATE_TERMINAL,
             _ if last_input_time.elapsed() < ACTIVITY_TIMEOUT => TICK_RATE_ACTIVE,
+            _ if has_aquarium => AQUARIUM_TICK_INTERVAL,
             _ => TICK_RATE_IDLE,
         };
         if crossterm_poll(tick)? {

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -50,14 +50,21 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let decoration_mode = DecorationMode::from_str(&app.config.general.decoration);
     let min_decoration_rows: u16 = if decoration_mode == DecorationMode::None { 0 } else { 4 };
 
+    // Cap decoration height at 20% of the total panel area.
+    let max_deco_h = area.height / 5;
+
     // If the area is too small to fit all zones, progressively hide decoration and detail.
     let total_needed = list_rows + detail_rows + min_decoration_rows;
     let (zone1_h, zone2_h, zone3_constraint) = if area.height >= total_needed {
-        // All zones fit.
-        (list_rows, detail_rows, Constraint::Min(0))
+        // All zones fit — cap decoration at 20%.
+        let remaining = area.height.saturating_sub(list_rows + detail_rows);
+        let deco_h = remaining.min(max_deco_h);
+        (list_rows, detail_rows, Constraint::Length(deco_h))
     } else if area.height >= list_rows + detail_rows {
-        // Detail fits but decoration might be tiny — show what's left.
-        (list_rows, detail_rows, Constraint::Min(0))
+        // Detail fits but decoration might be tiny — show what's left, capped.
+        let remaining = area.height.saturating_sub(list_rows + detail_rows);
+        let deco_h = remaining.min(max_deco_h);
+        (list_rows, detail_rows, Constraint::Length(deco_h))
     } else if area.height >= list_rows + 3 {
         // Squeeze detail, no decoration.
         let remaining = area.height.saturating_sub(list_rows);
@@ -69,7 +76,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let zones = Layout::vertical([
         Constraint::Length(zone1_h),
-        Constraint::Length(zone2_h),
+        Constraint::Min(zone2_h),  // Detail absorbs leftover space from capped decoration
         zone3_constraint,
     ])
     .split(area);


### PR DESCRIPTION
## Summary
- 水族館デコレーションの高さをパネル全体の下から最大20%に制限（余白はDetailゾーンが吸収）
- アニメーションtickを`ui_tick`（フレーム連動）から独立した50ms固定タイマーに変更し、フォーカスパネルによるFPS変動を解消
- IME入力中の表示干渉も解消

## Test plan
- [ ] ターミナルフォーカス時とWorktreeフォーカス時で水族館のアニメーション速度が同じことを確認
- [ ] 水族館の高さがパネルの20%を超えないことを確認
- [ ] 日本語入力中に水族館の挙動が変わらないことを確認