### PR TITLE
feat: worktreeパネルからpull (u key)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -304,6 +304,10 @@ pub struct App {
     /// Receiver for branch lists fetched in the background.
     pub bg_branch_rx: Option<mpsc::Receiver<Vec<String>>>,
 
+    // ── Background pull ────────────────────────────────────────
+    /// Receiver for pull results from a background thread.
+    pub bg_pull_rx: Option<mpsc::Receiver<Result<String, String>>>,
+
     // ── Smart Worktree ──────────────────────────────────────────
     /// Multi-line task description buffer for smart worktree creation.
     pub smart_description_buffer: String,
@@ -488,6 +492,7 @@ impl App {
             worktree_heads: HashMap::new(),
             ccusage_info: None,
             bg_branch_rx: None,
+            bg_pull_rx: None,
             smart_description_buffer: String::new(),
             smart_gen_rx: None,
             smart_branch_name: String::new(),
@@ -2120,6 +2125,70 @@ impl App {
             Err(mpsc::TryRecvError::Empty) => { /* still fetching */ }
             Err(mpsc::TryRecvError::Disconnected) => {
                 self.bg_branch_rx = None;
+            }
+        }
+    }
+
+    // ── Pull worktree (fetch + fast-forward) ──────────────────────────
+
+    /// Start a background pull (fetch + fast-forward) for the selected worktree.
+    pub fn start_pull_worktree(&mut self) {
+        if self.bg_pull_rx.is_some() {
+            self.set_status("A pull is already in progress.".to_string(), StatusLevel::Warning);
+            return;
+        }
+
+        let wt = match self.worktrees.get(self.selected_worktree) {
+            Some(wt) => wt,
+            None => return,
+        };
+
+        let branch = wt.branch.clone();
+        let wt_path = wt.path.clone();
+        let repo_path = self.repo_path.clone();
+
+        self.set_status(format!("Pulling '{branch}'..."), StatusLevel::Info);
+
+        let (tx, rx) = mpsc::channel();
+        self.bg_pull_rx = Some(rx);
+
+        std::thread::spawn(move || {
+            let result = (|| -> Result<String, String> {
+                let engine = git_engine::GitEngine::open(&repo_path)
+                    .map_err(|e| format!("Failed to open repo: {e}"))?;
+                engine.pull_worktree(&wt_path)
+                    .map_err(|e| format!("{e}"))
+            })();
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Poll the background pull channel. Non-blocking.
+    pub fn poll_bg_pull(&mut self) {
+        let rx = match self.bg_pull_rx.as_ref() {
+            Some(rx) => rx,
+            None => return,
+        };
+        match rx.try_recv() {
+            Ok(Ok(msg)) => {
+                let level = if msg.contains("up-to-date") {
+                    StatusLevel::Info
+                } else if msg.contains("fast-forward") {
+                    StatusLevel::Success
+                } else {
+                    StatusLevel::Warning
+                };
+                self.set_status(msg, level);
+                self.refresh_worktrees();
+                self.bg_pull_rx = None;
+            }
+            Ok(Err(err)) => {
+                self.set_status(format!("Pull failed: {err}"), StatusLevel::Error);
+                self.bg_pull_rx = None;
+            }
+            Err(mpsc::TryRecvError::Empty) => { /* still pulling */ }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.bg_pull_rx = None;
             }
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -414,6 +414,9 @@ fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 }
             }
         }
+        KeyCode::Char('u') => {
+            app.start_pull_worktree();
+        }
         KeyCode::Char('H') => {
             app.history_active = true;
             app.load_session_history();

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -636,6 +636,99 @@ impl GitEngine {
         Ok(())
     }
 
+    // ── Pull (fetch + fast-forward) ────────────────────────────────────
+
+    /// Fetch from origin and fast-forward the branch in the given worktree.
+    ///
+    /// Returns a human-readable status message describing the outcome.
+    /// Only fast-forward merges are performed; non-FF situations are reported
+    /// so the user can resolve them manually.
+    ///
+    /// NOTE: calls `fetch_origin()` internally, so this performs network I/O.
+    /// Must be called from a background thread.
+    pub fn pull_worktree(&self, worktree_path: &Path) -> Result<String> {
+        let wt_repo = Repository::open(worktree_path)
+            .with_context(|| format!("cannot open worktree at {}", worktree_path.display()))?;
+
+        // Ensure HEAD points to a branch (not detached).
+        let head = wt_repo.head().context("cannot read HEAD")?;
+        if !head.is_branch() {
+            anyhow::bail!("Cannot pull: HEAD is detached");
+        }
+        let branch_name = head.shorthand().unwrap_or("unknown").to_string();
+
+        // Ensure the branch has an upstream configured.
+        let local_branch = wt_repo
+            .find_branch(&branch_name, git2::BranchType::Local)
+            .with_context(|| format!("branch '{branch_name}' not found"))?;
+        let upstream = local_branch
+            .upstream()
+            .with_context(|| format!("No upstream configured for '{branch_name}'"))?;
+        let upstream_name = upstream
+            .name()?
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Fetch from origin (updates all remote refs).
+        self.fetch_origin()?;
+
+        // Re-open the repo to pick up the updated remote refs.
+        let wt_repo = Repository::open(worktree_path)
+            .with_context(|| format!("cannot re-open worktree at {}", worktree_path.display()))?;
+
+        // Resolve upstream OID after fetch.
+        let upstream_ref = wt_repo
+            .find_reference(&format!("refs/remotes/{upstream_name}"))
+            .with_context(|| format!("upstream ref 'refs/remotes/{upstream_name}' not found after fetch"))?;
+        let upstream_oid = upstream_ref
+            .peel_to_commit()
+            .context("upstream ref is not a commit")?
+            .id();
+        let annotated = wt_repo
+            .find_annotated_commit(upstream_oid)
+            .context("failed to find annotated commit for upstream")?;
+
+        // Merge analysis.
+        let (analysis, _preference) = wt_repo.merge_analysis(&[&annotated])?;
+
+        if analysis.is_up_to_date() {
+            return Ok(format!("'{branch_name}' is already up-to-date"));
+        }
+
+        if analysis.is_fast_forward() {
+            // Count commits for the status message.
+            let head_oid = wt_repo.head()?.peel_to_commit()?.id();
+            let count = {
+                let mut revwalk = wt_repo.revwalk()?;
+                revwalk.push(upstream_oid)?;
+                revwalk.hide(head_oid)?;
+                revwalk.count()
+            };
+
+            // Move branch ref forward.
+            let mut branch_ref = wt_repo.find_reference(&format!("refs/heads/{branch_name}"))?;
+            branch_ref.set_target(
+                upstream_oid,
+                &format!("conductor: fast-forward pull {upstream_name} into {branch_name}"),
+            )?;
+            // Update working directory (safe — won't clobber local changes).
+            wt_repo.checkout_head(Some(
+                git2::build::CheckoutBuilder::new().safe()
+            ))?;
+            return Ok(format!(
+                "Pulled '{branch_name}': fast-forward ({count} commit(s))"
+            ));
+        }
+
+        if analysis.is_normal() {
+            return Ok(format!(
+                "Cannot fast-forward '{branch_name}'. Manual merge needed"
+            ));
+        }
+
+        anyhow::bail!("pull: unexpected merge analysis result for '{branch_name}'");
+    }
+
     // ── Merge / Reset operations ─────────────────────────────────────
 
     /// Merge `branch_name` into the main branch using a fast-forward-only merge.

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,6 +323,9 @@ fn run_loop(
         // Check if a background fetch for the switch-branch overlay has finished.
         app.poll_bg_branches();
 
+        // Check if a background pull has finished.
+        app.poll_bg_pull();
+
         // Check if smart worktree generation has finished.
         app.poll_smart_generation();
 


### PR DESCRIPTION
## Summary
- Worktreeパネルで `u` キーを押すと、選択中worktreeのブランチをorigin からfetch + fast-forward mergeする
- バックグラウンドスレッドで実行するためUIがブロックされない
- detached HEAD、upstream未設定、non-FF等のエラーケースをステータスメッセージで通知

## Changed files
| File | Change |
|------|--------|
| `src/git_engine.rs` | `pull_worktree()` メソッド追加 |
| `src/app.rs` | `bg_pull_rx` フィールド + `start_pull_worktree()` + `poll_bg_pull()` |
| `src/main.rs` | `poll_bg_pull()` ポーリング呼び出し追加 |
| `src/event.rs` | `u` キーバインド追加 |

## Test plan
- [x] `cargo check` — コンパイル確認
- [x] `cargo clippy` — lint確認
- [x] `cargo test` — 全35テスト通過
- [ ] 手動テスト: originから遅れているworktreeで `u` → pull成功
- [ ] 手動テスト: upstreamのないworktreeで `u` → warning表示
- [ ] 手動テスト: already up-to-dateなworktreeで `u` → info表示