### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/plugins/conductor/.claude-plugin/plugin.json
+++ b/plugins/conductor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hooks, MCP tools, and commands for Claude Code sessions running inside Conductor TUI",
   "author": {
     "name": "S-Nakamur-a"

--- a/plugins/conductor/mcp/conductor-comment/package-lock.json
+++ b/plugins/conductor/mcp/conductor-comment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conductor-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conductor-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "better-sqlite3": "^11.8.1",

--- a/plugins/conductor/mcp/conductor-comment/package.json
+++ b/plugins/conductor/mcp/conductor-comment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump all version numbers from 0.1.0 to 0.2.0 across Cargo.toml, plugin.json, package.json, and package-lock.json