### PR TITLE
feat: 起動時バージョンチェック機能の追加

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -300,6 +300,10 @@ pub struct App {
     /// Cached ccusage info (refreshed periodically via background thread).
     pub ccusage_info: Option<CcusageInfo>,
 
+    // ── Update check ───────────────────────────────────────────
+    /// Latest release info when a newer version is available.
+    pub update_info: Option<crate::update_checker::UpdateInfo>,
+
     // ── Background fetch for switch-branch overlay ──────────────
     /// Receiver for branch lists fetched in the background.
     pub bg_branch_rx: Option<mpsc::Receiver<Vec<String>>>,
@@ -491,6 +495,7 @@ impl App {
             today_stats,
             worktree_heads: HashMap::new(),
             ccusage_info: None,
+            update_info: None,
             bg_branch_rx: None,
             bg_pull_rx: None,
             smart_description_buffer: String::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub notification: NotificationConfig,
     /// `[ccusage]` -- Claude Code token usage display.
     pub ccusage: CcusageConfig,
+    /// `[updates]` -- startup version check settings.
+    pub updates: UpdatesConfig,
 }
 
 
@@ -257,6 +259,25 @@ impl Default for CcusageConfig {
     }
 }
 
+/// `[updates]` section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdatesConfig {
+    /// Check for new versions on startup.
+    pub check_on_startup: bool,
+    /// Minimum interval (seconds) between update checks (cache TTL).
+    pub check_interval_secs: u64,
+}
+
+impl Default for UpdatesConfig {
+    fn default() -> Self {
+        Self {
+            check_on_startup: true,
+            check_interval_secs: 86400, // 24 hours
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -323,6 +344,8 @@ mod tests {
         assert!(!cfg2.notification.cc_waiting);
         assert!(!cfg2.ccusage.enabled);
         assert_eq!(cfg2.ccusage.poll_interval_secs, 120);
+        assert!(cfg2.updates.check_on_startup);
+        assert_eq!(cfg2.updates.check_interval_secs, 86400);
     }
 
     #[test]
@@ -361,6 +384,16 @@ poll_interval_secs = 60"#)
                 .expect("parse");
         assert!(cfg.enabled);
         assert_eq!(cfg.poll_interval_secs, 60);
+    }
+
+    #[test]
+    fn updates_config_parse() {
+        let cfg: UpdatesConfig =
+            toml::from_str(r#"check_on_startup = false
+check_interval_secs = 3600"#)
+                .expect("parse");
+        assert!(!cfg.check_on_startup);
+        assert_eq!(cfg.check_interval_secs, 3600);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod review_state;
 mod review_store;
 mod theme;
 mod ui;
+mod update_checker;
 mod viewer_state;
 
 use std::io;
@@ -186,6 +187,31 @@ fn run_loop(
     // Schedule the first freshness check after a short delay so the UI
     // renders immediately, then we check/refresh the cache in background.
     let mut last_ccusage_poll = Instant::now() - ccusage_poll;
+
+    // ── Update check (opt-out via [updates] check_on_startup = false) ─
+    let update_check_enabled = app.config.updates.check_on_startup;
+    let update_check_interval = app.config.updates.check_interval_secs;
+    let update_result: Arc<Mutex<Option<update_checker::UpdateInfo>>> =
+        Arc::new(Mutex::new(None));
+
+    if update_check_enabled {
+        if let Some(cached) = update_checker::read_cache(update_check_interval) {
+            if update_checker::is_newer(&cached.latest_version, update_checker::current_version()) {
+                app.update_info = Some(cached);
+            }
+        }
+        // If cache was stale or missing, kick off a background check.
+        if app.update_info.is_none() && !update_checker::cache_is_fresh(update_check_interval) {
+            let result_handle = Arc::clone(&update_result);
+            std::thread::spawn(move || {
+                if let Some(info) = update_checker::check_for_update() {
+                    if let Ok(mut lock) = result_handle.lock() {
+                        *lock = Some(info);
+                    }
+                }
+            });
+        }
+    }
 
     let mut needs_redraw = true;
 
@@ -384,6 +410,18 @@ fn run_loop(
                 if let Some(info) = lock.take() {
                     app.ccusage_info = Some(info);
                     needs_redraw = true;
+                }
+            }
+        }
+
+        // Pick up update check result from background thread.
+        if update_check_enabled && app.update_info.is_none() {
+            if let Ok(mut lock) = update_result.try_lock() {
+                if let Some(info) = lock.take() {
+                    if update_checker::is_newer(&info.latest_version, update_checker::current_version()) {
+                        app.update_info = Some(info);
+                        needs_redraw = true;
+                    }
                 }
             }
         }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -300,6 +300,18 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
                 Style::default().fg(Color::LightGreen).bg(bar_bg),
             ));
         }
+        if let Some(ref update) = app.update_info {
+            if !spans.is_empty() {
+                spans.push(Span::styled(" ", Style::default().bg(bar_bg)));
+            }
+            spans.push(Span::styled(
+                format!(" ↑ v{} available ", update.latest_version),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
 
         if !spans.is_empty() {
             // Add padding spaces

--- a/src/update_checker.rs
+++ b/src/update_checker.rs
@@ -1,0 +1,221 @@
+//! Startup version check against GitHub Releases.
+//!
+//! On startup, checks `GET /repos/S-Nakamur-a/conductor/releases/latest` via
+//! `curl` (no extra dependencies). Results are cached at
+//! `~/.cache/conductor/update-check.json` with a configurable TTL (default 24h).
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Information about the latest available release.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub latest_version: String,
+    pub release_url: String,
+}
+
+/// On-disk cache representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    updated_at: u64,
+    latest_version: String,
+    release_url: String,
+}
+
+/// Return the current crate version from `Cargo.toml`.
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Return the cache file path: `~/.cache/conductor/update-check.json`.
+fn cache_path() -> Option<PathBuf> {
+    Some(dirs::cache_dir()?.join("conductor").join("update-check.json"))
+}
+
+/// Current Unix timestamp in seconds.
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Check whether the cache file exists and was written within `max_age_secs`.
+pub fn cache_is_fresh(max_age_secs: u64) -> bool {
+    let Some(path) = cache_path() else {
+        return false;
+    };
+    let Ok(data) = fs::read_to_string(&path) else {
+        return false;
+    };
+    let Ok(entry) = serde_json::from_str::<CacheEntry>(&data) else {
+        return false;
+    };
+    let age = now_epoch_secs().saturating_sub(entry.updated_at);
+    age <= max_age_secs
+}
+
+/// Read cached update info if it exists and is within `max_age_secs`.
+pub fn read_cache(max_age_secs: u64) -> Option<UpdateInfo> {
+    let path = cache_path()?;
+    let data = fs::read_to_string(&path).ok()?;
+    let entry: CacheEntry = serde_json::from_str(&data).ok()?;
+    let age = now_epoch_secs().saturating_sub(entry.updated_at);
+    if age <= max_age_secs {
+        Some(UpdateInfo {
+            latest_version: entry.latest_version,
+            release_url: entry.release_url,
+        })
+    } else {
+        None
+    }
+}
+
+/// Write cache entry atomically.
+fn write_cache(info: &UpdateInfo) {
+    let Some(path) = cache_path() else { return };
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    let entry = CacheEntry {
+        updated_at: now_epoch_secs(),
+        latest_version: info.latest_version.clone(),
+        release_url: info.release_url.clone(),
+    };
+    let Ok(json) = serde_json::to_string(&entry) else {
+        return;
+    };
+    let tmp = path.with_extension("tmp");
+    if fs::write(&tmp, &json).is_ok() {
+        let _ = fs::rename(&tmp, &path);
+    }
+}
+
+/// Query GitHub Releases API via `curl`, write cache, and return the result.
+///
+/// Returns `None` on network errors, 404 (no releases yet), or parse failures.
+pub fn check_for_update() -> Option<UpdateInfo> {
+    let output = std::process::Command::new("curl")
+        .args([
+            "-sfL",
+            "--max-time",
+            "5",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "https://api.github.com/repos/S-Nakamur-a/conductor/releases/latest",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8(output.stdout).ok()?;
+    let val: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+    let tag = val.get("tag_name")?.as_str()?;
+    let html_url = val
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Strip leading 'v' if present (e.g. "v0.3.0" → "0.3.0").
+    let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
+
+    let info = UpdateInfo {
+        latest_version: version,
+        release_url: html_url,
+    };
+    write_cache(&info);
+    Some(info)
+}
+
+/// Compare two semver strings (`major.minor.patch`).
+///
+/// Returns `true` if `latest` is strictly newer than `current`.
+/// Non-parseable versions return `false`.
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    let parse = |s: &str| -> Option<(u64, u64, u64)> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return None;
+        }
+        Some((
+            parts[0].parse().ok()?,
+            parts[1].parse().ok()?,
+            parts[2].parse().ok()?,
+        ))
+    };
+
+    let Some((lmaj, lmin, lpat)) = parse(latest) else {
+        return false;
+    };
+    let Some((cmaj, cmin, cpat)) = parse(current) else {
+        return false;
+    };
+
+    (lmaj, lmin, lpat) > (cmaj, cmin, cpat)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_major() {
+        assert!(is_newer("2.0.0", "1.9.9"));
+    }
+
+    #[test]
+    fn newer_minor() {
+        assert!(is_newer("1.1.0", "1.0.9"));
+    }
+
+    #[test]
+    fn newer_patch() {
+        assert!(is_newer("1.0.1", "1.0.0"));
+    }
+
+    #[test]
+    fn same_version() {
+        assert!(!is_newer("1.0.0", "1.0.0"));
+    }
+
+    #[test]
+    fn older_version() {
+        assert!(!is_newer("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn invalid_latest() {
+        assert!(!is_newer("abc", "1.0.0"));
+    }
+
+    #[test]
+    fn invalid_current() {
+        assert!(!is_newer("1.0.0", "abc"));
+    }
+
+    #[test]
+    fn two_part_version() {
+        assert!(!is_newer("1.0", "1.0.0"));
+    }
+
+    #[test]
+    fn current_version_is_valid() {
+        let v = current_version();
+        let parts: Vec<&str> = v.split('.').collect();
+        assert_eq!(parts.len(), 3, "CARGO_PKG_VERSION should be major.minor.patch");
+    }
+}


### PR DESCRIPTION
## Summary

- 起動時に GitHub Releases API (`curl`) で最新バージョンをチェック
- 新バージョンがあればタイトルバー右側に黄色バッジ `↑ vX.Y.Z available` を表示
- キャッシュ (`~/.cache/conductor/update-check.json`) で24時間有効、重複チェックを回避
- `[updates] check_on_startup = false` で opt-out 可能

## Test plan

- [x] `cargo test` — config パース、semver 比較 (is_newer) のテスト全67件パス
- [x] `cargo clippy` — 警告なし
- [ ] `cargo run` で起動し、GitHub Releases 未作成時にエラーが出ないこと確認
- [ ] GitHub Release 作成後、古いバージョンで起動してバッジ表示を確認
- [ ] `[updates] check_on_startup = false` で無効化できること確認