### PR TITLE
refactor: 削除キーバインドを x から Delete キーに変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -180,7 +180,7 @@ pub const COMMANDS: &[PaletteCommand] = &[
     PaletteCommand { id: CommandId::ViewCommentDetail, label: "Review: View Comment Detail",
         category: CommandCategory::Review, keybinding: Some("Space"), keywords: "detail preview" },
     PaletteCommand { id: CommandId::DeleteComment, label: "Review: Delete Comment",
-        category: CommandCategory::Review, keybinding: Some("x"), keywords: "remove delete" },
+        category: CommandCategory::Review, keybinding: Some("Del"), keywords: "remove delete" },
     PaletteCommand { id: CommandId::ToggleCommentResolve, label: "Review: Toggle Resolve",
         category: CommandCategory::Review, keybinding: Some("r"), keywords: "resolve unresolve status" },
     PaletteCommand { id: CommandId::EditComment, label: "Review: Edit Comment",

--- a/src/event.rs
+++ b/src/event.rs
@@ -675,7 +675,7 @@ fn handle_explorer_comment_list_key(app: &mut App, key: KeyEvent) {
         KeyCode::Esc => {
             app.viewer_state.explorer_focus_on_diff_list = false;
         }
-        KeyCode::Char('x') => {
+        KeyCode::Delete => {
             // Delete the selected comment (resolve via parent).
             if row_count > 0 {
                 app.delete_selected_review_comment();
@@ -1555,7 +1555,7 @@ fn handle_comment_detail_key(app: &mut App, key: KeyEvent) {
             app.review_state.selected = idx;
             app.review_state.comment_detail_active = false;
         }
-        KeyCode::Char('x') => {
+        KeyCode::Delete => {
             // Delete from the detail view.
             let idx = app.review_state.comment_detail_idx;
             app.review_state.selected = idx;
@@ -1787,7 +1787,7 @@ fn handle_review_template_key(app: &mut App, key: KeyEvent) {
         KeyCode::Esc => {
             app.review_state.template_picker_active = false;
         }
-        KeyCode::Char('x') => {
+        KeyCode::Delete => {
             if let Some(tmpl) =
                 app.review_state.templates.get(app.review_state.template_selected)
             {

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1021,7 +1021,7 @@ fn help_lines_for(focus: crate::app::Focus, theme: &Theme) -> Vec<Line<'static>>
             help_key(&mut lines, "Enter / l", "Expand/collapse replies or jump", theme);
             help_key(&mut lines, "h", "Collapse thread", theme);
             help_key(&mut lines, "e", "Edit selected comment", theme);
-            help_key(&mut lines, "x", "Delete selected comment", theme);
+            help_key(&mut lines, "Del", "Delete selected comment", theme);
             help_key(&mut lines, "r", "Toggle resolve/pending", theme);
             help_key(&mut lines, "R", "Reply to comment", theme);
             help_key(&mut lines, "Esc", "Back to file tree", theme);

--- a/src/ui/review.rs
+++ b/src/ui/review.rs
@@ -160,7 +160,7 @@ pub fn render_template_picker_overlay(frame: &mut Frame, area: Rect, state: &Rev
     frame.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(" Templates (Enter: use, x: delete, Esc: close) ")
+        .title(" Templates (Enter: use, Del: delete, Esc: close) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme.border_focused));
 
@@ -238,7 +238,7 @@ pub fn render_comment_detail_overlay(frame: &mut Frame, area: Rect, app: &mut Ap
         crate::review_store::CommentStatus::Resolved => "\u{2713} Resolved",
     };
 
-    let title = format!(" {icon} {kind_label} \u{2502} {status_label} (Esc/q: close, e: edit, R: reply, r: resolve, x: delete) ");
+    let title = format!(" {icon} {kind_label} \u{2502} {status_label} (Esc/q: close, e: edit, R: reply, r: resolve, Del: delete) ");
 
     let block = Block::default()
         .title(title)


### PR DESCRIPTION
## Summary
- 削除アクション（レビューコメント削除、テンプレート削除）のキーバインドを `x` から `Delete` キーに変更
- UI上のヘルプテキスト・コマンドパレットの表示を `Del` に更新
- バージョンを 0.2.0 → 0.2.1 に bump

## Test plan
- [x] `cargo check` — エラーなし
- [x] `cargo clippy` — 警告なし
- レビューコメント一覧で `Delete` キーによるコメント削除が動作すること
- コメント詳細ビューで `Delete` キーによる削除が動作すること
- テンプレートピッカーで `Delete` キーによるテンプレート削除が動作すること