### PR TITLE
fix: add conductor: prefix to skill invocations and optimize dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.50.0"
+version = "0.50.1"
 edition = "2024"
 
 [dependencies]
@@ -36,6 +36,12 @@ tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 tree-sitter-go = "0.25"
 tree-sitter-typescript = "0.23"
+
+[profile.dev]
+debug = "limited"
+
+[profile.dev.package."*"]
+opt-level = 2
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -9,9 +9,9 @@ use crate::terminal_link;
 use super::explorer::{navigate_to_comment_with_focus, open_viewer_comment};
 use super::terminal::{handle_terminal_tab_click, spawn_terminal_session};
 
-/// Send all pending comments to Claude via /address-conductor-comment (no ID = bulk mode).
+/// Send all pending comments to Claude via /conductor:address-conductor-comment (no ID = bulk mode).
 fn ask_claude_all_comments(app: &mut App) {
-    let prompt = "/address-conductor-comment\n".to_string();
+    let prompt = "/conductor:address-conductor-comment\n".to_string();
     if let Some(idx) = app.terminal.active_claude_session {
         if app.terminal.pty_manager.is_waiting_for_input(idx) {
             let _ = app.terminal.pty_manager.write_chunked_to_session(idx, &prompt);
@@ -47,7 +47,7 @@ fn resolve_screen_line(app: &App, screen_offset: usize) -> Option<usize> {
 
 /// Send a comment to the active Claude Code PTY via the address-conductor-comment skill.
 fn ask_claude_about_comment(app: &mut App, comment_id: &str) {
-    let prompt = format!("/address-conductor-comment {comment_id}\n");
+    let prompt = format!("/conductor:address-conductor-comment {comment_id}\n");
 
     // Write to the active Claude Code session.
     if let Some(idx) = app.terminal.active_claude_session {


### PR DESCRIPTION
## Summary
- Fix skill invocation prefix: `/address-conductor-comment` → `/conductor:address-conductor-comment` (3箇所)
- Add dev profile optimization: `debug = "limited"` and `opt-level = 2` for dependencies

## Test plan
- [ ] Conductor UI からコメントの「Ask Claude」ボタンが正しくスキルを呼び出せることを確認
- [ ] `cargo build` が dev profile 設定で正常にビルドできることを確認
