### PR TITLE
feat: push UI refresh from MCP via named pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -431,6 +431,7 @@ dependencies = [
  "git2",
  "ignore",
  "image",
+ "libc",
  "log",
  "notify",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.50.1"
+version = "0.51.0"
 edition = "2024"
 
 [dependencies]
@@ -36,6 +36,7 @@ tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 tree-sitter-go = "0.25"
 tree-sitter-typescript = "0.23"
+libc = "0.2"
 
 [profile.dev]
 debug = "limited"

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -68,6 +68,33 @@ function currentBranch(): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// UI refresh signal
+// ---------------------------------------------------------------------------
+
+/**
+ * Write to the named pipe `.conductor/refresh.pipe` to trigger a UI refresh
+ * in the Conductor TUI.  Non-blocking and best-effort — silently ignores
+ * errors (pipe may not exist if TUI is not running).
+ */
+function signalUiRefresh(): void {
+  // Derive the pipe path from the DB path (sibling file in .conductor/).
+  try {
+    const dbPath = findDbPath();
+    const pipePath = path.join(path.dirname(dbPath), "refresh.pipe");
+
+    // Open with O_WRONLY | O_NONBLOCK (flag 0x0001 | 0x0004 on macOS,
+    // but we use fs constants).  If the pipe doesn't exist or no reader
+    // is attached, this will throw — which we silently catch.
+    const fd = fs.openSync(pipePath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+    fs.writeSync(fd, "r");
+    fs.closeSync(fd);
+  } catch {
+    // Pipe not available — TUI is not running or pipe doesn't exist.
+    // This is expected and harmless.
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -331,6 +358,8 @@ server.tool(
       "INSERT INTO review_replies (id, review_id, body, author) VALUES (?, ?, ?, 'claude')"
     ).run(id, resolvedId, body);
 
+    signalUiRefresh();
+
     return {
       content: [
         {
@@ -396,6 +425,8 @@ server.tool(
         isError: true,
       };
     }
+
+    signalUiRefresh();
 
     return {
       content: [

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod config;
 mod diff_state;
 mod event;
 mod file_watcher;
+mod refresh_pipe;
 mod git_engine;
 mod grep_search;
 mod keymap;
@@ -199,6 +200,9 @@ fn run_loop(
 
     // Set up socket listener for CC state notifications (instant delivery).
     let cc_notify = crate::cc_notify::CcNotifyListener::new(&app.repo_path).ok();
+
+    // Set up named pipe for MCP-triggered review refresh.
+    let refresh_pipe = crate::refresh_pipe::RefreshPipe::new(&app.repo_path).ok();
 
     let mut last_frame_area = Rect::default();
     let mut last_claude_size: (u16, u16) = (0, 0);
@@ -497,6 +501,17 @@ fn run_loop(
             while let Some(event) = cc_notify.poll() {
                 app.handle_cc_notify(event);
                 app.dirty.mark(crate::app::DirtyPanels::WORKTREE | crate::app::DirtyPanels::TERMINAL);
+            }
+        }
+
+        // MCP refresh pipe — reload review comments when MCP writes to the pipe.
+        if let Some(ref refresh_pipe) = refresh_pipe {
+            if refresh_pipe.poll().is_some() {
+                // Drain any extra events (coalesce multiple rapid writes).
+                while refresh_pipe.poll().is_some() {}
+                app.refresh_reviews();
+                app.dirty.mark_all();
+                log::debug!("refresh_pipe: reloaded reviews from MCP trigger");
             }
         }
 

--- a/src/refresh_pipe.rs
+++ b/src/refresh_pipe.rs
@@ -1,0 +1,281 @@
+//! Named pipe (FIFO) listener for MCP-triggered UI refresh.
+//!
+//! The MCP server writes to `.conductor/refresh.pipe` after modifying review
+//! data (reply, resolve, etc.).  A background thread reads from the pipe and
+//! forwards events through an `mpsc` channel to the main loop, which then
+//! calls `refresh_reviews()`.
+
+use std::io::Read;
+use std::os::unix::io::{FromRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+/// Event sent when MCP writes to the refresh pipe.
+#[derive(Debug)]
+pub struct RefreshEvent;
+
+/// Listens on a named pipe for UI refresh signals from the MCP server.
+pub struct RefreshPipe {
+    rx: mpsc::Receiver<RefreshEvent>,
+    pipe_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl RefreshPipe {
+    /// Create a new listener bound to `.conductor/refresh.pipe` under the
+    /// given repository root.
+    pub fn new(repo_path: &Path) -> anyhow::Result<Self> {
+        let conductor_dir = crate::git_engine::GitEngine::open(repo_path)
+            .and_then(|e| e.main_worktree_path())
+            .unwrap_or_else(|_| repo_path.to_path_buf())
+            .join(".conductor");
+        std::fs::create_dir_all(&conductor_dir)?;
+
+        let pipe_path = conductor_dir.join("refresh.pipe");
+
+        // Remove stale pipe from a previous run and recreate.
+        if pipe_path.exists() {
+            let _ = std::fs::remove_file(&pipe_path);
+        }
+
+        // Create the FIFO.
+        let path_cstr = std::ffi::CString::new(
+            pipe_path.to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 path"))?,
+        )?;
+        // SAFETY: mkfifo is a standard POSIX call; path_cstr is valid and
+        // null-terminated.  Mode 0o660 gives owner+group read/write.
+        let ret = unsafe { libc::mkfifo(path_cstr.as_ptr(), 0o660) };
+        if ret != 0 {
+            return Err(anyhow::anyhow!(
+                "mkfifo failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_flag = Arc::clone(&shutdown);
+        let path_for_thread = pipe_path.clone();
+
+        let thread = std::thread::Builder::new()
+            .name("refresh-pipe".into())
+            .spawn(move || {
+                Self::read_loop(path_for_thread, tx, shutdown_flag);
+            })?;
+
+        Ok(Self {
+            rx,
+            pipe_path,
+            shutdown,
+            thread: Some(thread),
+        })
+    }
+
+    /// Non-blocking poll for the next event.
+    pub fn poll(&self) -> Option<RefreshEvent> {
+        self.rx.try_recv().ok()
+    }
+
+    fn read_loop(
+        pipe_path: PathBuf,
+        tx: mpsc::Sender<RefreshEvent>,
+        shutdown: Arc<AtomicBool>,
+    ) {
+        // We loop re-opening the pipe because a FIFO returns EOF when all
+        // writers close.  After each EOF we re-open to wait for the next
+        // writer.
+        while !shutdown.load(Ordering::Relaxed) {
+            // Open the FIFO for reading (blocking until a writer connects).
+            // We use raw libc::open because Rust's File::open does not
+            // support O_NONBLOCK at open time on FIFOs.
+            let path_cstr = match std::ffi::CString::new(
+                pipe_path.to_string_lossy().as_ref(),
+            ) {
+                Ok(c) => c,
+                Err(_) => break,
+            };
+
+            // SAFETY: standard POSIX open; path_cstr is valid and null-terminated.
+            let fd: RawFd =
+                unsafe { libc::open(path_cstr.as_ptr(), libc::O_RDONLY) };
+            if fd < 0 {
+                // Pipe was removed (shutdown or cleanup).
+                break;
+            }
+
+            // Wrap in a File for convenient reading. SAFETY: fd is a valid
+            // open file descriptor that we own exclusively.
+            let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+
+            let mut buf = [0u8; 64];
+            loop {
+                if shutdown.load(Ordering::Relaxed) {
+                    return;
+                }
+                match file.read(&mut buf) {
+                    Ok(0) => {
+                        // EOF — all writers closed. Re-open.
+                        break;
+                    }
+                    Ok(_) => {
+                        if tx.send(RefreshEvent).is_err() {
+                            // Receiver dropped — main loop exited.
+                            return;
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        continue;
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Small sleep before re-opening to avoid busy-loop on rapid
+            // EOF cycles.
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Create a listener from an explicit pipe path (for testing).
+    #[cfg(test)]
+    fn from_path(pipe_path: PathBuf) -> anyhow::Result<Self> {
+        if pipe_path.exists() {
+            let _ = std::fs::remove_file(&pipe_path);
+        }
+
+        let path_cstr = std::ffi::CString::new(
+            pipe_path.to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 path"))?,
+        )?;
+        let ret = unsafe { libc::mkfifo(path_cstr.as_ptr(), 0o660) };
+        if ret != 0 {
+            return Err(anyhow::anyhow!(
+                "mkfifo failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_flag = Arc::clone(&shutdown);
+        let path_for_thread = pipe_path.clone();
+
+        let thread = std::thread::Builder::new()
+            .name("refresh-pipe-test".into())
+            .spawn(move || {
+                Self::read_loop(path_for_thread, tx, shutdown_flag);
+            })?;
+
+        Ok(Self {
+            rx,
+            pipe_path,
+            shutdown,
+            thread: Some(thread),
+        })
+    }
+}
+
+impl Drop for RefreshPipe {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+
+        // Unblock the reader by opening the pipe for writing briefly.
+        if self.pipe_path.exists() {
+            let path_cstr = std::ffi::CString::new(
+                self.pipe_path.to_string_lossy().as_ref(),
+            );
+            if let Ok(cstr) = path_cstr {
+                // SAFETY: standard POSIX open with O_WRONLY | O_NONBLOCK.
+                // O_NONBLOCK prevents blocking if no reader exists.
+                unsafe {
+                    let fd = libc::open(
+                        cstr.as_ptr(),
+                        libc::O_WRONLY | libc::O_NONBLOCK,
+                    );
+                    if fd >= 0 {
+                        libc::close(fd);
+                    }
+                }
+            }
+        }
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        let _ = std::fs::remove_file(&self.pipe_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write to the FIFO the same way the MCP server does (O_WRONLY | O_NONBLOCK).
+    fn write_to_pipe(pipe_path: &Path) {
+        let path_cstr =
+            std::ffi::CString::new(pipe_path.to_str().unwrap()).unwrap();
+        unsafe {
+            let fd =
+                libc::open(path_cstr.as_ptr(), libc::O_WRONLY | libc::O_NONBLOCK);
+            assert!(fd >= 0, "failed to open pipe for writing");
+            let mut file = std::fs::File::from_raw_fd(fd);
+            file.write_all(b"r").unwrap();
+            // file is dropped here, closing the fd.
+        }
+    }
+
+    #[test]
+    fn single_write_produces_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipe_path = dir.path().join("refresh.pipe");
+        let listener = RefreshPipe::from_path(pipe_path.clone()).unwrap();
+
+        // Give the background thread time to open the pipe for reading.
+        std::thread::sleep(Duration::from_millis(100));
+
+        write_to_pipe(&pipe_path);
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(listener.poll().is_some(), "expected a RefreshEvent");
+
+        drop(listener);
+        assert!(!pipe_path.exists(), "pipe should be cleaned up on drop");
+    }
+
+    #[test]
+    fn multiple_writes_produce_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipe_path = dir.path().join("refresh.pipe");
+        let listener = RefreshPipe::from_path(pipe_path.clone()).unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        write_to_pipe(&pipe_path);
+        // Writer closes → EOF → reader re-opens. Wait for re-open.
+        std::thread::sleep(Duration::from_millis(200));
+
+        write_to_pipe(&pipe_path);
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Should have received at least 2 events.
+        let mut count = 0;
+        while listener.poll().is_some() {
+            count += 1;
+        }
+        assert!(count >= 2, "expected at least 2 events, got {count}");
+    }
+
+    #[test]
+    fn no_event_without_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipe_path = dir.path().join("refresh.pipe");
+        let listener = RefreshPipe::from_path(pipe_path).unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(listener.poll().is_none(), "expected no event");
+    }
+}


### PR DESCRIPTION
## Summary

- MCP サーバ (`reply_to_comment` / `resolve_comment`) からレビューDBを更新した直後に、TUI 側で即座にレビューをリロードできるよう **named pipe (FIFO)** ベースの即時リフレッシュ機構を追加
- Rust 側に `RefreshPipe` を新設し、`.conductor/refresh.pipe` を作成して専用スレッドで読み取り。`mpsc` チャネル経由で main loop に通知し `app.refresh_reviews()` を実行
- Node MCP 側に `signalUiRefresh()` を追加し、`O_WRONLY | O_NONBLOCK` でベストエフォート書き込み（TUI 未起動時は黙ってスキップ）

## Why

これまで MCP からの DB 更新は file watcher / 3秒ポーリング頼りで反映が遅れた。push 通知化することで、Claude Code がコメントに reply / resolve した瞬間に UI が追従する。

## Versioning

- `0.50.1` → `0.51.0` (MINOR: 後方互換のある機能追加)
- 新規依存: `libc = "0.2"` (mkfifo / open 直叩き用)

## Test plan

- [x] `cargo check` 通過
- [x] `refresh_pipe.rs` 内に 3 つの単体テスト (single write / multiple writes / no event)
- [ ] 実機で MCP からの reply / resolve 後に TUI のレビュー一覧が即時更新されることを確認
