### PR TITLE
feat: add api.provider option to skip Gemini and call claude CLI directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -55,7 +55,7 @@ const SMART_WORKTREE_JSON_SCHEMA: &str = r#"{"type":"object","properties":{"bran
 
 /// Fallback: call `claude -p` CLI with the same system prompt and description.
 fn run_smart_generation_claude_cli(desc: &str) -> Result<String, String> {
-    log::info!("Smart worktree: falling back to claude -p CLI");
+    log::info!("Smart worktree: using claude -p CLI");
     let output = std::process::Command::new("claude")
         .args(["-p", "--output-format", "json"])
         .arg("--json-schema")
@@ -86,25 +86,32 @@ fn run_smart_generation_claude_cli(desc: &str) -> Result<String, String> {
 
 /// Run the LLM generation for smart worktree (branch name + prompt).
 ///
-/// Tries the Gemini API first; if it fails, falls back to `claude -p` CLI.
+/// Provider selection (from `[api] provider`):
+/// - `"gemini"` (default): try Gemini API first; on error fall back to `claude -p` CLI.
+/// - `"claude"`: skip Gemini and call `claude -p` CLI directly.
+///
 /// Checks `cancel_token` before each call; the API calls are blocking.
-fn run_smart_generation(desc: &str, cancel_token: &Arc<AtomicBool>, model: &str) -> Result<SmartGenResult, String> {
+fn run_smart_generation(desc: &str, cancel_token: &Arc<AtomicBool>, model: &str, provider: &str) -> Result<SmartGenResult, String> {
     if cancel_token.load(Ordering::Relaxed) {
         return Err("Cancelled".to_string());
     }
 
-    // Phase 1: Try Gemini API.
-    let raw = match crate::gemini_api::call_messages_api(SMART_WORKTREE_SYSTEM_PROMPT, desc, Some(model), 1024) {
-        Ok(raw) => raw,
-        Err(gemini_err) => {
-            log::warn!("Gemini API failed, falling back to claude CLI: {gemini_err}");
+    let raw = if provider.eq_ignore_ascii_case("claude") {
+        run_smart_generation_claude_cli(desc)?
+    } else {
+        // Phase 1: Try Gemini API.
+        match crate::gemini_api::call_messages_api(SMART_WORKTREE_SYSTEM_PROMPT, desc, Some(model), 1024) {
+            Ok(raw) => raw,
+            Err(gemini_err) => {
+                log::warn!("Gemini API failed, falling back to claude CLI: {gemini_err}");
 
-            if cancel_token.load(Ordering::Relaxed) {
-                return Err("Cancelled".to_string());
+                if cancel_token.load(Ordering::Relaxed) {
+                    return Err("Cancelled".to_string());
+                }
+
+                // Phase 1b: Fallback to claude -p CLI.
+                run_smart_generation_claude_cli(desc)?
             }
-
-            // Phase 1b: Fallback to claude -p CLI.
-            run_smart_generation_claude_cli(desc)?
         }
     };
 
@@ -777,6 +784,7 @@ impl App {
 
         let tx = self.worktree_op_sender();
         let api_model = self.config.api.model.clone();
+        let api_provider = self.config.api.provider.clone();
 
         let cancel = cancel_token;
         std::thread::spawn(move || {
@@ -784,7 +792,7 @@ impl App {
             let desc_panic = desc.clone();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 // Phase 1: LLM generation.
-                let gen_result = match run_smart_generation(&desc, &cancel, &api_model) {
+                let gen_result = match run_smart_generation(&desc, &cancel, &api_model, &api_provider) {
                     Ok(r) => r,
                     Err(e) => {
                         let _ = tx.send(WorktreeOpResult::SmartFailed {

--- a/src/config.rs
+++ b/src/config.rs
@@ -309,12 +309,17 @@ impl Default for UpdatesConfig {
 pub struct ApiConfig {
     /// Model ID for the Gemini API.
     pub model: String,
+    /// Which LLM provider to use for smart worktree generation.
+    /// `"gemini"` (default): try Gemini first, fall back to claude CLI on error.
+    /// `"claude"`: skip Gemini and call claude CLI directly.
+    pub provider: String,
 }
 
 impl Default for ApiConfig {
     fn default() -> Self {
         Self {
             model: String::from("gemini-2.5-flash"),
+            provider: String::from("gemini"),
         }
     }
 }
@@ -413,6 +418,7 @@ pub fn generate_default_config() -> String {
 # check_interval_secs = 3600            # minimum interval between checks (default: 1h)
 
 [api]
+# provider = "gemini"                   # "gemini" (try Gemini, fall back to claude CLI) or "claude" (skip Gemini)
 # model = "gemini-2.5-flash"            # model for smart worktree generation (Gemini API)
 "#,
     )


### PR DESCRIPTION
## Summary

Smart worktree generation の LLM provider を `[api] provider` で切替可能に。

- `"gemini"` (default): 現状どおり Gemini API を呼び、失敗時 `claude -p` にフォールバック
- `"claude"`: Gemini をスキップして直接 `claude -p` を呼ぶ

GEMINI_API_KEY が無効/未設定でも、毎回 Gemini で失敗 → CLI フォールバックという待ち時間を省けます。

## Changes

- `src/config.rs`: `ApiConfig` に `provider: String` 追加 (default `"gemini"`)。サンプル config にコメント追記
- `src/app/worktree.rs`: `run_smart_generation` が `provider == "claude"` のとき Gemini をスキップ
- `Cargo.toml`: 0.51.0 → 0.52.0 (MINOR — 後方互換のある新オプション)

## Test plan

- [x] `cargo check`
- [x] `cargo test --bin conductor parse` (既存 parse_smart_gen_result テスト通過)
- [ ] `~/.config/conductor/config.toml` に `[api] provider = "claude"` を書いて smart worktree を起動、Gemini を経由せず claude CLI を呼ぶことを確認
- [ ] `provider` 未設定時は従来どおり Gemini → claude CLI フォールバックを確認
