### PR TITLE
feat: review navigation, Claude self-review comments, and jump-to-expand hotkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.53.0"
+version = "0.53.1"
 edition = "2024"
 
 [dependencies]

--- a/plugins/conductor/mcp/conductor-comment/package.json
+++ b/plugins/conductor/mcp/conductor-comment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -128,7 +128,7 @@ interface ReviewReply {
 
 const server = new McpServer({
   name: "conductor",
-  version: "0.1.0",
+  version: "0.3.0",
 });
 
 let db: Database.Database;
@@ -433,6 +433,134 @@ server.tool(
         {
           type: "text" as const,
           text: `Comment ${resolvedId.slice(0, 8)} marked as resolved.`,
+        },
+      ],
+    };
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Tool: create_comment
+// ---------------------------------------------------------------------------
+
+server.tool(
+  "create_comment",
+  "Leave an inline self-review comment on a specific file and line range in the current branch's diff. Author is automatically set to 'claude' and the comment appears inline in the Conductor diff view. " +
+    "Use this SPARINGLY and with high signal: flag ONLY what a human reviewer genuinely needs to know — non-obvious or tricky logic, deliberate tradeoffs, decisions worth a second look, or places you are unsure about. " +
+    "Do NOT narrate routine changes or restate what the diff already makes obvious; a flood of low-value comments defeats the purpose. Prefer a handful of important notes over many.",
+  {
+    file_path: z
+      .string()
+      .describe("Repo-relative file path the comment attaches to (e.g. src/foo.rs)"),
+    line_start: z
+      .number()
+      .int()
+      .positive()
+      .describe("1-based line number the comment starts on"),
+    line_end: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "1-based end line for a multi-line range; omit for a single-line comment"
+      ),
+    body: z.string().min(1).describe("The comment text"),
+    kind: z
+      .enum(["suggest", "question"])
+      .optional()
+      .describe(
+        "'suggest' (default) for a note/observation/tradeoff; 'question' when you want the human to answer something"
+      ),
+  },
+  async ({ file_path, line_start, line_end, body, kind }) => {
+    const d = getDb();
+
+    if (line_end !== undefined && line_end < line_start) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Invalid range: line_end (${line_end}) is before line_start (${line_start}).`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // Comments are rendered inline keyed on the file path. An absolute or
+    // dot-prefixed path won't match the repo-relative key the TUI uses, so the
+    // comment would insert successfully but never appear — fail loudly instead.
+    if (path.isAbsolute(file_path)) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `file_path must be repo-relative (e.g. src/foo.rs), got absolute path: ${file_path}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    const relPath = file_path.replace(/^\.\//, "");
+
+    // Comments are keyed to a branch/worktree. The Rust side stores the
+    // worktree's branch name in both the `worktree` and `branch` columns
+    // (see add_review in review_store.rs), and uses the symbolic ref "HEAD"
+    // as commit_ref — mirror that exactly so the comment shows up in the TUI.
+    // A detached HEAD reports the literal "HEAD", which is not a usable key.
+    const branch = currentBranch();
+    if (!branch || branch === "HEAD") {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Cannot determine the current git branch (detached HEAD?); a comment must be attached to a branch.",
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const id = crypto.randomUUID();
+    try {
+      d.prepare(
+        `INSERT INTO reviews
+           (id, worktree, file_path, line_start, line_end, kind, body, commit_ref, author, branch)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'HEAD', 'claude', ?)`
+      ).run(
+        id,
+        branch,
+        relPath,
+        line_start,
+        line_end ?? null,
+        kind ?? "suggest",
+        body,
+        branch
+      );
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to create comment: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    signalUiRefresh();
+
+    const loc = line_end
+      ? `${relPath}:${line_start}-${line_end}`
+      : `${relPath}:${line_start}`;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Comment created (id: ${id.slice(0, 8)}) at ${loc} on branch "${branch}".`,
         },
       ],
     };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -906,6 +906,16 @@ impl App {
         self.focus = focus;
     }
 
+    /// Focus a panel and expand it to full width in a single action.
+    ///
+    /// `set_focus` clears `expanded_panel` whenever focus moves to a panel the
+    /// current expansion wouldn't cover, so the expansion is set *after*
+    /// focusing to keep `focus` and `expanded_panel` consistent.
+    pub fn focus_and_expand(&mut self, focus: Focus) {
+        self.set_focus(focus);
+        self.expanded_panel = Some(focus);
+    }
+
     /// Request the application to quit.
     pub fn quit(&mut self) {
         self.should_quit = true;

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -35,6 +35,10 @@ impl App {
             .map(|w| w.branch.clone());
 
         if let Some(store) = &self.review_store {
+            // Invariant: a comment's `worktree` column stores the branch name,
+            // `commit_ref` is the symbolic "HEAD", and `branch` is the same
+            // branch. The MCP `create_comment` tool (plugins/.../mcp) is a
+            // sibling writer that mirrors this exactly — keep the two in sync.
             let wt = self.selected_worktree_branch();
             match store.add_review(
                 &wt,

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -32,6 +32,16 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
         Action::FocusViewer => { app.set_focus(Focus::Viewer); true }
         Action::FocusTerminalClaude => { app.set_focus(Focus::TerminalClaude); true }
         Action::FocusTerminalShell => { app.set_focus(Focus::TerminalShell); true }
+        Action::FocusExpandWorktree => { app.focus_and_expand(Focus::Worktree); true }
+        Action::FocusExpandExplorer => { app.focus_and_expand(Focus::Explorer); true }
+        Action::FocusExpandExplorerDiffList => {
+            app.focus_and_expand(Focus::Explorer);
+            app.viewer_state.explorer.explorer_focus_on_diff_list = true;
+            true
+        }
+        Action::FocusExpandViewer => { app.focus_and_expand(Focus::Viewer); true }
+        Action::FocusExpandTerminalClaude => { app.focus_and_expand(Focus::TerminalClaude); true }
+        Action::FocusExpandTerminalShell => { app.focus_and_expand(Focus::TerminalShell); true }
         Action::NewClaudeCode => {
             app.set_status("Starting Claude Code...".to_string(), StatusLevel::Info);
             if let Err(e) = app.spawn_claude_code() {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -105,7 +105,13 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             | Action::FocusExplorerDiffList
             | Action::FocusViewer
             | Action::FocusTerminalClaude
-            | Action::FocusTerminalShell => {
+            | Action::FocusTerminalShell
+            | Action::FocusExpandWorktree
+            | Action::FocusExpandExplorer
+            | Action::FocusExpandExplorerDiffList
+            | Action::FocusExpandViewer
+            | Action::FocusExpandTerminalClaude
+            | Action::FocusExpandTerminalShell => {
                 dismiss_overlays(app);
                 dispatch_global_action(app, action);
                 return;

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -2,8 +2,12 @@
 
 use crossterm::event::{KeyCode, KeyEvent};
 
+use std::collections::HashMap;
+
 use crate::app::{App, StatusLevel};
+use crate::diff_state::DiffLineTag;
 use crate::keymap::{Action, KeyContext};
+use crate::viewer::UnifiedDiffEntry;
 
 use super::explorer::open_viewer_comment_detail;
 
@@ -190,6 +194,42 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
         Some(Action::GoToBottom) => {
             app.viewer_state.diff_view.diff_view_scroll = total.saturating_sub(1);
         }
+        Some(Action::NextHunk) => {
+            let lines = &app.viewer_state.diff_view.diff_view_lines;
+            if let Some(idx) =
+                next_change_block(lines, app.viewer_state.diff_view.diff_view_scroll)
+            {
+                app.viewer_state.diff_view.diff_view_scroll = idx;
+            }
+        }
+        Some(Action::PrevHunk) => {
+            let lines = &app.viewer_state.diff_view.diff_view_lines;
+            if let Some(idx) =
+                prev_change_block(lines, app.viewer_state.diff_view.diff_view_scroll)
+            {
+                app.viewer_state.diff_view.diff_view_scroll = idx;
+            }
+        }
+        Some(Action::NextComment) => {
+            let idx = next_comment_line(
+                &app.viewer_state.diff_view.diff_view_lines,
+                &app.review_state.file_comments,
+                app.viewer_state.diff_view.diff_view_scroll,
+            );
+            if let Some(idx) = idx {
+                app.viewer_state.diff_view.diff_view_scroll = idx;
+            }
+        }
+        Some(Action::PrevComment) => {
+            let idx = prev_comment_line(
+                &app.viewer_state.diff_view.diff_view_lines,
+                &app.review_state.file_comments,
+                app.viewer_state.diff_view.diff_view_scroll,
+            );
+            if let Some(idx) = idx {
+                app.viewer_state.diff_view.diff_view_scroll = idx;
+            }
+        }
         Some(Action::ScrollLeft) => {
             app.viewer_state.content.h_scroll = app.viewer_state.content.h_scroll.saturating_sub(4);
         }
@@ -222,6 +262,66 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
         }
         _ => {}
     }
+}
+
+// ── Diff navigation helpers ──────────────────────────────────────────
+
+/// A changed (added or removed) line in the unified diff.
+fn is_change_line(entry: &UnifiedDiffEntry) -> bool {
+    matches!(
+        entry,
+        UnifiedDiffEntry::Line {
+            tag: DiffLineTag::Insert | DiffLineTag::Delete,
+            ..
+        }
+    )
+}
+
+/// `true` when index `i` is the first line of a contiguous block of changes.
+fn is_change_block_start(lines: &[UnifiedDiffEntry], i: usize) -> bool {
+    is_change_line(&lines[i]) && (i == 0 || !is_change_line(&lines[i - 1]))
+}
+
+/// Index of the next change block strictly after `from`.
+fn next_change_block(lines: &[UnifiedDiffEntry], from: usize) -> Option<usize> {
+    (from + 1..lines.len()).find(|&i| is_change_block_start(lines, i))
+}
+
+/// Index of the previous change block strictly before `from`.
+fn prev_change_block(lines: &[UnifiedDiffEntry], from: usize) -> Option<usize> {
+    (0..from).rev().find(|&i| is_change_block_start(lines, i))
+}
+
+/// `true` when the diff entry carries a review comment. A `Line` matches when
+/// its new-file line number has a comment; a collapsed `ExpandableContext`
+/// matches when any hidden line in its range does, so a comment that currently
+/// sits inside a fold is still reachable (the jump lands on the fold to expand).
+fn entry_has_comment<V>(entry: &UnifiedDiffEntry, comments: &HashMap<usize, V>) -> bool {
+    match entry {
+        UnifiedDiffEntry::Line { new_line_no: Some(n), .. } => comments.contains_key(n),
+        UnifiedDiffEntry::ExpandableContext { new_line_start, new_line_end, .. } => {
+            (*new_line_start..=*new_line_end).any(|l| comments.contains_key(&l))
+        }
+        _ => false,
+    }
+}
+
+/// Index of the next commented diff entry strictly after `from`.
+fn next_comment_line<V>(
+    lines: &[UnifiedDiffEntry],
+    comments: &HashMap<usize, V>,
+    from: usize,
+) -> Option<usize> {
+    (from + 1..lines.len()).find(|&i| entry_has_comment(&lines[i], comments))
+}
+
+/// Index of the previous commented diff entry strictly before `from`.
+fn prev_comment_line<V>(
+    lines: &[UnifiedDiffEntry],
+    comments: &HashMap<usize, V>,
+    from: usize,
+) -> Option<usize> {
+    (0..from).rev().find(|&i| entry_has_comment(&lines[i], comments))
 }
 
 // ── Inline thread helpers ────────────────────────────────────────────
@@ -522,4 +622,126 @@ fn handle_find_references(app: &mut App) {
     app.references_overlay.results = refs;
     app.references_overlay.selected = 0;
     app.references_overlay.scroll = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ln(tag: DiffLineTag) -> UnifiedDiffEntry {
+        UnifiedDiffEntry::Line {
+            tag,
+            new_line_no: Some(1),
+            content: String::new(),
+            inline_segments: Vec::new(),
+        }
+    }
+    fn eq() -> UnifiedDiffEntry { ln(DiffLineTag::Equal) }
+    fn ins() -> UnifiedDiffEntry { ln(DiffLineTag::Insert) }
+    fn del() -> UnifiedDiffEntry { ln(DiffLineTag::Delete) }
+    fn sep() -> UnifiedDiffEntry {
+        UnifiedDiffEntry::HunkSeparator { func_header: None }
+    }
+    /// A `Line` carrying an explicit new-file line number.
+    fn line_no(tag: DiffLineTag, n: usize) -> UnifiedDiffEntry {
+        UnifiedDiffEntry::Line {
+            tag,
+            new_line_no: Some(n),
+            content: String::new(),
+            inline_segments: Vec::new(),
+        }
+    }
+    /// A `Line` for a deletion (no new-file line number).
+    fn del_no_line() -> UnifiedDiffEntry {
+        UnifiedDiffEntry::Line {
+            tag: DiffLineTag::Delete,
+            new_line_no: None,
+            content: String::new(),
+            inline_segments: Vec::new(),
+        }
+    }
+    fn fold(start: usize, end: usize) -> UnifiedDiffEntry {
+        UnifiedDiffEntry::ExpandableContext {
+            hidden_count: end - start + 1,
+            new_line_start: start,
+            new_line_end: end,
+            func_header: None,
+        }
+    }
+
+    #[test]
+    fn change_block_start_detection() {
+        assert!(is_change_block_start(&[ins()], 0));
+        assert!(is_change_block_start(&[eq(), ins()], 1));
+        assert!(!is_change_block_start(&[ins(), ins()], 1)); // mid-block
+        assert!(!is_change_block_start(&[eq()], 0)); // not a change line
+        assert!(is_change_block_start(&[sep(), ins()], 1)); // separator breaks runs
+        assert!(!is_change_block_start(&[del(), ins()], 1)); // del+ins = one modified block
+    }
+
+    #[test]
+    fn next_change_block_cases() {
+        assert_eq!(next_change_block(&[], 0), None);
+        assert_eq!(next_change_block(&[eq(), eq()], 0), None);
+        let v = vec![eq(), ins(), eq(), ins(), eq()];
+        assert_eq!(next_change_block(&v, 0), Some(1));
+        assert_eq!(next_change_block(&v, 1), Some(3));
+        assert_eq!(next_change_block(&v, 3), None);
+        // From mid-block, skip the rest of the current block.
+        let v = vec![ins(), ins(), ins(), eq(), ins()];
+        assert_eq!(next_change_block(&v, 1), Some(4));
+        // A separator splits two otherwise-adjacent change lines.
+        assert_eq!(next_change_block(&[ins(), sep(), ins()], 0), Some(2));
+    }
+
+    #[test]
+    fn prev_change_block_cases() {
+        assert_eq!(prev_change_block(&[], 0), None);
+        let v = vec![eq(), ins(), eq(), ins(), eq()];
+        assert_eq!(prev_change_block(&v, 4), Some(3));
+        assert_eq!(prev_change_block(&v, 3), Some(1));
+        assert_eq!(prev_change_block(&v, 1), None);
+        // From mid-block, land on the current block's start.
+        assert_eq!(prev_change_block(&[ins(), ins(), ins()], 2), Some(0));
+        assert_eq!(prev_change_block(&[ins(), ins()], 0), None);
+    }
+
+    #[test]
+    fn comment_navigation() {
+        let comments: HashMap<usize, ()> = [(5, ()), (8, ())].into_iter().collect();
+        let v = vec![
+            line_no(DiffLineTag::Equal, 4),   // 0: no comment
+            line_no(DiffLineTag::Insert, 5),  // 1: commented
+            del_no_line(),                    // 2: delete, never commented
+            line_no(DiffLineTag::Equal, 8),   // 3: commented
+        ];
+        assert_eq!(next_comment_line(&v, &comments, 0), Some(1));
+        assert_eq!(next_comment_line(&v, &comments, 1), Some(3));
+        assert_eq!(next_comment_line(&v, &comments, 3), None);
+        assert_eq!(prev_comment_line(&v, &comments, 3), Some(1));
+        assert_eq!(prev_comment_line(&v, &comments, 1), None);
+        // Empty comment set → nothing found.
+        let none: HashMap<usize, ()> = HashMap::new();
+        assert_eq!(next_comment_line(&v, &none, 0), None);
+    }
+
+    #[test]
+    fn delete_line_is_never_commented() {
+        // A deletion has no new-file line number, so it can't carry a comment
+        // even if that line number is in the map.
+        let comments: HashMap<usize, ()> = [(1, ())].into_iter().collect();
+        assert!(!entry_has_comment(&del_no_line(), &comments));
+    }
+
+    #[test]
+    fn comment_hidden_in_fold_is_reachable() {
+        // A comment on line 7 sits inside a collapsed context spanning 5..=10;
+        // the jump should land on the fold so it can be expanded.
+        let comments: HashMap<usize, ()> = [(7, ())].into_iter().collect();
+        let v = vec![ins(), fold(5, 10)];
+        assert_eq!(next_comment_line(&v, &comments, 0), Some(1));
+        // No comment in the fold's range → not matched.
+        let comments: HashMap<usize, ()> = [(99, ())].into_iter().collect();
+        assert_eq!(next_comment_line(&v, &comments, 0), None);
+    }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -28,6 +28,13 @@ pub enum Action {
     FocusViewer,
     FocusTerminalClaude,
     FocusTerminalShell,
+    // Jump to a panel AND expand it to full width in one action.
+    FocusExpandWorktree,
+    FocusExpandExplorer,
+    FocusExpandExplorerDiffList,
+    FocusExpandViewer,
+    FocusExpandTerminalClaude,
+    FocusExpandTerminalShell,
     NewClaudeCode,
     NewShell,
     OpenRepo,
@@ -103,6 +110,12 @@ pub enum Action {
     ToggleInlineThread,
     InlineReply,
 
+    // ── Diff navigation ─────────────────────────────────────────
+    NextHunk,
+    PrevHunk,
+    NextComment,
+    PrevComment,
+
     // ── Diff context expansion ─────────────────────────────────
     ExpandContext,
     ExpandAllContext,
@@ -127,6 +140,12 @@ impl Action {
             "focus_viewer" => Some(Action::FocusViewer),
             "focus_terminal_claude" => Some(Action::FocusTerminalClaude),
             "focus_terminal_shell" => Some(Action::FocusTerminalShell),
+            "focus_expand_worktree" => Some(Action::FocusExpandWorktree),
+            "focus_expand_explorer" => Some(Action::FocusExpandExplorer),
+            "focus_expand_explorer_diff_list" => Some(Action::FocusExpandExplorerDiffList),
+            "focus_expand_viewer" => Some(Action::FocusExpandViewer),
+            "focus_expand_terminal_claude" => Some(Action::FocusExpandTerminalClaude),
+            "focus_expand_terminal_shell" => Some(Action::FocusExpandTerminalShell),
             "new_claude_code" => Some(Action::NewClaudeCode),
             "new_shell" => Some(Action::NewShell),
             "open_repo" => Some(Action::OpenRepo),
@@ -183,6 +202,10 @@ impl Action {
             "find_references" => Some(Action::FindReferences),
             "jump_back" => Some(Action::JumpBack),
             "jump_forward" => Some(Action::JumpForward),
+            "next_hunk" => Some(Action::NextHunk),
+            "prev_hunk" => Some(Action::PrevHunk),
+            "next_comment" => Some(Action::NextComment),
+            "prev_comment" => Some(Action::PrevComment),
             "expand_context" => Some(Action::ExpandContext),
             "expand_all_context" => Some(Action::ExpandAllContext),
             "toggle_inline_thread" => Some(Action::ToggleInlineThread),
@@ -208,6 +231,12 @@ impl Action {
             Action::FocusViewer => "focus_viewer",
             Action::FocusTerminalClaude => "focus_terminal_claude",
             Action::FocusTerminalShell => "focus_terminal_shell",
+            Action::FocusExpandWorktree => "focus_expand_worktree",
+            Action::FocusExpandExplorer => "focus_expand_explorer",
+            Action::FocusExpandExplorerDiffList => "focus_expand_explorer_diff_list",
+            Action::FocusExpandViewer => "focus_expand_viewer",
+            Action::FocusExpandTerminalClaude => "focus_expand_terminal_claude",
+            Action::FocusExpandTerminalShell => "focus_expand_terminal_shell",
             Action::NewClaudeCode => "new_claude_code",
             Action::NewShell => "new_shell",
             Action::OpenRepo => "open_repo",
@@ -264,6 +293,10 @@ impl Action {
             Action::FindReferences => "find_references",
             Action::JumpBack => "jump_back",
             Action::JumpForward => "jump_forward",
+            Action::NextHunk => "next_hunk",
+            Action::PrevHunk => "prev_hunk",
+            Action::NextComment => "next_comment",
+            Action::PrevComment => "prev_comment",
             Action::ExpandContext => "expand_context",
             Action::ExpandAllContext => "expand_all_context",
             Action::ToggleInlineThread => "toggle_inline_thread",
@@ -553,6 +586,16 @@ impl KeyMap {
         self.bind_char(Global, '¢', FocusViewer);
         self.bind_char(Global, '∞', FocusTerminalClaude);
         self.bind_char(Global, '§', FocusTerminalShell);
+        // Jump to a panel AND maximize it in one stroke, from anywhere (including
+        // terminal panels). F-keys are chosen because they reach the app reliably
+        // through Alacritty/Ghostty and tmux, where Cmd/Super combos often do not.
+        // F2..F7 mirror the Cmd/Alt+1..6 focus order (F1 left for help convention).
+        self.bind_key(Global, KeyCode::F(2), FocusExpandWorktree);
+        self.bind_key(Global, KeyCode::F(3), FocusExpandExplorer);
+        self.bind_key(Global, KeyCode::F(4), FocusExpandExplorerDiffList);
+        self.bind_key(Global, KeyCode::F(5), FocusExpandViewer);
+        self.bind_key(Global, KeyCode::F(6), FocusExpandTerminalClaude);
+        self.bind_key(Global, KeyCode::F(7), FocusExpandTerminalShell);
         self.bind_ctrl(Global, 'g', SearchFullText);
         self.bind(Global, KeyCode::Char(' '), KeyModifiers::SUPER, TogglePanelExpand);
         self.bind(Global, KeyCode::Char('/'), KeyModifiers::ALT, TogglePanelOverlay);
@@ -683,6 +726,11 @@ impl KeyMap {
         self.bind_char(ViewerDiffMode, 'l', ScrollRight);
         self.bind_key(ViewerDiffMode, KeyCode::Right, ScrollRight);
         self.bind_char(ViewerDiffMode, '0', ScrollHome);
+        // Jump between changes (hunks) and between review comments.
+        self.bind_char(ViewerDiffMode, ']', NextHunk);
+        self.bind_char(ViewerDiffMode, '[', PrevHunk);
+        self.bind_char(ViewerDiffMode, '}', NextComment);
+        self.bind_char(ViewerDiffMode, '{', PrevComment);
         self.bind_char(ViewerDiffMode, ' ', ToggleInlineThread);
         self.bind_key(ViewerDiffMode, KeyCode::Esc, ExitToExplorer);
         self.bind_key(ViewerDiffMode, KeyCode::Enter, ExpandContext);

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -1051,23 +1051,32 @@ fn merge_syntax_with_inline(
     tab_width: usize,
 ) -> Option<Vec<Span<'static>>> {
     // Build expanded text and per-byte emphasis flag from inline segments.
+    // Tabs are expanded with a *shared* column counter across segments so the
+    // result matches the column-correct expansion of the syntax tokens below.
     let mut expanded_text = String::new();
     let mut byte_emphasis: Vec<bool> = Vec::new();
 
+    let mut col = 0;
     for seg in segments {
         let trimmed = seg.text.trim_end_matches('\n').trim_end_matches('\r');
-        let expanded = expand_tabs(trimmed, tab_width);
+        let expanded = expand_tabs_at(trimmed, tab_width, &mut col);
         byte_emphasis.resize(byte_emphasis.len() + expanded.len(), seg.emphasized);
         expanded_text.push_str(&expanded);
     }
 
-    // Build per-byte fg style from syntax tokens.
+    // Build per-byte fg style from syntax tokens. The syntax cache stores raw
+    // (un-expanded) tabs, so expand them here too — using the same shared
+    // column counter — otherwise any line containing a tab would fail the
+    // equality check below and silently lose its syntax + emphasis colouring.
     let mut syntax_text = String::new();
     let mut byte_fg: Vec<Style> = Vec::new();
 
+    let mut col = 0;
     for (style, text) in syntax_tokens {
-        byte_fg.resize(byte_fg.len() + text.len(), *style);
-        syntax_text.push_str(text);
+        let trimmed = text.trim_end_matches('\n').trim_end_matches('\r');
+        let expanded = expand_tabs_at(trimmed, tab_width, &mut col);
+        byte_fg.resize(byte_fg.len() + expanded.len(), *style);
+        syntax_text.push_str(&expanded);
     }
 
     // The texts must match after tab expansion; bail out otherwise.
@@ -1114,18 +1123,27 @@ fn expand_tabs(line: &str, tab_width: usize) -> String {
     if !line.contains('\t') {
         return line.to_string();
     }
-    let mut result = String::with_capacity(line.len());
     let mut col = 0;
-    for ch in line.chars() {
+    expand_tabs_at(line, tab_width, &mut col)
+}
+
+/// Expand tabs starting from column `col`, advancing `col` past the piece.
+///
+/// Threading a shared `col` across consecutive pieces of one line keeps tab
+/// stops column-correct, so two different tokenisations of the same line
+/// (word-diff segments vs. syntax tokens) expand to identical text.
+fn expand_tabs_at(piece: &str, tab_width: usize, col: &mut usize) -> String {
+    let mut result = String::with_capacity(piece.len());
+    for ch in piece.chars() {
         if ch == '\t' {
-            let spaces = tab_width - (col % tab_width);
+            let spaces = tab_width - (*col % tab_width);
             for _ in 0..spaces {
                 result.push(' ');
             }
-            col += spaces;
+            *col += spaces;
         } else {
             result.push(ch);
-            col += 1;
+            *col += 1;
         }
     }
     result
@@ -1437,4 +1455,52 @@ fn replace_span_range(
         pos = span_end;
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(text: &str, emphasized: bool) -> InlineSegment {
+        InlineSegment { text: text.to_string(), emphasized }
+    }
+
+    #[test]
+    fn merge_handles_tabbed_lines() {
+        // A line "\tlet x" highlighted as two syntax tokens carrying a raw tab.
+        // The word-diff segments expand the tab; the syntax tokens must be
+        // expanded the same way or the merge silently drops to plain rendering.
+        let segments = vec![seg("\tlet ", false), seg("x", true)];
+        let syntax_tokens = vec![
+            (Style::default().fg(Color::Red), "\t".to_string()),
+            (Style::default().fg(Color::Blue), "let x".to_string()),
+        ];
+        let merged = merge_syntax_with_inline(
+            &segments,
+            &syntax_tokens,
+            Color::Rgb(0, 40, 0),
+            Color::Rgb(0, 80, 0),
+            4,
+        );
+        // Before the tab fix this returned None (texts mismatched on the tab).
+        let spans = merged.expect("tabbed line should merge, not fall back to plain");
+        let joined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(joined, "    let x"); // tab expanded to 4 spaces at column 0
+    }
+
+    #[test]
+    fn merge_bails_on_text_mismatch() {
+        // Genuinely different text (not just tabs) must still bail out so the
+        // caller can fall back to plain rendering.
+        let segments = vec![seg("foo", false)];
+        let syntax_tokens = vec![(Style::default(), "bar".to_string())];
+        let merged = merge_syntax_with_inline(
+            &segments,
+            &syntax_tokens,
+            Color::Rgb(0, 40, 0),
+            Color::Rgb(0, 80, 0),
+            4,
+        );
+        assert!(merged.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

レビューワークフローを快適にする3つの機能追加と、関連するdiff表示のバグ修正。

- **Claudeのセルフレビュー注釈**: MCPサーバに `create_comment` ツールを追加。Claude Codeセッションが自分の変更したdiffに対し、難所・トレードオフ・要確認点をインラインコメントとして残せる（表示UIは既存のものを利用）。`author='claude'` / `commit_ref='HEAD'` / `worktree=branch` でRust側 `add_review` の不変条件をミラー。detached HEADガード・`file_path` の絶対パス拒否・INSERTのtry/catchで堅牢化。
- **diff内ジャンプ**: diffビューで `]`/`[` = 次/前の変更ハンク、`}`/`{` = 次/前のレビューコメントへジャンプ。折りたたみ(ExpandableContext)内に隠れたコメントへも到達可能。
- **どこでもexpand**: `F2`〜`F7` で任意のパネルにフォーカスしつつ全幅化（ターミナルパネル内からも効く）。`Cmd/Alt+1..6` のフォーカス順と対称。Alacritty/Ghostty/tmux を貫通しやすいF-keyを採用（config override 可能）。
- **タブ行のハイライト修正**: syntax tokens（タブ生）と word-diff segments（タブ展開）の不整合で、タブを含む変更行が syntax + word-level emphasis 着色を失いプレーン描画に落ちていたのを修正。共有列カウンタで両側を同条件展開。

semver: MINOR機能追加 + バグ修正 → `0.52.0` → `0.53.1`。MCPサーバは `0.2.0` → `0.3.0`。

## Test plan

- `cargo build` / `cargo clippy`（新規コードの警告なし）
- `cargo test` — 171 tests passing（新規10件: diffナビゲーションのブロック/コメント探索、タブマージのregression）
- MCP: `npm run build`（tsc 通過）
- 手動: F2〜F7 が実機ターミナル（Alacritty/Ghostty、tmux経由）でアプリに届くか要確認。届かない場合は `config.toml` の keybinds（`focus_expand_*`）で上書き可能。
