### PR TITLE
feat: 本物のCatppuccin Mocha配色・フォーカス面表示・通知アニメの鎮静

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.53.2"
+version = "0.54.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.53.2"
+version = "0.54.0"
 edition = "2024"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,10 @@ const TICK_RATE_IDLE: Duration = Duration::from_millis(500);
 const ACTIVITY_TIMEOUT: Duration = Duration::from_millis(500);
 /// Fixed interval for decoration animation updates (~10fps), independent of main tick rate.
 const DECORATION_TICK_INTERVAL: Duration = Duration::from_millis(100);
+/// Interval for the "Claude is waiting" notification breathing pulse (~12fps).
+/// Drives redraws while a session waits, independent of decoration/PTY activity,
+/// so the pulse keeps breathing even when the user is focused elsewhere.
+const PULSE_TICK_INTERVAL: Duration = Duration::from_millis(80);
 /// Interval for refreshing unfocused terminal panels (~2fps).
 /// Balances visibility of background PTY output with CPU usage.
 const UNFOCUSED_TERMINAL_REFRESH: Duration = Duration::from_millis(500);
@@ -267,6 +271,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
 
     timers.register("decoration", DECORATION_TICK_INTERVAL);
     timers.register("unfocused_terminal", UNFOCUSED_TERMINAL_REFRESH);
+    timers.register("pulse", PULSE_TICK_INTERVAL);
 
     // Maximum time to spend draining events before rendering a frame.
     // Prevents input starvation during rapid scroll (trackpad inertia
@@ -304,6 +309,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
                 _ if !app.worktree_mgr.pending_worktrees.is_empty() => TICK_RATE_ACTIVE,
                 _ if app.show_panel_number_overlay => TICK_RATE_ACTIVE,
                 _ if last_input_time.elapsed() < ACTIVITY_TIMEOUT => TICK_RATE_ACTIVE,
+                _ if !app.terminal.cc_waiting_worktrees.is_empty() => PULSE_TICK_INTERVAL,
                 _ if decoration_active => DECORATION_TICK_INTERVAL,
                 _ => TICK_RATE_IDLE,
             }
@@ -404,7 +410,11 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
         let input_active = last_input_time.elapsed() < ACTIVITY_TIMEOUT;
         for name in timers.check_due() {
             match name {
-                "decoration" => {
+                // Calm mode: only advance the decoration while the worktree panel
+                // is focused, so it never moves in the user's periphery during
+                // review/terminal work. It freezes in place otherwise and resumes
+                // when focus returns.
+                "decoration" if app.focus == crate::app::Focus::Worktree => {
                     let left_w = app.layout_cache.columns[0].width;
                     let panel_h = app.layout_cache.main_area.height;
                     let list_h = (app.worktrees.len() as u16 + 2).max(5);
@@ -413,6 +423,11 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
                     if app.tick_decoration(left_w.saturating_sub(2), deco_h) {
                         app.dirty.mark(crate::app::DirtyPanels::WORKTREE);
                     }
+                }
+                // Drive notification-bar breathing while any session waits,
+                // regardless of focus or whether decoration is animating.
+                "pulse" if !app.terminal.cc_waiting_worktrees.is_empty() => {
+                    app.dirty.mark(crate::app::DirtyPanels::WORKTREE);
                 }
                 "unfocused_terminal" => {
                     match app.focus {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -115,6 +115,13 @@ pub struct Theme {
     pub comment_preview_bg: Color,
     /// Text color for reply content.
     pub reply_text: Color,
+
+    // ── Panel surface ────────────────────────────────────────────────
+    /// Subtle background filled behind the currently focused list panel
+    /// (worktree / explorer) to lift it out of the surrounding columns.
+    /// A gentle step above each theme's base so focus reads in peripheral
+    /// vision without straining the eye on long sessions.
+    pub panel_focused_bg: Color,
 }
 
 impl Theme {
@@ -148,62 +155,70 @@ impl Theme {
 
     // ── Built-in themes ──────────────────────────────────────────────
 
-    /// Default theme — matches the original hardcoded colors exactly.
+    /// Default theme — the official Catppuccin Mocha palette.
+    ///
+    /// Palette reference (https://catppuccin.com/palette): Base #1e1e2e,
+    /// Mantle #181825, Surface0 #313244, Surface1 #45475a, Surface2 #585b70,
+    /// Overlay0 #6c7086, Overlay1 #7f849c, Text #cdd6f4, Subtext0 #a6adc8,
+    /// Mauve #cba6f7, Blue #89b4fa, Sky #89dceb, Green #a6e3a1, Red #f38ba8,
+    /// Yellow #f9e2af, Peach #fab387.
     fn catppuccin_mocha() -> Self {
         Self {
-            fg: Color::White,
-            accent: Color::Yellow,
-            muted: Color::DarkGray,
-            success: Color::Green,
-            error: Color::Red,
-            warning: Color::Yellow,
-            info: Color::Cyan,
+            fg: Color::Rgb(205, 214, 244),      // Text
+            accent: Color::Rgb(203, 166, 247),  // Mauve
+            muted: Color::Rgb(69, 71, 90),      // Surface1
+            success: Color::Rgb(166, 227, 161), // Green
+            error: Color::Rgb(243, 139, 168),   // Red
+            warning: Color::Rgb(249, 226, 175), // Yellow
+            info: Color::Rgb(137, 220, 235),    // Sky
 
-            diff_add: Color::Green,
-            diff_add_bg: Color::Rgb(0, 40, 0),
-            diff_del: Color::Red,
-            diff_del_bg: Color::Rgb(40, 0, 0),
-            diff_add_bg_emphasis: Color::Rgb(0, 80, 0),
-            diff_del_bg_emphasis: Color::Rgb(80, 0, 0),
-            diff_section_header: Color::Gray,
+            diff_add: Color::Rgb(166, 227, 161),
+            diff_add_bg: Color::Rgb(31, 46, 38),
+            diff_del: Color::Rgb(243, 139, 168),
+            diff_del_bg: Color::Rgb(49, 33, 42),
+            diff_add_bg_emphasis: Color::Rgb(45, 72, 52),
+            diff_del_bg_emphasis: Color::Rgb(78, 44, 56),
+            diff_section_header: Color::Rgb(127, 132, 156), // Overlay1
 
-            border_focused: Color::Yellow,
-            border_unfocused: Color::DarkGray,
-            border_secondary: Color::White,
+            border_focused: Color::Rgb(203, 166, 247), // Mauve
+            border_unfocused: Color::Rgb(69, 71, 90),  // Surface1
+            border_secondary: Color::Rgb(88, 91, 112), // Surface2
 
-            selected_bg: Color::Yellow,
-            selected_fg: Color::Black,
-            selected_bg_inactive: Color::DarkGray,
-            selected_fg_inactive: Color::Black,
+            selected_bg: Color::Rgb(203, 166, 247), // Mauve
+            selected_fg: Color::Rgb(30, 30, 46),    // Base
+            selected_bg_inactive: Color::Rgb(69, 71, 90), // Surface1
+            selected_fg_inactive: Color::Rgb(205, 214, 244), // Text
 
-            line_selected_bg: Color::DarkGray,
-            line_selected_fg: Color::White,
+            line_selected_bg: Color::Rgb(49, 50, 68), // Surface0
+            line_selected_fg: Color::Rgb(205, 214, 244), // Text
 
-            gutter_selected_bg: Color::LightBlue,
-            gutter_selected_fg: Color::Black,
-            gutter_hover_fg: Color::Gray,
-            gutter_hover_bg: Color::Rgb(45, 45, 55),
-            gutter_pending_bg: Color::Rgb(50, 70, 90),
-            line_pending_bg: Color::Rgb(40, 40, 50),
+            gutter_selected_bg: Color::Rgb(137, 180, 250), // Blue
+            gutter_selected_fg: Color::Rgb(30, 30, 46),    // Base
+            gutter_hover_fg: Color::Rgb(127, 132, 156),    // Overlay1
+            gutter_hover_bg: Color::Rgb(40, 41, 56),
+            gutter_pending_bg: Color::Rgb(54, 64, 98),
+            line_pending_bg: Color::Rgb(40, 41, 58),
 
-            hint: Color::Gray,
-            search_match_fg: Color::Yellow,
-            search_match_bg: Color::Yellow,
-            search_current_fg: Color::Black,
+            hint: Color::Rgb(108, 112, 134),            // Overlay0
+            search_match_fg: Color::Rgb(249, 226, 175), // Yellow
+            search_match_bg: Color::Rgb(249, 226, 175), // Yellow
+            search_current_fg: Color::Rgb(30, 30, 46),  // Base
 
-            waiting_primary: Color::Rgb(255, 165, 0),
-            waiting_secondary: Color::Rgb(200, 120, 0),
+            waiting_primary: Color::Rgb(250, 179, 135), // Peach
+            waiting_secondary: Color::Rgb(200, 140, 100),
 
-            titlebar_bg: Color::DarkGray,
-            dir_fg: Color::Gray,
+            titlebar_bg: Color::Rgb(24, 24, 37), // Mantle
+            dir_fg: Color::Rgb(108, 112, 134),   // Overlay0
 
-            status_bg_success: Color::Rgb(0, 30, 0),
-            status_bg_error: Color::Rgb(40, 0, 0),
-            status_bg_warning: Color::Rgb(40, 30, 0),
-            status_bg_info: Color::Rgb(0, 20, 40),
+            status_bg_success: Color::Rgb(25, 40, 30),
+            status_bg_error: Color::Rgb(48, 28, 36),
+            status_bg_warning: Color::Rgb(46, 40, 26),
+            status_bg_info: Color::Rgb(24, 36, 48),
 
-            comment_preview_bg: Color::Rgb(42, 42, 68),
-            reply_text: Color::Rgb(180, 180, 200),
+            comment_preview_bg: Color::Rgb(49, 50, 68), // Surface0
+            reply_text: Color::Rgb(166, 173, 200),      // Subtext0
+
+            panel_focused_bg: Color::Rgb(40, 41, 58), // between Base and Surface0
         }
     }
 
@@ -262,6 +277,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(52, 54, 76),
             reply_text: Color::Rgb(189, 147, 249),
+
+            panel_focused_bg: Color::Rgb(50, 52, 66),
         }
     }
 
@@ -320,6 +337,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(56, 62, 82),
             reply_text: Color::Rgb(129, 161, 193),
+
+            panel_focused_bg: Color::Rgb(56, 62, 78),
         }
     }
 
@@ -378,6 +397,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(15, 64, 84),
             reply_text: Color::Rgb(108, 113, 196),
+
+            panel_focused_bg: Color::Rgb(8, 52, 64),
         }
     }
 
@@ -436,6 +457,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(42, 44, 66),
             reply_text: Color::Rgb(125, 207, 255),
+
+            panel_focused_bg: Color::Rgb(36, 38, 52),
         }
     }
 
@@ -494,6 +517,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(62, 58, 68),
             reply_text: Color::Rgb(131, 165, 152),
+
+            panel_focused_bg: Color::Rgb(58, 55, 52),
         }
     }
 
@@ -552,6 +577,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(48, 44, 70),
             reply_text: Color::Rgb(196, 167, 231),
+
+            panel_focused_bg: Color::Rgb(38, 35, 52),
         }
     }
 
@@ -610,6 +637,8 @@ impl Theme {
 
             comment_preview_bg: Color::Rgb(42, 42, 62),
             reply_text: Color::Rgb(127, 180, 202),
+
+            panel_focused_bg: Color::Rgb(34, 34, 46),
         }
     }
 }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -155,7 +155,7 @@ pub fn build_pty_lines(
 /// Render previously built PTY lines from a [`PtyRenderCache`].
 ///
 /// This is cheap: it just clones the cached `Line` data into a `Paragraph`.
-pub fn render_pty_cached(frame: &mut Frame, area: Rect, cache: &PtyRenderCache) {
+pub fn render_pty_cached(frame: &mut Frame, area: Rect, cache: &PtyRenderCache, theme: &Theme) {
     let paragraph = Paragraph::new(cache.lines.clone());
     frame.render_widget(paragraph, area);
 
@@ -165,7 +165,7 @@ pub fn render_pty_cached(frame: &mut Frame, area: Rect, cache: &PtyRenderCache) 
                 " ↑ scrollback ({} lines — Shift+End to return) ",
                 cache.effective_offset
             ),
-            Style::default().fg(Color::Black).bg(Color::Yellow),
+            Style::default().fg(theme.selected_fg).bg(theme.accent),
         ));
         frame.render_widget(Paragraph::new(indicator), Rect { height: 1, ..area });
     }
@@ -308,7 +308,7 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
             spans.push(sep.clone());
             spans.push(Span::styled(
                 format!("{} reviews", stats.reviews_created),
-                Style::default().fg(Color::Magenta).bg(bar_bg),
+                Style::default().fg(theme.warning).bg(bar_bg),
             ));
         }
         if let Some(ref info) = app.ccusage_info {
@@ -322,7 +322,7 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
             spans.push(sep.clone());
             spans.push(Span::styled(
                 format!("${:.2}", info.total_cost),
-                Style::default().fg(Color::LightGreen).bg(bar_bg),
+                Style::default().fg(theme.success).bg(bar_bg),
             ));
         }
         // Track the update badge text for position calculation.
@@ -336,8 +336,8 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
             spans.push(Span::styled(
                 badge,
                 Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
+                    .fg(theme.selected_fg)
+                    .bg(theme.warning)
                     .add_modifier(Modifier::BOLD),
             ));
         }
@@ -405,13 +405,15 @@ pub fn render_notification_bar(frame: &mut Frame, area: Rect, app: &mut crate::a
                 .map(|p| p.as_path());
 
     // Orange-tinted background for the notification bar.
-    let pulse_on = (app.ui_tick / 20).is_multiple_of(2);
+    // Breathing pulse: a smooth triangle wave rather than a hard on/off blink,
+    // so the bar gently rises and falls instead of flickering in the periphery.
+    let cycle = 56u64;
+    let phase = (app.ui_tick % cycle) as f64 / cycle as f64;
+    let breath = 1.0 - (2.0 * phase - 1.0).abs(); // 0.0 → 1.0 → 0.0
     let bar_bg = if all_suppressed {
         Theme::darken(theme.waiting_primary, 0.17)
-    } else if pulse_on {
-        Theme::darken(theme.waiting_primary, 0.20)
     } else {
-        Theme::darken(theme.waiting_primary, 0.14)
+        Theme::darken(theme.waiting_primary, 0.14 + 0.06 * breath)
     };
 
     // Fill background.
@@ -455,12 +457,8 @@ pub fn render_notification_bar(frame: &mut Frame, area: Rect, app: &mut crate::a
         .collect();
     waiting.sort_by(|a, b| a.1.cmp(&b.1));
 
-    // Badge colors: pulsing vs static (for focused session).
-    let badge_bg_pulse = if pulse_on {
-        theme.waiting_secondary
-    } else {
-        Theme::darken(theme.waiting_secondary, 0.90)
-    };
+    // Badge colors: breathing vs static (for focused session).
+    let badge_bg_pulse = Theme::darken(theme.waiting_secondary, 0.85 + 0.15 * breath);
     let badge_bg_static = theme.waiting_secondary;
 
     let sep_style = Style::default()

--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -119,8 +119,13 @@ fn render_file_tree(frame: &mut Frame, area: Rect, app: &mut App, panel_focused:
         BorderType::Plain
     };
 
+    let title_style = if tree_focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
     let block = Block::default()
-        .title(title)
+        .title(Span::styled(title, title_style))
         .title_top(
             Line::from(Span::styled(
                 expand_label,
@@ -216,8 +221,13 @@ fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_focused: boo
         BorderType::Plain
     };
 
+    let title_style = if diff_focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
     let block = Block::default()
-        .title(title)
+        .title(Span::styled(title, title_style))
         .borders(Borders::ALL)
         .border_type(border_type)
         .border_style(Style::default().fg(border_color));
@@ -365,8 +375,13 @@ fn render_comment_list(frame: &mut Frame, area: Rect, app: &App, panel_focused: 
         BorderType::Plain
     };
 
+    let title_style = if list_focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
     let block = Block::default()
-        .title(title)
+        .title(Span::styled(title, title_style))
         .title_bottom(
             Line::from(vec![Span::styled(
                 ask_claude_label,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -150,6 +150,23 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // ── Accordion column widths (from cache) ───────────────────────
     let columns = app.layout_cache.columns;
 
+    // ── Focused-panel surface ───────────────────────────────────────
+    // Lift the focused list panel (worktree / explorer) out of its
+    // neighbours with a subtle surface fill, so the active column reads
+    // at a glance in peripheral vision. Painted before the panels so
+    // their (bg-transparent) content draws on top; viewer is left alone
+    // as a reading pane and the terminal keeps its own PTY background.
+    let focused_surface_col = match app.focus {
+        crate::app::Focus::Worktree => Some(0),
+        crate::app::Focus::Explorer => Some(1),
+        _ => None,
+    };
+    if let Some(col) = focused_surface_col {
+        let fill = ratatui::widgets::Block::default()
+            .style(ratatui::style::Style::default().bg(app.theme.panel_focused_bg));
+        frame.render_widget(fill, columns[col]);
+    }
+
     // ── Column 0: Worktree panel ────────────────────────────────────
     super::worktree_panel::render(frame, columns[0], app);
 
@@ -206,13 +223,7 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
             super::dashboard::render_delete_branch_confirm_overlay(frame, main_area, app);
         }
         crate::app::WorktreeInputMode::ConfirmingUngrab => {
-            render_confirm_overlay(
-                frame,
-                main_area,
-                app,
-                " Confirm Ungrab ",
-                ratatui::style::Color::Yellow,
-            );
+            render_confirm_overlay(frame, main_area, app, " Confirm Ungrab ", app.theme.warning);
         }
         crate::app::WorktreeInputMode::SmartDescription => {
             super::dashboard::render_smart_description_overlay(frame, main_area, app);
@@ -295,7 +306,7 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
 
     // ── Skip reason modal ────────────────────────────────────────────
     if let Some(ref reason) = app.worktree_mgr.skip_reason {
-        render_skip_reason_overlay(frame, main_area, reason);
+        render_skip_reason_overlay(frame, main_area, reason, &app.theme);
     }
 
     // ── Status bar ──────────────────────────────────────────────────
@@ -317,13 +328,7 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
 
 /// Render a small confirmation overlay for worktree deletion.
 fn render_confirming_delete_overlay(frame: &mut Frame, area: Rect, app: &App) {
-    render_confirm_overlay(
-        frame,
-        area,
-        app,
-        " Confirm Delete ",
-        ratatui::style::Color::Red,
-    );
+    render_confirm_overlay(frame, area, app, " Confirm Delete ", app.theme.error);
 }
 
 /// Generic small confirmation overlay with a customizable title and border color.
@@ -354,14 +359,19 @@ fn render_confirm_overlay(
 
         let paragraph = ratatui::widgets::Paragraph::new(ratatui::text::Span::styled(
             msg.as_str(),
-            ratatui::style::Style::default().fg(ratatui::style::Color::Yellow),
+            ratatui::style::Style::default().fg(app.theme.fg),
         ));
         frame.render_widget(paragraph, inner);
     }
 }
 
 /// Render a skip-reason informational popup.
-fn render_skip_reason_overlay(frame: &mut Frame, area: Rect, reason: &str) {
+fn render_skip_reason_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    reason: &str,
+    theme: &crate::theme::Theme,
+) {
     let popup_height = 5_u16;
     let popup_width = area.width.saturating_sub(8).min(60);
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
@@ -373,7 +383,7 @@ fn render_skip_reason_overlay(frame: &mut Frame, area: Rect, reason: &str) {
     let block = ratatui::widgets::Block::default()
         .title(" Skipped ")
         .borders(ratatui::widgets::Borders::ALL)
-        .border_style(ratatui::style::Style::default().fg(ratatui::style::Color::Yellow));
+        .border_style(ratatui::style::Style::default().fg(theme.warning));
 
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
@@ -381,11 +391,11 @@ fn render_skip_reason_overlay(frame: &mut Frame, area: Rect, reason: &str) {
     let text = vec![
         ratatui::text::Line::from(ratatui::text::Span::styled(
             reason,
-            ratatui::style::Style::default().fg(ratatui::style::Color::Yellow),
+            ratatui::style::Style::default().fg(theme.warning),
         )),
         ratatui::text::Line::from(ratatui::text::Span::styled(
             "(Esc) 閉じる",
-            ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+            ratatui::style::Style::default().fg(theme.muted),
         )),
     ];
     let paragraph =

--- a/src/ui/panel_overlay.rs
+++ b/src/ui/panel_overlay.rs
@@ -124,7 +124,7 @@ fn render_single_panel_overlay(frame: &mut Frame, panel: &PanelInfo, theme: &cra
     // Build the number + label text, vertically centered.
     let number_style = Style::default()
         .fg(if is_focused {
-            Color::White
+            theme.fg
         } else {
             Color::Rgb(180, 180, 200)
         })

--- a/src/ui/review.rs
+++ b/src/ui/review.rs
@@ -8,7 +8,7 @@ use crate::review_store::CommentKind;
 use crate::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
@@ -21,15 +21,15 @@ pub fn kind_icon(kind: CommentKind) -> &'static str {
 }
 
 /// Styled span for a comment kind badge.
-pub fn kind_badge_span(kind: CommentKind) -> Span<'static> {
+pub fn kind_badge_span(kind: CommentKind, theme: &Theme) -> Span<'static> {
     match kind {
         CommentKind::Suggest => Span::styled(
             format!("{} ", kind_icon(kind)),
-            Style::default().fg(Color::Green),
+            Style::default().fg(theme.success),
         ),
         CommentKind::Question => Span::styled(
             format!("{} ", kind_icon(kind)),
-            Style::default().fg(Color::Magenta),
+            Style::default().fg(theme.info),
         ),
     }
 }
@@ -173,7 +173,7 @@ pub fn render_template_picker_overlay(
     for (i, tmpl) in state.templates.iter().enumerate() {
         let is_selected = i == state.template_selected;
 
-        let badge = kind_badge_span(tmpl.kind);
+        let badge = kind_badge_span(tmpl.kind, theme);
 
         let max_body_len = (popup_width as usize).saturating_sub(tmpl.name.chars().count() + 10);
         let body_preview: String = tmpl.body.chars().take(max_body_len).collect();

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -68,11 +68,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     };
 
     if sessions.is_empty() {
+        let title_style = if focused {
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.muted)
+        };
         let block = if is_expanded {
-            Block::default().title(" Claude Code ")
+            Block::default().title(Span::styled(" Claude Code ", title_style))
         } else {
             Block::default()
-                .title(" Claude Code ")
+                .title(Span::styled(" Claude Code ", title_style))
                 .borders(Borders::ALL)
                 .border_type(border_type)
                 .border_style(Style::default().fg(border_color))
@@ -194,7 +199,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 app.terminal.dirty_claude = false;
             }
             // If try_lock failed (reader thread busy), keep using old cache.
-            crate::ui::common::render_pty_cached(frame, inner, &app.terminal.cache_claude);
+            crate::ui::common::render_pty_cached(
+                frame,
+                inner,
+                &app.terminal.cache_claude,
+                &app.theme,
+            );
 
             // Set cursor position for IME when focused, not scrolled back,
             // and no overlay is covering this panel.

--- a/src/ui/terminal_shell.rs
+++ b/src/ui/terminal_shell.rs
@@ -61,11 +61,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     };
 
     if sessions.is_empty() {
+        let title_style = if focused {
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.muted)
+        };
         let block = if is_expanded {
-            Block::default().title(" Shell ")
+            Block::default().title(Span::styled(" Shell ", title_style))
         } else {
             Block::default()
-                .title(" Shell ")
+                .title(Span::styled(" Shell ", title_style))
                 .borders(Borders::ALL)
                 .border_type(border_type)
                 .border_style(Style::default().fg(border_color))
@@ -164,7 +169,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 app.terminal.cache_shell = cache;
                 app.terminal.dirty_shell = false;
             }
-            crate::ui::common::render_pty_cached(frame, inner, &app.terminal.cache_shell);
+            crate::ui::common::render_pty_cached(
+                frame,
+                inner,
+                &app.terminal.cache_shell,
+                &app.theme,
+            );
 
             // Set cursor position for IME when focused, not scrolled back,
             // and no overlay is covering this panel.

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -86,8 +86,13 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         BorderType::Plain
     };
 
+    let title_style = if focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
     let block = Block::default()
-        .title(title)
+        .title(Span::styled(title, title_style))
         .title_top(
             Line::from(Span::styled(
                 expand_label,
@@ -294,9 +299,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                                 tab_width,
                             )
                         })
-                        .unwrap_or_else(|| syntax_spans_for_line(vs, line_no, Some(diff_bg)))
+                        .unwrap_or_else(|| {
+                            syntax_spans_for_line(vs, line_no, Some(diff_bg), theme.fg)
+                        })
                 } else {
-                    render_inline_diff_spans(ann_segments, diff_bg, emphasis_bg, tab_width)
+                    render_inline_diff_spans(
+                        ann_segments,
+                        diff_bg,
+                        emphasis_bg,
+                        theme.fg,
+                        tab_width,
+                    )
                 }
             } else {
                 // Line-level diff only: use syntax highlighting with diff bg.
@@ -305,10 +318,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                     DiffLineTag::Delete => Some(app.theme.diff_del_bg),
                     _ => None,
                 };
-                syntax_spans_for_line(vs, line_no, diff_bg)
+                syntax_spans_for_line(vs, line_no, diff_bg, theme.fg)
             }
         } else {
-            syntax_spans_for_line(vs, line_no, gutter_bg)
+            syntax_spans_for_line(vs, line_no, gutter_bg, theme.fg)
         };
 
         // Apply horizontal scroll to content spans, clipping to panel width.
@@ -661,6 +674,7 @@ fn render_diff_content_line(
                                 inline_segments,
                                 diff_bg.unwrap_or(Color::Reset),
                                 emphasis_bg.unwrap_or(Color::Reset),
+                                theme.fg,
                                 tab_width,
                             )
                         })
@@ -669,6 +683,7 @@ fn render_diff_content_line(
                         inline_segments,
                         diff_bg.unwrap_or(Color::Reset),
                         emphasis_bg.unwrap_or(Color::Reset),
+                        theme.fg,
                         tab_width,
                     )
                 }
@@ -677,11 +692,12 @@ fn render_diff_content_line(
                 inline_segments,
                 diff_bg.unwrap_or(Color::Reset),
                 emphasis_bg.unwrap_or(Color::Reset),
+                theme.fg,
                 tab_width,
             ),
             DiffLineTag::Equal => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, None)
+                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -695,7 +711,7 @@ fn render_diff_content_line(
         match tag {
             DiffLineTag::Insert => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, diff_bg)
+                    syntax_spans_for_line(vs, line_no - 1, diff_bg, theme.fg)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -715,7 +731,7 @@ fn render_diff_content_line(
             }
             DiffLineTag::Equal => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, None)
+                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -881,7 +897,7 @@ fn render_media_view(frame: &mut Frame, area: Rect, app: &App, block: Block<'_>)
         }
         MediaContent::Error(msg) => {
             let error = Paragraph::new(msg)
-                .style(Style::default().fg(Color::Red))
+                .style(Style::default().fg(theme.error))
                 .block(block);
             frame.render_widget(error, area);
         }
@@ -1089,9 +1105,11 @@ fn build_inline_thread_lines<'a>(
             // Clickable action icons: ↩ reply  ✔ resolve  x delete  ...  ✨ ask claude
             let reply_style = Style::default().fg(theme.info).bg(theme.comment_preview_bg);
             let resolve_style = Style::default()
-                .fg(Color::Green)
+                .fg(theme.success)
                 .bg(theme.comment_preview_bg);
-            let delete_style = Style::default().fg(Color::Red).bg(theme.comment_preview_bg);
+            let delete_style = Style::default()
+                .fg(theme.error)
+                .bg(theme.comment_preview_bg);
             let claude_style = Style::default()
                 .fg(Color::Rgb(180, 140, 255))
                 .bg(theme.comment_preview_bg);
@@ -1197,12 +1215,14 @@ fn ensure_diff_annotations_cached(app: &mut App) {
     app.viewer_state.content.cached_diff_annotations_file = current_file;
 }
 
-/// Render intra-line diff segments with emphasis highlighting (plain white fg).
-/// Used for Delete lines where syntax tokens are unavailable.
+/// Render intra-line diff segments with emphasis highlighting.
+/// Used for Delete lines where syntax tokens are unavailable; `fg` is the
+/// plain text color (the active theme's foreground).
 fn render_inline_diff_spans(
     segments: &[InlineSegment],
     diff_bg: Color,
     emphasis_bg: Color,
+    fg: Color,
     tab_width: usize,
 ) -> Vec<Span<'static>> {
     segments
@@ -1213,7 +1233,7 @@ fn render_inline_diff_spans(
                 seg.text.trim_end_matches('\n').trim_end_matches('\r'),
                 tab_width,
             );
-            Span::styled(text, Style::default().fg(Color::White).bg(bg))
+            Span::styled(text, Style::default().fg(fg).bg(bg))
         })
         .collect()
 }
@@ -1367,6 +1387,7 @@ fn syntax_spans_for_line(
     vs: &crate::viewer::ViewerState,
     line_no: usize,
     diff_bg: Option<Color>,
+    fg: Color,
 ) -> Vec<Span<'static>> {
     if let Some(tokens) = vs.content.highlighted_lines.get(line_no) {
         tokens
@@ -1382,14 +1403,14 @@ fn syntax_spans_for_line(
             })
             .collect()
     } else {
-        // Fallback: plain white text.
+        // Fallback: plain text in the theme foreground.
         let text = vs
             .content
             .file_content
             .get(line_no)
             .cloned()
             .unwrap_or_default();
-        vec![Span::styled(text, Style::default().fg(Color::White))]
+        vec![Span::styled(text, Style::default().fg(fg))]
     }
 }
 
@@ -1530,7 +1551,7 @@ fn apply_hint_labels(
         let is_matching = input.is_empty() || hint.label.starts_with(input);
         let label_style = if is_matching {
             Style::default()
-                .fg(Color::Black)
+                .fg(theme.selected_fg)
                 .bg(theme.accent)
                 .add_modifier(Modifier::BOLD)
         } else {

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -65,8 +65,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         Style::default()
             .fg(theme.waiting_primary)
             .add_modifier(Modifier::BOLD)
+    } else if focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {
-        Style::default()
+        Style::default().fg(theme.muted)
     };
     let border_type = if focused {
         BorderType::Thick


### PR DESCRIPTION
## Summary

TUIの見た目を「もっと美しく」するための、色の土台とフォーカス可視化のリファクタ。多視点ディスカッション（ada / priscilla / ursula）で方針を固めてから実装した。

### 色の本物化・統一
- デフォルトテーマ `catppuccin_mocha()` が名前に反してANSI16色（端末依存）を使っていたのを、**公式Catppuccin Mocha RGB**に全面書き換え（Base/Mantle/Surface/Text/Mauve/Sky/Peach）。他7テーマと同じ品質に揃えた。
- 各所のハードコードANSI色（タイトルバー、確認/Skipオーバーレイ、スクロールバック表示、コメント種別バッジ、diff本文、シンボルヒント等）をテーマ経由に統一し、テーマ切り替えが全画面に効くようにした。

### フォーカスの可視化（Phase 2-A）
- `Theme` に `panel_focused_bg` を追加。フォーカス中のリスト列（worktree / explorer）だけ控えめな面色で塗り、周辺視野でも焦点が分かるようにした。viewer は読むペインとして除外、terminal は PTY 自身の背景を尊重して除外。
- 各パネルの見出しを focus 連動で出し分け（フォーカス時は `fg` + Bold、非フォーカス時は `muted` にdim）。

### アニメーションの鎮静（Phase 2-B）
- 通知バーのパルスを矩形波の点滅 → 三角波の breathing フェードに変更。
- 装飾アニメ（水族館等）を worktree フォーカス時のみ前進させ、レビュー/ターミナル作業中は静止。
- 装飾を止めても通知パルスが凍らないよう、専用の `pulse` タイマー（80ms）を追加。

## Test plan
- `cargo build` / `cargo clippy` 警告なし
- `cargo fmt --check` クリーン
- `cargo test` 184 passed
- デフォルトテーマ含む8テーマ、フォーカス移動時の面色・見出しdim、通知バーの breathing、装飾のフォーカス連動停止を `cargo run` で目視確認（要レビュアー確認）
