### PR TITLE
feat: persist/restore worktree view state and fix release CI ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,37 +29,14 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-  create-release:
+  # Build every platform binary FIRST and stash each as a workflow artifact.
+  # Nothing is published yet — no tag, no GitHub Release. If any target fails,
+  # the `release` job below never runs, so a half-built version is never
+  # advertised to the in-app updater.
+  build:
     needs: check-version
     if: needs.check-version.outputs.version_changed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create and push tag
-        run: |
-          git tag "v${{ needs.check-version.outputs.version }}"
-          git push origin "v${{ needs.check-version.outputs.version }}"
-
-      - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.check-version.outputs.version }}
-          name: v${{ needs.check-version.outputs.version }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-and-upload:
-    needs: [check-version, create-release]
-    if: needs.check-version.outputs.version_changed == 'true'
-    permissions:
-      contents: write
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
@@ -69,7 +46,6 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -81,15 +57,57 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+          TARGET: ${{ matrix.target }}
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../conductor-${{ needs.check-version.outputs.version }}-${{ matrix.target }}.tar.gz conductor
+          cd "target/${TARGET}/release"
+          tar czf "../../../conductor-${VERSION}-${TARGET}.tar.gz" conductor
           cd ../../..
 
-      - name: Upload release asset
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: conductor-${{ matrix.target }}
+          path: conductor-${{ needs.check-version.outputs.version }}-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  # Publish atomically: only after ALL binaries built successfully. This single
+  # step creates the tag, the GitHub Release, attaches every asset, and marks it
+  # `latest`. Because `/releases/latest` only surfaces this version once it
+  # exists, the in-app updater always finds a matching pre-built binary and never
+  # falls back to the slow source build.
+  release:
+    needs: [check-version, build]
+    if: needs.check-version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Verify all platform binaries are present
+        run: |
+          count=$(ls dist/*.tar.gz 2>/dev/null | wc -l | tr -d ' ')
+          echo "found $count binary tarball(s):"
+          ls -l dist/ || true
+          if [ "$count" -ne 3 ]; then
+            echo "::error::expected 3 platform binaries, found $count — refusing to publish an incomplete release"
+            exit 1
+          fi
+
+      - name: Create GitHub Release (tag + assets, atomically)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
-          files: conductor-${{ needs.check-version.outputs.version }}-${{ matrix.target }}.tar.gz
+          name: v${{ needs.check-version.outputs.version }}
+          generate_release_notes: true
+          make_latest: true
+          files: dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -209,6 +209,17 @@ pub struct GrabbedBranch {
     pub claude_session_id: Option<String>,
 }
 
+/// A pending view restore: open this file and scroll to this line once the
+/// file tree for the current worktree is loaded. Used to restore where the
+/// user was after a restart (or when switching back to a worktree).
+#[derive(Debug, Clone)]
+pub struct PendingViewRestore {
+    /// Worktree-relative path of the file to re-open.
+    pub file: String,
+    /// Top visible line (0-based) to scroll to.
+    pub scroll: usize,
+}
+
 /// State of the in-app update flow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateState {
@@ -410,6 +421,15 @@ pub struct App {
     // ── Auto-resume Claude sessions ─────────────────────────────
     /// Whether auto-resume should run on the next frame (one-shot).
     pub pending_auto_resume: bool,
+
+    // ── View state restore (persist where the user was) ─────────
+    /// Branch of the worktree whose viewer state is currently loaded in
+    /// memory. Tracks the "owner" of `viewer_state` so it can be persisted
+    /// before we switch away. `None` until the first worktree is loaded.
+    pub current_view_branch: Option<String>,
+    /// A saved file+scroll to restore once the file tree is available
+    /// (one-shot; consumed by [`App::consume_pending_view_restore`]).
+    pub pending_view_restore: Option<PendingViewRestore>,
 
     /// Cached layout rectangles (recomputed when frame size or expansion state changes).
     pub layout_cache: crate::ui::layout::LayoutCache,
@@ -632,6 +652,8 @@ impl App {
             branch_details: Default::default(),
             gh_available: Self::check_gh_available(),
             pending_auto_resume: auto_resume,
+            current_view_branch: None,
+            pending_view_restore: None,
             layout_cache: Default::default(),
             symbol_index: SymbolIndex::new(PathBuf::new()),
             jump_history: JumpHistory::new(),
@@ -645,6 +667,9 @@ impl App {
         };
         app.symbol_index = SymbolIndex::new(app.repo_path.clone());
         app.refresh_worktrees();
+        // Restore the previously selected worktree + its open file/scroll so a
+        // restart (e.g. after an update) lands the user where they left off.
+        app.restore_selected_worktree_and_view();
         app.refresh_reviews();
 
         // Restore grab state from $git_common_dir/wt-grab if it exists.
@@ -683,6 +708,8 @@ impl App {
         if index >= self.repo_list.len() {
             return;
         }
+        // Persist the outgoing repo's view before swapping the store.
+        self.persist_view_state();
         self.repo_list_index = index;
         self.repo_path = self.repo_list[index].clone();
 
@@ -714,6 +741,8 @@ impl App {
         self.viewer_state = ViewerState::default();
         self.diff_state =
             DiffState::new(&self.config.general.main_branch, self.diff_state.view_mode);
+        // Restore the new repo's last selected worktree + open file/scroll.
+        self.restore_selected_worktree_and_view();
         self.refresh_reviews();
         self.terminal.active_claude_session = None;
         self.terminal.active_shell_session = None;
@@ -904,8 +933,110 @@ impl App {
             let path = wt.path.clone();
             let tab_width = self.config.viewer.tab_width;
             self.viewer_state.load_file_tree(&path, tab_width);
+            // Startup restore: this is the lazy (synchronous) tree-load path
+            // (e.g. first time the viewer is focused), so re-open any pending
+            // file here. The async worktree-switch path does this in
+            // `poll_worktree_switch_ops`.
+            self.consume_pending_view_restore();
             self.rehighlight_viewer();
         }
+    }
+
+    /// Restore the previously selected worktree and seed its saved view
+    /// (open file + scroll) for the current repo. Safe to call when nothing
+    /// was persisted — it just leaves the defaults in place.
+    ///
+    /// Used at startup and when switching repos. The worktree list is already
+    /// populated synchronously by [`App::refresh_worktrees`], so the selection
+    /// is restored without a frame of flicker. The file itself is restored
+    /// lazily once its tree loads (see [`App::consume_pending_view_restore`]).
+    pub fn restore_selected_worktree_and_view(&mut self) {
+        // Restore which worktree was selected (fall back to current on miss).
+        let saved_branch = self
+            .review_store
+            .as_ref()
+            .and_then(|s| s.get_selected_worktree().ok().flatten());
+        if let Some(branch) = saved_branch
+            && let Some(idx) = self.worktrees.iter().position(|w| w.branch == branch)
+        {
+            self.selected_worktree = idx;
+        }
+
+        // Point the worktree-list cursor at the restored worktree.
+        self.rebuild_worktree_list_rows();
+        let sel = self.selected_worktree;
+        if let Some(pos) = self
+            .worktree_list_rows
+            .iter()
+            .position(|r| matches!(r, WorktreeListRow::Worktree(i) if *i == sel))
+        {
+            self.worktree_list_selected = pos;
+        }
+
+        // Track the loaded worktree and seed its saved file/scroll.
+        let branch = self.selected_worktree_branch();
+        self.pending_view_restore = None;
+        if branch.is_empty() {
+            self.current_view_branch = None;
+            return;
+        }
+        self.current_view_branch = Some(branch.clone());
+        if let Some(store) = &self.review_store
+            && let Ok(Some((Some(file), line))) = store.get_view_state(&branch)
+        {
+            self.pending_view_restore = Some(PendingViewRestore {
+                file,
+                scroll: line.max(0) as usize,
+            });
+        }
+    }
+
+    /// Persist the in-memory view (open file + scroll) for `branch`.
+    ///
+    /// If a restore is still pending (the user never opened the viewer for this
+    /// worktree this session), the unconsumed pending value is written back
+    /// unchanged so we don't clobber the saved state with an empty view.
+    fn save_view_for(&self, branch: &str) {
+        let Some(store) = &self.review_store else {
+            return;
+        };
+        let (file, line) = match &self.pending_view_restore {
+            Some(r) => (Some(r.file.clone()), r.scroll as i64),
+            None => (
+                self.viewer_state.content.current_file.clone(),
+                self.viewer_state.content.file_scroll as i64,
+            ),
+        };
+        let _ = store.save_view_state(branch, file.as_deref(), line);
+    }
+
+    /// Save the current worktree's view and selection. Called before exit /
+    /// restart and before switching repos.
+    pub fn persist_view_state(&self) {
+        if let Some(branch) = &self.current_view_branch {
+            self.save_view_for(branch);
+            if let Some(store) = &self.review_store {
+                let _ = store.set_selected_worktree(branch);
+            }
+        }
+    }
+
+    /// Consume a one-shot [`PendingViewRestore`]: open the saved file and
+    /// scroll to the saved line. No-op if nothing is pending or the file no
+    /// longer exists. The scroll target is clamped to the file length so a
+    /// shrunken file doesn't leave a blank viewer.
+    pub fn consume_pending_view_restore(&mut self) {
+        let Some(restore) = self.pending_view_restore.take() else {
+            return;
+        };
+        let wt_path = self.selected_worktree_path();
+        if !wt_path.join(&restore.file).is_file() {
+            return;
+        }
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.open_file(&wt_path, &restore.file, tab_width);
+        let max = self.viewer_state.content.file_content.len().saturating_sub(1);
+        self.viewer_state.content.file_scroll = restore.scroll.min(max);
     }
 
     /// Run syntect highlighting on the currently loaded file content.

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -1442,7 +1442,33 @@ impl App {
     /// dispatched to background threads so the UI stays responsive. Results are
     /// applied in `poll_worktree_switch_ops()`.
     pub fn on_worktree_changed(&mut self) {
+        // Persist the outgoing worktree's view before we wipe it.
+        if let Some(outgoing) = self.current_view_branch.clone() {
+            self.save_view_for(&outgoing);
+        }
+
         self.viewer_state = ViewerState::default();
+
+        // Track the worktree now being loaded and seed its saved file/scroll
+        // so it gets re-opened once the file tree arrives.
+        let new_branch = self.selected_worktree_branch();
+        self.pending_view_restore = None;
+        self.current_view_branch = if new_branch.is_empty() {
+            None
+        } else {
+            Some(new_branch.clone())
+        };
+        if let Some(store) = &self.review_store {
+            if !new_branch.is_empty() {
+                let _ = store.set_selected_worktree(&new_branch);
+            }
+            if let Ok(Some((Some(file), line))) = store.get_view_state(&new_branch) {
+                self.pending_view_restore = Some(crate::app::PendingViewRestore {
+                    file,
+                    scroll: line.max(0) as usize,
+                });
+            }
+        }
 
         // Clear "new" badge for the worktree the user just selected.
         if let Some(wt) = self.worktrees.get(self.selected_worktree) {
@@ -1627,17 +1653,9 @@ impl App {
         if let Some(entries) = self.bg.file_tree.poll() {
             self.viewer_state.tree.file_tree = entries;
             self.viewer_state.invalidate_visible_cache();
-            // Re-open the previously viewed file if it still exists.
-            if let Some(wt) = self.worktrees.get(self.selected_worktree) {
-                let wt_path = wt.path.clone();
-                if let Some(ref rel_path) = self.viewer_state.content.current_file.clone() {
-                    let full = wt_path.join(rel_path);
-                    if full.is_file() {
-                        let tab_width = self.config.viewer.tab_width;
-                        self.viewer_state.open_file(&wt_path, rel_path, tab_width);
-                    }
-                }
-            }
+            // Restore the previously viewed file + scroll for this worktree now
+            // that its file tree is available (one-shot).
+            self.consume_pending_view_restore();
             self.rehighlight_viewer();
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,11 @@ fn main() -> Result<()> {
     )?;
     terminal.show_cursor()?;
 
+    // ── Persist view state (covers both normal quit and update-restart) ─
+    // Must run before the `exec` below: `exec` replaces the process image, so
+    // no Drop or later code would execute on the restart path.
+    app.persist_view_state();
+
     // ── Restart if update was installed ───────────────────────────────
     if app.should_restart {
         println!("Restarting Conductor...");

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -215,6 +215,13 @@ impl ReviewStore {
                 scroll_positions TEXT
             );
 
+            -- Single-row table holding cross-cutting UI state for this repo
+            -- (currently just which worktree was last selected).
+            CREATE TABLE IF NOT EXISTS ui_state (
+                id                INTEGER PRIMARY KEY CHECK (id = 1),
+                selected_worktree TEXT
+            );
+
             CREATE TABLE IF NOT EXISTS comment_templates (
                 id          TEXT PRIMARY KEY,
                 name        TEXT NOT NULL,
@@ -666,6 +673,59 @@ impl ReviewStore {
         Ok(out)
     }
 
+    // -- View state (restore where the user was on restart) -----------------
+
+    /// Persist the last-viewed file (relative path) and scroll position for a
+    /// worktree branch. `file` may be `None` when no file was open.
+    pub fn save_view_state(&self, worktree: &str, file: Option<&str>, line: i64) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO worktree_state (worktree, last_viewed_file, last_viewed_line)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(worktree) DO UPDATE SET
+                 last_viewed_file = excluded.last_viewed_file,
+                 last_viewed_line = excluded.last_viewed_line",
+            params![worktree, file, line],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve `(last_viewed_file, last_viewed_line)` for a worktree branch.
+    pub fn get_view_state(&self, worktree: &str) -> Result<Option<(Option<String>, i64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT last_viewed_file, last_viewed_line FROM worktree_state WHERE worktree = ?1",
+        )?;
+        let result = stmt
+            .query_row(params![worktree], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<i64>>(1)?.unwrap_or(0),
+                ))
+            })
+            .ok();
+        Ok(result)
+    }
+
+    /// Persist which worktree branch was last selected (per-repo).
+    pub fn set_selected_worktree(&self, branch: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO ui_state (id, selected_worktree) VALUES (1, ?1)",
+            params![branch],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve the last selected worktree branch, if any.
+    pub fn get_selected_worktree(&self) -> Result<Option<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT selected_worktree FROM ui_state WHERE id = 1")?;
+        let result = stmt
+            .query_row([], |row| row.get::<_, Option<String>>(0))
+            .ok()
+            .flatten();
+        Ok(result)
+    }
+
     // -- Daily Stats / Gamification -----------------------------------------
 
     /// Increment a counter in the daily_stats table for today.
@@ -986,6 +1046,56 @@ mod tests {
         store.update_review_body(&review.id, "edited").unwrap();
         let reviews = store.reviews_for_worktree("wt1").unwrap();
         assert_eq!(reviews[0].body, "edited");
+    }
+
+    #[test]
+    fn view_state_save_and_get() {
+        let store = test_store();
+
+        // Absent worktree returns None.
+        assert_eq!(store.get_view_state("feat/x").unwrap(), None);
+
+        // Save and read back a file + scroll.
+        store
+            .save_view_state("feat/x", Some("src/main.rs"), 42)
+            .unwrap();
+        assert_eq!(
+            store.get_view_state("feat/x").unwrap(),
+            Some((Some("src/main.rs".to_string()), 42))
+        );
+
+        // Upsert overwrites the previous value (no duplicate rows).
+        store
+            .save_view_state("feat/x", Some("src/app/mod.rs"), 7)
+            .unwrap();
+        assert_eq!(
+            store.get_view_state("feat/x").unwrap(),
+            Some((Some("src/app/mod.rs".to_string()), 7))
+        );
+
+        // A None file (nothing open) round-trips.
+        store.save_view_state("feat/x", None, 0).unwrap();
+        assert_eq!(store.get_view_state("feat/x").unwrap(), Some((None, 0)));
+    }
+
+    #[test]
+    fn selected_worktree_save_and_get() {
+        let store = test_store();
+
+        assert_eq!(store.get_selected_worktree().unwrap(), None);
+
+        store.set_selected_worktree("feat/a").unwrap();
+        assert_eq!(
+            store.get_selected_worktree().unwrap(),
+            Some("feat/a".to_string())
+        );
+
+        // Single-row table: setting again replaces, never accumulates.
+        store.set_selected_worktree("feat/b").unwrap();
+        assert_eq!(
+            store.get_selected_worktree().unwrap(),
+            Some("feat/b".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related improvements to the self-update experience, plus the persistence that makes a restart feel seamless.

### 1. Fix the slow / opaque update experience (release CI)
The release workflow published the GitHub Release **before** building the platform binaries, leaving a ~5-minute window where `/releases/latest` advertised a new version with no assets attached. An in-app update during that window found no matching pre-built binary and fell back to a full `cargo install` source build (several minutes) — the "閉じてから立ち上がるまですごい時間かかる" symptom.

`release.yml` is now **build-first / atomic publish**:
- A `build` matrix compiles all three targets and uploads each as a workflow artifact. Nothing is published yet.
- A `release` job downloads the artifacts, **verifies all three platform binaries are present** (refuses to publish otherwise), then creates the tag + Release + assets + `make_latest` in a single atomic step.
- If any build fails, no tag and no Release are left behind.

Result: a version is only ever advertised once every binary is attached, so the in-app updater always takes the fast download path.

### 2. Persist & restore worktree view state across restarts
The `worktree_state` table existed in the schema but was never read or written (dead code). It is now wired up so a restart (e.g. after an update) — and ordinary `q` quit, worktree switches, and repo switches — restores **which worktree was selected, which file was open, and the scroll position**.

- New `ReviewStore` methods (`save_view_state` / `get_view_state` / `set_selected_worktree` / `get_selected_worktree`); a single-row `ui_state` table added via `CREATE TABLE IF NOT EXISTS` (no migration, backward compatible).
- Per-worktree state is saved on switch-away and at exit; selection + file/scroll restored at startup and on repo switch.
- Save runs before the restart `exec` (which replaces the process image, so `Drop` would not fire) and on every normal exit path.
- Guards: missing file, renamed/deleted branch, shrunken file (scroll clamped), empty repo, absent DB.
- Scope kept minimal (`scroll_positions` column intentionally left unused).

Version bumped to **0.55.0** (backward-compatible feature addition).

## Test plan

- [x] `cargo build` / `cargo clippy` clean
- [x] `cargo test` — 186 tests pass, including new `view_state_save_and_get` and `selected_worktree_save_and_get` (upsert dedup + single-row replacement)
- [x] `actionlint` passes on the rewritten `release.yml`
- [x] Verified the "verify all binaries present" guard logic (3 -> ok, 2 -> refuse) locally
- [x] Rebased onto latest `main` (#230) and re-verified `cargo check`
- [ ] End-to-end: the `v0.55.0` release produced by merging this PR exercises the new atomic workflow
- [ ] Manual: open a file, switch worktrees / quit / restart, confirm the worktree + file + scroll are restored
