### PR TITLE
feat: 自己レビューコメントの密度ガードレールと explain-comment バグ修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 
 [dependencies]

--- a/plugins/conductor/commands/explain-comment.md
+++ b/plugins/conductor/commands/explain-comment.md
@@ -32,10 +32,10 @@ $ARGUMENTS
 
 ### 3. 説明コメントを追加
 
-各箇所に対して `mcp__plugin_general_code-comment__add_comment` を使用してコメントを追加する。
+各箇所に対して `mcp__conductor__create_comment` を使用してコメントを追加する。
 
 ```
-mcp__plugin_general_code-comment__add_comment:
+mcp__conductor__create_comment:
   file_path: <対象ファイルの相対パス>
   line_start: <開始行番号>
   line_end: <終了行番号（省略可）>
@@ -84,6 +84,6 @@ mcp__plugin_general_code-comment__add_comment:
 
 ## 重要
 
-- コメントはコードファイルに直接書き込むのではなく、**Conductor の code comment 機能**（`mcp__plugin_general_code-comment__add_comment`）を使って追加する
+- コメントはコードファイルに直接書き込むのではなく、**Conductor の code comment 機能**（`mcp__conductor__create_comment`）を使って追加する
 - 追加されたコメントは Conductor の Viewer パネルで 💬 マークとして表示される
-- conductor 独自の MCP ツール（`mcp__plugin_conductor_conductor__reply_to_comment` 等）も利用可能な場合は活用してよい
+- 関連する MCP ツール（`mcp__conductor__reply_to_comment` 等）も必要に応じて活用してよい

--- a/plugins/conductor/mcp/conductor-comment/package.json
+++ b/plugins/conductor/mcp/conductor-comment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -128,7 +128,7 @@ interface ReviewReply {
 
 const server = new McpServer({
   name: "conductor",
-  version: "0.3.0",
+  version: "0.4.0",
 });
 
 let db: Database.Database;
@@ -443,11 +443,15 @@ server.tool(
 // Tool: create_comment
 // ---------------------------------------------------------------------------
 
+// Above this many unresolved self-review comments on one branch, the success
+// message adds a nudge so the author notices the density is getting high.
+// A soft signal, not a hard cap — tuned by feel, adjust as usage shows.
+const SELF_REVIEW_SOFT_LIMIT = 5;
+
 server.tool(
   "create_comment",
-  "Leave an inline self-review comment on a specific file and line range in the current branch's diff. Author is automatically set to 'claude' and the comment appears inline in the Conductor diff view. " +
-    "Use this SPARINGLY and with high signal: flag ONLY what a human reviewer genuinely needs to know — non-obvious or tricky logic, deliberate tradeoffs, decisions worth a second look, or places you are unsure about. " +
-    "Do NOT narrate routine changes or restate what the diff already makes obvious; a flood of low-value comments defeats the purpose. Prefer a handful of important notes over many.",
+  "Leave an inline self-review comment on a file/line range in the current branch's diff. Author is set to 'claude' and it appears inline in the Conductor diff view. " +
+    "High-signal, low-frequency tool: flag only what a human reviewer genuinely needs — tricky logic, deliberate tradeoffs, or spots you are unsure about — not routine changes the diff already makes obvious.",
   {
     file_path: z
       .string()
@@ -556,11 +560,28 @@ server.tool(
       ? `${relPath}:${line_start}-${line_end}`
       : `${relPath}:${line_start}`;
 
+    // Running count of unresolved self-review comments on this branch. Surfaced
+    // back to the author so it can observe its own comment density and self-pace
+    // — a far stronger restraint than a static "use sparingly" instruction. The
+    // count only colours into a nudge once it's high (see SELF_REVIEW_SOFT_LIMIT).
+    const selfReviewCount = (
+      d
+        .prepare(
+          "SELECT COUNT(*) AS n FROM reviews WHERE author = 'claude' AND status = 'pending' AND (branch = ? OR worktree = ?)"
+        )
+        .get(branch, branch) as { n: number }
+    ).n;
+
+    const densityNudge =
+      selfReviewCount > SELF_REVIEW_SOFT_LIMIT
+        ? " — that's a lot; make sure each one is genuinely high-signal before adding more"
+        : "";
+
     return {
       content: [
         {
           type: "text" as const,
-          text: `Comment created (id: ${id.slice(0, 8)}) at ${loc} on branch "${branch}".`,
+          text: `Comment created (id: ${id.slice(0, 8)}) at ${loc} on branch "${branch}". (${selfReviewCount} unresolved self-review comment(s) now on this branch${densityNudge}.)`,
         },
       ],
     };


### PR DESCRIPTION
## 概要

レビューコメント機能の自己レビュー（Claude→人間）まわりを、`/daisy` での多視点設計議論を経て改善する。MCP層の責務を整理し、コメント氾濫を抑える実効的なガードレールを追加する。

設計の核は「意図/文脈を A=データ不変条件 / B=能力契約 / C=運用方針 に三分し、強制力と発火タイミングに応じた層へ置く」こと。今回は B/C の置き場所を是正する（A のスキーマ一元化は別PRで対応予定）。

## 変更内容

### fix: explain-comment コマンドの古いツール名を修正
- `mcp__plugin_general_code-comment__add_comment` / `mcp__plugin_conductor_conductor__reply_to_comment` という**実在しないツール名**を呼んでいたバグを修正。
- 実在の `mcp__conductor__create_comment` / `mcp__conductor__reply_to_comment` に統一（`address-conductor-comment` と同じ `mcp__conductor__` プレフィックス）。

### feat: 自己レビューコメントの密度フィードバックと create_comment ガイダンスの整理
- **説明文の圧縮**: `create_comment` の90語3文の訓示を2文に。「high-signal, low-frequency tool」というツールの性質ラベル＋「何を書く/書かない」のアフォーダンスは保持し、冗長な動機づけの反復を削除。
- **件数フィードバック（主役のガードレール）**: 作成成功時の戻り値に「このブランチの未解決 self-review: 計N件」を追加。静的な "use sparingly" より強い、観測可能な「鏡」として density を自己抑制させる。
- N が `SELF_REVIEW_SOFT_LIMIT`(=5) を超えたときだけ「多いかも」という解釈を添える（高い時だけ鏡に色をつける）。
- バージョン: Cargo.toml `0.57.0 → 0.58.0`、MCPサーバー `0.3.0 → 0.4.0`（後方互換の機能追加＝MINOR）。

## 設計の背景（採用/見送り）

- **採用**: 三層配置（説明文1行＋戻り値件数＋将来のフック）、Adaの三分法、Beatriceの「能力契約 vs 方針契約」分離。
- **見送り**: Stopフックでの自己レビュー発火（効果不確実・既存 signal-waiting と同居危険のため実験扱いに）、`get_pending_comments` のJSON化（消費者がLLM1つで見返り薄く後回し）。

## 検証

- `tsc`（MCPサーバー）ビルド成功。
- `cargo check` 成功（Cargo.lock 同期）。
- COUNTクエリのフィルタ（author='claude' / status='pending' / branch・worktree）はスキーマのCHECK制約と既存 `get_pending_comments` との対称性で担保。
