### PR TITLE
refactor: レビューコメントの不変条件をDBスキーマで担保（手ミラー負債の解消）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2024"
 
 [dependencies]

--- a/plugins/conductor/mcp/conductor-comment/package.json
+++ b/plugins/conductor/mcp/conductor-comment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -128,7 +128,7 @@ interface ReviewReply {
 
 const server = new McpServer({
   name: "conductor",
-  version: "0.4.0",
+  version: "0.5.0",
 });
 
 let db: Database.Database;
@@ -508,10 +508,11 @@ server.tool(
     }
     const relPath = file_path.replace(/^\.\//, "");
 
-    // Comments are keyed to a branch/worktree. The Rust side stores the
-    // worktree's branch name in both the `worktree` and `branch` columns
-    // (see add_review in review_store.rs), and uses the symbolic ref "HEAD"
-    // as commit_ref — mirror that exactly so the comment shows up in the TUI.
+    // Comments are keyed to a branch/worktree: the same branch name goes in
+    // both the `worktree` and `branch` columns. We no longer mirror the Rust
+    // side's commit_ref — the schema defaults it to 'HEAD' (reviews table, v4
+    // migration), and a CHECK enforces worktree = branch, so this writer just
+    // supplies the branch and lets the schema own the rest.
     // A detached HEAD reports the literal "HEAD", which is not a usable key.
     const branch = currentBranch();
     if (!branch || branch === "HEAD") {
@@ -530,8 +531,8 @@ server.tool(
     try {
       d.prepare(
         `INSERT INTO reviews
-           (id, worktree, file_path, line_start, line_end, kind, body, commit_ref, author, branch)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'HEAD', 'claude', ?)`
+           (id, worktree, file_path, line_start, line_end, kind, body, author, branch)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'claude', ?)`
       ).run(
         id,
         branch,

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -352,6 +352,65 @@ impl ReviewStore {
             .context("failed to migrate to v3 (worktree_metadata)")?;
         }
 
+        if version < 4 {
+            // Move two facts that were previously duplicated by every writer
+            // (the Rust TUI and the sibling Node MCP server) into the schema
+            // itself, so neither side has to mirror the other:
+            //   * `commit_ref` defaults to 'HEAD' — writers may now omit it.
+            //   * `worktree = branch` is enforced by a CHECK, turning a silent
+            //     shared assumption into a guarded contract. Legacy rows created
+            //     before the `branch` column existed have branch IS NULL, which
+            //     the CHECK deliberately permits.
+            // SQLite can neither add a DEFAULT to an existing column nor add a
+            // table-level CHECK in place, so the table is rebuilt. FK
+            // enforcement is disabled for the swap (review_replies references
+            // reviews by name and ids are preserved, so integrity holds).
+            conn.execute_batch("PRAGMA foreign_keys = OFF;")
+                .context("failed to disable foreign keys for v4 migration")?;
+            conn.execute_batch(
+                "
+                BEGIN;
+
+                CREATE TABLE reviews_new (
+                    id          TEXT PRIMARY KEY,
+                    worktree    TEXT NOT NULL,
+                    file_path   TEXT NOT NULL,
+                    line_start  INTEGER NOT NULL,
+                    line_end    INTEGER,
+                    kind        TEXT NOT NULL CHECK (kind IN ('suggest', 'question')),
+                    body        TEXT NOT NULL,
+                    status      TEXT NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending', 'resolved')),
+                    commit_ref  TEXT NOT NULL DEFAULT 'HEAD',
+                    author      TEXT NOT NULL DEFAULT 'user'
+                                  CHECK (author IN ('user', 'claude')),
+                    branch      TEXT,
+                    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    CHECK (branch IS NULL OR worktree = branch)
+                );
+
+                INSERT INTO reviews_new
+                    (id, worktree, file_path, line_start, line_end, kind, body,
+                     status, commit_ref, author, branch, created_at, updated_at)
+                SELECT
+                     id, worktree, file_path, line_start, line_end, kind, body,
+                     status, commit_ref, author, branch, created_at, updated_at
+                FROM reviews;
+
+                DROP TABLE reviews;
+                ALTER TABLE reviews_new RENAME TO reviews;
+
+                PRAGMA user_version = 4;
+
+                COMMIT;
+                ",
+            )
+            .context("failed to migrate to v4 (commit_ref default, worktree=branch check)")?;
+            conn.execute_batch("PRAGMA foreign_keys = ON;")
+                .context("failed to re-enable foreign keys after v4 migration")?;
+        }
+
         Ok(Self { conn })
     }
 
@@ -1026,6 +1085,55 @@ mod tests {
     }
 
     #[test]
+    fn v4_commit_ref_defaults_to_head() {
+        let store = test_store();
+        // Insert omitting commit_ref — the v4 schema default should fill it,
+        // which is what lets the Node MCP writer stop mirroring 'HEAD'.
+        store
+            .conn
+            .execute(
+                "INSERT INTO reviews (id, worktree, file_path, line_start, kind, body, branch)
+                 VALUES ('r1', 'feat/x', 'src/main.rs', 1, 'suggest', 'note', 'feat/x')",
+                [],
+            )
+            .unwrap();
+        let reviews = store.reviews_for_worktree("feat/x").unwrap();
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].commit_ref, "HEAD");
+    }
+
+    #[test]
+    fn v4_check_rejects_worktree_branch_mismatch() {
+        let store = test_store();
+        // worktree != branch (both non-null) must violate the CHECK so a
+        // drifting writer fails loudly instead of inserting an unreachable row.
+        let result = store.conn.execute(
+            "INSERT INTO reviews (id, worktree, file_path, line_start, kind, body, commit_ref, branch)
+             VALUES ('r1', 'feat/x', 'src/main.rs', 1, 'suggest', 'note', 'HEAD', 'feat/y')",
+            [],
+        );
+        assert!(result.is_err(), "worktree != branch should violate the CHECK");
+    }
+
+    #[test]
+    fn v4_check_allows_null_branch() {
+        let store = test_store();
+        // Legacy rows created before the `branch` column existed have branch
+        // IS NULL; the CHECK must keep permitting them.
+        store
+            .conn
+            .execute(
+                "INSERT INTO reviews (id, worktree, file_path, line_start, kind, body, commit_ref, branch)
+                 VALUES ('r1', 'wt1', 'src/main.rs', 1, 'suggest', 'note', 'HEAD', NULL)",
+                [],
+            )
+            .unwrap();
+        let reviews = store.reviews_for_worktree("wt1").unwrap();
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].branch, None);
+    }
+
+    #[test]
     fn update_body() {
         let store = test_store();
 
@@ -1169,9 +1277,11 @@ mod tests {
     fn line_range_and_author() {
         let store = test_store();
 
+        // worktree and branch carry the same branch name (the v4 CHECK enforces
+        // this); the comment column stores it in both.
         let review = store
             .add_review(
-                "wt1",
+                "feature/x",
                 "src/main.rs",
                 10,
                 Some(20),


### PR DESCRIPTION
## 概要

`/daisy` の設計議論で特定した負債を根治する。MCPサーバー(Node)が `add_review`(Rust)の挙動を**手でミラー**していた状態を、不変条件を**DBスキーマの宣言的契約**に降ろすことで解消する。

> #235（自己レビューの密度ガードレール）にスタックしていた #236 を再作成したもの。#235 マージ時にベースブランチを削除したため #236 が自動クローズされた。内容は同一。

> 当初は「Rustに `conductor comment add` を生やしNodeがexecして書き手を一元化する」案だったが、execはバイナリPATH/版の結合を純増させ「MCPは生きてるのにバイナリ未発見で作成全停止」という新障害モードを持ち込むためボツ。書き手をNodeのまま残し、スキーマ側で不変条件を担保する折衷案。

## 変更内容

### Rust: reviews テーブルの v4 マイグレーション（`review_store.rs`）
- `commit_ref TEXT NOT NULL DEFAULT 'HEAD'` — 値の所有をスキーマへ。書き手は省略可能に。
- `CHECK (branch IS NULL OR worktree = branch)` — 暗黙の共有前提だった「worktree=branch」を契約として強制。ズレた瞬間に静かに不可視コメントを作るのではなく、INSERTで明示的に失敗する。
- レガシー行（`branch IS NULL`）は CHECK が意図的に許容。
- SQLiteは既存列へのDEFAULT追加・テーブルCHECK追加が不可なため、FK無効化→テーブル再作成→コピー→rename の標準手順で実施。

### Node: 手ミラーの削除（`index.ts`）
- `create_comment` の INSERT から `commit_ref` を省略し、スキーマのDEFAULTに委譲。
- 「Rustをexactlyミラーせよ」コメントを「スキーマがcommit_refをデフォルト、CHECKがworktree=branchを強制する」に書き換え。

### テスト（`review_store.rs`）
- `v4_commit_ref_defaults_to_head` / `v4_check_rejects_worktree_branch_mismatch` / `v4_check_allows_null_branch` を追加。
- 既存 `line_range_and_author` の非現実的データ（worktree≠branch）を実不変条件に修正。

## 結合についての注記

Nodeが `commit_ref` を省略するため、MCPサーバーは DBがv4スキーマ済みであることに依存する。ただしMCPサーバーは元々スキーマ（列名）に密結合しており、conductorバイナリ起動時にマイグレーションが走るため実運用では常にv4。失敗時もNOT NULL制約で明示エラー。

## 検証

- `cargo test` 全206件パス（新規v4テスト3件含む）／`cargo clippy` クリーン／`tsc` ビルド成功。
- バージョン: Cargo.toml `0.58.0 → 0.59.0`、MCPサーバー `0.4.0 → 0.5.0`。
