### PR TITLE
fix: 背景輝度に応じてプロジェクト名バッジの文字色を自動選択する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.59.0"
+version = "0.59.1"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -234,12 +234,47 @@ fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
     )
 }
 
-/// Generate badge background and branch text colors from a repository name.
+/// Relative luminance of an sRGB color per WCAG 2.1 (SC 1.4.3, D65).
 ///
-/// Uses a hash of the name to pick a hue, then produces two colors:
+/// Channels are 0-255. Each is normalized to 0-1, gamma-expanded to linear
+/// light, then combined with the standard luminance coefficients.
+fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
+    fn linearize(c: u8) -> f64 {
+        let c = c as f64 / 255.0;
+        if c <= 0.03928 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+}
+
+/// Pick black or white text for the best WCAG contrast against the given
+/// background. The badge is for identifying the repository at a glance, so we
+/// always take the higher-contrast option rather than failing when neither
+/// candidate clears the 4.5:1 guideline. Explicit RGB (not named ANSI colors)
+/// keeps the rendered result aligned with the luminance computation.
+fn readable_fg_on(r: u8, g: u8, b: u8) -> Color {
+    let bg = relative_luminance(r, g, b);
+    // Contrast ratio (L1 + 0.05) / (L2 + 0.05); black has L=0, white has L=1.
+    let contrast = |fg: f64| (bg.max(fg) + 0.05) / (bg.min(fg) + 0.05);
+    if contrast(0.0) >= contrast(1.0) {
+        Color::Rgb(0, 0, 0)
+    } else {
+        Color::Rgb(255, 255, 255)
+    }
+}
+
+/// Generate badge background, badge text, and branch text colors from a
+/// repository name.
+///
+/// Uses a hash of the name to pick a hue, then produces three colors:
 /// - Badge background: muted (S=0.6, L=0.45)
+/// - Badge text: black or white, whichever contrasts better with the
+///   background (hues vary widely in perceived luminance at a fixed lightness)
 /// - Branch text: brighter (S=0.7, L=0.75)
-fn name_to_color(name: &str) -> (Color, Color) {
+fn name_to_color(name: &str) -> (Color, Color, Color) {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     name.hash(&mut hasher);
     let hash = hasher.finish();
@@ -247,7 +282,8 @@ fn name_to_color(name: &str) -> (Color, Color) {
 
     let (br, bg, bb) = hsl_to_rgb(hue, 0.6, 0.45);
     let (tr, tg, tb) = hsl_to_rgb(hue, 0.7, 0.75);
-    (Color::Rgb(br, bg, bb), Color::Rgb(tr, tg, tb))
+    let badge_fg = readable_fg_on(br, bg, bb);
+    (Color::Rgb(br, bg, bb), badge_fg, Color::Rgb(tr, tg, tb))
 }
 
 /// Render the title bar at the top showing worktree name and working directory.
@@ -264,11 +300,11 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
         .map(|w| w.path.display().to_string())
         .unwrap_or_else(|| app.repo_path.display().to_string());
 
-    let (badge_bg, branch_fg) = name_to_color(&app.main_repo_name);
+    let (badge_bg, badge_fg, branch_fg) = name_to_color(&app.main_repo_name);
 
     let bar_bg = theme.titlebar_bg;
     let conductor_bg = badge_bg;
-    let conductor_fg = Color::Black;
+    let conductor_fg = badge_fg;
 
     let badge_text = format!(" {} ", app.main_repo_name);
     let line = Line::from(vec![
@@ -651,5 +687,59 @@ fn format_tokens(tokens: u64) -> String {
         format!("{:.1}K", tokens as f64 / 1_000.0)
     } else {
         format!("{tokens}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Contrast ratio between two relative-luminance values per WCAG 2.1.
+    fn contrast_ratio(l1: f64, l2: f64) -> f64 {
+        (l1.max(l2) + 0.05) / (l1.min(l2) + 0.05)
+    }
+
+    #[test]
+    fn relative_luminance_endpoints() {
+        assert!(relative_luminance(0, 0, 0).abs() < 1e-9);
+        assert!((relative_luminance(255, 255, 255) - 1.0).abs() < 1e-9);
+        // Green contributes far more luminance than blue at full intensity.
+        assert!(relative_luminance(0, 255, 0) > relative_luminance(0, 0, 255));
+    }
+
+    #[test]
+    fn readable_fg_matches_higher_contrast_choice() {
+        // Bright background → black text wins.
+        assert_eq!(readable_fg_on(255, 255, 0), Color::Rgb(0, 0, 0));
+        // Dark background → white text wins.
+        assert_eq!(readable_fg_on(20, 20, 120), Color::Rgb(255, 255, 255));
+    }
+
+    /// Across every hue the badge can take, the chosen text color must beat the
+    /// rejected one — guaranteeing the project name never collides with its
+    /// background, whether the badge lands light or dark.
+    #[test]
+    fn badge_fg_is_always_the_more_readable_choice() {
+        for hue in 0..360 {
+            let (r, g, b) = hsl_to_rgb(hue as f64, 0.6, 0.45);
+            let bg = relative_luminance(r, g, b);
+            let fg = readable_fg_on(r, g, b);
+            let (chosen, rejected) = match fg {
+                Color::Rgb(0, 0, 0) => (0.0, 1.0),
+                Color::Rgb(255, 255, 255) => (1.0, 0.0),
+                other => panic!("unexpected fg {other:?} at hue {hue}"),
+            };
+            assert!(
+                contrast_ratio(bg, chosen) >= contrast_ratio(bg, rejected),
+                "hue {hue}: chosen fg has worse contrast than the alternative",
+            );
+            // Sanity: the badge stays comfortably above the 3:1 large-text /
+            // UI-component floor for every hue.
+            assert!(
+                contrast_ratio(bg, chosen) >= 3.0,
+                "hue {hue}: contrast {:.2} fell below 3:1",
+                contrast_ratio(bg, chosen),
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

左上タイトルバーのリポジトリ名バッジは、リポジトリ名のハッシュから hue だけを変える方式で背景色を生成しています（彩度・明度は固定）。同じ HSL 明度でも hue によって知覚輝度が大きく変わるため、文字色が常に黒固定だと暗い hue（青・紫など）のバッジでプロジェクト名が読めなくなっていました。

文字色を背景色の輝度に応じて動的に決定するよう修正します。既存のランダム背景色の仕様は変更しません。

- `relative_luminance(r, g, b)`: WCAG 2.1 SC 1.4.3 に基づく相対輝度（sRGB をガンマ展開して `0.2126R + 0.7152G + 0.0722B`）を追加
- `readable_fg_on(r, g, b)`: 背景に対し黒・白それぞれのコントラスト比 `(L1+0.05)/(L2+0.05)` を比較し、コントラストの高い方を返す。名前付き ANSI 色ではなく明示 RGB（`Rgb(0,0,0)` / `Rgb(255,255,255)`）で返し、計算と実描画を一致させる
- `name_to_color` がバッジ文字色も返すようにし、`render_title_bar` の `Color::Black` ハードコードを撤去
- バグ修正のため version を `0.59.0` → `0.59.1`（PATCH）に更新

## Test plan

- [x] `src/ui/common.rs` に単体テストを追加
  - `relative_luminance_endpoints`: 黒=0.0 / 白=1.0、緑 > 青 の輝度関係を検証
  - `readable_fg_matches_higher_contrast_choice`: 明るい背景→黒、暗い背景→白を検証
  - `badge_fg_is_always_the_more_readable_choice`: バッジが取りうる全 360 hue について、選ばれた文字色が必ず棄却色よりコントラストが高く、かつどの hue でも 3:1 を下回らないことを保証
- [x] `cargo test` 全 212 件パス
- [x] `cargo clippy` 警告なし
- [x] `cargo build` 成功
