### PR TITLE
fix: セッション切り替え時にレンダーキャッシュを無効化してパネルを同期させる

### DIFF
--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -50,8 +50,7 @@ impl App {
             &self.repo_path,
             session_name,
         )?;
-        self.terminal.pty_manager.activate_session(idx);
-        self.terminal.active_claude_session = Some(idx);
+        self.terminal.switch_claude_session(idx);
         self.rebuild_worktree_list_rows();
         Ok(idx)
     }
@@ -81,8 +80,7 @@ impl App {
             &self.repo_path,
             None,
         )?;
-        self.terminal.pty_manager.activate_session(idx);
-        self.terminal.active_shell_session = Some(idx);
+        self.terminal.switch_shell_session(idx);
         Ok(idx)
     }
 
@@ -121,17 +119,37 @@ impl App {
         }
 
         // Clear invalidated indices and fall back to next available session.
+        // The closed session was the displayed one, so the fallback target's
+        // content differs — switch through the helper to reset scroll and the
+        // render cache (otherwise the panel would show the closed session's
+        // stale output). When no session remains, clear the cache directly.
         if self.terminal.active_claude_session == Some(usize::MAX) {
-            self.terminal.active_claude_session = self
+            match self
                 .current_worktree_claude_sessions()
                 .first()
-                .map(|(idx, _)| *idx);
+                .map(|(idx, _)| *idx)
+            {
+                Some(idx) => self.terminal.switch_claude_session(idx),
+                None => {
+                    self.terminal.active_claude_session = None;
+                    self.terminal.scroll_claude = 0;
+                    self.terminal.cache_claude = Default::default();
+                }
+            }
         }
         if self.terminal.active_shell_session == Some(usize::MAX) {
-            self.terminal.active_shell_session = self
+            match self
                 .current_worktree_shell_sessions()
                 .first()
-                .map(|(idx, _)| *idx);
+                .map(|(idx, _)| *idx)
+            {
+                Some(idx) => self.terminal.switch_shell_session(idx),
+                None => {
+                    self.terminal.active_shell_session = None;
+                    self.terminal.scroll_shell = 0;
+                    self.terminal.cache_shell = Default::default();
+                }
+            }
         }
         self.rebuild_worktree_list_rows();
     }
@@ -267,8 +285,7 @@ impl App {
             &self.repo_path,
             None,
         )?;
-        self.terminal.pty_manager.activate_session(idx);
-        self.terminal.active_claude_session = Some(idx);
+        self.terminal.switch_claude_session(idx);
         Ok(idx)
     }
 
@@ -335,8 +352,7 @@ impl App {
                     Ok(idx) => {
                         resumed_count += 1;
                         if wt.path == selected_wt_path {
-                            self.terminal.pty_manager.activate_session(idx);
-                            self.terminal.active_claude_session = Some(idx);
+                            self.terminal.switch_claude_session(idx);
                         }
                     }
                     Err(e) => {
@@ -381,10 +397,9 @@ impl App {
             ) {
                 Ok(idx) => {
                     resumed_count += 1;
-                    // Only activate + set active_claude_session for the currently selected worktree.
+                    // Only switch to this session for the currently selected worktree.
                     if wt.path == selected_wt_path {
-                        self.terminal.pty_manager.activate_session(idx);
-                        self.terminal.active_claude_session = Some(idx);
+                        self.terminal.switch_claude_session(idx);
                     }
                 }
                 Err(e) => {

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -350,8 +350,7 @@ impl App {
             &self.repo_path,
             None,
         )?;
-        self.terminal.pty_manager.activate_session(idx);
-        self.terminal.active_claude_session = Some(idx);
+        self.terminal.switch_claude_session(idx);
         Ok(idx)
     }
 

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -424,8 +424,7 @@ fn handle_worktree_column_click(app: &mut App, row: u16, geom: &ClickGeometry) {
         match app.worktree_list_rows[item_row] {
             crate::app::WorktreeListRow::Session { pty_idx, .. } => {
                 app.on_worktree_changed();
-                app.terminal.active_claude_session = Some(pty_idx);
-                app.terminal.pty_manager.activate_session(pty_idx);
+                app.terminal.switch_claude_session(pty_idx);
                 // Single click: keep focus on worktree panel.
                 // Double click: move focus to terminal.
                 if is_double {

--- a/src/event/terminal.rs
+++ b/src/event/terminal.rs
@@ -268,14 +268,12 @@ pub(super) fn handle_terminal_tab_click(
                 }
                 return;
             }
-            // Otherwise, activate the session.
-            app.terminal.pty_manager.activate_session(global_idx);
+            // Otherwise, switch to the session (resets scroll + render cache
+            // so the panel re-renders the newly selected session).
             if is_claude {
-                app.terminal.active_claude_session = Some(global_idx);
-                app.terminal.scroll_claude = 0;
+                app.terminal.switch_claude_session(global_idx);
             } else {
-                app.terminal.active_shell_session = Some(global_idx);
-                app.terminal.scroll_shell = 0;
+                app.terminal.switch_shell_session(global_idx);
             }
             return;
         }

--- a/src/event/worktree.rs
+++ b/src/event/worktree.rs
@@ -44,8 +44,7 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 .copied()
             {
                 Some(WorktreeListRow::Session { pty_idx, .. }) => {
-                    app.terminal.active_claude_session = Some(pty_idx);
-                    app.terminal.pty_manager.activate_session(pty_idx);
+                    app.terminal.switch_claude_session(pty_idx);
                     app.set_focus(Focus::TerminalClaude);
                 }
                 Some(WorktreeListRow::Worktree(_)) | None => {

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -76,4 +76,93 @@ impl TerminalState {
             dirty_shell: true,
         }
     }
+
+    /// Switch the Claude panel to display the session at `idx`.
+    ///
+    /// Marks the PTY session active, records it as the active Claude session,
+    /// and resets the panel's scroll offset and render cache. Clearing the
+    /// cache is essential: it is a single buffer shared across sessions, so
+    /// without this the panel would keep rendering the previous session's
+    /// content until some other trigger (scroll, new output) happened to
+    /// rebuild it. See `ui::terminal_claude` for the rebuild condition.
+    pub fn switch_claude_session(&mut self, idx: usize) {
+        self.pty_manager.activate_session(idx);
+        self.active_claude_session = Some(idx);
+        self.scroll_claude = 0;
+        self.cache_claude = PtyRenderCache::default();
+    }
+
+    /// Switch the Shell panel to display the session at `idx`.
+    ///
+    /// Shell-side counterpart of [`Self::switch_claude_session`]; same cache
+    /// invalidation rationale applies.
+    pub fn switch_shell_session(&mut self, idx: usize) {
+        self.pty_manager.activate_session(idx);
+        self.active_shell_session = Some(idx);
+        self.scroll_shell = 0;
+        self.cache_shell = PtyRenderCache::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::Line;
+
+    /// Seed a render cache so we can prove `switch_*` clears it. Mirrors the
+    /// stale state that caused the panel-not-syncing bug: a non-empty cache
+    /// left over from a previously displayed session.
+    fn stale_cache() -> PtyRenderCache {
+        PtyRenderCache {
+            lines: vec![Line::from("previous session output")],
+            effective_offset: 7,
+            cursor_position: Some((3, 4)),
+        }
+    }
+
+    #[test]
+    fn switch_claude_session_resets_scroll_and_cache() {
+        let mut term = TerminalState::new(1000, 100);
+        term.scroll_claude = 42;
+        term.cache_claude = stale_cache();
+
+        // No sessions exist; activate_session is a tolerant no-op, so this
+        // exercises the panel-state reset in isolation.
+        term.switch_claude_session(0);
+
+        assert_eq!(term.active_claude_session, Some(0));
+        assert_eq!(term.scroll_claude, 0);
+        assert!(
+            term.cache_claude.lines.is_empty(),
+            "cache must be cleared so the render guard rebuilds for the new session"
+        );
+        assert_eq!(term.cache_claude.effective_offset, 0);
+    }
+
+    #[test]
+    fn switch_shell_session_resets_scroll_and_cache() {
+        let mut term = TerminalState::new(1000, 100);
+        term.scroll_shell = 42;
+        term.cache_shell = stale_cache();
+
+        term.switch_shell_session(2);
+
+        assert_eq!(term.active_shell_session, Some(2));
+        assert_eq!(term.scroll_shell, 0);
+        assert!(term.cache_shell.lines.is_empty());
+        assert_eq!(term.cache_shell.effective_offset, 0);
+    }
+
+    #[test]
+    fn switch_claude_session_leaves_shell_panel_untouched() {
+        let mut term = TerminalState::new(1000, 100);
+        term.scroll_shell = 5;
+        term.cache_shell = stale_cache();
+
+        term.switch_claude_session(0);
+
+        // Switching the Claude panel must not disturb the Shell panel's state.
+        assert_eq!(term.scroll_shell, 5);
+        assert!(!term.cache_shell.lines.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Claude Code パネルでセッションタブ (CC:1 / CC:2 など) を切り替えても、パネルの中身が以前のセッションのまま更新されないことがある不具合を修正した。

### 原因
`cache_claude` / `cache_shell`（`TerminalState`）は**全セッションで共有される単一のレンダーキャッシュ**で、レンダ側 (`ui/terminal_claude.rs` / `ui/terminal_shell.rs`) の再構築条件は「キャッシュが空」「`focused && dirty`」「スクロールオフセット変化」のいずれかでしか発火しない。**アクティブセッションの変更ではキャッシュが無効化されない**。

worktree の j/k 切り替えが正しく動いていたのは `on_worktree_changed()` がたまたま `cache = Default::default()` でキャッシュをクリアしていたため。一方タブクリックによる切り替え経路はキャッシュをクリアしておらず、直前のキャッシュのオフセットが 0 かつ新しい出力が来ない場合に旧セッションの内容を描画し続けていた（断続的に発生する症状の正体）。

### 修正
セッション切り替えを `TerminalState` の共通ヘルパーに集約し、全切り替え経路をそこへ通した。

- `switch_claude_session(idx)` / `switch_shell_session(idx)`: PTY をアクティブ化 + アクティブセッション設定 + スクロールリセット + **レンダーキャッシュのクリア**
- 適用経路: タブクリック (Claude / Shell 両方)、worktree の Enter 選択、worktree のマウスクリック、spawn / resume / auto-resume、grab、および `close_terminal_session` のフォールバック
- `close_terminal_session` はアクティブなタブを閉じた際に別セッションへフォールバックするため、同じ stale バグの潜在的インスタンスだった。これもヘルパー経由にして解消した。

### 見送り（別PR）
- `active_*_session` を private 化してセッターを必須にし、この種のバグをコンパイル時に防ぐリファクタ
- `terminal_claude.rs` / `terminal_shell.rs` に重複しているキャッシュ再構築条件の純粋関数への抽出

## Test plan

- `cargo clippy` — 警告なし
- `cargo test` — 212 passed（うち新規 3 件）
  - `switch_claude_session_resets_scroll_and_cache`: 切り替え後にスクロール 0 / キャッシュ空になることを保証
  - `switch_shell_session_resets_scroll_and_cache`: Shell 側の同等保証
  - `switch_claude_session_leaves_shell_panel_untouched`: Claude 切り替えが Shell パネルの状態を壊さないことを保証
- 画面描画そのもの (vt100 → ratatui) は E2E 領域のためユニットテスト対象外。上記テストで「切り替え時にキャッシュが空になり次フレームで再構築される」という根本の不変条件を固定している。
