### PR TITLE
feat: jump to file via fuzzy search from the maximized viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.59.1"
+version = "0.60.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.59.1"
+version = "0.60.0"
 edition = "2024"
 
 [dependencies]

--- a/src/event/explorer.rs
+++ b/src/event/explorer.rs
@@ -103,20 +103,7 @@ pub(super) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
             }
         }
         Some(Action::SearchFilename) => {
-            app.viewer_state.filename_search.filename_search_active = true;
-            app.viewer_state
-                .filename_search
-                .filename_search_query
-                .clear();
-            app.viewer_state
-                .filename_search
-                .filename_search_results
-                .clear();
-            app.viewer_state.filename_search.filename_search_selected = 0;
-            if let Some(wt) = app.worktrees.get(app.selected_worktree) {
-                app.viewer_state.populate_filename_search_cache(&wt.path);
-            }
-            app.viewer_state.execute_filename_search();
+            super::open_filename_search(app);
         }
         _ => {}
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -523,6 +523,23 @@ fn adjust_tree_scroll(app: &mut App) {
     }
 }
 
+/// Open the fuzzy filename-search modal and seed it with the current
+/// worktree's file list. Triggerable from both the Explorer (file tree) and
+/// the Viewer, so files can be switched even while the viewer is maximized.
+pub(super) fn open_filename_search(app: &mut App) {
+    app.viewer_state.filename_search.filename_search_active = true;
+    app.viewer_state.filename_search.filename_search_query.clear();
+    app.viewer_state
+        .filename_search
+        .filename_search_results
+        .clear();
+    app.viewer_state.filename_search.filename_search_selected = 0;
+    if let Some(wt) = app.worktrees.get(app.selected_worktree) {
+        app.viewer_state.populate_filename_search_cache(&wt.path);
+    }
+    app.viewer_state.execute_filename_search();
+}
+
 /// Dismiss all active overlays so that focus-switching keys work globally.
 fn dismiss_overlays(app: &mut App) {
     app.worktree_mgr.skip_reason = None;

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -81,6 +81,13 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Fuzzy filename jump — handled before the empty-buffer guard so it works
+    // even when no file is open, and keeps the viewer maximized after jumping.
+    if let Some(Action::SearchFilename) = action {
+        super::open_filename_search(app);
+        return;
+    }
+
     if total == 0 {
         return;
     }
@@ -163,6 +170,12 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
             app.viewer_state.exit_diff_mode();
             app.set_focus(crate::app::Focus::Explorer);
         }
+        return;
+    }
+
+    // Fuzzy filename jump — also reachable from the maximized diff viewer.
+    if let Some(Action::SearchFilename) = action {
+        super::open_filename_search(app);
         return;
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -810,6 +810,9 @@ impl KeyMap {
         self.bind_char(Viewer, '/', SearchInFile);
         self.bind_char(Viewer, 'n', NextSearchMatch);
         self.bind_char(Viewer, 'N', PrevSearchMatch);
+        // Fuzzy filename jump — usable even when the viewer is maximized and the
+        // file tree is hidden, so you can switch files without un-maximizing.
+        self.bind_ctrl(Viewer, 'f', SearchFilename);
         self.bind_char(Viewer, ' ', ToggleInlineThread);
         self.bind_key(Viewer, KeyCode::Esc, ExitToExplorer);
         self.bind_char(Viewer, ':', CommandPalette);
@@ -832,6 +835,8 @@ impl KeyMap {
         self.bind_char(ViewerDiffMode, 'l', ScrollRight);
         self.bind_key(ViewerDiffMode, KeyCode::Right, ScrollRight);
         self.bind_char(ViewerDiffMode, '0', ScrollHome);
+        // Fuzzy filename jump — same as the file viewer, available in diff mode too.
+        self.bind_ctrl(ViewerDiffMode, 'f', SearchFilename);
         // Jump between changes (hunks) and between review comments.
         self.bind_char(ViewerDiffMode, ']', NextHunk);
         self.bind_char(ViewerDiffMode, '[', PrevHunk);
@@ -1150,6 +1155,24 @@ mod tests {
             let parsed = Action::from_str(s);
             assert_eq!(parsed, Some(action), "roundtrip failed for {s}");
         }
+    }
+
+    #[test]
+    fn test_ctrl_f_jumps_to_filename_search_in_viewer() {
+        let config = KeybindsConfig::default();
+        let km = KeyMap::new(&config);
+
+        // Ctrl+f opens the fuzzy filename jump from the viewer, so files can be
+        // switched without un-maximizing it.
+        let key = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&key, KeyContext::Viewer),
+            Some(Action::SearchFilename)
+        );
+        assert_eq!(
+            km.resolve(&key, KeyContext::ViewerDiffMode),
+            Some(Action::SearchFilename)
+        );
     }
 
     #[test]

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -752,6 +752,100 @@ pub fn render_resume_session_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_stateful_widget(list, list_inner, &mut state);
 }
 
+// ── Filename fuzzy-search overlay ─────────────────────────────────────────
+
+/// Render the fuzzy filename-search ("jump to file") modal as a centered popup.
+///
+/// Rendered at the top level so it stays visible regardless of which panel is
+/// focused or maximized — in particular, when the viewer is maximized and the
+/// file tree column is collapsed to zero width.
+pub fn render_filename_search_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let vs = &app.viewer_state.filename_search;
+
+    let popup_width = 80_u16.min(area.width.saturating_sub(4));
+    let popup_height = 24_u16.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3), // Search input
+        Constraint::Min(1),    // Results
+    ])
+    .split(popup_area);
+
+    // Search input.
+    let total_files = vs.filename_search_all_files.len();
+    let match_count = vs.filename_search_results.len();
+    let input_block = Block::default()
+        .title(format!(
+            " Jump to file ({match_count}/{total_files}) — Enter: open, Esc: cancel "
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_focused));
+    let input_inner = input_block.inner(chunks[0]);
+    frame.render_widget(input_block, chunks[0]);
+
+    let query_text = format_input_with_cursor(&vs.filename_search_query);
+    frame.render_widget(
+        Paragraph::new(Span::styled(query_text, Style::default().fg(theme.fg))),
+        input_inner,
+    );
+    set_cursor_for_input(frame, input_inner, &vs.filename_search_query);
+
+    // Results list.
+    let list_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_focused));
+    let list_inner = list_block.inner(chunks[1]);
+    frame.render_widget(list_block, chunks[1]);
+
+    if vs.filename_search_results.is_empty() {
+        let msg = if vs.filename_search_query.is_empty() {
+            "  Type to search files…"
+        } else {
+            "  No matches."
+        };
+        frame.render_widget(
+            Paragraph::new(msg).style(Style::default().fg(theme.muted)),
+            list_inner,
+        );
+        return;
+    }
+
+    let items: Vec<ListItem> = vs
+        .filename_search_results
+        .iter()
+        .enumerate()
+        .map(|(i, result)| {
+            let selected = i == vs.filename_search_selected;
+            let style = if selected {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.fg)
+            };
+            let line = Line::from(vec![
+                Span::styled(
+                    if selected { " > " } else { "   " },
+                    Style::default().fg(theme.accent),
+                ),
+                Span::styled(result.path.clone(), style),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items);
+    let mut state = ListState::default();
+    state.select(Some(vs.filename_search_selected));
+    frame.render_stateful_widget(list, list_inner, &mut state);
+}
+
 // ── Command palette overlay ──────────────────────────────────────────────
 
 /// Render the command palette overlay with search bar and command list.
@@ -1304,6 +1398,12 @@ fn help_lines_for(app: &App, focus: crate::app::Focus, theme: &Theme) -> Vec<Lin
                 &mut lines,
                 fmt_keys(app, ctx, Action::SearchInFile),
                 "Search in file",
+                theme,
+            );
+            help_key_dyn(
+                &mut lines,
+                fmt_keys(app, ctx, Action::SearchFilename),
+                "Jump to file (fuzzy, keeps maximized)",
                 theme,
             );
             help_key_dyn(

--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -50,10 +50,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         );
     }
 
-    // Show filename search overlay.
-    if app.viewer_state.filename_search.filename_search_active {
-        render_filename_search_overlay(frame, chunks[0], app, overlay_active);
-    }
+    // The fuzzy filename-search modal is rendered at the top level
+    // (see `layout::render_ui`) so it stays visible even when this panel is
+    // collapsed to zero width (e.g. while the viewer is maximized).
 }
 
 /// Cached indent strings by depth level to avoid repeated allocation.
@@ -559,103 +558,3 @@ fn render_search_box(
     }
 }
 
-/// Render the filename search overlay on top of the file tree area.
-fn render_filename_search_overlay(frame: &mut Frame, area: Rect, app: &App, suppress_cursor: bool) {
-    let theme = &app.theme;
-    let vs = &app.viewer_state.filename_search;
-    let inner_width = area.width.saturating_sub(2);
-    let inner_height = area.height.saturating_sub(2) as usize;
-
-    if inner_width == 0 || inner_height == 0 {
-        return;
-    }
-
-    // Input box at the top of the panel (inside the border).
-    let input_y = area.y + 1;
-    let input_area = Rect::new(area.x + 1, input_y, inner_width, 1);
-    frame.render_widget(ratatui::widgets::Clear, input_area);
-
-    let total_files = vs.filename_search_all_files.len();
-    let match_count = vs.filename_search_results.len();
-    let counter = format!(" {match_count}/{total_files}");
-    let query_width = inner_width.saturating_sub(counter.len() as u16 + 1) as usize;
-
-    let query_input = &vs.filename_search_query;
-    let query_text = format!(
-        "/{}\u{2588}{}",
-        query_input.text_before_cursor(),
-        query_input.text_after_cursor()
-    );
-    // Truncate display if needed.
-    let query_truncated: String = query_text.chars().take(query_width).collect();
-
-    let input_line = Line::from(vec![
-        Span::styled(query_truncated, Style::default().fg(theme.search_match_fg)),
-        Span::styled(counter, Style::default().fg(theme.muted)),
-    ]);
-    frame.render_widget(ratatui::widgets::Paragraph::new(input_line), input_area);
-    if !suppress_cursor {
-        // +1 for the leading '/' character
-        let cursor_x = input_area.x + 1 + query_input.display_width_before_cursor() as u16;
-        if cursor_x < input_area.x + input_area.width {
-            frame.set_cursor_position(Position::new(cursor_x, input_area.y));
-        }
-    }
-
-    // Results list below the input.
-    let results_start_y = input_y + 1;
-    let results_height = (area.y + area.height).saturating_sub(results_start_y + 1) as usize;
-
-    if results_height == 0 {
-        return;
-    }
-
-    // Scroll the results if selected is beyond visible range.
-    let scroll = if vs.filename_search_selected >= results_height {
-        vs.filename_search_selected - results_height + 1
-    } else {
-        0
-    };
-
-    if vs.filename_search_results.is_empty() && !vs.filename_search_query.is_empty() {
-        let no_match_area = Rect::new(area.x + 1, results_start_y, inner_width, 1);
-        frame.render_widget(ratatui::widgets::Clear, no_match_area);
-        frame.render_widget(
-            ratatui::widgets::Paragraph::new(Span::styled(
-                "No matches",
-                Style::default().fg(theme.muted),
-            )),
-            no_match_area,
-        );
-        return;
-    }
-
-    for (vi, result) in vs
-        .filename_search_results
-        .iter()
-        .skip(scroll)
-        .take(results_height)
-        .enumerate()
-    {
-        let y = results_start_y + vi as u16;
-        let row_area = Rect::new(area.x + 1, y, inner_width, 1);
-        frame.render_widget(ratatui::widgets::Clear, row_area);
-
-        let is_selected = scroll + vi == vs.filename_search_selected;
-        let style = if is_selected {
-            Style::default()
-                .fg(theme.search_current_fg)
-                .bg(theme.search_match_bg)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg)
-        };
-
-        // Truncate path to fit.
-        let display: String = result.path.chars().take(inner_width as usize).collect();
-        frame.render_widget(
-            ratatui::widgets::Paragraph::new(Span::styled(display, style)),
-            row_area,
-        );
-    }
-}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -282,6 +282,11 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
             super::dashboard::render_help_overlay(frame, main_area, app);
         }
     }
+    // Fuzzy filename-search ("jump to file") modal — rendered at the top level
+    // so it works even when the explorer column is collapsed (viewer maximized).
+    if app.viewer_state.filename_search.filename_search_active {
+        super::dashboard::render_filename_search_overlay(frame, main_area, app);
+    }
     match app.update_state {
         crate::app::UpdateState::Confirming => {
             super::dashboard::render_update_confirm_overlay(frame, main_area, app);


### PR DESCRIPTION
## Summary

Viewer を最大化（フルスクリーン）してファイルツリーが見えない状態でも、ファジーなファイル名検索でほかのファイルへすばやくジャンプできるようにしました。

- 既存のファジーファイル名検索モーダル（Explorer の `/`）を **Viewer / Viewer(diff mode) からも `Ctrl+f` で起動**できるように
- 起動ロジックを共有ヘルパー `open_filename_search()` に切り出し、Explorer 側の重複を解消
- ジャンプ後も focus・`expanded_panel` を変更しないため、**Viewer の最大化状態は維持されたまま**ファイルが切り替わる
- モーダルの描画を Explorer パネル内からトップレベルの中央モーダルへ移設。Explorer 幅が 0 になる最大化時でも確実に表示される（他の検索 / コマンドパレットと一貫した見た目）
- 操作はキーボードのみで完結：入力で絞り込み、`j/k`・`↑↓`・`Ctrl+n/p` で選択、`Enter` で確定、`Esc` でキャンセル
- ヘルプ（Viewer セクション）にショートカットを追記
- `Ctrl+f` は Viewer / ViewerDiffMode コンテキスト限定で割り当て、ターミナルのキー入力は奪わない

## Test plan

- [x] `cargo build` / `cargo clippy` 警告なし
- [x] `cargo test` 全件パス（`Ctrl+f` → `SearchFilename` の解決を検証する keymap テストを追加）
- [ ] 実機確認: Viewer を最大化 → `Ctrl+f` → ファジー検索 → `Enter` でジャンプ → 最大化を維持したまま Viewer が更新されること
- [ ] 実機確認: Explorer の `/` による従来のファイル名検索が引き続き動作すること
