### PR TITLE
feat: replace keybinding engine with keymap-rs; scoped command palette, dynamic footer, keybind cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -431,6 +431,8 @@ dependencies = [
  "git2",
  "ignore",
  "image",
+ "keymap-config",
+ "keymap-core",
  "libc",
  "log",
  "notify",
@@ -446,7 +448,7 @@ dependencies = [
  "syntect",
  "syntect-tui",
  "tempfile",
- "toml",
+ "toml 1.1.0+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-rust",
@@ -1469,6 +1471,33 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keymap-config"
+version = "0.1.0"
+source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+dependencies = [
+ "keymap-core",
+ "keymap-seq",
+ "serde",
+ "toml 0.8.23",
+]
+
+[[package]]
+name = "keymap-core"
+version = "0.1.0"
+source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
+name = "keymap-seq"
+version = "0.1.0"
+source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+dependencies = [
+ "keymap-core",
 ]
 
 [[package]]
@@ -2614,6 +2643,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
@@ -3022,17 +3060,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3045,13 +3104,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3921,6 +4000,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2024"
 
 [dependencies]
@@ -37,6 +37,8 @@ tree-sitter-rust = "0.24"
 tree-sitter-go = "0.25"
 tree-sitter-typescript = "0.23"
 libc = "0.2"
+keymap-core = { git = "https://github.com/S-Nakamur-a/keymap-rs", rev = "6c1f899b077f42ecb5963e04cef7cafc5062b72c", features = ["crossterm"] }
+keymap-config = { git = "https://github.com/S-Nakamur-a/keymap-rs", rev = "6c1f899b077f42ecb5963e04cef7cafc5062b72c" }
 
 [profile.dev]
 debug = "limited"

--- a/README.md
+++ b/README.md
@@ -135,19 +135,19 @@ theme = "catppuccin-mocha"              # syntax highlighting theme
 # prompt_action = "clipboard"           # clipboard | send_to_session
 
 [keybinds]
-# Per-context key-bind overrides. Keys are action names, values are a key chord
-# string or an array of alternatives.
+# Key-bind overrides, in key->action form (powered by keymap-rs). Each entry
+# maps a key chord to an action name and LAYERS OVER the built-in defaults
+# per-chord. [keybinds.keys] is the global layer; each [keybinds.layers.<name>]
+# is a per-panel layer (worktree, explorer, explorer_diff_list,
+# explorer_comment_list, viewer, viewer_diff_mode, terminal, overlay).
 #
-# [keybinds.global]
-# quit = "q"
+# [keybinds.keys]
+# "ctrl+q" = "quit"
 #
-# [keybinds.worktree]
-# navigate_down = ["j", "down"]
-# create_worktree = "w"
-#
-# [keybinds.explorer]
-# [keybinds.viewer]
-# [keybinds.terminal]
+# [keybinds.layers.worktree]
+# "j" = "navigate_down"
+# "down" = "navigate_down"
+# "w" = "create_worktree"
 
 [notification]
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -134,6 +134,8 @@ pub enum WorktreeInputMode {
     ConfirmingDeleteBranch,
     /// Confirming ungrab (y/n).
     ConfirmingUngrab,
+    /// Confirming a hard reset of main to origin (y/n) — discards local commits.
+    ConfirmingReset,
     /// Smart Worktree: typing a multi-line task description.
     SmartDescription,
 }
@@ -1538,7 +1540,21 @@ impl App {
         }
     }
 
-    fn cmd_reset_main_to_origin(&mut self) {
+    /// Ask before resetting main — this discards local commits, so it must not
+    /// fire on a bare keystroke (`R` sits next to `r` refresh). The actual reset
+    /// runs in [`perform_reset_main_to_origin`](Self::perform_reset_main_to_origin)
+    /// once confirmed. Both the `R` key and the palette enter through here.
+    pub fn cmd_reset_main_to_origin(&mut self) {
+        let main_branch = self.config.general.main_branch.clone();
+        self.worktree_mgr.input_mode = WorktreeInputMode::ConfirmingReset;
+        self.set_status_info(format!(
+            "Reset '{main_branch}' to origin? Discards local commits on it. (y/n)"
+        ));
+    }
+
+    /// Perform the hard reset of main to its origin tracking branch. Call only
+    /// after the user confirms (see [`cmd_reset_main_to_origin`](Self::cmd_reset_main_to_origin)).
+    pub fn perform_reset_main_to_origin(&mut self) {
         let main_branch = self.config.general.main_branch.clone();
         match crate::git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => match engine.reset_main_to_origin(&main_branch) {
@@ -1654,7 +1670,7 @@ impl App {
         self.set_focus(Focus::Explorer);
     }
 
-    fn cmd_add_review_comment(&mut self) {
+    pub fn cmd_add_review_comment(&mut self) {
         if let Some(file_path) = self.viewer_state.content.current_file.clone() {
             let location = if let Some((start, end)) = self.viewer_state.selected_range() {
                 if start == end {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,6 +103,21 @@ pub enum Focus {
     TerminalShell,
 }
 
+impl Focus {
+    /// The base keymap context for this panel. Both terminals share the
+    /// `Terminal` context (sub-modes like diff/comment lists are tracked
+    /// separately by the panels themselves).
+    pub fn key_context(self) -> crate::keymap::KeyContext {
+        use crate::keymap::KeyContext;
+        match self {
+            Focus::Worktree => KeyContext::Worktree,
+            Focus::Explorer => KeyContext::Explorer,
+            Focus::Viewer => KeyContext::Viewer,
+            Focus::TerminalClaude | Focus::TerminalShell => KeyContext::Terminal,
+        }
+    }
+}
+
 /// Input mode for worktree operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorktreeInputMode {
@@ -585,7 +600,7 @@ impl App {
             .as_ref()
             .and_then(|store| store.get_today_stats().ok());
 
-        let keymap = KeyMap::new(&config.keybinds);
+        let (keymap, keybind_warnings) = KeyMap::with_warnings(&config.keybinds);
         let theme = Theme::from_name(&config.viewer.theme);
         let auto_resume = config.general.auto_resume;
 
@@ -666,6 +681,24 @@ impl App {
             panel_overlay_since: None,
         };
         app.symbol_index = SymbolIndex::new(app.repo_path.clone());
+
+        // Surface keybind config problems: a TUI hides stdout, so a silent
+        // log::warn! would never reach the user whose customizations were
+        // dropped. Log each, flash one consolidated line on startup.
+        if !keybind_warnings.is_empty() {
+            for w in &keybind_warnings {
+                log::warn!("keybind config: {w}");
+            }
+            let msg = match keybind_warnings.as_slice() {
+                [one] => format!("Keybind config: {one}"),
+                many => format!(
+                    "Keybind config: {} issues ignored (see log; run with RUST_LOG=warn)",
+                    many.len()
+                ),
+            };
+            app.set_status(msg, StatusLevel::Warning);
+        }
+
         app.refresh_worktrees();
         // Restore the previously selected worktree + its open file/scroll so a
         // restart (e.g. after an update) lands the user where they left off.
@@ -1111,50 +1144,6 @@ impl App {
     /// Request the application to quit.
     pub fn quit(&mut self) {
         self.should_quit = true;
-    }
-
-    /// Return a help text string describing the keybindings for the current focus.
-    pub fn status_bar_text(&self) -> &'static str {
-        #[cfg(target_os = "macos")]
-        {
-            match self.focus {
-                Focus::Worktree => {
-                    "Cmd+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune"
-                }
-                Focus::Explorer => {
-                    "Cmd+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list"
-                }
-                Focus::Viewer => {
-                    "Cmd+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment"
-                }
-                Focus::TerminalClaude => {
-                    "Cmd+1-5: jump | Alt+h/l: panel | Ctrl+n: new CC | Ctrl+p: palette | keys → PTY"
-                }
-                Focus::TerminalShell => {
-                    "Cmd+1-5: jump | Alt+h/l: panel | Ctrl+t: new shell | keys → PTY"
-                }
-            }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            match self.focus {
-                Focus::Worktree => {
-                    "Cmd+1-5: jump | Tab: next | q: quit | j/k: nav | w/W: new/del | s: switch | g: grab | G: ungrab | P: prune"
-                }
-                Focus::Explorer => {
-                    "Cmd+1-5: jump | Tab: next panel | j/k: navigate | Enter: open file | h/l: collapse/expand | d: diff list"
-                }
-                Focus::Viewer => {
-                    "Cmd+1-5: jump | Tab: next panel | Esc: back to explorer | j/k: scroll | /: search | c: comment"
-                }
-                Focus::TerminalClaude => {
-                    "Cmd+1-5: jump | Alt+h/l: panel | Ctrl+n: new CC | Ctrl+p: palette | keys → PTY"
-                }
-                Focus::TerminalShell => {
-                    "Cmd+1-5: jump | Alt+h/l: panel | Ctrl+t: new shell | keys → PTY"
-                }
-            }
-        }
     }
 
     /// Set a styled status message.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1408,6 +1408,7 @@ impl App {
             }
             CommandId::ResetMainToOrigin => self.cmd_reset_main_to_origin(),
             CommandId::CherryPick => self.cmd_cherry_pick(),
+            CommandId::PullWorktree => self.start_pull_worktree(),
             CommandId::NewClaudeCode => self.cmd_new_claude_code(),
             CommandId::NewShell => self.cmd_new_shell(),
             CommandId::ResumeClaudeSession => self.cmd_resume_claude_session(),
@@ -1483,7 +1484,7 @@ impl App {
     fn cmd_grab_branch(&mut self) {
         if self.worktree_mgr.grabbed_branch.is_some() {
             self.set_status(
-                "Already grabbing a branch. Ungrab first (Y).".to_string(),
+                "Already grabbing a branch. Ungrab first (G).".to_string(),
                 StatusLevel::Warning,
             );
         } else {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -1,7 +1,12 @@
 //! Command palette — fuzzy-searchable command index.
 //!
-//! Provides a VSCode-style command palette (`Ctrl+Shift+P` / `:`) for
-//! discovering and executing any application command.
+//! Provides a VSCode-style command palette (`Ctrl+P` / `:`) for discovering and
+//! executing any application command. Each command carries the keymap [`Action`]
+//! it corresponds to (when it has one), so its displayed shortcut and its scope
+//! (global vs. the focused panel's layer) are derived live from the keymap and
+//! never go stale. Palette-only commands (no keybinding) carry `action: None`.
+
+use crate::keymap::{Action, KeyContext, KeyMap};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandId {
@@ -23,6 +28,7 @@ pub enum CommandId {
     RefreshWorktrees,
     ResetMainToOrigin,
     CherryPick,
+    PullWorktree,
 
     // Terminal
     NewClaudeCode,
@@ -103,11 +109,32 @@ impl CommandCategory {
     }
 }
 
+/// Where a command sits relative to the focused panel: bound globally, bound in
+/// the current panel's own layer, or bound only in some other panel's layer
+/// (still runnable from the palette). Drives the grouped display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandScope {
+    Current,
+    Global,
+    Other,
+}
+
+fn scope_rank(scope: CommandScope) -> u8 {
+    match scope {
+        CommandScope::Current => 0,
+        CommandScope::Global => 1,
+        CommandScope::Other => 2,
+    }
+}
+
 pub struct PaletteCommand {
     pub id: CommandId,
     pub label: &'static str,
     pub category: CommandCategory,
-    pub keybinding: Option<&'static str>,
+    /// The keymap action this command runs, if it has a keybinding. `None` for
+    /// palette-only commands (no chord). The displayed shortcut and scope are
+    /// derived from this via the keymap.
+    pub action: Option<Action>,
     pub keywords: &'static str,
 }
 
@@ -117,42 +144,42 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::FocusWorktree,
         label: "Focus: Worktree Panel",
         category: CommandCategory::Navigation,
-        keybinding: Some("Alt+h/l"),
+        action: Some(Action::FocusWorktree),
         keywords: "panel switch",
     },
     PaletteCommand {
         id: CommandId::FocusExplorer,
         label: "Focus: Explorer Panel",
         category: CommandCategory::Navigation,
-        keybinding: Some("Alt+h/l"),
+        action: Some(Action::FocusExplorer),
         keywords: "panel files",
     },
     PaletteCommand {
         id: CommandId::FocusViewer,
         label: "Focus: Viewer Panel",
         category: CommandCategory::Navigation,
-        keybinding: Some("Alt+h/l"),
+        action: Some(Action::FocusViewer),
         keywords: "panel file view",
     },
     PaletteCommand {
         id: CommandId::FocusTerminalClaude,
         label: "Focus: Claude Code Terminal",
         category: CommandCategory::Navigation,
-        keybinding: Some("Alt+h/l"),
+        action: Some(Action::FocusTerminalClaude),
         keywords: "terminal claude",
     },
     PaletteCommand {
         id: CommandId::FocusTerminalShell,
         label: "Focus: Shell Terminal",
         category: CommandCategory::Navigation,
-        keybinding: Some("Alt+h/l"),
+        action: Some(Action::FocusTerminalShell),
         keywords: "terminal shell",
     },
     PaletteCommand {
         id: CommandId::TogglePanelExpand,
         label: "Toggle Panel Expand",
         category: CommandCategory::Navigation,
-        keybinding: Some("Cmd+Space"),
+        action: Some(Action::TogglePanelExpand),
         keywords: "resize maximize fullscreen",
     },
     // Worktree
@@ -160,71 +187,78 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::CreateWorktree,
         label: "Worktree: Create New",
         category: CommandCategory::Worktree,
-        keybinding: Some("w"),
+        action: Some(Action::CreateWorktree),
         keywords: "branch new add",
     },
     PaletteCommand {
         id: CommandId::DeleteWorktree,
         label: "Worktree: Delete Selected",
         category: CommandCategory::Worktree,
-        keybinding: Some("X"),
+        action: Some(Action::DeleteWorktree),
         keywords: "remove branch",
     },
     PaletteCommand {
         id: CommandId::SwitchBranch,
         label: "Worktree: Switch Branch (Remote)",
         category: CommandCategory::Worktree,
-        keybinding: Some("s"),
+        action: Some(Action::SwitchBranch),
         keywords: "checkout remote",
     },
     PaletteCommand {
         id: CommandId::GrabBranch,
         label: "Worktree: Grab Branch",
         category: CommandCategory::Worktree,
-        keybinding: Some("g"),
+        action: Some(Action::GrabBranch),
         keywords: "grab checkout branch",
     },
     PaletteCommand {
         id: CommandId::PruneWorktrees,
         label: "Worktree: Prune Stale",
         category: CommandCategory::Worktree,
-        keybinding: Some("P"),
+        action: Some(Action::PruneWorktrees),
         keywords: "clean stale",
     },
     PaletteCommand {
         id: CommandId::MergeToMain,
         label: "Worktree: Merge into Main",
         category: CommandCategory::Worktree,
-        keybinding: Some("m"),
+        action: Some(Action::MergeToMain),
         keywords: "merge main",
     },
     PaletteCommand {
         id: CommandId::RefreshWorktrees,
         label: "Worktree: Refresh List",
         category: CommandCategory::Worktree,
-        keybinding: Some("r"),
+        action: Some(Action::RefreshWorktrees),
         keywords: "reload update",
     },
     PaletteCommand {
         id: CommandId::ResetMainToOrigin,
         label: "Worktree: Reset Main to Origin",
         category: CommandCategory::Worktree,
-        keybinding: Some("R"),
+        action: Some(Action::ResetMainToOrigin),
         keywords: "reset origin",
     },
     PaletteCommand {
         id: CommandId::CherryPick,
         label: "Worktree: Cherry-pick",
         category: CommandCategory::Worktree,
-        keybinding: Some("p"),
+        action: Some(Action::CherryPick),
         keywords: "cherry pick commit",
+    },
+    PaletteCommand {
+        id: CommandId::PullWorktree,
+        label: "Worktree: Pull (fast-forward)",
+        category: CommandCategory::Worktree,
+        action: Some(Action::PullWorktree),
+        keywords: "pull fetch update fast-forward ff sync",
     },
     // Worktree (additional)
     PaletteCommand {
         id: CommandId::UngrabBranch,
         label: "Worktree: Ungrab Branch",
         category: CommandCategory::Worktree,
-        keybinding: Some("G"),
+        action: Some(Action::UngrabBranch),
         keywords: "ungrab release branch",
     },
     // Terminal
@@ -232,21 +266,21 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::NewClaudeCode,
         label: "Terminal: New Claude Code",
         category: CommandCategory::Terminal,
-        keybinding: Some("Ctrl+n"),
+        action: Some(Action::NewClaudeCode),
         keywords: "spawn ai",
     },
     PaletteCommand {
         id: CommandId::NewShell,
         label: "Terminal: New Shell",
         category: CommandCategory::Terminal,
-        keybinding: Some("Ctrl+t"),
+        action: Some(Action::NewShell),
         keywords: "spawn bash zsh",
     },
     PaletteCommand {
         id: CommandId::ResumeClaudeSession,
         label: "Terminal: Resume Claude Session",
         category: CommandCategory::Terminal,
-        keybinding: None,
+        action: None,
         keywords: "resume continue",
     },
     // Git
@@ -254,7 +288,7 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::RefreshDiff,
         label: "Diff: Refresh",
         category: CommandCategory::Git,
-        keybinding: None,
+        action: None,
         keywords: "reload diff",
     },
     // View
@@ -262,35 +296,35 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::SearchInFile,
         label: "Search in File",
         category: CommandCategory::View,
-        keybinding: Some("/"),
+        action: Some(Action::SearchInFile),
         keywords: "find grep",
     },
     PaletteCommand {
         id: CommandId::SearchFullText,
         label: "Search: Full-text Search (Grep)",
         category: CommandCategory::View,
-        keybinding: Some("Ctrl+g"),
+        action: Some(Action::SearchFullText),
         keywords: "grep search find text content regex ripgrep fulltext",
     },
     PaletteCommand {
         id: CommandId::ToggleHelp,
         label: "Show Help",
         category: CommandCategory::View,
-        keybinding: Some("?"),
+        action: Some(Action::ShowHelp),
         keywords: "keybindings shortcuts",
     },
     PaletteCommand {
         id: CommandId::ShowDiffList,
         label: "Explorer: Show Diff List",
         category: CommandCategory::View,
-        keybinding: Some("d"),
+        action: Some(Action::ShowDiffList),
         keywords: "diff changed files",
     },
     PaletteCommand {
         id: CommandId::ShowCommentList,
         label: "Explorer: Show Comment List",
         category: CommandCategory::View,
-        keybinding: Some("c"),
+        action: Some(Action::ShowCommentList),
         keywords: "comment review list",
     },
     // Review
@@ -298,70 +332,70 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::ShowReviewComments,
         label: "Review: Show Comments",
         category: CommandCategory::Review,
-        keybinding: Some("c"),
+        action: None,
         keywords: "comment list",
     },
     PaletteCommand {
         id: CommandId::ShowReviewTemplates,
         label: "Review: Show Templates",
         category: CommandCategory::Review,
-        keybinding: None,
+        action: None,
         keywords: "template prompt",
     },
     PaletteCommand {
         id: CommandId::SessionHistory,
         label: "Review: Session History",
         category: CommandCategory::Review,
-        keybinding: Some("H"),
+        action: Some(Action::SessionHistory),
         keywords: "history log",
     },
     PaletteCommand {
         id: CommandId::AddReviewComment,
         label: "Review: Add Comment",
         category: CommandCategory::Review,
-        keybinding: Some("c"),
+        action: Some(Action::AddComment),
         keywords: "new comment add write",
     },
     PaletteCommand {
         id: CommandId::ViewCommentDetail,
         label: "Review: View Comment Detail",
         category: CommandCategory::Review,
-        keybinding: Some("Space"),
+        action: Some(Action::ViewCommentDetail),
         keywords: "detail preview",
     },
     PaletteCommand {
         id: CommandId::DeleteComment,
         label: "Review: Delete Comment",
         category: CommandCategory::Review,
-        keybinding: Some("Del"),
+        action: Some(Action::DeleteComment),
         keywords: "remove delete",
     },
     PaletteCommand {
         id: CommandId::ToggleCommentResolve,
         label: "Review: Toggle Resolve",
         category: CommandCategory::Review,
-        keybinding: Some("r"),
+        action: Some(Action::ToggleResolve),
         keywords: "resolve unresolve status",
     },
     PaletteCommand {
         id: CommandId::EditComment,
         label: "Review: Edit Comment",
         category: CommandCategory::Review,
-        keybinding: Some("e"),
+        action: Some(Action::EditComment),
         keywords: "edit modify update",
     },
     PaletteCommand {
         id: CommandId::ReplyToComment,
         label: "Review: Reply to Comment",
         category: CommandCategory::Review,
-        keybinding: Some("R"),
+        action: Some(Action::ReplyToComment),
         keywords: "reply respond",
     },
     PaletteCommand {
         id: CommandId::SaveSessionHistory,
         label: "Session: Save History",
         category: CommandCategory::Review,
-        keybinding: Some("s"),
+        action: None,
         keywords: "save record session",
     },
     // Repository
@@ -369,14 +403,14 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::OpenRepo,
         label: "Repository: Open by Path",
         category: CommandCategory::Repository,
-        keybinding: Some("Ctrl+o"),
+        action: Some(Action::OpenRepo),
         keywords: "open directory",
     },
     PaletteCommand {
         id: CommandId::SwitchRepo,
         label: "Repository: Switch",
         category: CommandCategory::Repository,
-        keybinding: Some("Ctrl+r"),
+        action: Some(Action::SwitchRepo),
         keywords: "project change",
     },
     // GitHub / PR
@@ -384,7 +418,7 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::OpenPullRequest,
         label: "Worktree: Open Pull Request",
         category: CommandCategory::Worktree,
-        keybinding: Some("v"),
+        action: Some(Action::OpenPullRequest),
         keywords: "pr github browser web open",
     },
     // App
@@ -392,14 +426,14 @@ pub const COMMANDS: &[PaletteCommand] = &[
         id: CommandId::UpdateAndRestart,
         label: "App: Update and Restart",
         category: CommandCategory::App,
-        keybinding: None,
+        action: None,
         keywords: "update upgrade restart download version",
     },
     PaletteCommand {
         id: CommandId::Quit,
         label: "Quit Conductor",
         category: CommandCategory::App,
-        keybinding: Some("q"),
+        action: Some(Action::Quit),
         keywords: "exit close",
     },
 ];
@@ -407,63 +441,174 @@ pub const COMMANDS: &[PaletteCommand] = &[
 pub struct ScoredCommand {
     pub index: usize,
     pub score: i32,
+    pub scope: CommandScope,
 }
 
-/// Filter and score commands against a query string.
-///
-/// Returns all commands (unscored) when `query` is empty, or only matching
-/// commands sorted by relevance score when a query is provided.
-pub fn filter_commands(query: &str) -> Vec<ScoredCommand> {
-    if query.is_empty() {
-        return COMMANDS
-            .iter()
-            .enumerate()
-            .map(|(i, _)| ScoredCommand { index: i, score: 0 })
-            .collect();
-    }
-
-    let query_lower = query.to_lowercase();
-    let mut results: Vec<ScoredCommand> = Vec::new();
-
-    for (i, cmd) in COMMANDS.iter().enumerate() {
-        let label_lower = cmd.label.to_lowercase();
-        let keywords_lower = cmd.keywords.to_lowercase();
-        let category_lower = cmd.category.label().to_lowercase();
-        let haystack = format!("{label_lower} {keywords_lower} {category_lower}");
-
-        if !haystack.contains(&query_lower) {
-            continue;
-        }
-
-        let mut score: i32 = 0;
-
-        // Exact prefix match on label.
-        if label_lower.starts_with(&query_lower) {
-            score += 100;
-        }
-        // Word-boundary match.
-        for word in label_lower.split(|c: char| !c.is_alphanumeric()) {
-            if word.starts_with(&query_lower) {
-                score += 50;
-                break;
+/// Classify a command relative to the focused panel. Global-bound actions are
+/// "global" even if a panel layer also binds them (e.g. `:` for the palette);
+/// otherwise an action bound in the current panel's own layer is "current", and
+/// anything else (bound only in another panel, runnable here via the palette) is
+/// "other". Palette-only commands count as global.
+fn command_scope(cmd: &PaletteCommand, keymap: &KeyMap, current: KeyContext) -> CommandScope {
+    match cmd.action {
+        None => CommandScope::Global,
+        Some(action) => {
+            if !keymap.keys_in_layer(KeyContext::Global, action).is_empty() {
+                CommandScope::Global
+            } else if current != KeyContext::Global
+                && !keymap.keys_in_layer(current, action).is_empty()
+            {
+                CommandScope::Current
+            } else {
+                CommandScope::Other
             }
         }
-        // Substring in label.
-        if label_lower.contains(&query_lower) {
-            score += 20;
-        }
-        // Match in keywords.
-        if keywords_lower.contains(&query_lower) {
-            score += 10;
-        }
-        // Match in category.
-        if category_lower.contains(&query_lower) {
-            score += 5;
-        }
+    }
+}
 
-        results.push(ScoredCommand { index: i, score });
+/// Fuzzy score for a command against a lowercased query; `None` if no match.
+fn score_command(cmd: &PaletteCommand, query_lower: &str) -> Option<i32> {
+    let label_lower = cmd.label.to_lowercase();
+    let keywords_lower = cmd.keywords.to_lowercase();
+    let category_lower = cmd.category.label().to_lowercase();
+    let haystack = format!("{label_lower} {keywords_lower} {category_lower}");
+
+    if !haystack.contains(query_lower) {
+        return None;
     }
 
-    results.sort_by_key(|c| std::cmp::Reverse(c.score));
+    let mut score: i32 = 0;
+    if label_lower.starts_with(query_lower) {
+        score += 100;
+    }
+    for word in label_lower.split(|c: char| !c.is_alphanumeric()) {
+        if word.starts_with(query_lower) {
+            score += 50;
+            break;
+        }
+    }
+    if label_lower.contains(query_lower) {
+        score += 20;
+    }
+    if keywords_lower.contains(query_lower) {
+        score += 10;
+    }
+    if category_lower.contains(query_lower) {
+        score += 5;
+    }
+    Some(score)
+}
+
+/// Filter and score commands against a query, grouped by scope relative to the
+/// focused panel (`current`). Returns all commands (sorted by scope) when the
+/// query is empty, or matching commands sorted by scope then relevance.
+///
+/// The ordering is shared by the renderer (for grouped display) and the key
+/// handler (for selection + execution), so `selected` indexes into this exact
+/// sequence.
+pub fn filter_commands(query: &str, keymap: &KeyMap, current: KeyContext) -> Vec<ScoredCommand> {
+    let query_lower = query.to_lowercase();
+
+    let mut results: Vec<ScoredCommand> = COMMANDS
+        .iter()
+        .enumerate()
+        .filter_map(|(i, cmd)| {
+            let score = if query.is_empty() {
+                0
+            } else {
+                score_command(cmd, &query_lower)?
+            };
+            Some(ScoredCommand {
+                index: i,
+                score,
+                scope: command_scope(cmd, keymap, current),
+            })
+        })
+        .collect();
+
+    results.sort_by(|a, b| {
+        scope_rank(a.scope)
+            .cmp(&scope_rank(b.scope))
+            .then_with(|| b.score.cmp(&a.score))
+            .then_with(|| a.index.cmp(&b.index))
+    });
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keymap() -> KeyMap {
+        KeyMap::new(&toml::Table::new())
+    }
+
+    #[test]
+    fn every_command_action_is_valid() {
+        // A Some(action) must round-trip through the action vocabulary, so a
+        // palette entry can never point at a stale/renamed action.
+        for cmd in COMMANDS {
+            if let Some(action) = cmd.action {
+                assert_eq!(
+                    Action::from_str(action.as_str()),
+                    Some(action),
+                    "command {:?} has an unrecognized action",
+                    cmd.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn comprehensive_worktree_commands_present() {
+        // Guards against silent omissions of high-value worktree commands —
+        // `pull_worktree` was previously missing entirely.
+        let must_have = [
+            Action::CreateWorktree,
+            Action::DeleteWorktree,
+            Action::SwitchBranch,
+            Action::GrabBranch,
+            Action::UngrabBranch,
+            Action::PruneWorktrees,
+            Action::MergeToMain,
+            Action::PullWorktree,
+            Action::CherryPick,
+            Action::OpenPullRequest,
+        ];
+        for action in must_have {
+            assert!(
+                COMMANDS.iter().any(|c| c.action == Some(action)),
+                "missing palette command for {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn scope_splits_global_from_current_layer() {
+        let km = keymap();
+        // Focused on the worktree panel: create-worktree is a worktree-layer
+        // action → Current; quit is global → Global.
+        let scoped = filter_commands("", &km, KeyContext::Worktree);
+        let scope_of = |action: Action| {
+            scoped
+                .iter()
+                .find(|s| COMMANDS[s.index].action == Some(action))
+                .map(|s| s.scope)
+        };
+        assert_eq!(scope_of(Action::CreateWorktree), Some(CommandScope::Current));
+        assert_eq!(scope_of(Action::Quit), Some(CommandScope::Global));
+        // A viewer-only action is neither global nor in the worktree layer.
+        assert_eq!(scope_of(Action::SearchInFile), Some(CommandScope::Other));
+    }
+
+    #[test]
+    fn results_are_grouped_current_then_global_then_other() {
+        let km = keymap();
+        let scoped = filter_commands("", &km, KeyContext::Worktree);
+        let ranks: Vec<u8> = scoped.iter().map(|s| scope_rank(s.scope)).collect();
+        assert!(
+            ranks.windows(2).all(|w| w[0] <= w[1]),
+            "scopes must be contiguous/ordered: {ranks:?}"
+        );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@
 //! Every field carries a serde default so the config file can be empty or
 //! partially specified.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -33,8 +32,10 @@ pub struct Config {
     pub diff: DiffConfig,
     /// `[review]` -- code-review prompt settings.
     pub review: ReviewConfig,
-    /// `[keybinds]` -- optional user key-bind overrides.
-    pub keybinds: KeybindsConfig,
+    /// `[keybinds]` -- optional user key-bind overrides, in keymap-config's
+    /// key→action TOML schema (`[keybinds.keys]`, `[keybinds.layers.<name>]`).
+    /// Kept as a raw table and handed to `keymap::KeyMap`, which owns the schema.
+    pub keybinds: toml::Table,
     /// `[ccusage]` -- Claude Code token usage display.
     pub ccusage: CcusageConfig,
     /// `[updates]` -- startup version check settings.
@@ -236,29 +237,6 @@ pub enum PromptAction {
     SendToSession,
 }
 
-/// A keybind value: either a single key chord or multiple alternatives.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum KeybindValue {
-    Single(String),
-    Multiple(Vec<String>),
-}
-
-/// `[keybinds]` section.
-///
-/// Per-context key-bind overrides. Keys are action names (e.g. `"navigate_down"`),
-/// values are key chord strings (e.g. `"j"` or `["j", "down"]`).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
-pub struct KeybindsConfig {
-    pub global: HashMap<String, KeybindValue>,
-    pub worktree: HashMap<String, KeybindValue>,
-    pub explorer: HashMap<String, KeybindValue>,
-    pub viewer: HashMap<String, KeybindValue>,
-    pub terminal: HashMap<String, KeybindValue>,
-    pub overlay: HashMap<String, KeybindValue>,
-}
-
 /// `[ccusage]` section.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -401,19 +379,30 @@ pub fn generate_default_config() -> String {
 # prompt_action = "clipboard"           # clipboard | send_to_session
 
 [keybinds]
-# Per-context key-bind overrides. Keys are action names, values are a key chord
-# string or an array of alternatives.
+# Key-bind overrides, in key→action form. Each entry maps a key chord to an
+# action name. Your bindings LAYER OVER the built-in defaults per-chord: a chord
+# you bind here overrides the default for that exact chord, and every default
+# you do not touch keeps working. (Note: you can rebind a default chord to a
+# different action, but there is no way to fully un-bind a default key — you can
+# only shadow it.)
 #
-# [keybinds.global]
-# quit = "q"
+# [keybinds.keys] is the global layer (active everywhere). Each
+# [keybinds.layers.<context>] table is a per-panel layer. Context names:
+# worktree, explorer, explorer_diff_list, explorer_comment_list, viewer,
+# viewer_diff_mode, terminal, overlay.
 #
-# [keybinds.worktree]
-# navigate_down = ["j", "down"]
-# create_worktree = "w"
+# Key grammar: modifiers ctrl/alt/shift/super joined with '+', then the key.
+# A single char is verbatim and case-sensitive (e.g. "G" is Shift+g). Back-tab
+# is "shift+tab". Named keys: enter, esc, tab, space, up/down/left/right, home,
+# end, pageup, pagedown, delete, f1..f24.
 #
-# [keybinds.explorer]
-# [keybinds.viewer]
-# [keybinds.terminal]
+# [keybinds.keys]
+# "ctrl+q" = "quit"
+#
+# [keybinds.layers.worktree]
+# "j" = "navigate_down"
+# "down" = "navigate_down"
+# "w" = "create_worktree"
 
 [ccusage]
 # enabled = false                       # token usage display in the title bar (requires ccusage)
@@ -523,29 +512,31 @@ check_interval_secs = 3600"#,
 
     #[test]
     fn keybinds_parse() {
+        // The [keybinds] section is captured as a raw table (key→action schema)
+        // and handed to keymap::KeyMap, which owns parsing.
         let toml_str = r#"
-[global]
-quit = "q"
+[keybinds.keys]
+"ctrl+q" = "quit"
 
-[worktree]
-navigate_down = ["j", "down"]
-create_worktree = "w"
+[keybinds.layers.worktree]
+"j" = "navigate_down"
+"w" = "create_worktree"
 "#;
-        let kb: KeybindsConfig = toml::from_str(toml_str).expect("parse keybinds");
-        match kb.global.get("quit").unwrap() {
-            KeybindValue::Single(s) => assert_eq!(s, "q"),
-            _ => panic!("expected Single"),
-        }
-        match kb.worktree.get("navigate_down").unwrap() {
-            KeybindValue::Multiple(v) => {
-                assert_eq!(v, &vec!["j".to_string(), "down".to_string()]);
-            }
-            _ => panic!("expected Multiple"),
-        }
-        match kb.worktree.get("create_worktree").unwrap() {
-            KeybindValue::Single(s) => assert_eq!(s, "w"),
-            _ => panic!("expected Single"),
-        }
+        let cfg: Config = toml::from_str(toml_str).expect("parse config");
+        let keys = cfg.keybinds.get("keys").and_then(|v| v.as_table()).unwrap();
+        assert_eq!(keys.get("ctrl+q").and_then(|v| v.as_str()), Some("quit"));
+
+        let worktree = cfg
+            .keybinds
+            .get("layers")
+            .and_then(|v| v.as_table())
+            .and_then(|t| t.get("worktree"))
+            .and_then(|v| v.as_table())
+            .unwrap();
+        assert_eq!(
+            worktree.get("j").and_then(|v| v.as_str()),
+            Some("navigate_down")
+        );
     }
 
     #[test]

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -1,0 +1,242 @@
+# Default keybindings, in keymap-config's key→action TOML schema.
+#
+# This file is embedded at compile time (include_str!) and parsed by
+# `keymap_config::from_str`. The bare `[keys]` table is the global layer;
+# each `[layers.<name>]` table is a per-context layer. User bindings from
+# `~/.config/conductor/config.toml` ([keybinds.keys] / [keybinds.layers.*])
+# are layered ON TOP of these per-chord — a user chord overrides the default
+# for that exact chord, while every default the user did not touch stays live.
+#
+# Key-string grammar (see keymap-core's KeyInput::FromStr): modifiers
+# `ctrl`/`alt`/`shift`/`super` (aliases: control, opt/option, cmd/win/meta)
+# joined with `+`, then the key. A single character is written verbatim and is
+# case-sensitive (`G` is Shift+g as most terminals deliver it). Back-tab is
+# `shift+tab`. Named keys: enter, esc, tab, space, up/down/left/right, home,
+# end, pageup, pagedown, delete, f1..f24.
+
+# ── Global ──────────────────────────────────────────────────────────────────
+[keys]
+"q" = "quit"
+"Q" = "quit"
+"?" = "show_help"
+# ':' is bound per non-terminal layer so it passes through to the PTY in
+# terminal panels. Ctrl+P stays global for command-palette access anywhere.
+"ctrl+p" = "command_palette"
+# Alt+h / Alt+l — panel cycle that works everywhere, including terminals.
+"alt+h" = "cycle_focus_backward"
+"alt+l" = "cycle_focus_forward"
+# macOS Unicode fallback (Option+h='˙', Option+l='¬') for terminals that send
+# Unicode instead of an Alt modifier. These are US-layout Option glyphs.
+"˙" = "cycle_focus_backward"
+"¬" = "cycle_focus_forward"
+"ctrl+w" = "focus_worktree"
+"ctrl+n" = "new_claude_code"
+"ctrl+t" = "new_shell"
+"ctrl+o" = "open_repo"
+"ctrl+r" = "switch_repo"
+"super+1" = "focus_worktree"
+"super+2" = "focus_explorer"
+"super+3" = "focus_explorer_diff_list"
+"super+4" = "focus_viewer"
+"super+5" = "focus_terminal_claude"
+"super+6" = "focus_terminal_shell"
+# Alt+number fallback — Cmd+number is intercepted by most macOS terminals.
+"alt+1" = "focus_worktree"
+"alt+2" = "focus_explorer"
+"alt+3" = "focus_explorer_diff_list"
+"alt+4" = "focus_viewer"
+"alt+5" = "focus_terminal_claude"
+"alt+6" = "focus_terminal_shell"
+# Option+Shift+1..6 — jump to a panel AND maximize it in one stroke. Under the
+# kitty keyboard protocol these arrive as a clean SHIFT|ALT + digit.
+"alt+shift+1" = "focus_expand_worktree"
+"alt+shift+2" = "focus_expand_explorer"
+"alt+shift+3" = "focus_expand_explorer_diff_list"
+"alt+shift+4" = "focus_expand_viewer"
+"alt+shift+5" = "focus_expand_terminal_claude"
+"alt+shift+6" = "focus_expand_terminal_shell"
+# macOS Option-produces-Unicode fallback (US layout): Option+1='¡' … Option+6='§'.
+"¡" = "focus_worktree"
+"™" = "focus_explorer"
+"£" = "focus_explorer_diff_list"
+"¢" = "focus_viewer"
+"∞" = "focus_terminal_claude"
+"§" = "focus_terminal_shell"
+# F2..F7 — jump-and-maximize from anywhere; F-keys reach the app reliably
+# through Alacritty/Ghostty and tmux where Cmd/Super combos often do not.
+"f2" = "focus_expand_worktree"
+"f3" = "focus_expand_explorer"
+"f4" = "focus_expand_explorer_diff_list"
+"f5" = "focus_expand_viewer"
+"f6" = "focus_expand_terminal_claude"
+"f7" = "focus_expand_terminal_shell"
+"ctrl+g" = "search_full_text"
+"super+space" = "toggle_panel_expand"
+"alt+/" = "toggle_panel_overlay"
+# macOS Unicode fallback (Option+/ = '÷', US layout).
+"÷" = "toggle_panel_overlay"
+
+# ── Worktree ──────────────────────────────────────────────────────────────────
+[layers.worktree]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"enter" = "select"
+"w" = "create_worktree"
+"x" = "delete_worktree"
+"delete" = "delete_worktree"
+"s" = "switch_branch"
+"g" = "grab_branch"
+"G" = "ungrab_branch"
+"P" = "prune_worktrees"
+"m" = "merge_to_main"
+"r" = "refresh_worktrees"
+"R" = "reset_main_to_origin"
+"p" = "cherry_pick"
+"u" = "pull_worktree"
+"H" = "session_history"
+"v" = "open_pull_request"
+":" = "command_palette"
+
+# ── Explorer (file tree) ───────────────────────────────────────────────────────
+[layers.explorer]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"l" = "expand_or_right"
+"right" = "expand_or_right"
+"h" = "collapse_or_left"
+"left" = "collapse_or_left"
+"enter" = "select"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"d" = "show_diff_list"
+"c" = "show_comment_list"
+"/" = "search_filename"
+":" = "command_palette"
+
+# ── Explorer: diff list ─────────────────────────────────────────────────────────
+[layers.explorer_diff_list]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"h" = "collapse_or_left"
+"left" = "collapse_or_left"
+"l" = "expand_or_right"
+"right" = "expand_or_right"
+"enter" = "select"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"esc" = "exit_sub_panel"
+":" = "command_palette"
+
+# ── Explorer: comment list ──────────────────────────────────────────────────────
+[layers.explorer_comment_list]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"h" = "collapse_or_left"
+"left" = "collapse_or_left"
+"enter" = "select"
+"l" = "expand_or_right"
+"right" = "expand_or_right"
+"x" = "delete_comment"
+"delete" = "delete_comment"
+"r" = "toggle_resolve"
+"e" = "edit_comment"
+"R" = "reply_to_comment"
+"space" = "view_comment_detail"
+"esc" = "exit_sub_panel"
+":" = "command_palette"
+
+# ── Viewer (file content) ───────────────────────────────────────────────────────
+[layers.viewer]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"ctrl+d" = "scroll_half_page_down"
+"ctrl+u" = "scroll_half_page_up"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"h" = "scroll_left"
+"left" = "scroll_left"
+"l" = "scroll_right"
+"right" = "scroll_right"
+"0" = "scroll_home"
+"/" = "search_in_file"
+"n" = "next_search_match"
+"N" = "prev_search_match"
+# Fuzzy filename jump — usable even when the viewer is maximized and the file
+# tree is hidden, so files can be switched without un-maximizing.
+"ctrl+f" = "search_filename"
+"space" = "toggle_inline_thread"
+"esc" = "exit_to_explorer"
+":" = "command_palette"
+"ctrl+o" = "jump_back"
+"ctrl+i" = "jump_forward"
+
+# ── Viewer: diff mode ────────────────────────────────────────────────────────────
+[layers.viewer_diff_mode]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"ctrl+d" = "scroll_half_page_down"
+"ctrl+u" = "scroll_half_page_up"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"h" = "scroll_left"
+"left" = "scroll_left"
+"l" = "scroll_right"
+"right" = "scroll_right"
+"0" = "scroll_home"
+"ctrl+f" = "search_filename"
+# Jump between changes (hunks) and between review comments.
+"]" = "next_hunk"
+"[" = "prev_hunk"
+"}" = "next_comment"
+"{" = "prev_comment"
+"space" = "toggle_inline_thread"
+"esc" = "exit_to_explorer"
+"enter" = "expand_context"
+"shift+enter" = "expand_all_context"
+":" = "command_palette"
+
+# ── Overlay (shared popup navigation) ──────────────────────────────────────────
+[layers.overlay]
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"enter" = "select"
+"esc" = "exit_sub_panel"
+
+# ── Terminal ──────────────────────────────────────────────────────────────────
+[layers.terminal]
+"ctrl+esc" = "leave_terminal"
+"shift+pageup" = "scrollback_up"
+"shift+pagedown" = "scrollback_down"
+"shift+home" = "scrollback_top"
+"shift+end" = "snap_to_live"
+"ctrl+g" = "open_file_from_terminal"

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -62,14 +62,6 @@
 "¢" = "focus_viewer"
 "∞" = "focus_terminal_claude"
 "§" = "focus_terminal_shell"
-# F2..F7 — jump-and-maximize from anywhere; F-keys reach the app reliably
-# through Alacritty/Ghostty and tmux where Cmd/Super combos often do not.
-"f2" = "focus_expand_worktree"
-"f3" = "focus_expand_explorer"
-"f4" = "focus_expand_explorer_diff_list"
-"f5" = "focus_expand_viewer"
-"f6" = "focus_expand_terminal_claude"
-"f7" = "focus_expand_terminal_shell"
 "ctrl+g" = "search_full_text"
 "super+space" = "toggle_panel_expand"
 "alt+/" = "toggle_panel_overlay"
@@ -186,6 +178,7 @@
 # Fuzzy filename jump — usable even when the viewer is maximized and the file
 # tree is hidden, so files can be switched without un-maximizing.
 "ctrl+f" = "search_filename"
+"c" = "add_comment"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 ":" = "command_palette"
@@ -215,6 +208,7 @@
 "[" = "prev_hunk"
 "}" = "next_comment"
 "{" = "prev_comment"
+"c" = "add_comment"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 "enter" = "expand_context"

--- a/src/event/overlay.rs
+++ b/src/event/overlay.rs
@@ -25,6 +25,35 @@ fn overlay_list_nav(keymap: &KeyMap, key: &KeyEvent, selected: &mut usize, count
     let Some(action) = keymap.resolve(key, KeyContext::Overlay) else {
         return false;
     };
+    apply_list_nav(action, selected, count)
+}
+
+/// Would this key event produce a literal character for a text field? A bare
+/// printable char (no Ctrl/Alt/Super) is typed input. SHIFT is intentionally
+/// NOT disqualifying: `Shift+G` is a literal `G` to type into a filter.
+fn is_text_input_key(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char(_))
+        && !key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+}
+
+/// List navigation for overlays that ALSO have a text filter (command palette,
+/// filename search, …). A bare printable key falls through to the filter, so
+/// only non-text keys (arrows, PageUp/Down) navigate — `j`/`k`/`g` get typed.
+fn filterable_overlay_list_nav(
+    keymap: &KeyMap,
+    key: &KeyEvent,
+    selected: &mut usize,
+    count: usize,
+) -> bool {
+    if is_text_input_key(key) {
+        return false;
+    }
+    overlay_list_nav(keymap, key, selected, count)
+}
+
+fn apply_list_nav(action: Action, selected: &mut usize, count: usize) -> bool {
     match action {
         Action::NavigateDown => {
             if count > 0 && *selected + 1 < count {
@@ -332,7 +361,7 @@ pub(super) fn handle_history_key(app: &mut App, key: KeyEvent) {
 
     let count = app.overlays.history.records.len();
 
-    if overlay_list_nav(&app.keymap, &key, &mut app.overlays.history.selected, count) {
+    if filterable_overlay_list_nav(&app.keymap, &key, &mut app.overlays.history.selected, count) {
         return;
     }
 
@@ -358,7 +387,7 @@ pub(super) fn handle_history_key(app: &mut App, key: KeyEvent) {
 pub(super) fn handle_resume_session_key(app: &mut App, key: KeyEvent) {
     let filtered_count = app.filtered_resume_sessions().len();
 
-    if overlay_list_nav(
+    if filterable_overlay_list_nav(
         &app.keymap,
         &key,
         &mut app.overlays.resume_session.selected,
@@ -617,7 +646,7 @@ pub(super) fn handle_filename_search_key(app: &mut App, key: KeyEvent) {
                 .delete_to_line_start();
             app.viewer_state.filename_search.filename_search_selected = 0;
         }
-        _ if overlay_list_nav(
+        _ if filterable_overlay_list_nav(
             &app.keymap,
             &key,
             &mut app.viewer_state.filename_search.filename_search_selected,
@@ -1087,7 +1116,7 @@ pub(super) fn handle_switch_branch_key(app: &mut App, key: KeyEvent) {
     let filtered = app.filtered_switch_branches();
     let count = filtered.len();
 
-    if overlay_list_nav(
+    if filterable_overlay_list_nav(
         &app.keymap,
         &key,
         &mut app.overlays.switch_branch.selected,
@@ -1145,7 +1174,7 @@ pub(super) fn handle_grab_key(app: &mut App, key: KeyEvent) {
     let filtered = app.filtered_grab_branches();
     let count = filtered.len();
 
-    if overlay_list_nav(&app.keymap, &key, &mut app.overlays.grab.selected, count) {
+    if filterable_overlay_list_nav(&app.keymap, &key, &mut app.overlays.grab.selected, count) {
         return;
     }
 
@@ -1211,7 +1240,7 @@ pub(super) fn handle_command_palette_key(app: &mut App, key: KeyEvent) {
     let filtered = command_palette::filter_commands(&app.overlays.command_palette.filter);
     let count = filtered.len();
 
-    if overlay_list_nav(
+    if filterable_overlay_list_nav(
         &app.keymap,
         &key,
         &mut app.overlays.command_palette.selected,
@@ -1546,4 +1575,35 @@ fn jump_to_symbol_references(app: &mut App, symbol: &str) {
     app.references_overlay.results = refs;
     app.references_overlay.selected = 0;
     app.references_overlay.scroll = 0;
+}
+
+#[cfg(test)]
+mod nav_guard_tests {
+    use super::is_text_input_key;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[test]
+    fn bare_printable_char_is_text_input() {
+        // In a filterable overlay these must be typed, not treated as navigation.
+        for c in ['j', 'k', 'g', 'G'] {
+            let key = KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty());
+            assert!(is_text_input_key(&key), "{c:?} should be text input");
+        }
+        // Shift is not disqualifying: Shift+G is a literal 'G' to type.
+        let shift_g = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        assert!(is_text_input_key(&shift_g));
+    }
+
+    #[test]
+    fn modified_and_named_keys_are_not_text_input() {
+        // These should still drive list navigation in a filterable overlay.
+        let ctrl_n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL);
+        let alt_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::ALT);
+        let up = KeyEvent::new(KeyCode::Up, KeyModifiers::empty());
+        let down = KeyEvent::new(KeyCode::Down, KeyModifiers::empty());
+        assert!(!is_text_input_key(&ctrl_n));
+        assert!(!is_text_input_key(&alt_j));
+        assert!(!is_text_input_key(&up));
+        assert!(!is_text_input_key(&down));
+    }
 }

--- a/src/event/overlay.rs
+++ b/src/event/overlay.rs
@@ -233,6 +233,16 @@ pub(super) fn handle_worktree_input_key(app: &mut App, key: KeyEvent) {
                 app.set_status("Ungrab cancelled.".to_string(), StatusLevel::Warning);
             }
         },
+        WorktreeInputMode::ConfirmingReset => match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                app.worktree_mgr.input_mode = WorktreeInputMode::Normal;
+                app.perform_reset_main_to_origin();
+            }
+            _ => {
+                app.worktree_mgr.input_mode = WorktreeInputMode::Normal;
+                app.set_status("Reset cancelled.".to_string(), StatusLevel::Warning);
+            }
+        },
         WorktreeInputMode::SmartDescription => {
             // Shift+Enter inserts a newline (multi-line editing).
             if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT) {

--- a/src/event/overlay.rs
+++ b/src/event/overlay.rs
@@ -1237,7 +1237,11 @@ pub(super) fn handle_prune_key(app: &mut App, key: KeyEvent) {
 pub(super) fn handle_command_palette_key(app: &mut App, key: KeyEvent) {
     use crate::command_palette;
 
-    let filtered = command_palette::filter_commands(&app.overlays.command_palette.filter);
+    let filtered = command_palette::filter_commands(
+        &app.overlays.command_palette.filter,
+        &app.keymap,
+        app.focus.key_context(),
+    );
     let count = filtered.len();
 
     if filterable_overlay_list_nav(

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -148,6 +148,9 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         Some(Action::ViewCommentDetail) => {
             open_viewer_comment_detail(app);
         }
+        Some(Action::AddComment) => {
+            app.cmd_add_review_comment();
+        }
         Some(Action::JumpBack) => {
             app.jump_back();
         }
@@ -262,6 +265,9 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::ViewCommentDetail) => {
             open_viewer_comment_detail(app);
+        }
+        Some(Action::AddComment) => {
+            app.cmd_add_review_comment();
         }
         Some(Action::ExpandContext) => {
             // Expand 10 lines at the first visible ExpandableContext.

--- a/src/event/worktree.rs
+++ b/src/event/worktree.rs
@@ -187,21 +187,8 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
             app.refresh_worktrees();
         }
         Some(Action::ResetMainToOrigin) => {
-            let main_branch = app.config.general.main_branch.clone();
-            match git_engine::GitEngine::open(&app.repo_path) {
-                Ok(engine) => match engine.reset_main_to_origin(&main_branch) {
-                    Ok(msg) => {
-                        app.set_status(msg, StatusLevel::Success);
-                        app.refresh_worktrees();
-                    }
-                    Err(e) => {
-                        app.set_status(format!("Reset error: {e}"), StatusLevel::Error);
-                    }
-                },
-                Err(e) => {
-                    app.set_status(format!("Error: {e}"), StatusLevel::Error);
-                }
-            }
+            // Confirm first — this discards local commits.
+            app.cmd_reset_main_to_origin();
         }
         Some(Action::OpenPullRequest) => {
             app.open_pr_in_browser();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -525,6 +525,29 @@ impl KeyMap {
         keys.dedup();
         keys
     }
+
+    /// Keys bound to `action` in `context`'s OWN layer only — unlike
+    /// [`keys_for_action`](Self::keys_for_action), this does NOT fold in the
+    /// global layer. Lets a caller tell "bound in this panel" from "bound
+    /// globally and merely reachable here" (used to scope the command palette).
+    pub fn keys_in_layer(&self, context: KeyContext, action: Action) -> Vec<String> {
+        let layer = if context == KeyContext::Global {
+            &self.global
+        } else {
+            match self.contexts.get(&context) {
+                Some(layer) => layer,
+                None => return Vec::new(),
+            }
+        };
+        let mut keys: Vec<String> = layer
+            .iter()
+            .filter(|(_, a)| **a == action)
+            .map(|(input, _)| input.to_string())
+            .collect();
+        keys.sort();
+        keys.dedup();
+        keys
+    }
 }
 
 /// Clone the layer for `ctx` out of a build, or an empty layer if absent.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -108,9 +108,6 @@ pub enum Action {
     SearchFullText,
 
     // ── Code navigation ─────────────────────────────────────────
-    GoToDefinition,
-    GoToImplementation,
-    FindReferences,
     JumpBack,
     JumpForward,
     ToggleInlineThread,
@@ -203,9 +200,6 @@ impl Action {
             "open_file_from_terminal" => Some(Action::OpenFileFromTerminal),
             "update_and_restart" => Some(Action::UpdateAndRestart),
             "search_full_text" => Some(Action::SearchFullText),
-            "go_to_definition" => Some(Action::GoToDefinition),
-            "go_to_implementation" => Some(Action::GoToImplementation),
-            "find_references" => Some(Action::FindReferences),
             "jump_back" => Some(Action::JumpBack),
             "jump_forward" => Some(Action::JumpForward),
             "next_hunk" => Some(Action::NextHunk),
@@ -294,9 +288,6 @@ impl Action {
             Action::OpenFileFromTerminal => "open_file_from_terminal",
             Action::UpdateAndRestart => "update_and_restart",
             Action::SearchFullText => "search_full_text",
-            Action::GoToDefinition => "go_to_definition",
-            Action::GoToImplementation => "go_to_implementation",
-            Action::FindReferences => "find_references",
             Action::JumpBack => "jump_back",
             Action::JumpForward => "jump_forward",
             Action::NextHunk => "next_hunk",
@@ -1001,6 +992,38 @@ mod tests {
             matches!(resolved, Some(Action::Quit) | Some(Action::ShowHelp)),
             "got {resolved:?}"
         );
+    }
+
+    #[test]
+    fn viewer_c_is_add_comment() {
+        let km = default_keymap();
+        let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty());
+        assert_eq!(
+            km.resolve(&key, KeyContext::Viewer),
+            Some(Action::AddComment)
+        );
+        assert_eq!(
+            km.resolve(&key, KeyContext::ViewerDiffMode),
+            Some(Action::AddComment)
+        );
+    }
+
+    #[test]
+    fn removed_lsp_actions_no_longer_parse() {
+        // Unwired actions were dropped from the vocabulary so binding them
+        // warns (UnknownAction) instead of silently doing nothing.
+        assert_eq!(Action::from_str("go_to_definition"), None);
+        assert_eq!(Action::from_str("go_to_implementation"), None);
+        assert_eq!(Action::from_str("find_references"), None);
+    }
+
+    #[test]
+    fn f_keys_are_unbound_after_cleanup() {
+        let km = default_keymap();
+        for n in 2..=7 {
+            let key = KeyEvent::new(KeyCode::F(n), KeyModifiers::empty());
+            assert_eq!(km.resolve(&key, KeyContext::Global), None, "F{n}");
+        }
     }
 
     #[test]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -2,13 +2,19 @@
 //!
 //! Provides a `KeyMap` that resolves `KeyEvent` → `Action` for a given
 //! `KeyContext`, with user overrides from `config.toml`.
+//!
+//! The lookup engine is [`keymap-core`](keymap_core): each `KeyContext` is a
+//! [`Keymap<Action>`] *layer*, and resolution is `resolve_layered([context,
+//! global], …)` — the context layer wins, missing chords fall through to the
+//! global layer, and a total miss returns `None` ("pass through to the PTY").
+//! Default bindings are authored in `default_keybinds.toml` (embedded at compile
+//! time) and parsed by [`keymap-config`](keymap_config); user bindings from
+//! `[keybinds]` in `config.toml` are layered on top per-chord.
 
 use std::collections::HashMap;
 
-use anyhow::{Result, bail};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
-use crate::config::{KeybindValue, KeybindsConfig};
+use crossterm::event::KeyEvent;
+use keymap_core::{Keymap, resolve_layered};
 
 // ---------------------------------------------------------------------------
 // Action — every customisable user action
@@ -308,7 +314,7 @@ impl Action {
 }
 
 // ---------------------------------------------------------------------------
-// KeyContext — determines which binding table to consult
+// KeyContext — selects which layer to consult
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -326,188 +332,192 @@ pub enum KeyContext {
     Overlay,
 }
 
-// ---------------------------------------------------------------------------
-// Key chord parsing
-// ---------------------------------------------------------------------------
+/// The non-global contexts, each backed by a named `[layers.<name>]` table.
+const PANEL_CONTEXTS: [KeyContext; 8] = [
+    KeyContext::Worktree,
+    KeyContext::Explorer,
+    KeyContext::ExplorerDiffList,
+    KeyContext::ExplorerCommentList,
+    KeyContext::Viewer,
+    KeyContext::ViewerDiffMode,
+    KeyContext::Terminal,
+    KeyContext::Overlay,
+];
 
-/// Parse a key chord string like `"ctrl+shift+a"`, `"enter"`, `"G"`, `"f1"`.
-pub fn parse_key_chord(s: &str) -> Result<(KeyCode, KeyModifiers)> {
-    let s = s.trim();
-    if s.is_empty() {
-        bail!("empty key chord");
-    }
-
-    let parts: Vec<&str> = s.split('+').collect();
-    let mut modifiers = KeyModifiers::empty();
-
-    // All parts except the last are modifiers.
-    for &part in &parts[..parts.len() - 1] {
-        match part.to_lowercase().as_str() {
-            "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
-            "alt" => modifiers |= KeyModifiers::ALT,
-            "shift" => modifiers |= KeyModifiers::SHIFT,
-            "super" | "cmd" | "meta" => modifiers |= KeyModifiers::SUPER,
-            other => bail!("unknown modifier: {other}"),
+impl KeyContext {
+    /// The keymap-config layer name backing this context. `Global` lives in the
+    /// bare `[keys]` table, which keymap-config exposes as the `GLOBAL_LAYER`.
+    fn layer_name(self) -> &'static str {
+        match self {
+            KeyContext::Global => keymap_config::GLOBAL_LAYER,
+            KeyContext::Worktree => "worktree",
+            KeyContext::Explorer => "explorer",
+            KeyContext::ExplorerDiffList => "explorer_diff_list",
+            KeyContext::ExplorerCommentList => "explorer_comment_list",
+            KeyContext::Viewer => "viewer",
+            KeyContext::ViewerDiffMode => "viewer_diff_mode",
+            KeyContext::Terminal => "terminal",
+            KeyContext::Overlay => "overlay",
         }
     }
-
-    let key_part = parts[parts.len() - 1];
-    let code = parse_key_name(key_part)?;
-
-    // Normalise: uppercase single char → remove explicit SHIFT
-    // (crossterm delivers 'G' with SHIFT set, but we store without it)
-    if let KeyCode::Char(c) = code
-        && c.is_ascii_uppercase()
-    {
-        modifiers &= !KeyModifiers::SHIFT;
-    }
-
-    Ok((code, modifiers))
 }
 
-fn parse_key_name(s: &str) -> Result<KeyCode> {
-    // Single character
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() == 1 {
-        return Ok(KeyCode::Char(chars[0]));
-    }
+// ---------------------------------------------------------------------------
+// KeybindWarning — survivable problems found while building the keymap
+// ---------------------------------------------------------------------------
 
-    // Named keys (case-insensitive)
-    match s.to_lowercase().as_str() {
-        "enter" | "return" => Ok(KeyCode::Enter),
-        "esc" | "escape" => Ok(KeyCode::Esc),
-        "tab" => Ok(KeyCode::Tab),
-        "backtab" => Ok(KeyCode::BackTab),
-        "backspace" => Ok(KeyCode::Backspace),
-        "delete" | "del" => Ok(KeyCode::Delete),
-        "up" => Ok(KeyCode::Up),
-        "down" => Ok(KeyCode::Down),
-        "left" => Ok(KeyCode::Left),
-        "right" => Ok(KeyCode::Right),
-        "home" => Ok(KeyCode::Home),
-        "end" => Ok(KeyCode::End),
-        "pageup" => Ok(KeyCode::PageUp),
-        "pagedown" => Ok(KeyCode::PageDown),
-        "space" => Ok(KeyCode::Char(' ')),
-        "f1" => Ok(KeyCode::F(1)),
-        "f2" => Ok(KeyCode::F(2)),
-        "f3" => Ok(KeyCode::F(3)),
-        "f4" => Ok(KeyCode::F(4)),
-        "f5" => Ok(KeyCode::F(5)),
-        "f6" => Ok(KeyCode::F(6)),
-        "f7" => Ok(KeyCode::F(7)),
-        "f8" => Ok(KeyCode::F(8)),
-        "f9" => Ok(KeyCode::F(9)),
-        "f10" => Ok(KeyCode::F(10)),
-        "f11" => Ok(KeyCode::F(11)),
-        "f12" => Ok(KeyCode::F(12)),
-        _ => bail!("unknown key name: {s}"),
-    }
+/// A non-fatal problem found while loading user keybindings. Conductor's own
+/// type so the public surface does not depend on `keymap_config::Warning`
+/// (which is `#[non_exhaustive]` and carries sequence concepts Conductor does
+/// not use).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeybindWarning {
+    /// An action name in the config was not recognized; the binding was skipped.
+    UnknownAction { key: String, action: String },
+    /// Two keys resolved to the same chord within one layer; the last one won.
+    Conflict { chord: String },
+    /// A `[keybinds.layers.<name>]` table used a layer name with no matching
+    /// context; its bindings were ignored.
+    UnknownLayer { layer: String },
+    /// The `[keybinds]` config could not be parsed at all (malformed, or the
+    /// pre-0.x `[keybinds.<context>]` action→key format). User overrides were
+    /// ignored and the built-in defaults are used.
+    InvalidConfig { detail: String },
 }
 
-/// Format a `(KeyCode, KeyModifiers)` pair back to a human-readable string.
-fn format_key_chord(code: &KeyCode, modifiers: &KeyModifiers) -> String {
-    let mut parts = Vec::new();
-    if modifiers.contains(KeyModifiers::CONTROL) {
-        parts.push("Ctrl".to_string());
+impl std::fmt::Display for KeybindWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeybindWarning::UnknownAction { key, action } => {
+                write!(f, "unknown keybind action {action:?} for key {key:?}")
+            }
+            KeybindWarning::Conflict { chord } => {
+                write!(
+                    f,
+                    "keybind chord {chord:?} is bound more than once in one layer"
+                )
+            }
+            KeybindWarning::UnknownLayer { layer } => {
+                write!(f, "unknown keybind layer {layer:?}")
+            }
+            KeybindWarning::InvalidConfig { detail } => {
+                write!(f, "could not parse [keybinds] config: {detail}")
+            }
+        }
     }
-    if modifiers.contains(KeyModifiers::ALT) {
-        parts.push("Alt".to_string());
-    }
-    if modifiers.contains(KeyModifiers::SHIFT) {
-        parts.push("Shift".to_string());
-    }
-    if modifiers.contains(KeyModifiers::SUPER) {
-        parts.push("Cmd".to_string());
-    }
-
-    let key_name = match code {
-        KeyCode::Char(' ') => "Space".to_string(),
-        KeyCode::Char(c) => c.to_string(),
-        KeyCode::Enter => "Enter".to_string(),
-        KeyCode::Esc => "Esc".to_string(),
-        KeyCode::Tab => "Tab".to_string(),
-        KeyCode::BackTab => "BackTab".to_string(),
-        KeyCode::Backspace => "Backspace".to_string(),
-        KeyCode::Delete => "Del".to_string(),
-        KeyCode::Up => "Up".to_string(),
-        KeyCode::Down => "Down".to_string(),
-        KeyCode::Left => "Left".to_string(),
-        KeyCode::Right => "Right".to_string(),
-        KeyCode::Home => "Home".to_string(),
-        KeyCode::End => "End".to_string(),
-        KeyCode::PageUp => "PageUp".to_string(),
-        KeyCode::PageDown => "PageDown".to_string(),
-        KeyCode::F(n) => format!("F{n}"),
-        _ => "?".to_string(),
-    };
-    parts.push(key_name);
-    parts.join("+")
 }
 
 // ---------------------------------------------------------------------------
 // KeyMap
 // ---------------------------------------------------------------------------
 
+/// Embedded default bindings (keymap-config key→action TOML). See the file for
+/// the schema; it is the reference for what users can write under `[keybinds]`.
+const DEFAULT_KEYBINDS: &str = include_str!("default_keybinds.toml");
+
 pub struct KeyMap {
-    bindings: HashMap<KeyContext, HashMap<(KeyCode, KeyModifiers), Action>>,
+    /// One effective layer per non-global context (defaults overlaid by user
+    /// bindings, per-chord).
+    contexts: HashMap<KeyContext, Keymap<Action>>,
+    /// The effective global layer, consulted last for every context.
+    global: Keymap<Action>,
 }
 
 impl KeyMap {
-    /// Build a new KeyMap with defaults, then apply user overrides.
-    pub fn new(config: &KeybindsConfig) -> Self {
-        let mut km = Self {
-            bindings: HashMap::new(),
-        };
-        km.load_defaults();
-        km.apply_overrides(config);
-        km
+    /// Build a `KeyMap` from defaults plus the user's `[keybinds]` config table,
+    /// discarding any warnings. See [`KeyMap::with_warnings`] to inspect them.
+    #[allow(dead_code)] // convenience constructor; the app uses `with_warnings`.
+    pub fn new(user: &toml::Table) -> Self {
+        Self::with_warnings(user).0
     }
 
-    /// Resolve a key event to an action in the given context.
-    /// Falls back to `KeyContext::Global` if no match in the specific context.
-    pub fn resolve(&self, key: &KeyEvent, context: KeyContext) -> Option<Action> {
-        let normalized = normalize_key(key);
+    /// Build a `KeyMap`, returning any non-fatal problems found in the user's
+    /// config so the caller can surface them (the app flashes them on startup).
+    pub fn with_warnings(user: &toml::Table) -> (Self, Vec<KeybindWarning>) {
+        let mut warnings = Vec::new();
 
-        // First try the specific context.
-        if context != KeyContext::Global
-            && let Some(map) = self.bindings.get(&context)
-            && let Some(action) = map.get(&normalized)
-        {
-            return Some(*action);
+        // 1. Embedded defaults. Authored in-repo, so any warning is a build bug:
+        //    fail loudly in debug, and never surface to the user.
+        let defaults = keymap_config::from_str(DEFAULT_KEYBINDS, Action::from_str)
+            .expect("embedded default keybinds must be valid TOML");
+        debug_assert!(
+            defaults.warnings.is_empty(),
+            "default keybinds produced warnings: {:?}",
+            defaults.warnings
+        );
+        for w in &defaults.warnings {
+            log::error!("default keybinds produced a warning (bug): {w:?}");
         }
 
-        // Fall back to global.
-        if let Some(map) = self.bindings.get(&KeyContext::Global)
-            && let Some(action) = map.get(&normalized)
-        {
-            return Some(*action);
-        }
+        // 2. Seed every layer from the defaults.
+        let mut global = layer_or_default(&defaults, KeyContext::Global);
+        let mut contexts: HashMap<KeyContext, Keymap<Action>> = PANEL_CONTEXTS
+            .iter()
+            .map(|&ctx| (ctx, layer_or_default(&defaults, ctx)))
+            .collect();
 
-        None
-    }
+        // 3. Parse user overrides and overlay them per-chord (user wins).
+        if let Some(user_build) = parse_user_keybinds(user, &mut warnings) {
+            collect_warnings(&user_build.warnings, &mut warnings);
 
-    /// Get the display strings for all keys bound to an action in a context.
-    pub fn keys_for_action(&self, context: KeyContext, action: Action) -> Vec<String> {
-        let mut keys = Vec::new();
-
-        // Check context-specific bindings.
-        if let Some(map) = self.bindings.get(&context) {
-            for ((code, mods), a) in map {
-                if *a == action {
-                    keys.push(format_key_chord(code, mods));
+            for (name, user_layer) in &user_build.layers {
+                let target = if name == keymap_config::GLOBAL_LAYER {
+                    Some(&mut global)
+                } else {
+                    match PANEL_CONTEXTS.iter().find(|c| c.layer_name() == name) {
+                        Some(&ctx) => contexts.get_mut(&ctx),
+                        None => {
+                            // keymap-config always inserts an empty GLOBAL_LAYER;
+                            // only warn on a genuinely unrecognized named layer.
+                            if !user_layer.is_empty() {
+                                warnings.push(KeybindWarning::UnknownLayer {
+                                    layer: name.clone(),
+                                });
+                            }
+                            None
+                        }
+                    }
+                };
+                if let Some(target) = target {
+                    for (input, action) in user_layer.iter() {
+                        target.bind(*input, *action);
+                    }
                 }
             }
         }
 
-        // Also check global bindings for global actions.
-        if context != KeyContext::Global
-            && let Some(map) = self.bindings.get(&KeyContext::Global)
-        {
-            for ((code, mods), a) in map {
+        (KeyMap { contexts, global }, warnings)
+    }
+
+    /// Resolve a key event to an action in the given context. The context layer
+    /// is consulted first, then the global layer; an unmappable key event or a
+    /// total miss yields `None` (the caller passes the key through).
+    pub fn resolve(&self, key: &KeyEvent, context: KeyContext) -> Option<Action> {
+        let input = keymap_core::KeyInput::try_from(*key).ok()?;
+        let resolved = match self.contexts.get(&context) {
+            Some(layer) => resolve_layered([layer, &self.global], &input),
+            None => resolve_layered([&self.global], &input),
+        };
+        resolved.copied()
+    }
+
+    /// Display strings for every key bound to an action in a context (context
+    /// layer plus the global layer), for the help screen. Strings are
+    /// keymap-core canonical form (e.g. `"ctrl+d"`, `"down"`, `"G"`), which
+    /// round-trips back through the config grammar.
+    pub fn keys_for_action(&self, context: KeyContext, action: Action) -> Vec<String> {
+        let mut keys = Vec::new();
+
+        if let Some(layer) = self.contexts.get(&context) {
+            for (input, a) in layer.iter() {
                 if *a == action {
-                    keys.push(format_key_chord(code, mods));
+                    keys.push(input.to_string());
                 }
+            }
+        }
+        for (input, a) in self.global.iter() {
+            if *a == action {
+                keys.push(input.to_string());
             }
         }
 
@@ -515,450 +525,78 @@ impl KeyMap {
         keys.dedup();
         keys
     }
+}
 
-    // ── Binding insertion helpers ─────────────────────────────────
+/// Clone the layer for `ctx` out of a build, or an empty layer if absent.
+fn layer_or_default(build: &keymap_config::BuildOutput<Action>, ctx: KeyContext) -> Keymap<Action> {
+    build
+        .layers
+        .get(ctx.layer_name())
+        .cloned()
+        .unwrap_or_default()
+}
 
-    fn bind(
-        &mut self,
-        context: KeyContext,
-        code: KeyCode,
-        modifiers: KeyModifiers,
-        action: Action,
-    ) {
-        let normalized = normalize_raw(code, modifiers);
-        self.bindings
-            .entry(context)
-            .or_default()
-            .insert(normalized, action);
+/// Parse the user's `[keybinds]` table into keymap-config layers. Returns
+/// `None` (no overrides) when the table is empty or cannot be parsed; a parse
+/// failure is recorded as a [`KeybindWarning::InvalidConfig`] so the app can
+/// tell the user their customizations were ignored.
+fn parse_user_keybinds(
+    user: &toml::Table,
+    warnings: &mut Vec<KeybindWarning>,
+) -> Option<keymap_config::BuildOutput<Action>> {
+    if user.is_empty() {
+        return None;
     }
 
-    fn bind_char(&mut self, context: KeyContext, c: char, action: Action) {
-        self.bind(context, KeyCode::Char(c), KeyModifiers::empty(), action);
-    }
+    // keymap-config parses a standalone document; re-emit just the [keybinds]
+    // subtree as TOML text. (Conductor's `toml` and keymap-config's may differ
+    // in version, so the interface between them is text, not types.)
+    let toml_text = match toml::to_string(user) {
+        Ok(text) => text,
+        Err(e) => {
+            warnings.push(KeybindWarning::InvalidConfig {
+                detail: e.to_string(),
+            });
+            return None;
+        }
+    };
 
-    fn bind_key(&mut self, context: KeyContext, code: KeyCode, action: Action) {
-        self.bind(context, code, KeyModifiers::empty(), action);
-    }
-
-    fn bind_ctrl(&mut self, context: KeyContext, c: char, action: Action) {
-        self.bind(context, KeyCode::Char(c), KeyModifiers::CONTROL, action);
-    }
-
-    // ── Default bindings (mirrors current event.rs hardcoded keys) ──
-
-    fn load_defaults(&mut self) {
-        use Action::*;
-        use KeyContext::*;
-
-        // ── Global ───────────────────────────────────────────────
-        self.bind_char(Global, 'q', Quit);
-        self.bind_char(Global, 'Q', Quit);
-        self.bind_char(Global, '?', ShowHelp);
-        // ':' is bound per non-terminal context so it passes through to PTY
-        // in terminal panels. Ctrl+P remains global for command palette access.
-        self.bind_ctrl(Global, 'p', CommandPalette);
-        // Alt+h / Alt+l — panel cycle that works everywhere, including terminal panels.
-        self.bind(
-            Global,
-            KeyCode::Char('h'),
-            KeyModifiers::ALT,
-            CycleFocusBackward,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('l'),
-            KeyModifiers::ALT,
-            CycleFocusForward,
-        );
-        // macOS Unicode fallback (Option+h='˙', Option+l='¬') for terminals that
-        // send Unicode instead of Alt modifier.
-        self.bind_char(Global, '˙', CycleFocusBackward);
-        self.bind_char(Global, '¬', CycleFocusForward);
-        self.bind_ctrl(Global, 'w', FocusWorktree);
-        self.bind_ctrl(Global, 'n', NewClaudeCode);
-        self.bind_ctrl(Global, 't', NewShell);
-        self.bind_ctrl(Global, 'o', OpenRepo);
-        self.bind_ctrl(Global, 'r', SwitchRepo);
-        self.bind(
-            Global,
-            KeyCode::Char('1'),
-            KeyModifiers::SUPER,
-            FocusWorktree,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('2'),
-            KeyModifiers::SUPER,
-            FocusExplorer,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('3'),
-            KeyModifiers::SUPER,
-            FocusExplorerDiffList,
-        );
-        self.bind(Global, KeyCode::Char('4'), KeyModifiers::SUPER, FocusViewer);
-        self.bind(
-            Global,
-            KeyCode::Char('5'),
-            KeyModifiers::SUPER,
-            FocusTerminalClaude,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('6'),
-            KeyModifiers::SUPER,
-            FocusTerminalShell,
-        );
-        // Alt+number as fallback — Cmd+number is intercepted by most terminal emulators on macOS.
-        // When terminal sends Alt as Esc prefix (e.g. iTerm2 "Option sends Esc+"):
-        self.bind(Global, KeyCode::Char('1'), KeyModifiers::ALT, FocusWorktree);
-        self.bind(Global, KeyCode::Char('2'), KeyModifiers::ALT, FocusExplorer);
-        self.bind(
-            Global,
-            KeyCode::Char('3'),
-            KeyModifiers::ALT,
-            FocusExplorerDiffList,
-        );
-        self.bind(Global, KeyCode::Char('4'), KeyModifiers::ALT, FocusViewer);
-        self.bind(
-            Global,
-            KeyCode::Char('5'),
-            KeyModifiers::ALT,
-            FocusTerminalClaude,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('6'),
-            KeyModifiers::ALT,
-            FocusTerminalShell,
-        );
-        // Option+Shift+1..6 — jump to a panel AND maximize it in one stroke.
-        // "Add Shift to the focus chord to also maximize." Under the kitty keyboard
-        // protocol (active when the terminal supports it) these arrive as a clean
-        // SHIFT|ALT + digit, so no Unicode fallbacks are needed. Chosen over
-        // Cmd+Shift+digit because macOS steals Cmd+Shift+3/4/5/6 for screenshots.
-        self.bind(
-            Global,
-            KeyCode::Char('1'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandWorktree,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('2'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandExplorer,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('3'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandExplorerDiffList,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('4'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandViewer,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('5'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandTerminalClaude,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('6'),
-            KeyModifiers::ALT | KeyModifiers::SHIFT,
-            FocusExpandTerminalShell,
-        );
-        // When macOS Option key produces Unicode (e.g. default Terminal.app / iTerm2 without Esc+ mode):
-        // Option+1='¡', Option+2='™', Option+3='£', Option+4='¢', Option+5='∞', Option+6='§'
-        self.bind_char(Global, '¡', FocusWorktree);
-        self.bind_char(Global, '™', FocusExplorer);
-        self.bind_char(Global, '£', FocusExplorerDiffList);
-        self.bind_char(Global, '¢', FocusViewer);
-        self.bind_char(Global, '∞', FocusTerminalClaude);
-        self.bind_char(Global, '§', FocusTerminalShell);
-        // Jump to a panel AND maximize it in one stroke, from anywhere (including
-        // terminal panels). F-keys are chosen because they reach the app reliably
-        // through Alacritty/Ghostty and tmux, where Cmd/Super combos often do not.
-        // F2..F7 mirror the Cmd/Alt+1..6 focus order (F1 left for help convention).
-        self.bind_key(Global, KeyCode::F(2), FocusExpandWorktree);
-        self.bind_key(Global, KeyCode::F(3), FocusExpandExplorer);
-        self.bind_key(Global, KeyCode::F(4), FocusExpandExplorerDiffList);
-        self.bind_key(Global, KeyCode::F(5), FocusExpandViewer);
-        self.bind_key(Global, KeyCode::F(6), FocusExpandTerminalClaude);
-        self.bind_key(Global, KeyCode::F(7), FocusExpandTerminalShell);
-        self.bind_ctrl(Global, 'g', SearchFullText);
-        self.bind(
-            Global,
-            KeyCode::Char(' '),
-            KeyModifiers::SUPER,
-            TogglePanelExpand,
-        );
-        self.bind(
-            Global,
-            KeyCode::Char('/'),
-            KeyModifiers::ALT,
-            TogglePanelOverlay,
-        );
-        // macOS Unicode fallback (Option+/ = '÷')
-        self.bind_char(Global, '÷', TogglePanelOverlay);
-
-        // ── Worktree ─────────────────────────────────────────────
-        self.bind_key(Worktree, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(Worktree, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(Worktree, 'j', NavigateDown);
-        self.bind_key(Worktree, KeyCode::Down, NavigateDown);
-        self.bind_char(Worktree, 'k', NavigateUp);
-        self.bind_key(Worktree, KeyCode::Up, NavigateUp);
-        self.bind_key(Worktree, KeyCode::Enter, Select);
-        self.bind_char(Worktree, 'w', CreateWorktree);
-        self.bind_char(Worktree, 'x', DeleteWorktree);
-        self.bind_key(Worktree, KeyCode::Delete, DeleteWorktree);
-        self.bind_char(Worktree, 's', SwitchBranch);
-        self.bind_char(Worktree, 'g', GrabBranch);
-        self.bind_char(Worktree, 'G', UngrabBranch);
-        self.bind_char(Worktree, 'P', PruneWorktrees);
-        self.bind_char(Worktree, 'm', MergeToMain);
-        self.bind_char(Worktree, 'r', RefreshWorktrees);
-        self.bind_char(Worktree, 'R', ResetMainToOrigin);
-        self.bind_char(Worktree, 'p', CherryPick);
-        self.bind_char(Worktree, 'u', PullWorktree);
-        self.bind_char(Worktree, 'H', SessionHistory);
-        self.bind_char(Worktree, 'v', OpenPullRequest);
-        self.bind_char(Worktree, ':', CommandPalette);
-
-        // ── Explorer (file tree) ─────────────────────────────────
-        self.bind_key(Explorer, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(Explorer, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(Explorer, 'j', NavigateDown);
-        self.bind_key(Explorer, KeyCode::Down, NavigateDown);
-        self.bind_char(Explorer, 'k', NavigateUp);
-        self.bind_key(Explorer, KeyCode::Up, NavigateUp);
-        self.bind_char(Explorer, 'l', ExpandOrRight);
-        self.bind_key(Explorer, KeyCode::Right, ExpandOrRight);
-        self.bind_char(Explorer, 'h', CollapseOrLeft);
-        self.bind_key(Explorer, KeyCode::Left, CollapseOrLeft);
-        self.bind_key(Explorer, KeyCode::Enter, Select);
-        self.bind_char(Explorer, 'g', GoToTop);
-        self.bind_char(Explorer, 'G', GoToBottom);
-        self.bind_char(Explorer, 'd', ShowDiffList);
-        self.bind_char(Explorer, 'c', ShowCommentList);
-        self.bind_char(Explorer, '/', SearchFilename);
-        self.bind_char(Explorer, ':', CommandPalette);
-
-        // ── Explorer: diff list ──────────────────────────────────
-        self.bind_key(ExplorerDiffList, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(ExplorerDiffList, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(ExplorerDiffList, 'j', NavigateDown);
-        self.bind_key(ExplorerDiffList, KeyCode::Down, NavigateDown);
-        self.bind_char(ExplorerDiffList, 'k', NavigateUp);
-        self.bind_key(ExplorerDiffList, KeyCode::Up, NavigateUp);
-        self.bind_char(ExplorerDiffList, 'h', CollapseOrLeft);
-        self.bind_key(ExplorerDiffList, KeyCode::Left, CollapseOrLeft);
-        self.bind_char(ExplorerDiffList, 'l', ExpandOrRight);
-        self.bind_key(ExplorerDiffList, KeyCode::Right, ExpandOrRight);
-        self.bind_key(ExplorerDiffList, KeyCode::Enter, Select);
-        self.bind_char(ExplorerDiffList, 'g', GoToTop);
-        self.bind_char(ExplorerDiffList, 'G', GoToBottom);
-        self.bind_key(ExplorerDiffList, KeyCode::Esc, ExitSubPanel);
-        self.bind_char(ExplorerDiffList, ':', CommandPalette);
-
-        // ── Explorer: comment list ───────────────────────────────
-        self.bind_key(ExplorerCommentList, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(ExplorerCommentList, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(ExplorerCommentList, 'j', NavigateDown);
-        self.bind_key(ExplorerCommentList, KeyCode::Down, NavigateDown);
-        self.bind_char(ExplorerCommentList, 'k', NavigateUp);
-        self.bind_key(ExplorerCommentList, KeyCode::Up, NavigateUp);
-        self.bind_char(ExplorerCommentList, 'g', GoToTop);
-        self.bind_char(ExplorerCommentList, 'G', GoToBottom);
-        self.bind_char(ExplorerCommentList, 'h', CollapseOrLeft);
-        self.bind_key(ExplorerCommentList, KeyCode::Left, CollapseOrLeft);
-        self.bind_key(ExplorerCommentList, KeyCode::Enter, Select);
-        self.bind_char(ExplorerCommentList, 'l', ExpandOrRight);
-        self.bind_key(ExplorerCommentList, KeyCode::Right, ExpandOrRight);
-        self.bind_char(ExplorerCommentList, 'x', DeleteComment);
-        self.bind_key(ExplorerCommentList, KeyCode::Delete, DeleteComment);
-        self.bind_char(ExplorerCommentList, 'r', ToggleResolve);
-        self.bind_char(ExplorerCommentList, 'e', EditComment);
-        self.bind_char(ExplorerCommentList, 'R', ReplyToComment);
-        self.bind_char(ExplorerCommentList, ' ', ViewCommentDetail);
-        self.bind_key(ExplorerCommentList, KeyCode::Esc, ExitSubPanel);
-        self.bind_char(ExplorerCommentList, ':', CommandPalette);
-
-        // ── Viewer ───────────────────────────────────────────────
-        self.bind_key(Viewer, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(Viewer, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(Viewer, 'j', NavigateDown);
-        self.bind_key(Viewer, KeyCode::Down, NavigateDown);
-        self.bind_char(Viewer, 'k', NavigateUp);
-        self.bind_key(Viewer, KeyCode::Up, NavigateUp);
-        self.bind_ctrl(Viewer, 'd', ScrollHalfPageDown);
-        self.bind_ctrl(Viewer, 'u', ScrollHalfPageUp);
-        self.bind_char(Viewer, 'g', GoToTop);
-        self.bind_char(Viewer, 'G', GoToBottom);
-        self.bind_char(Viewer, 'h', ScrollLeft);
-        self.bind_key(Viewer, KeyCode::Left, ScrollLeft);
-        self.bind_char(Viewer, 'l', ScrollRight);
-        self.bind_key(Viewer, KeyCode::Right, ScrollRight);
-        self.bind_char(Viewer, '0', ScrollHome);
-        self.bind_char(Viewer, '/', SearchInFile);
-        self.bind_char(Viewer, 'n', NextSearchMatch);
-        self.bind_char(Viewer, 'N', PrevSearchMatch);
-        // Fuzzy filename jump — usable even when the viewer is maximized and the
-        // file tree is hidden, so you can switch files without un-maximizing.
-        self.bind_ctrl(Viewer, 'f', SearchFilename);
-        self.bind_char(Viewer, ' ', ToggleInlineThread);
-        self.bind_key(Viewer, KeyCode::Esc, ExitToExplorer);
-        self.bind_char(Viewer, ':', CommandPalette);
-        self.bind_ctrl(Viewer, 'o', JumpBack);
-        self.bind_ctrl(Viewer, 'i', JumpForward);
-
-        // ── Viewer: diff mode ────────────────────────────────────
-        self.bind_key(ViewerDiffMode, KeyCode::Tab, CycleFocusForward);
-        self.bind_key(ViewerDiffMode, KeyCode::BackTab, CycleFocusBackward);
-        self.bind_char(ViewerDiffMode, 'j', NavigateDown);
-        self.bind_key(ViewerDiffMode, KeyCode::Down, NavigateDown);
-        self.bind_char(ViewerDiffMode, 'k', NavigateUp);
-        self.bind_key(ViewerDiffMode, KeyCode::Up, NavigateUp);
-        self.bind_ctrl(ViewerDiffMode, 'd', ScrollHalfPageDown);
-        self.bind_ctrl(ViewerDiffMode, 'u', ScrollHalfPageUp);
-        self.bind_char(ViewerDiffMode, 'g', GoToTop);
-        self.bind_char(ViewerDiffMode, 'G', GoToBottom);
-        self.bind_char(ViewerDiffMode, 'h', ScrollLeft);
-        self.bind_key(ViewerDiffMode, KeyCode::Left, ScrollLeft);
-        self.bind_char(ViewerDiffMode, 'l', ScrollRight);
-        self.bind_key(ViewerDiffMode, KeyCode::Right, ScrollRight);
-        self.bind_char(ViewerDiffMode, '0', ScrollHome);
-        // Fuzzy filename jump — same as the file viewer, available in diff mode too.
-        self.bind_ctrl(ViewerDiffMode, 'f', SearchFilename);
-        // Jump between changes (hunks) and between review comments.
-        self.bind_char(ViewerDiffMode, ']', NextHunk);
-        self.bind_char(ViewerDiffMode, '[', PrevHunk);
-        self.bind_char(ViewerDiffMode, '}', NextComment);
-        self.bind_char(ViewerDiffMode, '{', PrevComment);
-        self.bind_char(ViewerDiffMode, ' ', ToggleInlineThread);
-        self.bind_key(ViewerDiffMode, KeyCode::Esc, ExitToExplorer);
-        self.bind_key(ViewerDiffMode, KeyCode::Enter, ExpandContext);
-        self.bind(
-            ViewerDiffMode,
-            KeyCode::Enter,
-            KeyModifiers::SHIFT,
-            ExpandAllContext,
-        );
-        self.bind_char(ViewerDiffMode, ':', CommandPalette);
-
-        // ── Overlay (shared popup navigation) ─────────────────────
-        self.bind_char(Overlay, 'j', NavigateDown);
-        self.bind_key(Overlay, KeyCode::Down, NavigateDown);
-        self.bind_char(Overlay, 'k', NavigateUp);
-        self.bind_key(Overlay, KeyCode::Up, NavigateUp);
-        self.bind_char(Overlay, 'g', GoToTop);
-        self.bind_char(Overlay, 'G', GoToBottom);
-        self.bind_key(Overlay, KeyCode::Enter, Select);
-        self.bind_key(Overlay, KeyCode::Esc, ExitSubPanel);
-
-        // ── Terminal ─────────────────────────────────────────────
-        self.bind(Terminal, KeyCode::Esc, KeyModifiers::CONTROL, LeaveTerminal);
-        self.bind(Terminal, KeyCode::PageUp, KeyModifiers::SHIFT, ScrollbackUp);
-        self.bind(
-            Terminal,
-            KeyCode::PageDown,
-            KeyModifiers::SHIFT,
-            ScrollbackDown,
-        );
-        self.bind(Terminal, KeyCode::Home, KeyModifiers::SHIFT, ScrollbackTop);
-        self.bind(Terminal, KeyCode::End, KeyModifiers::SHIFT, SnapToLive);
-        self.bind(
-            Terminal,
-            KeyCode::Char('g'),
-            KeyModifiers::CONTROL,
-            OpenFileFromTerminal,
-        );
-    }
-
-    /// Apply user overrides from config. For each overridden action,
-    /// remove all existing bindings for that action in the context,
-    /// then insert the new key(s).
-    fn apply_overrides(&mut self, config: &KeybindsConfig) {
-        self.apply_section_overrides(KeyContext::Global, &config.global);
-        self.apply_section_overrides(KeyContext::Worktree, &config.worktree);
-        self.apply_section_overrides(KeyContext::Explorer, &config.explorer);
-        self.apply_section_overrides(KeyContext::Viewer, &config.viewer);
-        self.apply_section_overrides(KeyContext::Terminal, &config.terminal);
-        self.apply_section_overrides(KeyContext::Overlay, &config.overlay);
-    }
-
-    fn apply_section_overrides(
-        &mut self,
-        context: KeyContext,
-        overrides: &HashMap<String, KeybindValue>,
-    ) {
-        for (action_name, value) in overrides {
-            let Some(action) = Action::from_str(action_name) else {
-                log::warn!("unknown keybind action: {action_name}");
-                continue;
-            };
-
-            // Remove all existing bindings for this action in this context.
-            if let Some(map) = self.bindings.get_mut(&context) {
-                map.retain(|_, a| *a != action);
-            }
-
-            // Parse and insert the new key(s).
-            let keys: Vec<&str> = match value {
-                KeybindValue::Single(s) => vec![s.as_str()],
-                KeybindValue::Multiple(v) => v.iter().map(|s| s.as_str()).collect(),
-            };
-
-            for key_str in keys {
-                match parse_key_chord(key_str) {
-                    Ok((code, mods)) => {
-                        self.bind(context, code, mods, action);
-                    }
-                    Err(e) => {
-                        log::warn!("invalid key chord '{key_str}' for action '{action_name}': {e}");
-                    }
-                }
-            }
+    match keymap_config::from_str(&toml_text, Action::from_str) {
+        Ok(build) => Some(build),
+        Err(e) => {
+            warnings.push(KeybindWarning::InvalidConfig {
+                detail: format!(
+                    "{e} (note: the keybind format is now key→action under \
+                     [keybinds.keys] / [keybinds.layers.*]; the old \
+                     [keybinds.<context>] action→key tables are no longer read)"
+                ),
+            });
+            None
         }
     }
 }
 
-// ---------------------------------------------------------------------------
-// Key normalisation
-// ---------------------------------------------------------------------------
-
-/// Normalise a KeyEvent for lookup: strip SHIFT from uppercase ASCII chars.
-fn normalize_key(key: &KeyEvent) -> (KeyCode, KeyModifiers) {
-    normalize_raw(key.code, key.modifiers)
-}
-
-fn normalize_raw(mut code: KeyCode, mut modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
-    if let KeyCode::Char(c) = code {
-        if c.is_ascii_lowercase() && modifiers.contains(KeyModifiers::SHIFT) {
-            // Some terminals may send lowercase + SHIFT instead of uppercase.
-            // Normalise to uppercase without SHIFT for consistent lookup.
-            code = KeyCode::Char(c.to_ascii_uppercase());
-            modifiers &= !KeyModifiers::SHIFT;
-        } else if c.is_ascii_uppercase() {
-            modifiers &= !KeyModifiers::SHIFT;
+/// Translate the keymap-config warnings Conductor cares about into its own
+/// warning type, dropping sequence-related variants it does not use.
+fn collect_warnings(from: &[keymap_config::Warning], into: &mut Vec<KeybindWarning>) {
+    for w in from {
+        match w {
+            keymap_config::Warning::UnknownAction { key, action } => {
+                into.push(KeybindWarning::UnknownAction {
+                    key: key.clone(),
+                    action: action.clone(),
+                });
+            }
+            keymap_config::Warning::Conflict { chord, .. } => {
+                into.push(KeybindWarning::Conflict {
+                    chord: chord.clone(),
+                });
+            }
+            // PrefixShadow / EmptySequence / SequenceShadow concern sequences,
+            // which Conductor does not use. `Warning` is #[non_exhaustive].
+            _ => {}
         }
     }
-    // BackTab already encodes Shift+Tab — strip the redundant SHIFT flag
-    // that crossterm's enhanced keyboard protocol may include.
-    if code == KeyCode::BackTab {
-        modifiers &= !KeyModifiers::SHIFT;
-    }
-    // Strip state flags that aren't meaningful for binding lookup.
-    modifiers &=
-        KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT | KeyModifiers::SUPER;
-    (code, modifiers)
 }
 
 // ---------------------------------------------------------------------------
@@ -968,87 +606,30 @@ fn normalize_raw(mut code: KeyCode, mut modifiers: KeyModifiers) -> (KeyCode, Ke
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-    #[test]
-    fn test_parse_key_chord_simple_char() {
-        let (code, mods) = parse_key_chord("j").unwrap();
-        assert_eq!(code, KeyCode::Char('j'));
-        assert_eq!(mods, KeyModifiers::empty());
+    fn default_keymap() -> KeyMap {
+        KeyMap::new(&toml::Table::new())
     }
 
     #[test]
-    fn test_parse_key_chord_uppercase() {
-        let (code, mods) = parse_key_chord("G").unwrap();
-        assert_eq!(code, KeyCode::Char('G'));
-        // Shift is stripped for uppercase chars.
-        assert_eq!(mods, KeyModifiers::empty());
+    fn defaults_build_without_warnings() {
+        let (_km, warnings) = KeyMap::with_warnings(&toml::Table::new());
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 
     #[test]
-    fn test_parse_key_chord_ctrl() {
-        let (code, mods) = parse_key_chord("ctrl+d").unwrap();
-        assert_eq!(code, KeyCode::Char('d'));
-        assert_eq!(mods, KeyModifiers::CONTROL);
+    fn every_default_action_name_resolves() {
+        // Guards against a typo in default_keybinds.toml: an unknown action name
+        // would surface as a warning when the defaults are parsed.
+        let build = keymap_config::from_str(DEFAULT_KEYBINDS, Action::from_str).unwrap();
+        assert!(build.warnings.is_empty(), "{:?}", build.warnings);
     }
 
     #[test]
-    fn test_parse_key_chord_ctrl_esc() {
-        let (code, mods) = parse_key_chord("ctrl+esc").unwrap();
-        assert_eq!(code, KeyCode::Esc);
-        assert_eq!(mods, KeyModifiers::CONTROL);
-    }
+    fn critical_defaults_resolve() {
+        let km = default_keymap();
 
-    #[test]
-    fn test_parse_key_chord_special_keys() {
-        assert_eq!(parse_key_chord("enter").unwrap().0, KeyCode::Enter);
-        assert_eq!(parse_key_chord("tab").unwrap().0, KeyCode::Tab);
-        assert_eq!(parse_key_chord("space").unwrap().0, KeyCode::Char(' '));
-        assert_eq!(parse_key_chord("delete").unwrap().0, KeyCode::Delete);
-        assert_eq!(parse_key_chord("up").unwrap().0, KeyCode::Up);
-        assert_eq!(parse_key_chord("f1").unwrap().0, KeyCode::F(1));
-    }
-
-    #[test]
-    fn test_parse_key_chord_alt_number() {
-        let (code, mods) = parse_key_chord("alt+1").unwrap();
-        assert_eq!(code, KeyCode::Char('1'));
-        assert_eq!(mods, KeyModifiers::ALT);
-    }
-
-    #[test]
-    fn test_parse_key_chord_shift_pageup() {
-        let (code, mods) = parse_key_chord("shift+pageup").unwrap();
-        assert_eq!(code, KeyCode::PageUp);
-        assert_eq!(mods, KeyModifiers::SHIFT);
-    }
-
-    #[test]
-    fn test_parse_key_chord_error() {
-        assert!(parse_key_chord("").is_err());
-        assert!(parse_key_chord("foobar").is_err());
-    }
-
-    #[test]
-    fn test_parse_key_chord_super() {
-        let (code, mods) = parse_key_chord("super+space").unwrap();
-        assert_eq!(code, KeyCode::Char(' '));
-        assert_eq!(mods, KeyModifiers::SUPER);
-
-        let (code, mods) = parse_key_chord("cmd+a").unwrap();
-        assert_eq!(code, KeyCode::Char('a'));
-        assert_eq!(mods, KeyModifiers::SUPER);
-
-        let (code, mods) = parse_key_chord("meta+b").unwrap();
-        assert_eq!(code, KeyCode::Char('b'));
-        assert_eq!(mods, KeyModifiers::SUPER);
-    }
-
-    #[test]
-    fn test_default_bindings_complete() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
-
-        // Check a few critical defaults.
         let key_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty());
         assert_eq!(km.resolve(&key_q, KeyContext::Global), Some(Action::Quit));
 
@@ -1064,6 +645,7 @@ mod tests {
             Some(Action::NewClaudeCode)
         );
 
+        // Ctrl+Esc leaves the terminal.
         let key_ctrl_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::CONTROL);
         assert_eq!(
             km.resolve(&key_ctrl_esc, KeyContext::Terminal),
@@ -1072,18 +654,19 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_context_fallback() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
+    fn context_falls_back_to_global() {
+        let km = default_keymap();
 
-        // Tab is bound per non-terminal context — resolves in Worktree but NOT in Terminal.
+        // Tab is bound per non-terminal context — resolves in Worktree but NOT
+        // in Terminal (terminal layer has no Tab, neither does global).
         let key_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::empty());
         assert_eq!(
             km.resolve(&key_tab, KeyContext::Worktree),
             Some(Action::CycleFocusForward)
         );
         assert_eq!(km.resolve(&key_tab, KeyContext::Terminal), None);
-        // Alt+l resolves globally (including Terminal fallback).
+
+        // Alt+l resolves globally, including from the Terminal context.
         let key_alt_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::ALT);
         assert_eq!(
             km.resolve(&key_alt_l, KeyContext::Terminal),
@@ -1092,17 +675,15 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_context_shadows_global() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
+    fn context_shadows_are_per_context() {
+        let km = default_keymap();
 
-        // 'g' in Worktree = GrabBranch, in Global = not bound.
+        // 'g' = GrabBranch in Worktree, GoToTop in Explorer.
         let key_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty());
         assert_eq!(
             km.resolve(&key_g, KeyContext::Worktree),
             Some(Action::GrabBranch)
         );
-        // In Explorer, 'g' = GoToTop.
         assert_eq!(
             km.resolve(&key_g, KeyContext::Explorer),
             Some(Action::GoToTop)
@@ -1110,60 +691,147 @@ mod tests {
     }
 
     #[test]
-    fn test_user_override_replaces_default() {
-        let mut config = KeybindsConfig::default();
-        config.worktree.insert(
-            "navigate_down".to_string(),
-            KeybindValue::Multiple(vec!["n".to_string(), "down".to_string()]),
+    fn shift_g_resolves_uppercase_binding() {
+        let km = default_keymap();
+        // A normal terminal delivers Shift+g as the resolved glyph 'G' + SHIFT;
+        // keymap-core folds the redundant SHIFT, matching the "G" binding.
+        let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        assert_eq!(
+            km.resolve(&key, KeyContext::Worktree),
+            Some(Action::UngrabBranch)
         );
+    }
 
-        let km = KeyMap::new(&config);
-
-        // 'j' should no longer be NavigateDown in worktree.
-        let key_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty());
-        assert_ne!(
-            km.resolve(&key_j, KeyContext::Worktree),
-            Some(Action::NavigateDown)
+    #[test]
+    fn shift_tab_is_cycle_backward() {
+        let km = default_keymap();
+        // BackTab and Tab+SHIFT both normalize to Tab+SHIFT in keymap-core.
+        let backtab = KeyEvent::new(KeyCode::BackTab, KeyModifiers::empty());
+        assert_eq!(
+            km.resolve(&backtab, KeyContext::Worktree),
+            Some(Action::CycleFocusBackward)
         );
+        let shift_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT);
+        assert_eq!(
+            km.resolve(&shift_tab, KeyContext::Worktree),
+            Some(Action::CycleFocusBackward)
+        );
+    }
 
-        // 'n' should now be NavigateDown.
+    #[test]
+    fn user_override_adds_a_chord() {
+        // Bind "n" -> navigate_down in the worktree layer.
+        let mut layer = toml::Table::new();
+        layer.insert(
+            "n".to_string(),
+            toml::Value::String("navigate_down".to_string()),
+        );
+        let mut layers = toml::Table::new();
+        layers.insert("worktree".to_string(), toml::Value::Table(layer));
+        let mut user = toml::Table::new();
+        user.insert("layers".to_string(), toml::Value::Table(layers));
+
+        let (km, warnings) = KeyMap::with_warnings(&user);
+        assert!(warnings.is_empty(), "{warnings:?}");
+
+        // 'n' now navigates down …
         let key_n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty());
         assert_eq!(
             km.resolve(&key_n, KeyContext::Worktree),
             Some(Action::NavigateDown)
         );
-
-        // Down arrow should still work.
-        let key_down = KeyEvent::new(KeyCode::Down, KeyModifiers::empty());
+        // … and the default 'j' still works (layering, not replacement).
+        let key_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty());
         assert_eq!(
-            km.resolve(&key_down, KeyContext::Worktree),
+            km.resolve(&key_j, KeyContext::Worktree),
             Some(Action::NavigateDown)
         );
     }
 
     #[test]
-    fn test_action_from_str_roundtrip() {
-        let actions = [
-            Action::Quit,
-            Action::NavigateDown,
-            Action::LeaveTerminal,
-            Action::AddComment,
-            Action::ScrollHalfPageDown,
-        ];
-        for action in actions {
-            let s = action.as_str();
-            let parsed = Action::from_str(s);
-            assert_eq!(parsed, Some(action), "roundtrip failed for {s}");
-        }
+    fn user_override_shadows_a_default_chord() {
+        // Rebind "g" -> go_to_top in worktree (default is grab_branch).
+        let mut layer = toml::Table::new();
+        layer.insert("g".to_string(), toml::Value::String("go_to_top".to_string()));
+        let mut layers = toml::Table::new();
+        layers.insert("worktree".to_string(), toml::Value::Table(layer));
+        let mut user = toml::Table::new();
+        user.insert("layers".to_string(), toml::Value::Table(layers));
+
+        let km = KeyMap::new(&user);
+        let key_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty());
+        assert_eq!(
+            km.resolve(&key_g, KeyContext::Worktree),
+            Some(Action::GoToTop)
+        );
     }
 
     #[test]
-    fn test_ctrl_f_jumps_to_filename_search_in_viewer() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
+    fn user_unknown_action_is_warned() {
+        let mut keys = toml::Table::new();
+        keys.insert(
+            "ctrl+z".to_string(),
+            toml::Value::String("frobnicate".to_string()),
+        );
+        let mut user = toml::Table::new();
+        user.insert("keys".to_string(), toml::Value::Table(keys));
 
-        // Ctrl+f opens the fuzzy filename jump from the viewer, so files can be
-        // switched without un-maximizing it.
+        let (_km, warnings) = KeyMap::with_warnings(&user);
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                KeybindWarning::UnknownAction { action, .. } if action == "frobnicate"
+            )),
+            "expected UnknownAction, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_format_is_reported_not_silent() {
+        // Old schema: [keybinds.worktree] navigate_down = "j" — a top-level
+        // table named "worktree" rather than "keys"/"layers".
+        let mut wt = toml::Table::new();
+        wt.insert(
+            "navigate_down".to_string(),
+            toml::Value::String("j".to_string()),
+        );
+        let mut user = toml::Table::new();
+        user.insert("worktree".to_string(), toml::Value::Table(wt));
+
+        let (_km, warnings) = KeyMap::with_warnings(&user);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, KeybindWarning::InvalidConfig { .. })),
+            "expected InvalidConfig, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn option_shift_digit_is_focus_expand() {
+        let km = default_keymap();
+        // Option+Shift+digit (ALT|SHIFT) maximizes; plain Option+digit (ALT)
+        // only focuses. keymap-core keeps SHIFT because ALT is also held.
+        let cases = [
+            ('1', Action::FocusExpandWorktree),
+            ('4', Action::FocusExpandViewer),
+            ('6', Action::FocusExpandTerminalShell),
+        ];
+        for (c, action) in cases {
+            let key = KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT | KeyModifiers::SHIFT);
+            assert_eq!(km.resolve(&key, KeyContext::Terminal), Some(action));
+        }
+
+        let alt_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT);
+        assert_eq!(
+            km.resolve(&alt_1, KeyContext::Global),
+            Some(Action::FocusWorktree)
+        );
+    }
+
+    #[test]
+    fn ctrl_f_is_filename_search_in_viewer() {
+        let km = default_keymap();
         let key = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL);
         assert_eq!(
             km.resolve(&key, KeyContext::Viewer),
@@ -1176,64 +844,162 @@ mod tests {
     }
 
     #[test]
-    fn test_keys_for_action() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
-
+    fn keys_for_action_lists_canonical_strings() {
+        let km = default_keymap();
         let keys = km.keys_for_action(KeyContext::Worktree, Action::NavigateDown);
-        assert!(keys.contains(&"j".to_string()));
-        assert!(keys.contains(&"Down".to_string()));
+        assert!(keys.contains(&"j".to_string()), "{keys:?}");
+        assert!(keys.contains(&"down".to_string()), "{keys:?}");
     }
 
     #[test]
-    fn test_normalize_shift_uppercase() {
-        // Simulates crossterm sending 'G' with SHIFT modifier.
-        let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
-        let (code, mods) = normalize_key(&key);
-        assert_eq!(code, KeyCode::Char('G'));
-        assert_eq!(mods, KeyModifiers::empty());
-    }
-
-    #[test]
-    fn test_normalize_keeps_shift_for_digits() {
-        // SHIFT must NOT be stripped for digit keys, so Option+Shift+digit
-        // (SHIFT|ALT) stays distinct from plain Option+digit (ALT).
-        let key = KeyEvent::new(
-            KeyCode::Char('1'),
-            KeyModifiers::SHIFT | KeyModifiers::ALT,
-        );
-        let (code, mods) = normalize_key(&key);
-        assert_eq!(code, KeyCode::Char('1'));
-        assert_eq!(mods, KeyModifiers::SHIFT | KeyModifiers::ALT);
-    }
-
-    #[test]
-    fn test_option_shift_digit_resolves_to_focus_expand() {
-        let config = KeybindsConfig::default();
-        let km = KeyMap::new(&config);
-
-        // Option+Shift+1..6 jump to a panel AND maximize it.
-        let cases = [
-            ('1', Action::FocusExpandWorktree),
-            ('2', Action::FocusExpandExplorer),
-            ('3', Action::FocusExpandExplorerDiffList),
-            ('4', Action::FocusExpandViewer),
-            ('5', Action::FocusExpandTerminalClaude),
-            ('6', Action::FocusExpandTerminalShell),
+    fn action_from_str_as_str_roundtrip() {
+        let actions = [
+            Action::Quit,
+            Action::NavigateDown,
+            Action::LeaveTerminal,
+            Action::AddComment,
+            Action::ScrollHalfPageDown,
         ];
-        for (c, action) in cases {
-            let key = KeyEvent::new(
-                KeyCode::Char(c),
-                KeyModifiers::ALT | KeyModifiers::SHIFT,
-            );
-            assert_eq!(km.resolve(&key, KeyContext::Terminal), Some(action));
+        for action in actions {
+            assert_eq!(Action::from_str(action.as_str()), Some(action));
         }
+    }
 
-        // Plain Option+digit still resolves to focus-only (no maximize).
-        let key_alt_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT);
+    #[test]
+    fn lowercase_char_with_shift_is_not_recased() {
+        // Behavior divergence from the old hand-rolled normalizer, locked in:
+        // keymap-core trusts the glyph and only drops a redundant sole SHIFT, so
+        // 'g'+SHIFT stays Char('g') and hits the bare 'g' binding (GrabBranch) —
+        // it is NOT re-cased to 'G' (UngrabBranch). A terminal that delivers the
+        // resolved glyph 'G' (the common case) still hits UngrabBranch; see
+        // `shift_g_resolves_uppercase_binding`.
+        let km = default_keymap();
+        let key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::SHIFT);
         assert_eq!(
-            km.resolve(&key_alt_1, KeyContext::Global),
+            km.resolve(&key, KeyContext::Worktree),
+            Some(Action::GrabBranch)
+        );
+    }
+
+    #[test]
+    fn macos_unicode_fallback_chords_resolve() {
+        // These glyphs are otherwise undetectable-by-eye in the TOML; this proves
+        // the file→keymap-config→keymap-core→crossterm path survives multi-byte
+        // chars for both the plain-Option and Shift-Option families.
+        let km = default_keymap();
+        let cases = [
+            ('˙', Action::CycleFocusBackward),
+            ('¬', Action::CycleFocusForward),
+            ('¡', Action::FocusWorktree),
+            ('§', Action::FocusTerminalShell),
+            ('÷', Action::TogglePanelOverlay),
+        ];
+        for (glyph, action) in cases {
+            let key = KeyEvent::new(KeyCode::Char(glyph), KeyModifiers::empty());
+            assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "glyph {glyph:?}");
+        }
+    }
+
+    #[test]
+    fn alt_digit_and_alt_shift_digit_stay_distinct() {
+        // The "keep SHIFT when another modifier is held" rule must keep these
+        // apart, or focus and focus-expand would collapse into one another.
+        let km = default_keymap();
+        let alt_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT);
+        let alt_shift_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT | KeyModifiers::SHIFT);
+        assert_eq!(
+            km.resolve(&alt_1, KeyContext::Global),
             Some(Action::FocusWorktree)
+        );
+        assert_eq!(
+            km.resolve(&alt_shift_1, KeyContext::Global),
+            Some(Action::FocusExpandWorktree)
+        );
+    }
+
+    #[test]
+    fn enter_and_shift_enter_distinct_in_diff_mode() {
+        // SHIFT discrimination on a named key, in one layer.
+        let km = default_keymap();
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::empty());
+        let shift_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT);
+        assert_eq!(
+            km.resolve(&enter, KeyContext::ViewerDiffMode),
+            Some(Action::ExpandContext)
+        );
+        assert_eq!(
+            km.resolve(&shift_enter, KeyContext::ViewerDiffMode),
+            Some(Action::ExpandAllContext)
+        );
+    }
+
+    #[test]
+    fn keys_for_action_uses_lowercase_canonical_form() {
+        // The help screen renders these verbatim; pin the casing that changed
+        // from the old "Ctrl+d" to keymap-core's canonical "ctrl+d".
+        let km = default_keymap();
+        let keys = km.keys_for_action(KeyContext::Viewer, Action::ScrollHalfPageDown);
+        assert_eq!(keys, vec!["ctrl+d".to_string()]);
+    }
+
+    #[test]
+    fn unmappable_key_event_passes_through() {
+        // A key with no neutral representation (CapsLock) fails KeyInput::try_from
+        // and must resolve to None ("pass through"), never panic.
+        let km = default_keymap();
+        let key = KeyEvent::new(KeyCode::CapsLock, KeyModifiers::empty());
+        assert_eq!(km.resolve(&key, KeyContext::Terminal), None);
+    }
+
+    #[test]
+    fn in_layer_conflict_is_warned() {
+        // Two spellings of the same chord in one layer: keymap-config reports a
+        // Conflict and the last binding wins.
+        let mut keys = toml::Table::new();
+        keys.insert("ctrl+x".to_string(), toml::Value::String("quit".to_string()));
+        keys.insert(
+            "control+x".to_string(),
+            toml::Value::String("show_help".to_string()),
+        );
+        let mut user = toml::Table::new();
+        user.insert("keys".to_string(), toml::Value::Table(keys));
+
+        let (km, warnings) = KeyMap::with_warnings(&user);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, KeybindWarning::Conflict { .. })),
+            "expected Conflict, got {warnings:?}"
+        );
+        // Whichever won, ctrl+x must resolve to one of the two contenders.
+        let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        let resolved = km.resolve(&key, KeyContext::Global);
+        assert!(
+            matches!(resolved, Some(Action::Quit) | Some(Action::ShowHelp)),
+            "got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_layer_with_bindings_is_warned() {
+        // Guards the empty-GLOBAL_LAYER suppression: a non-empty unrecognized
+        // layer name must warn (an empty one, always injected, must not).
+        let mut layer = toml::Table::new();
+        layer.insert(
+            "j".to_string(),
+            toml::Value::String("navigate_down".to_string()),
+        );
+        let mut layers = toml::Table::new();
+        layers.insert("bogus".to_string(), toml::Value::Table(layer));
+        let mut user = toml::Table::new();
+        user.insert("layers".to_string(), toml::Value::Table(layers));
+
+        let (_km, warnings) = KeyMap::with_warnings(&user);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, KeybindWarning::UnknownLayer { layer } if layer == "bogus")),
+            "expected UnknownLayer, got {warnings:?}"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,18 +348,21 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
             let drain_deadline = Instant::now() + MAX_DRAIN;
             loop {
                 match crossterm_read()? {
-                    Event::Key(key) if key.kind == KeyEventKind::Press => {
-                        log::debug!("key: code={:?} mods={:?}", key.code, key.modifiers);
+                    // Treat auto-repeat (held key) the same as a press, so holding
+                    // j/k/up/down scrolls or navigates continuously. Repeat events
+                    // only arrive under the kitty keyboard protocol; without it,
+                    // terminals deliver auto-repeat as a stream of Press events.
+                    Event::Key(key)
+                        if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat =>
+                    {
+                        log::debug!(
+                            "key: code={:?} mods={:?} kind={:?}",
+                            key.code,
+                            key.modifiers,
+                            key.kind
+                        );
                         last_input_time = Instant::now();
                         handle_key_event(app, key);
-                    }
-                    Event::Key(key) if key.kind == KeyEventKind::Repeat => {
-                        last_input_time = Instant::now();
-                        if app.focus == crate::app::Focus::TerminalClaude
-                            || app.focus == crate::app::Focus::TerminalShell
-                        {
-                            handle_key_event(app, key);
-                        }
                     }
                     Event::Mouse(mouse) => {
                         last_input_time = Instant::now();

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -604,10 +604,139 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &crate::app::App) {
         let span = Span::styled(display_text, style);
         frame.render_widget(Paragraph::new(span), area);
     } else {
-        // Default keybinding hint text.
-        let hint = app.status_bar_text();
+        // Default keybinding hint text, derived live from the keymap so it
+        // never drifts from the actual bindings (including user overrides).
+        let hint = status_bar_hint(app.focus, &app.keymap);
         let span = Span::styled(hint, Style::default().fg(theme.hint));
         frame.render_widget(Paragraph::new(span), area);
+    }
+}
+
+/// Build the footer keybinding hint for the focused panel from the live keymap.
+///
+/// Each panel has an ordered list of `(label, actions)`; for each entry we show
+/// one representative chord per action (joined by `/`), e.g. `j/k: nav`. Entries
+/// whose actions are all unbound are dropped, so the hint can never advertise a
+/// key that does nothing.
+fn status_bar_hint(focus: crate::app::Focus, keymap: &crate::keymap::KeyMap) -> String {
+    use crate::app::Focus;
+    use crate::keymap::Action;
+
+    // (label, actions whose representative chords are shown joined by '/').
+    let entries: &[(&str, &[Action])] = match focus {
+        Focus::Worktree => &[
+            ("nav", &[Action::NavigateDown, Action::NavigateUp]),
+            ("panel", &[Action::CycleFocusForward]),
+            ("open", &[Action::Select]),
+            ("new", &[Action::CreateWorktree]),
+            ("switch", &[Action::SwitchBranch]),
+            ("grab", &[Action::GrabBranch]),
+        ],
+        Focus::Explorer => &[
+            ("nav", &[Action::NavigateDown, Action::NavigateUp]),
+            ("panel", &[Action::CycleFocusForward]),
+            ("open", &[Action::Select]),
+            ("fold", &[Action::CollapseOrLeft, Action::ExpandOrRight]),
+            ("diff", &[Action::ShowDiffList]),
+            ("search", &[Action::SearchFilename]),
+        ],
+        Focus::Viewer => &[
+            ("scroll", &[Action::NavigateDown, Action::NavigateUp]),
+            ("panel", &[Action::CycleFocusForward]),
+            ("search", &[Action::SearchInFile]),
+            ("thread", &[Action::ToggleInlineThread]),
+            ("back", &[Action::ExitToExplorer]),
+        ],
+        Focus::TerminalClaude => &[
+            ("leave", &[Action::LeaveTerminal]),
+            ("panel", &[Action::CycleFocusForward]),
+            ("new CC", &[Action::NewClaudeCode]),
+            ("palette", &[Action::CommandPalette]),
+        ],
+        Focus::TerminalShell => &[
+            ("leave", &[Action::LeaveTerminal]),
+            ("panel", &[Action::CycleFocusForward]),
+            ("new shell", &[Action::NewShell]),
+            ("palette", &[Action::CommandPalette]),
+        ],
+    };
+
+    let context = focus.key_context();
+    let mut parts: Vec<String> = Vec::new();
+    for (label, actions) in entries {
+        let chords: Vec<String> = actions
+            .iter()
+            .filter_map(|a| representative_chord(keymap, context, *a))
+            .collect();
+        if !chords.is_empty() {
+            parts.push(format!("{}: {label}", chords.join("/")));
+        }
+    }
+
+    // Terminals forward everything else to the PTY — set that expectation.
+    if matches!(focus, Focus::TerminalClaude | Focus::TerminalShell) {
+        parts.push("keys → terminal".to_string());
+    }
+
+    parts.join(" | ")
+}
+
+/// The single chord best suited to show a user for `action` in `context`:
+/// shortest, ASCII-only. The macOS Option-glyph fallbacks (`¬`, `˙`, …) and
+/// other non-ASCII chords round-trip through the keymap but are meaningless on
+/// screen, so a plain chord is preferred whenever one exists.
+fn representative_chord(
+    keymap: &crate::keymap::KeyMap,
+    context: crate::keymap::KeyContext,
+    action: crate::keymap::Action,
+) -> Option<String> {
+    keymap
+        .keys_for_action(context, action)
+        .into_iter()
+        .filter(|c| c.is_ascii())
+        .min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
+}
+
+#[cfg(test)]
+mod status_bar_tests {
+    use super::status_bar_hint;
+    use crate::app::Focus;
+    use crate::keymap::{Action, KeyContext, KeyMap};
+
+    fn keymap() -> KeyMap {
+        KeyMap::new(&toml::Table::new())
+    }
+
+    #[test]
+    fn representative_chord_prefers_short_ascii_over_unicode() {
+        let km = keymap();
+        // cycle_focus_backward is bound to alt+h AND the macOS glyph '˙'; the
+        // glyph must never be shown.
+        let chord = super::representative_chord(&km, KeyContext::Global, Action::CycleFocusBackward);
+        assert_eq!(chord, Some("alt+h".to_string()));
+
+        // nav prefers the bare 'j' over the 'down' alias.
+        let nav = super::representative_chord(&km, KeyContext::Worktree, Action::NavigateDown);
+        assert_eq!(nav, Some("j".to_string()));
+    }
+
+    #[test]
+    fn worktree_footer_is_truthful_and_has_no_unicode() {
+        let hint = status_bar_hint(Focus::Worktree, &keymap());
+        assert!(hint.contains("j/k: nav"), "{hint}");
+        assert!(hint.contains("tab: panel"), "{hint}");
+        assert!(hint.contains("w: new"), "{hint}");
+        // The old hardcoded lie must be gone, and no fallback glyphs leak in.
+        assert!(!hint.contains("Cmd+1-5"), "{hint}");
+        assert!(hint.is_ascii(), "footer must be ASCII-only: {hint}");
+    }
+
+    #[test]
+    fn terminal_footer_notes_passthrough_and_leave_key() {
+        let hint = status_bar_hint(Focus::TerminalClaude, &keymap());
+        assert!(hint.contains("keys → terminal"), "{hint}");
+        // leave_terminal is ctrl+esc, not a bare Esc.
+        assert!(hint.contains("ctrl+esc: leave"), "{hint}");
     }
 }
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -685,7 +685,7 @@ fn status_bar_hint(focus: crate::app::Focus, keymap: &crate::keymap::KeyMap) -> 
 /// shortest, ASCII-only. The macOS Option-glyph fallbacks (`¬`, `˙`, …) and
 /// other non-ASCII chords round-trip through the keymap but are meaningless on
 /// screen, so a plain chord is preferred whenever one exists.
-fn representative_chord(
+pub(crate) fn representative_chord(
     keymap: &crate::keymap::KeyMap,
     context: crate::keymap::KeyContext,
     action: crate::keymap::Action,

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -889,7 +889,12 @@ pub fn render_command_palette_overlay(frame: &mut Frame, area: Rect, app: &App) 
     let list_inner = list_block.inner(chunks[1]);
     frame.render_widget(list_block, chunks[1]);
 
-    let filtered = command_palette::filter_commands(&app.overlays.command_palette.filter);
+    let context = app.focus.key_context();
+    let filtered = command_palette::filter_commands(
+        &app.overlays.command_palette.filter,
+        &app.keymap,
+        context,
+    );
     if filtered.is_empty() {
         frame.render_widget(
             Paragraph::new("  No matching commands.").style(Style::default().fg(theme.muted)),
@@ -898,40 +903,71 @@ pub fn render_command_palette_overlay(frame: &mut Frame, area: Rect, app: &App) 
         return;
     }
 
-    // Build list items with keybinding hints
-    let items: Vec<ListItem> = filtered
-        .iter()
-        .enumerate()
-        .map(|(i, scored)| {
-            let cmd = &command_palette::COMMANDS[scored.index];
-            let style = if i == app.overlays.command_palette.selected {
-                Style::default()
-                    .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(theme.fg)
-            };
+    let current_label = match app.focus {
+        crate::app::Focus::Worktree => "Worktree",
+        crate::app::Focus::Explorer => "Explorer",
+        crate::app::Focus::Viewer => "Viewer",
+        crate::app::Focus::TerminalClaude => "Claude Code",
+        crate::app::Focus::TerminalShell => "Shell",
+    };
+    let scope_header = |scope: command_palette::CommandScope| match scope {
+        command_palette::CommandScope::Current => current_label,
+        command_palette::CommandScope::Global => "Global",
+        command_palette::CommandScope::Other => "Other",
+    };
 
-            let kb = cmd.keybinding.unwrap_or("");
-            let line = Line::from(vec![
-                Span::styled(
-                    if i == app.overlays.command_palette.selected {
-                        " > "
-                    } else {
-                        "   "
-                    },
-                    Style::default().fg(theme.accent),
-                ),
-                Span::styled(cmd.label, style),
-                Span::styled(format!("  {kb:>12}"), Style::default().fg(theme.muted)),
-            ]);
-            ListItem::new(line)
-        })
-        .collect();
+    // Interleave non-selectable scope headers between the (selectable) command
+    // rows. `selected` indexes the command rows only, so track the visual row
+    // index of the selected command to drive the highlight.
+    let selected = app.overlays.command_palette.selected;
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut selected_row: Option<usize> = None;
+    let mut last_scope: Option<command_palette::CommandScope> = None;
+
+    for (cmd_idx, scored) in filtered.iter().enumerate() {
+        if last_scope != Some(scored.scope) {
+            items.push(ListItem::new(Line::from(Span::styled(
+                format!("  {}", scope_header(scored.scope)),
+                Style::default()
+                    .fg(theme.muted)
+                    .add_modifier(Modifier::BOLD | Modifier::DIM),
+            ))));
+            last_scope = Some(scored.scope);
+        }
+
+        let cmd = &command_palette::COMMANDS[scored.index];
+        let is_selected = cmd_idx == selected;
+        if is_selected {
+            selected_row = Some(items.len());
+        }
+        let style = if is_selected {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+
+        // Live keybinding from the keymap for the focused context (blank for
+        // palette-only commands and commands not bound in this context).
+        let kb = cmd
+            .action
+            .and_then(|a| crate::ui::common::representative_chord(&app.keymap, context, a))
+            .unwrap_or_default();
+        let line = Line::from(vec![
+            Span::styled(
+                if is_selected { " > " } else { "   " },
+                Style::default().fg(theme.accent),
+            ),
+            Span::styled(cmd.label, style),
+            Span::styled(format!("  {kb:>12}"), Style::default().fg(theme.muted)),
+        ]);
+        items.push(ListItem::new(line));
+    }
 
     let list = List::new(items);
     let mut state = ListState::default();
-    state.select(Some(app.overlays.command_palette.selected));
+    state.select(selected_row);
     frame.render_stateful_widget(list, list_inner, &mut state);
 }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -225,6 +225,9 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
         crate::app::WorktreeInputMode::ConfirmingUngrab => {
             render_confirm_overlay(frame, main_area, app, " Confirm Ungrab ", app.theme.warning);
         }
+        crate::app::WorktreeInputMode::ConfirmingReset => {
+            render_confirm_overlay(frame, main_area, app, " Confirm Reset ", app.theme.error);
+        }
         crate::app::WorktreeInputMode::SmartDescription => {
             super::dashboard::render_smart_description_overlay(frame, main_area, app);
         }


### PR DESCRIPTION
## Summary

Replaces Conductor's hand-rolled keybinding engine with the [`keymap-rs`](https://github.com/S-Nakamur-a/keymap-rs) library and builds several UX improvements on top.

- **Keybinding engine → keymap-rs.** `keymap.rs` now resolves keys via `keymap-core`'s layered `Keymap<Action>` + `resolve_layered`, with defaults authored in an embedded `default_keybinds.toml` parsed by `keymap-config`. The public `KeyMap`/`resolve`/`keys_for_action`/`Action`/`KeyContext` seam is preserved, so event handlers are untouched.
  - **Breaking (config):** the `[keybinds]` schema changes from action→keys (`[keybinds.worktree] navigate_down = ["j","down"]`) to keymap-config's key→action form (`[keybinds.keys]` / `[keybinds.layers.<panel>]`). Old `[keybinds.<context>]` tables are detected and reported on startup instead of silently failing.
  - Config warnings (unknown actions, conflicts, legacy format) surface as a startup status flash instead of vanishing into the log.

- **Dynamic footer & help.** The status-bar hint is derived live from the keymap per focused panel (no more hardcoded, drifting "Cmd+1-5: jump").

- **Held-key repeat.** `KeyEventKind::Repeat` is now handled in all panels (was terminal-only), so holding `j`/`k`/arrows scrolls/navigates continuously.

- **Fuzzy-overlay typing.** In filterable overlays (command palette, filename search, history, resume, switch-branch, grab), bare printable keys now type into the filter; only arrows navigate.

- **Command palette redesign.** Grouped by scope — current panel / global / other — with keybindings derived live from the keymap. Added the missing `Worktree: Pull` command.

- **Keybind safety & cleanup.** `R` (reset main to origin) now requires `(y/n)` confirmation through a unified path; `add_comment` wired to `c` in the viewer; three unwired LSP actions removed from the vocabulary so binding them warns; the confusing F2-F7 panel row dropped.

Version bumped 0.60.0 -> 0.61.0.

## Test plan

- `cargo test` — 229 unit tests pass (keymap resolution/normalization, config parsing & legacy-format detection, command-palette scope grouping & completeness, footer hint generation, overlay nav guard).
- `cargo clippy --all-targets` — clean.
- `cargo build` — clean.
- Manual (recommended before relying on it): open the command palette (`Ctrl+P`) to verify the grouped sections render; press `R` in the worktree panel to verify the reset confirmation dialog; hold `j`/`k` to verify repeat.
