### PR TITLE
feat: worktreeバーの横スクロール・作成中スピナー・Ctrl+Tab切替

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -453,6 +453,13 @@ pub struct App {
     /// Clickable regions of the worktree bar, recorded during render and read by
     /// the mouse handler (worktree select / delete / add).
     pub wtbar_hits: Vec<crate::ui::worktree_bar::WtbarHit>,
+    /// Index of the first worktree chip shown in the bar (horizontal scroll
+    /// position). Adjusted by wheel/arrow paging and re-clamped each render.
+    pub wtbar_scroll: usize,
+    /// When set, the next bar render pans `wtbar_scroll` just enough to keep the
+    /// selected worktree's chip visible. Set when the selection changes so a
+    /// jump always reveals its chip, without disturbing free scrolling otherwise.
+    pub wtbar_reveal_selected: bool,
 
     // ── Code navigation (symbol index + jump history) ───────────
     pub symbol_index: SymbolIndex,
@@ -676,6 +683,8 @@ impl App {
             pending_view_restore: None,
             layout_cache: Default::default(),
             wtbar_hits: Vec::new(),
+            wtbar_scroll: 0,
+            wtbar_reveal_selected: false,
             symbol_index: SymbolIndex::new(PathBuf::new()),
             jump_history: JumpHistory::new(),
             references_overlay: ReferencesOverlay::default(),
@@ -1416,6 +1425,8 @@ impl App {
             CommandId::FocusViewer => self.set_focus(Focus::Viewer),
             CommandId::FocusTerminalClaude => self.set_focus(Focus::TerminalClaude),
             CommandId::FocusTerminalShell => self.set_focus(Focus::TerminalShell),
+            CommandId::NextWorktree => self.select_next_worktree(),
+            CommandId::PrevWorktree => self.select_prev_worktree(),
             CommandId::TogglePanelExpand => self.cmd_toggle_panel_expand(),
             CommandId::CreateWorktree => self.cmd_create_worktree(),
             CommandId::DeleteWorktree => self.cmd_delete_worktree(),

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -1384,7 +1384,39 @@ impl App {
     /// Heavy operations (file tree walk, diff computation, branch details) are
     /// dispatched to background threads so the UI stays responsive. Results are
     /// applied in `poll_worktree_switch_ops()`.
+    /// Switch the selection to the next worktree, wrapping around. Mirrors a
+    /// click on the strip (updates views + active sessions via
+    /// `on_worktree_changed`, which also makes the strip follow), but keeps the
+    /// current panel focus rather than jumping to the terminal. No-op with ≤1
+    /// worktree.
+    pub fn select_next_worktree(&mut self) {
+        let n = self.worktrees.len();
+        if n <= 1 {
+            return;
+        }
+        self.selected_worktree = (self.selected_worktree + 1) % n;
+        self.on_worktree_changed();
+    }
+
+    /// Switch the selection to the previous worktree, wrapping around. See
+    /// [`Self::select_next_worktree`].
+    pub fn select_prev_worktree(&mut self) {
+        let n = self.worktrees.len();
+        if n <= 1 {
+            return;
+        }
+        self.selected_worktree = (self.selected_worktree + n - 1) % n;
+        self.on_worktree_changed();
+    }
+
     pub fn on_worktree_changed(&mut self) {
+        // Reveal the newly selected worktree's chip in the bar on the next
+        // render (width-dependent panning happens there, where the area is known).
+        // This is only safe to set on *user-initiated* selection changes: if a
+        // background event ever drives selection while the user is free-scrolling
+        // the strip to peek elsewhere, setting this would yank the bar back.
+        self.wtbar_reveal_selected = true;
+
         // Persist the outgoing worktree's view before we wipe it.
         if let Some(outgoing) = self.current_view_branch.clone() {
             self.save_view_for(&outgoing);

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -16,6 +16,8 @@ pub enum CommandId {
     FocusViewer,
     FocusTerminalClaude,
     FocusTerminalShell,
+    NextWorktree,
+    PrevWorktree,
     TogglePanelExpand,
 
     // Worktree
@@ -174,6 +176,20 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Navigation,
         action: Some(Action::FocusTerminalShell),
         keywords: "terminal shell",
+    },
+    PaletteCommand {
+        id: CommandId::NextWorktree,
+        label: "Next Worktree",
+        category: CommandCategory::Navigation,
+        action: Some(Action::NextWorktree),
+        keywords: "worktree switch next cycle tab",
+    },
+    PaletteCommand {
+        id: CommandId::PrevWorktree,
+        label: "Previous Worktree",
+        category: CommandCategory::Navigation,
+        action: Some(Action::PrevWorktree),
+        keywords: "worktree switch previous cycle tab",
     },
     PaletteCommand {
         id: CommandId::TogglePanelExpand,

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -29,6 +29,11 @@
 # Unicode instead of an Alt modifier. These are US-layout Option glyphs.
 "˙" = "cycle_focus_backward"
 "¬" = "cycle_focus_forward"
+# Ctrl+Tab / Ctrl+Shift+Tab — switch the selected worktree (next/prev) from
+# anywhere, browser-tab style. The worktree strip follows the selection. This
+# is separate from Tab's panel-focus cycle.
+"ctrl+tab" = "next_worktree"
+"ctrl+shift+tab" = "prev_worktree"
 "ctrl+w" = "focus_worktree"
 "ctrl+n" = "new_claude_code"
 "ctrl+t" = "new_shell"

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -37,6 +37,14 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.cycle_focus_backward();
             true
         }
+        Action::NextWorktree => {
+            app.select_next_worktree();
+            true
+        }
+        Action::PrevWorktree => {
+            app.select_prev_worktree();
+            true
+        }
         Action::FocusWorktree => {
             app.set_focus(Focus::Worktree);
             true

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -317,6 +317,14 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
                     app.cycle_focus_backward();
                     return;
                 }
+                Action::NextWorktree => {
+                    app.select_next_worktree();
+                    return;
+                }
+                Action::PrevWorktree => {
+                    app.select_prev_worktree();
+                    return;
+                }
                 Action::TogglePanelOverlay => {
                     app.toggle_panel_overlay();
                     return;

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -223,6 +223,19 @@ fn handle_notification_bar_click(
     true
 }
 
+/// How many chips a single wheel tick scrolls the worktree strip: a screenful
+/// minus one chip of overlap (at least 1). The visible count is read back from
+/// the `Select` regions recorded by the last render.
+fn wtbar_page_step(app: &App) -> usize {
+    use crate::ui::worktree_bar::WtbarAction;
+    let visible = app
+        .wtbar_hits
+        .iter()
+        .filter(|h| matches!(h.action, WtbarAction::Select(_)))
+        .count();
+    visible.saturating_sub(1).max(1)
+}
+
 /// Handle a left click on the worktree bar: select (jump to the worktree and
 /// its Claude session), delete (with confirmation), or add. Returns `true` if
 /// the click landed on the bar row (and was thus consumed).
@@ -249,6 +262,12 @@ fn handle_wtbar_click(
             app.selected_worktree = i;
             app.on_worktree_changed();
             app.set_focus(Focus::TerminalClaude);
+        }
+        Some(WtbarAction::ScrollLeft) => {
+            app.wtbar_scroll = app.wtbar_scroll.saturating_sub(1);
+        }
+        Some(WtbarAction::ScrollRight) => {
+            app.wtbar_scroll = app.wtbar_scroll.saturating_add(1);
         }
         Some(WtbarAction::Add) => {
             app.worktree_mgr.input_mode = WorktreeInputMode::CreatingWorktree;
@@ -350,6 +369,15 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
     };
 
     match mouse.kind {
+        MouseEventKind::ScrollDown if wtbar_area.height > 0 && row == wtbar_area.y => {
+            // Wheel over the worktree strip pages it sideways by ~a screenful
+            // (one chip of overlap) so trackpad bursts and wheel detents both
+            // move a useful amount without skipping chips.
+            app.wtbar_scroll = app.wtbar_scroll.saturating_add(wtbar_page_step(app));
+        }
+        MouseEventKind::ScrollUp if wtbar_area.height > 0 && row == wtbar_area.y => {
+            app.wtbar_scroll = app.wtbar_scroll.saturating_sub(wtbar_page_step(app));
+        }
         MouseEventKind::ScrollDown => {
             handle_mouse_scroll(app, col, row, main_area, left_end, explorer_end, viewer_end, explorer_mid_y, terminal_split_y, 3);
         }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -28,6 +28,10 @@ pub enum Action {
     CommandPalette,
     CycleFocusForward,
     CycleFocusBackward,
+    /// Switch the selected worktree to the next/previous one, from any panel
+    /// (the worktree strip follows the selection). Distinct from focus cycling.
+    NextWorktree,
+    PrevWorktree,
     FocusWorktree,
     FocusExplorer,
     FocusExplorerDiffList,
@@ -144,6 +148,8 @@ impl Action {
             "command_palette" => Some(Action::CommandPalette),
             "cycle_focus_forward" => Some(Action::CycleFocusForward),
             "cycle_focus_backward" => Some(Action::CycleFocusBackward),
+            "next_worktree" => Some(Action::NextWorktree),
+            "prev_worktree" => Some(Action::PrevWorktree),
             "focus_worktree" => Some(Action::FocusWorktree),
             "focus_explorer" => Some(Action::FocusExplorer),
             "focus_explorer_diff_list" => Some(Action::FocusExplorerDiffList),
@@ -235,6 +241,8 @@ impl Action {
             Action::CommandPalette => "command_palette",
             Action::CycleFocusForward => "cycle_focus_forward",
             Action::CycleFocusBackward => "cycle_focus_backward",
+            Action::NextWorktree => "next_worktree",
+            Action::PrevWorktree => "prev_worktree",
             Action::FocusWorktree => "focus_worktree",
             Action::FocusExplorer => "focus_explorer",
             Action::FocusExplorerDiffList => "focus_explorer_diff_list",
@@ -742,6 +750,35 @@ mod tests {
         assert_eq!(
             km.resolve(&shift_tab, KeyContext::Worktree),
             Some(Action::CycleFocusBackward)
+        );
+    }
+
+    #[test]
+    fn ctrl_tab_switches_worktree() {
+        let km = default_keymap();
+        // Global layer, so it resolves in every non-terminal context. Ctrl+Tab
+        // jumps worktrees while plain Tab still cycles panel focus.
+        let ctrl_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&ctrl_tab, KeyContext::Explorer),
+            Some(Action::NextWorktree)
+        );
+        let plain_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::empty());
+        assert_eq!(
+            km.resolve(&plain_tab, KeyContext::Explorer),
+            Some(Action::CycleFocusForward)
+        );
+        // Ctrl+Shift+Tab and Ctrl+BackTab both normalize to Ctrl+Shift+Tab.
+        let ctrl_shift_tab =
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+        assert_eq!(
+            km.resolve(&ctrl_shift_tab, KeyContext::Explorer),
+            Some(Action::PrevWorktree)
+        );
+        let ctrl_backtab = KeyEvent::new(KeyCode::BackTab, KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&ctrl_backtab, KeyContext::Explorer),
+            Some(Action::PrevWorktree)
         );
     }
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -16,6 +16,16 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::theme::Theme;
 
+/// Braille spinner frames for in-progress (async) operations.
+const BRAILLE_SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// The current spinner frame for the given UI tick. Advances roughly every
+/// four frames so the animation reads as a steady spin. Shared by every panel
+/// that shows an async-operation spinner so they stay in sync.
+pub fn spinner_frame(ui_tick: u64) -> &'static str {
+    BRAILLE_SPINNER[(ui_tick as usize / 4) % BRAILLE_SPINNER.len()]
+}
+
 /// Cached PTY render output to avoid expensive vt100 snapshots every frame.
 ///
 /// When a terminal panel is not focused, we reuse the previously built

--- a/src/ui/worktree_bar.rs
+++ b/src/ui/worktree_bar.rs
@@ -25,6 +25,10 @@ pub enum WtbarAction {
     Delete(usize),
     /// Create a new worktree.
     Add,
+    /// Scroll the strip to reveal worktrees hidden off the left edge.
+    ScrollLeft,
+    /// Scroll the strip to reveal worktrees hidden off the right edge.
+    ScrollRight,
 }
 
 /// A clickable region of the worktree bar, in absolute screen columns
@@ -40,6 +44,82 @@ fn w(s: &str) -> u16 {
     UnicodeWidthStr::width(s) as u16
 }
 
+/// Per-worktree data gathered before rendering, so the variable-width window
+/// can be computed without holding a borrow on `app`.
+struct Chip {
+    text: String,
+    width: u16,
+    /// Delete button (`✕ `), empty for the main worktree.
+    del: &'static str,
+    del_width: u16,
+    waiting: bool,
+    active: bool,
+    is_current: bool,
+}
+
+/// Compute the visible chip window `[start, end)` for the bar.
+///
+/// `slots[i]` is the full rendered width of chip `i` (chip + its delete button)
+/// and `sep_w` the width of the separator drawn before every chip except the
+/// first visible one. `avail` is the width left for chips and separators (the
+/// caller has already reserved room for the overflow hints). `desired_start` is
+/// the current scroll position; when `reveal` is set the window is panned the
+/// minimum amount needed to include `selected`.
+fn visible_window(
+    slots: &[u16],
+    sep_w: u16,
+    avail: u16,
+    desired_start: usize,
+    selected: usize,
+    reveal: bool,
+) -> (usize, usize) {
+    let total = slots.len();
+    if total == 0 {
+        return (0, 0);
+    }
+
+    // Greedily fill forward from `start`; always show at least one chip.
+    let fill = |start: usize| -> usize {
+        let mut used = 0u16;
+        let mut end = start;
+        while end < total {
+            let extra = slots[end] + if end > start { sep_w } else { 0 };
+            if used + extra > avail && end > start {
+                break;
+            }
+            used = used.saturating_add(extra);
+            end += 1;
+        }
+        end.max(start + 1).min(total)
+    };
+
+    // Smallest start that still reaches the last chip — clamps over-scrolling so
+    // we never leave blank space on the right while chips stay hidden left.
+    // A larger start can only push the window's end later or equal, so scanning
+    // upward the first `start` that reaches the end is the smallest such start.
+    let mut tail_start = 0;
+    for s in 0..total {
+        if fill(s) == total {
+            tail_start = s;
+            break;
+        }
+    }
+
+    let mut start = desired_start.min(tail_start);
+
+    if reveal {
+        if selected < start {
+            start = selected;
+        } else {
+            while start < selected && selected >= fill(start) {
+                start += 1;
+            }
+        }
+    }
+
+    (start, fill(start))
+}
+
 /// Render the worktree monitor strip and record its clickable regions into
 /// `app.wtbar_hits`.
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -48,19 +128,41 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
 
+    let muted = app.theme.muted;
+    let success = app.theme.success;
+    let accent = app.theme.accent;
+    let warning = app.theme.warning;
+    let border = app.theme.border_secondary;
+    let error = app.theme.error;
+
+    // A smart/normal worktree is being created in the background → spin the
+    // far-left marker so the activity is visible at a glance.
+    let creating = app.worktree_mgr.pending_worktrees.iter().any(|p| {
+        matches!(
+            p.op,
+            crate::app::PendingWorktreeOp::Creating | crate::app::PendingWorktreeOp::SmartCreating
+        )
+    });
+
     let max_x = area.x + area.width;
     let mut x = area.x;
     let mut spans: Vec<Span> = Vec::new();
     let mut hits: Vec<WtbarHit> = Vec::new();
 
-    // Identity marker so the strip reads as "worktrees".
+    // Identity marker (spins while a worktree is being created).
     {
-        let icon = "\u{2387} ";
-        spans.push(Span::styled(
-            icon,
-            Style::default().fg(app.theme.muted).add_modifier(Modifier::BOLD),
-        ));
-        x += w(icon);
+        let icon = if creating {
+            format!("{} ", crate::ui::common::spinner_frame(app.ui_tick))
+        } else {
+            "\u{2387} ".to_string()
+        };
+        let style = if creating {
+            Style::default().fg(success).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(muted).add_modifier(Modifier::BOLD)
+        };
+        x += w(&icon);
+        spans.push(Span::styled(icon, style));
     }
     // New-worktree button.
     {
@@ -68,9 +170,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         let aw = w(add);
         spans.push(Span::styled(
             add,
-            Style::default()
-                .fg(app.theme.success)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(success).add_modifier(Modifier::BOLD),
         ));
         hits.push(WtbarHit {
             x0: x,
@@ -80,94 +180,223 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         x += aw;
     }
 
-    let total = app.worktrees.len();
-    let mut shown = 0usize;
-    // Reserve a little room on the right for the "+N" overflow hint.
-    let reserve = 5u16;
+    // Gather chip data up front (releases the borrow on `app.worktrees`).
+    let chips: Vec<Chip> = app
+        .worktrees
+        .iter()
+        .enumerate()
+        .map(|(i, wt)| {
+            let waiting = app.terminal.cc_waiting_worktrees.contains(&wt.path);
+            let active = app.terminal.cc_active_worktrees.contains(&wt.path);
 
-    for (i, wt) in app.worktrees.iter().enumerate() {
-        let waiting = app.terminal.cc_waiting_worktrees.contains(&wt.path);
-        let active = app.terminal.cc_active_worktrees.contains(&wt.path);
-        let is_current = i == app.selected_worktree;
+            let mut text = String::from(" ");
+            if waiting {
+                text.push_str("\u{23f3} ");
+            } else if active {
+                text.push_str("\u{25cf} ");
+            }
+            text.push_str(&wt.branch);
+            if !wt.is_clean {
+                text.push_str(&format!(" ~{}", wt.added + wt.modified + wt.deleted));
+            }
+            if let Some(a) = wt.ahead
+                && a > 0
+            {
+                text.push_str(&format!(" \u{2191}{a}"));
+            }
+            if let Some(b) = wt.behind
+                && b > 0
+            {
+                text.push_str(&format!(" \u{2193}{b}"));
+            }
+            text.push(' ');
 
-        let mut chip = String::from(" ");
-        if waiting {
-            chip.push_str("\u{23f3} ");
-        } else if active {
-            chip.push_str("\u{25cf} ");
-        }
-        chip.push_str(&wt.branch);
-        if !wt.is_clean {
-            chip.push_str(&format!(" ~{}", wt.added + wt.modified + wt.deleted));
-        }
-        if let Some(a) = wt.ahead
-            && a > 0
-        {
-            chip.push_str(&format!(" \u{2191}{a}"));
-        }
-        if let Some(b) = wt.behind
-            && b > 0
-        {
-            chip.push_str(&format!(" \u{2193}{b}"));
-        }
-        chip.push(' ');
+            let del = if wt.is_main { "" } else { "\u{2715} " };
+            Chip {
+                width: w(&text),
+                del,
+                del_width: w(del),
+                waiting,
+                active,
+                is_current: i == app.selected_worktree,
+                text,
+            }
+        })
+        .collect();
 
-        let chip_w = w(&chip);
-        let del = if wt.is_main { "" } else { "\u{2715} " };
-        let del_w = w(del);
-        let sep = if shown > 0 { "\u{2502} " } else { "" };
-        let sep_w = w(sep);
+    let total = chips.len();
+    // Separator drawn before every chip except the first visible one; its width
+    // and the literal are defined together so they can't drift apart.
+    let sep = "\u{2502} ";
+    let sep_w = w(sep);
+    let avail_full = max_x.saturating_sub(x);
 
-        // Stop before we overrun (always keep room for the overflow hint).
-        if shown > 0 && x + sep_w + chip_w + del_w + reserve > max_x {
-            break;
-        }
+    // Does everything fit with no overflow hints? If so, skip the hint reserve.
+    let slots: Vec<u16> = chips.iter().map(|c| c.width + c.del_width).collect();
+    let all_fit = visible_window(&slots, sep_w, avail_full, 0, 0, false).1 == total;
 
-        if !sep.is_empty() {
-            spans.push(Span::styled(sep, Style::default().fg(app.theme.border_secondary)));
+    // Reserve room for the left/right overflow hints when scrolling is needed.
+    let hint_reserve_per_side = 5u16;
+    let avail = if all_fit {
+        avail_full
+    } else {
+        avail_full.saturating_sub(hint_reserve_per_side * 2)
+    };
+
+    let (start, end) = if all_fit {
+        (0, total)
+    } else {
+        visible_window(
+            &slots,
+            sep_w,
+            avail,
+            app.wtbar_scroll,
+            app.selected_worktree,
+            app.wtbar_reveal_selected,
+        )
+    };
+
+    // Left overflow hint (clickable: scroll left). Tinted with warning if any
+    // hidden worktree on that side is waiting for the user.
+    if start > 0 {
+        let waiting_left = chips[..start].iter().any(|c| c.waiting);
+        let hint = format!("\u{2039}{} ", start);
+        let hw = w(&hint);
+        spans.push(Span::styled(
+            hint,
+            Style::default().fg(if waiting_left { warning } else { muted }),
+        ));
+        hits.push(WtbarHit {
+            x0: x,
+            x1: x + hw,
+            action: WtbarAction::ScrollLeft,
+        });
+        x += hw;
+    }
+
+    for (offset, chip) in chips[start..end].iter().enumerate() {
+        let i = start + offset;
+        if offset > 0 {
+            spans.push(Span::styled(sep, Style::default().fg(border)));
             x += sep_w;
         }
 
-        let chip_style = if is_current {
-            Style::default()
-                .fg(app.theme.accent)
-                .add_modifier(Modifier::BOLD)
-        } else if waiting {
-            Style::default().fg(app.theme.warning)
-        } else if active {
-            Style::default().fg(app.theme.success)
+        let chip_style = if chip.is_current {
+            Style::default().fg(accent).add_modifier(Modifier::BOLD)
+        } else if chip.waiting {
+            Style::default().fg(warning)
+        } else if chip.active {
+            Style::default().fg(success)
         } else {
-            Style::default().fg(app.theme.muted)
+            Style::default().fg(muted)
         };
-        spans.push(Span::styled(chip.clone(), chip_style));
+        spans.push(Span::styled(chip.text.clone(), chip_style));
         hits.push(WtbarHit {
             x0: x,
-            x1: x + chip_w,
+            x1: x + chip.width,
             action: WtbarAction::Select(i),
         });
-        x += chip_w;
+        x += chip.width;
 
-        if !del.is_empty() {
-            spans.push(Span::styled(del, Style::default().fg(app.theme.error)));
+        if !chip.del.is_empty() {
+            spans.push(Span::styled(chip.del, Style::default().fg(error)));
             hits.push(WtbarHit {
                 x0: x,
-                x1: x + del_w,
+                x1: x + chip.del_width,
                 action: WtbarAction::Delete(i),
             });
-            x += del_w;
+            x += chip.del_width;
         }
-        shown += 1;
     }
 
-    if shown < total {
+    // Right overflow hint (clickable: scroll right).
+    if end < total {
+        let waiting_right = chips[end..].iter().any(|c| c.waiting);
+        let hint = format!(" {}\u{203a}", total - end);
+        let hw = w(&hint);
         spans.push(Span::styled(
-            format!(" +{}", total - shown),
-            Style::default().fg(app.theme.muted),
+            hint,
+            Style::default().fg(if waiting_right { warning } else { muted }),
         ));
+        hits.push(WtbarHit {
+            x0: x,
+            x1: x + hw,
+            action: WtbarAction::ScrollRight,
+        });
     }
 
+    app.wtbar_scroll = start;
+    app.wtbar_reveal_selected = false;
     app.wtbar_hits = hits;
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::visible_window;
+
+    // Ten uniform-width chips, separator width 1.
+    const W: &[u16] = &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
+
+    #[test]
+    fn everything_fits_when_avail_is_large() {
+        // Plenty of room → full window, no panning.
+        let (start, end) = visible_window(W, 1, 1000, 0, 0, false);
+        assert_eq!((start, end), (0, 10));
+    }
+
+    #[test]
+    fn greedy_fill_stops_at_available_width() {
+        // avail 32: chip(10) + sep1+chip(10) + sep1+chip(10) = 32 → 3 chips.
+        let (start, end) = visible_window(W, 1, 32, 0, 0, false);
+        assert_eq!((start, end), (0, 3));
+    }
+
+    #[test]
+    fn at_least_one_chip_even_when_too_narrow() {
+        let (start, end) = visible_window(W, 1, 4, 0, 0, false);
+        assert_eq!((start, end), (0, 1));
+    }
+
+    #[test]
+    fn scroll_offset_moves_the_window() {
+        let (start, end) = visible_window(W, 1, 32, 4, 4, false);
+        assert_eq!((start, end), (4, 7));
+    }
+
+    #[test]
+    fn over_scroll_is_clamped_to_keep_right_edge_full() {
+        // Desired start 9 would waste space; clamp so the last chip sits at the
+        // right edge (window of 3 ending at the tail).
+        let (start, end) = visible_window(W, 1, 32, 9, 0, false);
+        assert_eq!((start, end), (7, 10));
+    }
+
+    #[test]
+    fn reveal_pans_left_when_selected_is_before_window() {
+        // Window currently at [4,7); select chip 1 → pan back so it's visible.
+        let (start, end) = visible_window(W, 1, 32, 4, 1, true);
+        assert_eq!(start, 1);
+        assert!((start..end).contains(&1));
+    }
+
+    #[test]
+    fn reveal_pans_right_when_selected_is_after_window() {
+        // Window at [0,3); select chip 8 → advance until it's visible.
+        let (start, end) = visible_window(W, 1, 32, 0, 8, true);
+        assert!((start..end).contains(&8));
+    }
+
+    #[test]
+    fn reveal_does_not_move_when_selected_already_visible() {
+        let (start, end) = visible_window(W, 1, 32, 3, 4, true);
+        assert_eq!((start, end), (3, 6));
+    }
+
+    #[test]
+    fn empty_list_is_handled() {
+        assert_eq!(visible_window(&[], 1, 100, 0, 0, true), (0, 0));
+    }
 }
 
 /// Render the worktree switcher modal: a centered popup that reuses the full

--- a/src/ui/worktree_panel.rs
+++ b/src/ui/worktree_panel.rs
@@ -138,9 +138,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let is_grab_branch =
         |wt: &crate::git_engine::WorktreeInfo| -> bool { wt.branch.ends_with("__grab") };
 
-    // Braille spinner frames for async operations.
-    const BRAILLE_SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-    let spinner_frame = BRAILLE_SPINNER[(app.ui_tick as usize / 4) % BRAILLE_SPINNER.len()];
+    // Braille spinner frame for async operations.
+    let spinner_frame = super::common::spinner_frame(app.ui_tick);
 
     // Pre-compute session data for inline display.
     let session_groups = app.all_cc_sessions_by_worktree();


### PR DESCRIPTION
## Summary

worktree が増えたときのバー操作性を改善し、smart worktree 作成中の視覚フィードバックとキーボードでの worktree 切替を追加しました。

- **worktree バーの横スクロール**: 従来は worktree が画面幅を超えると片側 `+N` を出すだけで隠れたものに到達できなかったのを、横スクロール可能にしました。
  - 選択中の worktree チップが常に見えるよう最小限だけ自動追従（既に見えていれば動かさない）
  - バー上のマウスホイールで横スクロール（1ティックで約1画面分、trackpad/ホイール両対応でチップを飛ばさない）
  - 両端のオーバーフローヒント `‹N` / `N›`（クリックでページ送り）。隠れている側に「⏳待ち」の worktree があるとヒントが警告色になる
- **作成中スピナー**: smart/通常 worktree のバックグラウンド作成中、バー左端の `⎇` アイコンをブレイルスピナーに差し替え
- **Ctrl+Tab / Ctrl+Shift+Tab で worktree 切替**: どのパネルからでも次/前の worktree へ移動（ラップアラウンド）。フォーカスは現在のパネルのまま、バーが追従。ターミナルフォーカス中も有効。コマンドパレットにも "Next/Previous Worktree" を追加
- 共通化: ブレイルスピナーのフレーム計算を `ui::common::spinner_frame` に抽出し、worktree_panel と共有

バージョンを 0.63.0 → 0.64.0 に更新（後方互換な機能追加 = MINOR）。

## Test plan

- [x] `cargo build` / `cargo clippy` クリーン
- [x] `cargo test` 全 241 件パス
- [x] 可変幅チップのスクロール窓計算 `visible_window` のユニットテスト 9 件を追加（greedy fill / 最小幅で最低1チップ / over-scroll クランプ / reveal の左右パン / 既に可視なら不動 / 空リスト）
- [x] キーマップ解決テスト `ctrl_tab_switches_worktree` を追加（`Ctrl+Tab`→Next、`Ctrl+Shift+Tab` と `Ctrl+BackTab` がどちらも Prev に正規化、plain Tab はパネル移動のまま）
- [x] `cargo install --path .` で動作するバイナリを確認
