### PR TITLE
fix: モーダルのテキスト入力中に裸のOptionグリフでフォーカスが奪われる問題を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.64.0"
+version = "0.64.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.64.0"
+version = "0.64.1"
 edition = "2024"
 
 [dependencies]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -13,7 +13,7 @@ mod terminal;
 mod viewer;
 mod worktree;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::app::{App, Focus, UpdateState, WorktreeInputMode};
 use crate::keymap::{Action, KeyContext};
@@ -93,13 +93,67 @@ fn effective_overlay(app: &App) -> EffectiveOverlay {
     EffectiveOverlay::None
 }
 
+/// True when a text-entry field is currently focused and expects printable
+/// characters to be inserted as literal text — every input target enumerated in
+/// [`handle_paste_event`]. Kept in lockstep with that function: a destination
+/// added there must be added here too. Notably this is `false` for the
+/// `WorktreeInputMode::Confirming*` y/n sub-modes, which are NOT text entry.
+fn is_text_input_active(app: &App) -> bool {
+    if app.viewer_state.explorer.inline_reply_line.is_some()
+        || app.review_state.input_mode != ReviewInputMode::Normal
+        || app.review_state.search_active
+        || app.viewer_state.search.search_active
+        || app.viewer_state.filename_search.filename_search_active
+    {
+        return true;
+    }
+    if matches!(
+        app.worktree_mgr.input_mode,
+        WorktreeInputMode::CreatingWorktree
+            | WorktreeInputMode::CreatingWorktreeBase
+            | WorktreeInputMode::SmartDescription
+    ) {
+        return true;
+    }
+    matches!(
+        app.overlays.active,
+        ActiveOverlay::GrepSearch
+            | ActiveOverlay::SwitchBranch
+            | ActiveOverlay::CommandPalette
+            | ActiveOverlay::OpenRepo
+            | ActiveOverlay::History
+            | ActiveOverlay::ResumeSession
+    )
+}
+
+/// True when `key` is a printable character carrying no command modifier
+/// (Ctrl/Alt/Super). A lone Shift still counts as "bare" — `Shift+a` is just
+/// `A`. Such a key is indistinguishable from typed text, so it must never be
+/// hijacked as a global accelerator while a text field is focused. This is what
+/// stops the macOS Option-glyph focus fallbacks (`¡ ™ £ ¢ ∞ §` …) from stealing
+/// focus mid-IME-input.
+fn is_bare_printable(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char(_))
+        && !key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+}
+
 // Re-export public API.
 pub use self::mouse::handle_mouse_event;
 
 /// Process a single key event, updating application state as needed.
 pub fn handle_key_event(app: &mut App, key: KeyEvent) {
-    // ── 0. Global focus-switching — always available, even over overlays ──
-    if let Some(action) = app.keymap.resolve(&key, KeyContext::Global) {
+    // ── 0. Global focus-switching — available even over overlays, EXCEPT a
+    // bare printable key while a text field is focused, which must reach the
+    // text buffer. The global layer binds macOS Option-glyph fallbacks (bare
+    // '¡ ™ £ ¢ ∞ § ÷ ˙ ¬') to focus actions; those glyphs are indistinguishable
+    // from typed text, so during IME / multi-byte input they would otherwise
+    // steal focus (e.g. '∞' jumping to the Claude panel). Modifier-carrying
+    // chords (alt+1, ctrl+w, super+1, alt+h …) still switch focus over a modal.
+    if !(is_text_input_active(app) && is_bare_printable(&key))
+        && let Some(action) = app.keymap.resolve(&key, KeyContext::Global)
+    {
         match action {
             Action::FocusWorktree
             | Action::FocusExplorer
@@ -566,5 +620,57 @@ fn adjust_diff_list_scroll(app: &mut App) {
         app.viewer_state.explorer.diff_list_scroll = selected;
     } else if selected >= app.viewer_state.explorer.diff_list_scroll + page_size {
         app.viewer_state.explorer.diff_list_scroll = selected.saturating_sub(page_size - 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    #[test]
+    fn bare_chars_are_printable_text() {
+        // Plain ASCII, a kana, and a macOS Option-glyph fallback are all "bare"
+        // and must be treated as typed text, never a global accelerator.
+        for c in ['a', 'あ', '∞', '¡', '§', '÷'] {
+            assert!(
+                is_bare_printable(&key(KeyCode::Char(c), KeyModifiers::empty())),
+                "{c:?} should be bare printable",
+            );
+        }
+    }
+
+    #[test]
+    fn shift_only_still_counts_as_bare() {
+        // Shift+a is just 'A' — still text, not a command.
+        assert!(is_bare_printable(&key(
+            KeyCode::Char('A'),
+            KeyModifiers::SHIFT
+        )));
+    }
+
+    #[test]
+    fn modifier_chords_are_not_bare() {
+        // Command-bearing chords must still reach the global focus switcher.
+        for m in [
+            KeyModifiers::CONTROL,
+            KeyModifiers::ALT,
+            KeyModifiers::SUPER,
+            KeyModifiers::ALT | KeyModifiers::SHIFT,
+        ] {
+            assert!(!is_bare_printable(&key(KeyCode::Char('1'), m)));
+        }
+    }
+
+    #[test]
+    fn named_keys_are_not_bare_printable() {
+        // Enter/Esc/Tab are not Char, so they keep flowing to global/overlay.
+        for code in [KeyCode::Enter, KeyCode::Esc, KeyCode::Tab] {
+            assert!(!is_bare_printable(&key(code, KeyModifiers::empty())));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Smart Worktree のタスク説明モーダルで日本語を入力していると、途中で入力が Claude パネルに取られて文字が打てなくなるバグを修正する。

**原因:** `handle_key_event`（`src/event/mod.rs`）のステップ0「グローバルなフォーカス切替」がモーダル処理より先に走り、テキスト入力中でもキーを横取りしていた。グローバルキーマップには macOS の Option キーが生む**修飾なしの裸グリフ**（`¡ ™ £ ¢ ∞ § ÷ ˙ ¬`）がフォーカス操作のフォールバックとして割り当てられている。これらは「打った文字」と区別できないため、IME / マルチバイト入力中（特に変換や複数文字のコミット時）に裸グリフが混じるとフォーカスが奪われる。`∞` はちょうど `focus_terminal_claude`（Claude パネル）で、症状と一致する。1文字（裸の `あ` 等）はどのフォーカスにも当たらず通るため入力できていた。

**修正:** 「テキスト入力中の裸の印字文字（修飾なし、Shift 単独は可）はコマンドとして横取りしない」というガードを追加。

- `is_bare_printable(key)` — `Char` かつ Ctrl/Alt/Super を含まない（Shift 単独は裸扱い）
- `is_text_input_active(app)` — `handle_paste_event` が列挙する全テキスト入力先をミラー（Smart 説明・worktree 名・review 入力・各種検索・コマンドパレット等）。WorktreeInput の `Confirming*`（y/n）は除外
- ステップ0を `if !(is_text_input_active && is_bare_printable) && let Some(action) = resolve(...)` でガード

修飾付きチョード（`alt+1` / `ctrl+w` / `super+1` / `alt+h` 等）は引き続きモーダル上でもフォーカス切替可能。通常パネルでの Option フォールバック（意図された機能・テストで担保）も温存される。

## Test plan

- `cargo build` / `cargo clippy` クリーン
- `cargo test` 全 235 passed（既存 231 + 新規 4: 裸文字 / Shift 単独 / 修飾チョード / 名前付きキーの分類）
- 手動: Smart Worktree モーダルで日本語（変換あり・複数文字）を入力し、フォーカスが Claude パネルに奪われず文字が入ることを確認
