### PR TITLE
fix: enable wheel scrolling for pagers on terminal alternate screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.64.2"
+version = "0.64.3"
 edition = "2024"
 
 [dependencies]

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -1092,14 +1092,33 @@ fn handle_mouse_scroll(
     } else {
         // Terminal panels (right column).
         let abs_delta = delta.unsigned_abs() as usize;
+        // ScrollUp (delta < 0) moves toward older content / into history.
+        let up = delta < 0;
+        let session_idx = if row < terminal_split_y {
+            app.terminal.active_claude_session
+        } else {
+            app.terminal.active_shell_session
+        };
+
+        // Pagers (less/bat/man) run on the alternate screen, which has no
+        // scrollback — translate the wheel into arrow keys for the child
+        // instead of bumping the (ignored) local scrollback offset.
+        if let Some(idx) = session_idx
+            && app
+                .terminal
+                .pty_manager
+                .scroll_alt_screen_session(idx, abs_delta, up)
+        {
+            return;
+        }
+
         if row < terminal_split_y {
-            if delta < 0 {
-                // ScrollUp = scroll into history.
+            if up {
                 app.terminal.scroll_claude = app.terminal.scroll_claude.saturating_add(abs_delta);
             } else {
                 app.terminal.scroll_claude = app.terminal.scroll_claude.saturating_sub(abs_delta);
             }
-        } else if delta < 0 {
+        } else if up {
             app.terminal.scroll_shell = app.terminal.scroll_shell.saturating_add(abs_delta);
         } else {
             app.terminal.scroll_shell = app.terminal.scroll_shell.saturating_sub(abs_delta);

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -294,6 +294,52 @@ impl PtyManager {
         Ok(())
     }
 
+    /// Translate a mouse-wheel scroll into arrow-key presses for a session
+    /// that is showing the **alternate screen** (e.g. pagers like `less`,
+    /// `bat`, `man`).
+    ///
+    /// The alternate screen has no scrollback of its own, so the local
+    /// scrollback offset is meaningless there — the user must scroll the
+    /// child program instead. This mirrors the "alternate-scroll" behavior
+    /// of tmux / iTerm2: each wheel notch becomes `lines` Up/Down arrow
+    /// presses sent to the child.
+    ///
+    /// Returns `true` if the scroll was handled by injecting arrow keys, in
+    /// which case the caller must **not** also adjust the local scrollback
+    /// offset. Returns `false` when the session is not on the alternate
+    /// screen, or when the child has enabled mouse reporting (in which case
+    /// it captures the wheel itself and synthesizing arrows would fight it).
+    pub fn scroll_alt_screen_session(&mut self, idx: usize, lines: usize, up: bool) -> bool {
+        // Read the relevant terminal modes, then drop the session/parser
+        // borrow before writing (write_to_session needs &mut self).
+        let (is_alt, app_cursor, mouse_on) = {
+            let Some(session) = self.sessions.get(idx) else {
+                return false;
+            };
+            let parser = session.screen.lock().unwrap_or_else(|e| e.into_inner());
+            let screen = parser.screen();
+            (
+                screen.alternate_screen(),
+                screen.application_cursor(),
+                screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None,
+            )
+        };
+
+        if !is_alt || mouse_on {
+            return false;
+        }
+
+        let arrow = scroll_arrow_sequence(up, app_cursor);
+        let mut buf = Vec::with_capacity(arrow.len() * lines);
+        for _ in 0..lines {
+            buf.extend_from_slice(arrow);
+        }
+        if let Err(e) = self.write_to_session(idx, &buf) {
+            log::warn!("failed to inject scroll arrows to PTY session: {e}");
+        }
+        true
+    }
+
     /// Send a large text payload to the PTY as regular typed input (no
     /// bracketed paste) using chunked writes to avoid hitting the kernel's
     /// PTY input buffer limit (typically 4096 bytes on macOS / Linux).
@@ -745,4 +791,36 @@ fn count_csi_dsr(bytes: &[u8]) -> usize {
         return 0;
     }
     bytes.windows(4).filter(|w| *w == b"\x1b[6n").count()
+}
+
+/// Return the escape sequence for an Up/Down arrow key press used to scroll a
+/// pager on the alternate screen.
+///
+/// `up` selects Up (`true`) vs Down (`false`). `app_cursor` honors DECCKM
+/// (application cursor keys mode): when set, terminals send SS3 (`ESC O`)
+/// sequences; otherwise CSI (`ESC [`). Pagers like `less` enable application
+/// cursor mode and bind the SS3 forms, so respecting it is necessary for the
+/// arrow keys to register reliably across programs.
+fn scroll_arrow_sequence(up: bool, app_cursor: bool) -> &'static [u8] {
+    match (up, app_cursor) {
+        (true, true) => b"\x1bOA",   // Up   (SS3)
+        (true, false) => b"\x1b[A",  // Up   (CSI)
+        (false, true) => b"\x1bOB",  // Down (SS3)
+        (false, false) => b"\x1b[B", // Down (CSI)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arrow_sequence_honors_decckm_and_direction() {
+        // Application cursor keys mode → SS3 (ESC O); note the letter O (0x4f).
+        assert_eq!(scroll_arrow_sequence(true, true), b"\x1bOA");
+        assert_eq!(scroll_arrow_sequence(false, true), b"\x1bOB");
+        // Normal mode → CSI (ESC [).
+        assert_eq!(scroll_arrow_sequence(true, false), b"\x1b[A");
+        assert_eq!(scroll_arrow_sequence(false, false), b"\x1b[B");
+    }
 }


### PR DESCRIPTION
## Summary

terminal panel で `bat` / `less` / `man` などのページャー系コマンドを実行した際、出力が画面に収まりきらなくてもマウスホイールでスクロールできないバグを修正した。

- **根本原因**: ページャーは alternate screen buffer (smcup/rmcup) を使う。alternate screen には独自のスクロールバックが無いため、レンダラ (`ui/common.rs`) は alternate screen 中はローカルのスクロールバックオフセットを 0 に固定している。そのためマウスホイール操作でオフセットを増減しても何も起きなかった。
- **修正方針**: tmux / iTerm2 の "alternate-scroll" 挙動に倣い、alternate screen 表示中はホイール操作を子プロセスへの矢印キー入力に変換して送る。
  - `PtyManager::scroll_alt_screen_session` を追加し、alternate screen のときだけホイール 1 ノッチを上下矢印キー押下に変換して PTY へ書き込む。
  - DECCKM (application cursor keys mode) を尊重し、有効時は SS3 (`ESC O A/B`)、無効時は CSI (`ESC [ A/B`) を送る (`less` は application cursor mode を有効化するため必須)。
  - 子プロセスがマウスレポートを有効化している場合 (htop/vim 等) は矢印注入せず `false` を返し、従来挙動に委ねる。
  - alternate screen でない通常画面では従来どおりローカルスクロールバックを操作する。

キーボードスクロール (矢印・space・j/k 等) は元々 PTY へ転送されており動作していたため、本修正はマウスホイール経路のみが対象。

## Test plan

- `cargo build` / `cargo clippy` / `cargo check` がクリーン
- `cargo test` が全件パス（新規追加した `arrow_sequence_honors_decckm_and_direction` を含む）
- 手動確認: terminal panel で `bat <large-file>` / `less <large-file>` / `man <cmd>` を開き、マウスホイールで上下スクロールできること
