### PR TITLE
feat: ヘッダー右上にworktree数・session数・バージョンを表示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.64.3"
+version = "0.65.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.64.3"
+version = "0.65.0"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -341,22 +341,30 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
         let sep = Span::styled(" | ", Style::default().fg(theme.muted).bg(bar_bg));
         let mut spans: Vec<Span> = Vec::new();
 
-        if let Some(ref stats) = app.today_stats {
-            spans.push(Span::styled(
-                format!("{} branches", stats.branches_created),
-                Style::default().fg(theme.info).bg(bar_bg),
-            ));
-            spans.push(sep.clone());
-            spans.push(Span::styled(
-                format!("{} commits", stats.commits_made),
-                Style::default().fg(theme.success).bg(bar_bg),
-            ));
-            spans.push(sep.clone());
-            spans.push(Span::styled(
-                format!("{} reviews", stats.reviews_created),
-                Style::default().fg(theme.warning).bg(bar_bg),
-            ));
-        }
+        // Workspace overview: worktree count, running Claude Code sessions,
+        // and the current Conductor version.
+        let worktree_count = app.worktrees.len();
+        let claude_session_count = app
+            .terminal
+            .pty_manager
+            .sessions()
+            .iter()
+            .filter(|s| s.kind == crate::pty_manager::SessionKind::ClaudeCode)
+            .count();
+        spans.push(Span::styled(
+            format!("{} worktrees", worktree_count),
+            Style::default().fg(theme.info).bg(bar_bg),
+        ));
+        spans.push(sep.clone());
+        spans.push(Span::styled(
+            format!("{} sessions", claude_session_count),
+            Style::default().fg(theme.success).bg(bar_bg),
+        ));
+        spans.push(sep.clone());
+        spans.push(Span::styled(
+            format!("v{}", crate::update_checker::current_version()),
+            Style::default().fg(theme.warning).bg(bar_bg),
+        ));
         if let Some(ref info) = app.ccusage_info {
             if !spans.is_empty() {
                 spans.push(sep.clone());


### PR DESCRIPTION
## Summary

アプリ右上ヘッダーの右寄せ表示を、その日の活動量（branches / commits / reviews）から、ワークスペースの現況を示す3項目に変更しました。

- **削除**: `N branches`（`today_stats.branches_created`）, `N commits`（`commits_made`）, `N reviews`（`reviews_created`）
- **追加**:
  - `N worktrees` — `app.worktrees.len()`
  - `N sessions` — `pty_manager.sessions()` のうち `SessionKind::ClaudeCode` の数（起動中の Claude Code セッション数）
  - `vX.Y.Z` — `update_checker::current_version()`（`CARGO_PKG_VERSION`）

既存のセパレータ（` | `）・配色（info / success / warning）・右寄せレイアウト・パディングをそのまま踏襲しており、後続の ccusage（tokens / cost）や update バッジの表示・位置計算ロジックにも影響しません。`today_stats` フィールド自体は CLI の `--stats` 出力などで引き続き使用されるため残しています。

変更ファイル: `src/ui/common.rs`（`render_title_bar`）

semver: 表示情報の差し替え（後方互換のある機能変更）のため MINOR bump → `0.65.0`。

## Test plan

- [x] `cargo check` — エラーなし
- [x] `cargo clippy` — 警告・エラーなし
- [ ] 実機でヘッダー右上に `N worktrees | N sessions | vX.Y.Z` が崩れず表示されること
- [ ] worktree の追加/削除、Claude Code セッションの起動/終了で各カウントが更新されること
