### PR TITLE
feat: diff インライン展開で resolved コメントを非表示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.65.1"
+version = "0.66.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.65.1"
+version = "0.66.0"
 edition = "2024"
 
 [dependencies]

--- a/src/review_state.rs
+++ b/src/review_state.rs
@@ -225,7 +225,10 @@ impl ReviewState {
     /// Build the per-file comment cache from in-memory comments.
     ///
     /// Filters `self.comments` by `file_path` and maps each line in the
-    /// comment's range to a vec of comments covering that line.
+    /// comment's range to a vec of comments covering that line. Resolved
+    /// comments are kept here so their badge still appears in the gutter;
+    /// the inline thread expansion (see `build_inline_thread_lines`) is what
+    /// hides resolved comments.
     pub fn build_file_comment_cache(&mut self, file_path: &str) {
         self.file_comments.clear();
         self.file_comments_path = Some(file_path.to_string());
@@ -260,5 +263,45 @@ impl ReviewState {
                 self.template_selected = 0;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review_store::{Author, CommentKind, CommentStatus, ReviewComment};
+
+    fn comment(id: &str, line: u32, status: CommentStatus) -> ReviewComment {
+        ReviewComment {
+            id: id.to_string(),
+            worktree: "wt".to_string(),
+            file_path: "src/main.rs".to_string(),
+            line_start: line,
+            line_end: None,
+            kind: CommentKind::Suggest,
+            body: "body".to_string(),
+            status,
+            commit_ref: "abc".to_string(),
+            author: Author::User,
+            branch: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn build_file_comment_cache_keeps_resolved_for_badges() {
+        let mut state = ReviewState::new();
+        state.comments = vec![
+            comment("c1", 10, CommentStatus::Pending),
+            comment("c2", 20, CommentStatus::Resolved),
+        ];
+
+        state.build_file_comment_cache("src/main.rs");
+
+        // Both lines keep a cache entry so the gutter badge still appears;
+        // resolved comments are only hidden from the inline thread expansion.
+        assert!(state.file_comments.contains_key(&10));
+        assert!(state.file_comments.contains_key(&20));
     }
 }

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -1087,10 +1087,19 @@ fn build_inline_thread_lines<'a>(
     reply_buffer: &crate::text_input::TextInput,
     theme: &Theme,
 ) -> Vec<(Line<'a>, crate::viewer::ScreenRow)> {
-    let comments = match review_state.file_comments.get(&line_1) {
+    let all_comments = match review_state.file_comments.get(&line_1) {
         Some(c) if !c.is_empty() => c,
         _ => return Vec::new(),
     };
+    // Only unresolved comments are expanded inline; resolved ones keep their
+    // gutter badge but are not shown in the thread box.
+    let comments: Vec<&crate::review_store::ReviewComment> = all_comments
+        .iter()
+        .filter(|c| c.status != crate::review_store::CommentStatus::Resolved)
+        .collect();
+    if comments.is_empty() {
+        return Vec::new();
+    }
 
     use crate::viewer::ScreenRow;
     let mut out: Vec<(Line, ScreenRow)> = Vec::new();


### PR DESCRIPTION
## Summary

diff表示のインラインコメント展開において、resolved（解決済み）状態のコメントを展開対象から除外するようにしました。

- バッジ（💬）はresolvedを含む全コメントで従来どおり表示される
- インライン展開（スレッドボックス）は未解決（pending）コメントのみ表示し、resolvedは展開しない
- resolvedコメントのみの行はバッジは出るがスレッドは展開されない

実装は `build_inline_thread_lines`（`src/ui/viewer_panel.rs`）で対象行のコメントを未解決のみにフィルタすることで実現。バッジ用キャッシュ `build_file_comment_cache`（`src/review_state.rs`）はresolvedも保持します。

## Test plan

- [x] `cargo build`
- [x] `cargo clippy`（警告なし）
- [x] `cargo test`（`build_file_comment_cache_keeps_resolved_for_badges` を追加し合格）
