### PR TITLE
feat!: source keymap crates from crates.io and overhaul keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -1476,7 +1476,8 @@ dependencies = [
 [[package]]
 name = "keymap-config"
 version = "0.1.0"
-source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15e6204ea0b1b5ba246ca0a6329e3b6a280c31edcde88356a60a08ca94dbd1c"
 dependencies = [
  "keymap-core",
  "keymap-seq",
@@ -1487,7 +1488,8 @@ dependencies = [
 [[package]]
 name = "keymap-core"
 version = "0.1.0"
-source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed80e88c3dfed328c5bed357859bff1b3378f3a65fddb09a53c00de082b972b9"
 dependencies = [
  "crossterm",
 ]
@@ -1495,7 +1497,8 @@ dependencies = [
 [[package]]
 name = "keymap-seq"
 version = "0.1.0"
-source = "git+https://github.com/S-Nakamur-a/keymap-rs?rev=6c1f899b077f42ecb5963e04cef7cafc5062b72c#6c1f899b077f42ecb5963e04cef7cafc5062b72c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41a33152c0ff29cc7b48a00c1c17002f219120fe79f46ab94d855215ecd7cd9"
 dependencies = [
  "keymap-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.66.0"
+version = "0.67.0"
 edition = "2024"
 
 [dependencies]
@@ -37,8 +37,8 @@ tree-sitter-rust = "0.24"
 tree-sitter-go = "0.25"
 tree-sitter-typescript = "0.23"
 libc = "0.2"
-keymap-core = { git = "https://github.com/S-Nakamur-a/keymap-rs", rev = "6c1f899b077f42ecb5963e04cef7cafc5062b72c", features = ["crossterm"] }
-keymap-config = { git = "https://github.com/S-Nakamur-a/keymap-rs", rev = "6c1f899b077f42ecb5963e04cef7cafc5062b72c" }
+keymap-core = { version = "0.1", features = ["crossterm"] }
+keymap-config = "0.1"
 
 [profile.dev]
 debug = "limited"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1176,20 +1176,6 @@ impl App {
         self.focus = focus;
     }
 
-    /// Focus a panel and expand it to full width in a single action.
-    ///
-    /// `set_focus` clears `expanded_panel` whenever focus moves to a panel the
-    /// current expansion wouldn't cover, so the expansion is set *after*
-    /// focusing to keep `focus` and `expanded_panel` consistent.
-    pub fn focus_and_expand(&mut self, focus: Focus) {
-        self.set_focus(focus);
-        // Worktree no longer has a column to expand — `set_focus` opened the
-        // switcher modal instead, so marking it expanded would blank the layout.
-        if focus != Focus::Worktree {
-            self.expanded_panel = Some(focus);
-        }
-    }
-
     /// Request the application to quit.
     pub fn quit(&mut self) {
         self.should_quit = true;

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -16,8 +16,9 @@
 
 # ── Global ──────────────────────────────────────────────────────────────────
 [keys]
-"q" = "quit"
-"Q" = "quit"
+# Quit lives on ctrl+q (not bare q) so a stray q never kills the app. Note:
+# ctrl+q is XON in some terminals' flow control — verify it reaches the app.
+"ctrl+q" = "quit"
 "?" = "show_help"
 # ':' is bound per non-terminal layer so it passes through to the PTY in
 # terminal panels. Ctrl+P stays global for command-palette access anywhere.
@@ -34,6 +35,11 @@
 # is separate from Tab's panel-focus cycle.
 "ctrl+tab" = "next_worktree"
 "ctrl+shift+tab" = "prev_worktree"
+# Reliable worktree-switch aliases for terminals without the kitty protocol
+# (where ctrl+tab degrades to bare tab). ] / [ mirror the next/prev idiom used
+# for hunks in diff mode.
+"alt+]" = "next_worktree"
+"alt+[" = "prev_worktree"
 "ctrl+w" = "focus_worktree"
 "ctrl+n" = "new_claude_code"
 "ctrl+t" = "new_shell"
@@ -52,14 +58,8 @@
 "alt+4" = "focus_viewer"
 "alt+5" = "focus_terminal_claude"
 "alt+6" = "focus_terminal_shell"
-# Option+Shift+1..6 — jump to a panel AND maximize it in one stroke. Under the
-# kitty keyboard protocol these arrive as a clean SHIFT|ALT + digit.
-"alt+shift+1" = "focus_expand_worktree"
-"alt+shift+2" = "focus_expand_explorer"
-"alt+shift+3" = "focus_expand_explorer_diff_list"
-"alt+shift+4" = "focus_expand_viewer"
-"alt+shift+5" = "focus_expand_terminal_claude"
-"alt+shift+6" = "focus_expand_terminal_shell"
+# Focus a panel with alt/super+digit, then maximize it with alt+m (below) —
+# this replaces the old hard-to-press alt+shift+digit "focus+expand" combo.
 # macOS Option-produces-Unicode fallback (US layout): Option+1='¡' … Option+6='§'.
 "¡" = "focus_worktree"
 "™" = "focus_explorer"
@@ -69,6 +69,9 @@
 "§" = "focus_terminal_shell"
 "ctrl+g" = "search_full_text"
 "super+space" = "toggle_panel_expand"
+# alt+m — maximize/zoom the focused panel. Reliable everywhere (super+space's
+# Cmd is eaten by macOS/terminals); the easy half of "focus then zoom".
+"alt+m" = "toggle_panel_expand"
 "alt+/" = "toggle_panel_overlay"
 # macOS Unicode fallback (Option+/ = '÷', US layout).
 "÷" = "toggle_panel_overlay"
@@ -86,16 +89,21 @@
 "x" = "delete_worktree"
 "delete" = "delete_worktree"
 "s" = "switch_branch"
-"g" = "grab_branch"
-"G" = "ungrab_branch"
-"P" = "prune_worktrees"
+# g/G are go_to_top/bottom in every other panel; keep them consistent here too.
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+# Grab (checkout branch onto main) / ungrab (restore main) — b for "branch",
+# capital for the undo, mirroring the do/undo shift-pairing they had on g/G.
+"b" = "grab_branch"
+"B" = "ungrab_branch"
+"X" = "prune_worktrees"
 "m" = "merge_to_main"
 "r" = "refresh_worktrees"
 "R" = "reset_main_to_origin"
-"p" = "cherry_pick"
-"u" = "pull_worktree"
+"c" = "cherry_pick"
+"p" = "pull_worktree"
 "H" = "session_history"
-"v" = "open_pull_request"
+"o" = "open_pull_request"
 ":" = "command_palette"
 
 # ── Explorer (file tree) ───────────────────────────────────────────────────────

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -70,31 +70,6 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.set_focus(Focus::TerminalShell);
             true
         }
-        Action::FocusExpandWorktree => {
-            app.focus_and_expand(Focus::Worktree);
-            true
-        }
-        Action::FocusExpandExplorer => {
-            app.focus_and_expand(Focus::Explorer);
-            true
-        }
-        Action::FocusExpandExplorerDiffList => {
-            app.focus_and_expand(Focus::Explorer);
-            app.viewer_state.explorer.explorer_focus_on_diff_list = true;
-            true
-        }
-        Action::FocusExpandViewer => {
-            app.focus_and_expand(Focus::Viewer);
-            true
-        }
-        Action::FocusExpandTerminalClaude => {
-            app.focus_and_expand(Focus::TerminalClaude);
-            true
-        }
-        Action::FocusExpandTerminalShell => {
-            app.focus_and_expand(Focus::TerminalShell);
-            true
-        }
         Action::NewClaudeCode => {
             app.set_status("Starting Claude Code...".to_string(), StatusLevel::Info);
             if let Err(e) = app.spawn_claude_code() {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -160,13 +160,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             | Action::FocusExplorerDiffList
             | Action::FocusViewer
             | Action::FocusTerminalClaude
-            | Action::FocusTerminalShell
-            | Action::FocusExpandWorktree
-            | Action::FocusExpandExplorer
-            | Action::FocusExpandExplorerDiffList
-            | Action::FocusExpandViewer
-            | Action::FocusExpandTerminalClaude
-            | Action::FocusExpandTerminalShell => {
+            | Action::FocusTerminalShell => {
                 dismiss_overlays(app);
                 dispatch_global_action(app, action);
                 return;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -263,122 +263,16 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             return;
         }
 
-        // Check terminal-specific and global bindings first.
-        if let Some(action) = app.keymap.resolve(&key, KeyContext::Terminal) {
-            match action {
-                Action::LeaveTerminal => {
-                    app.set_focus(Focus::Explorer);
-                    return;
-                }
-                Action::FocusWorktree => {
-                    app.set_focus(Focus::Worktree);
-                    return;
-                }
-                Action::FocusExplorer => {
-                    app.set_focus(Focus::Explorer);
-                    return;
-                }
-                Action::FocusExplorerDiffList => {
-                    app.set_focus(Focus::Explorer);
-                    app.viewer_state.explorer.explorer_focus_on_diff_list = true;
-                    return;
-                }
-                Action::FocusViewer => {
-                    app.set_focus(Focus::Viewer);
-                    return;
-                }
-                Action::FocusTerminalClaude => {
-                    app.set_focus(Focus::TerminalClaude);
-                    return;
-                }
-                Action::FocusTerminalShell => {
-                    app.set_focus(Focus::TerminalShell);
-                    return;
-                }
-                Action::CommandPalette => {
-                    app.overlays.active = ActiveOverlay::CommandPalette;
-                    app.overlays.command_palette.filter.clear();
-                    app.overlays.command_palette.selected = 0;
-                    return;
-                }
-                Action::ScrollbackUp => {
-                    let page = match app.focus {
-                        Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
-                        Focus::TerminalShell => app.terminal.size_shell.0 as usize / 2,
-                        _ => unreachable!(),
-                    };
-                    let scroll = match app.focus {
-                        Focus::TerminalClaude => &mut app.terminal.scroll_claude,
-                        Focus::TerminalShell => &mut app.terminal.scroll_shell,
-                        _ => unreachable!(),
-                    };
-                    *scroll = scroll.saturating_add(page.max(1));
-                    return;
-                }
-                Action::ScrollbackDown => {
-                    let page = match app.focus {
-                        Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
-                        Focus::TerminalShell => app.terminal.size_shell.0 as usize / 2,
-                        _ => unreachable!(),
-                    };
-                    let scroll = match app.focus {
-                        Focus::TerminalClaude => &mut app.terminal.scroll_claude,
-                        Focus::TerminalShell => &mut app.terminal.scroll_shell,
-                        _ => unreachable!(),
-                    };
-                    *scroll = scroll.saturating_sub(page.max(1));
-                    return;
-                }
-                Action::ScrollbackTop => {
-                    match app.focus {
-                        Focus::TerminalClaude => app.terminal.scroll_claude = 1000,
-                        Focus::TerminalShell => app.terminal.scroll_shell = 1000,
-                        _ => unreachable!(),
-                    }
-                    return;
-                }
-                Action::SnapToLive => {
-                    match app.focus {
-                        Focus::TerminalClaude => app.terminal.scroll_claude = 0,
-                        Focus::TerminalShell => app.terminal.scroll_shell = 0,
-                        _ => unreachable!(),
-                    }
-                    return;
-                }
-                Action::TogglePanelExpand => {
-                    if app.expanded_panel == Some(app.focus) {
-                        app.expanded_panel = None;
-                    } else {
-                        app.expanded_panel = Some(app.focus);
-                    }
-                    return;
-                }
-                Action::OpenFileFromTerminal => {
-                    terminal::open_file_from_terminal_output(app);
-                    return;
-                }
-                Action::CycleFocusForward => {
-                    app.cycle_focus_forward();
-                    return;
-                }
-                Action::CycleFocusBackward => {
-                    app.cycle_focus_backward();
-                    return;
-                }
-                Action::NextWorktree => {
-                    app.select_next_worktree();
-                    return;
-                }
-                Action::PrevWorktree => {
-                    app.select_prev_worktree();
-                    return;
-                }
-                Action::TogglePanelOverlay => {
-                    app.toggle_panel_overlay();
-                    return;
-                }
-                _ => {} // Other global actions not intercepted in terminal
-            }
+        // Resolve via the keymap (terminal layer + global fallback, already
+        // filtered to actions that fire in the terminal). Terminal-only actions
+        // need terminal state; everything else reuses the shared global
+        // dispatch. A miss falls through to the PTY below — the keymap is the
+        // single source of truth for what the terminal steals from the inner
+        // program (no hand-maintained allowlist).
+        if let Some(action) = app.keymap.resolve(&key, KeyContext::Terminal)
+            && (handle_terminal_only_action(app, action) || dispatch_global_action(app, action))
+        {
+            return;
         }
 
         // Forward all remaining keys to the active PTY session.
@@ -418,6 +312,57 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         Focus::Viewer => handle_viewer_key(app, key),
         Focus::TerminalClaude | Focus::TerminalShell => unreachable!(),
     }
+}
+
+/// Handle the terminal-only actions (scrollback, leave, open-file) that need
+/// terminal state and have no meaning in any other panel, so they cannot route
+/// through `dispatch_global_action`. Returns `true` if handled; `false` for any
+/// other action (which the caller then sends to `dispatch_global_action`).
+/// Only called while a terminal panel is focused, so the `unreachable!()` arms
+/// hold.
+fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
+    match action {
+        Action::LeaveTerminal => app.set_focus(Focus::Explorer),
+        Action::ScrollbackUp => {
+            let page = match app.focus {
+                Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
+                Focus::TerminalShell => app.terminal.size_shell.0 as usize / 2,
+                _ => unreachable!(),
+            };
+            let scroll = match app.focus {
+                Focus::TerminalClaude => &mut app.terminal.scroll_claude,
+                Focus::TerminalShell => &mut app.terminal.scroll_shell,
+                _ => unreachable!(),
+            };
+            *scroll = scroll.saturating_add(page.max(1));
+        }
+        Action::ScrollbackDown => {
+            let page = match app.focus {
+                Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
+                Focus::TerminalShell => app.terminal.size_shell.0 as usize / 2,
+                _ => unreachable!(),
+            };
+            let scroll = match app.focus {
+                Focus::TerminalClaude => &mut app.terminal.scroll_claude,
+                Focus::TerminalShell => &mut app.terminal.scroll_shell,
+                _ => unreachable!(),
+            };
+            *scroll = scroll.saturating_sub(page.max(1));
+        }
+        Action::ScrollbackTop => match app.focus {
+            Focus::TerminalClaude => app.terminal.scroll_claude = 1000,
+            Focus::TerminalShell => app.terminal.scroll_shell = 1000,
+            _ => unreachable!(),
+        },
+        Action::SnapToLive => match app.focus {
+            Focus::TerminalClaude => app.terminal.scroll_claude = 0,
+            Focus::TerminalShell => app.terminal.scroll_shell = 0,
+            _ => unreachable!(),
+        },
+        Action::OpenFileFromTerminal => terminal::open_file_from_terminal_output(app),
+        _ => return false,
+    }
+    true
 }
 
 // ── Paste event handling ────────────────────────────────────────────────

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -304,6 +304,41 @@ impl Action {
             Action::TogglePanelOverlay => "toggle_panel_overlay",
         }
     }
+
+    /// Whether this action is intercepted while a terminal panel (PTY) is
+    /// focused. `false` (the default) means the chord is forwarded to the inner
+    /// program (shell / Claude Code), so Conductor never steals a key the
+    /// program needs — `ctrl+r` reverse-search, `ctrl+q`/XON, etc. Only the
+    /// focus/navigation/scrollback actions listed here are stolen back. This is
+    /// the single source of truth for terminal interception: both [`KeyMap::resolve`]
+    /// and [`KeyMap::keys_for_action`] honor it, so resolution == behavior ==
+    /// the rendered help, with no hand-maintained allowlist in the dispatcher.
+    fn fires_in_terminal(self) -> bool {
+        matches!(
+            self,
+            // Terminal-only actions (meaningful only with a terminal focused).
+            Action::LeaveTerminal
+                | Action::ScrollbackUp
+                | Action::ScrollbackDown
+                | Action::ScrollbackTop
+                | Action::SnapToLive
+                | Action::OpenFileFromTerminal
+                // Global focus/navigation that stays useful over a PTY.
+                | Action::FocusWorktree
+                | Action::FocusExplorer
+                | Action::FocusExplorerDiffList
+                | Action::FocusViewer
+                | Action::FocusTerminalClaude
+                | Action::FocusTerminalShell
+                | Action::CommandPalette
+                | Action::CycleFocusForward
+                | Action::CycleFocusBackward
+                | Action::NextWorktree
+                | Action::PrevWorktree
+                | Action::TogglePanelExpand
+                | Action::TogglePanelOverlay
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -485,13 +520,23 @@ impl KeyMap {
     /// Resolve a key event to an action in the given context. The context layer
     /// is consulted first, then the global layer; an unmappable key event or a
     /// total miss yields `None` (the caller passes the key through).
+    ///
+    /// In the terminal context, an action that does not [fire in the
+    /// terminal](Action::fires_in_terminal) resolves to `None` so the chord
+    /// reaches the PTY — the global fallback stays, but globally-bound actions
+    /// the terminal shouldn't steal (quit, switch-repo, …) are filtered here
+    /// rather than by an allowlist in the dispatcher.
     pub fn resolve(&self, key: &KeyEvent, context: KeyContext) -> Option<Action> {
         let input = keymap_core::KeyInput::try_from(*key).ok()?;
         let resolved = match self.contexts.get(&context) {
             Some(layer) => resolve_layered([layer, &self.global], &input),
             None => resolve_layered([&self.global], &input),
         };
-        resolved.copied()
+        let action = resolved.copied()?;
+        if context == KeyContext::Terminal && !action.fires_in_terminal() {
+            return None;
+        }
+        Some(action)
     }
 
     /// Display strings for every key bound to an action in a context (context
@@ -499,6 +544,12 @@ impl KeyMap {
     /// keymap-core canonical form (e.g. `"ctrl+d"`, `"down"`, `"G"`), which
     /// round-trips back through the config grammar.
     pub fn keys_for_action(&self, context: KeyContext, action: Action) -> Vec<String> {
+        // Keep the rendered help honest with `resolve`: in the terminal context,
+        // a globally-bound action that doesn't fire there has no working chord.
+        if context == KeyContext::Terminal && !action.fires_in_terminal() {
+            return Vec::new();
+        }
+
         let mut keys = Vec::new();
 
         if let Some(layer) = self.contexts.get(&context) {
@@ -685,6 +736,81 @@ mod tests {
         ];
         for (key, action) in cases {
             assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "{key:?}");
+        }
+    }
+
+    #[test]
+    fn terminal_intercepts_only_firing_actions() {
+        let km = default_keymap();
+
+        // Quit (ctrl+q) is global but does NOT fire in the terminal — the chord
+        // reaches the PTY instead of killing the app (so the inner program keeps
+        // ctrl+q / XON). Same for switch_repo (ctrl+r → shell reverse-search).
+        let ctrl_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL);
+        assert_eq!(km.resolve(&ctrl_q, KeyContext::Global), Some(Action::Quit));
+        assert_eq!(km.resolve(&ctrl_q, KeyContext::Terminal), None);
+        let ctrl_r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
+        assert_eq!(km.resolve(&ctrl_r, KeyContext::Global), Some(Action::SwitchRepo));
+        assert_eq!(km.resolve(&ctrl_r, KeyContext::Terminal), None);
+
+        // Focus/navigation chords ARE stolen back from the PTY.
+        let ctrl_p = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&ctrl_p, KeyContext::Terminal),
+            Some(Action::CommandPalette)
+        );
+        let alt_next = KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT);
+        assert_eq!(
+            km.resolve(&alt_next, KeyContext::Terminal),
+            Some(Action::NextWorktree)
+        );
+        let ctrl_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&ctrl_esc, KeyContext::Terminal),
+            Some(Action::LeaveTerminal)
+        );
+
+        // Rendered help stays honest with resolution: no chord is advertised for
+        // Quit in the terminal, but terminal-firing actions keep theirs.
+        assert!(km.keys_for_action(KeyContext::Terminal, Action::Quit).is_empty());
+        assert!(
+            !km.keys_for_action(KeyContext::Terminal, Action::LeaveTerminal)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn terminal_usable_actions_all_resolve_in_terminal() {
+        // Every action classified as firing in the terminal must actually have a
+        // chord that resolves there — guards against adding a variant to
+        // `fires_in_terminal` but forgetting to bind it (or vice versa).
+        let km = default_keymap();
+        let usable = [
+            Action::LeaveTerminal,
+            Action::ScrollbackUp,
+            Action::ScrollbackDown,
+            Action::ScrollbackTop,
+            Action::SnapToLive,
+            Action::OpenFileFromTerminal,
+            Action::FocusWorktree,
+            Action::FocusExplorer,
+            Action::FocusExplorerDiffList,
+            Action::FocusViewer,
+            Action::FocusTerminalClaude,
+            Action::FocusTerminalShell,
+            Action::CommandPalette,
+            Action::CycleFocusForward,
+            Action::CycleFocusBackward,
+            Action::NextWorktree,
+            Action::PrevWorktree,
+            Action::TogglePanelExpand,
+            Action::TogglePanelOverlay,
+        ];
+        for a in usable {
+            assert!(
+                !km.keys_for_action(KeyContext::Terminal, a).is_empty(),
+                "{a:?} should have a working chord in the terminal"
+            );
         }
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -38,13 +38,6 @@ pub enum Action {
     FocusViewer,
     FocusTerminalClaude,
     FocusTerminalShell,
-    // Jump to a panel AND expand it to full width in one action.
-    FocusExpandWorktree,
-    FocusExpandExplorer,
-    FocusExpandExplorerDiffList,
-    FocusExpandViewer,
-    FocusExpandTerminalClaude,
-    FocusExpandTerminalShell,
     NewClaudeCode,
     NewShell,
     OpenRepo,
@@ -156,12 +149,6 @@ impl Action {
             "focus_viewer" => Some(Action::FocusViewer),
             "focus_terminal_claude" => Some(Action::FocusTerminalClaude),
             "focus_terminal_shell" => Some(Action::FocusTerminalShell),
-            "focus_expand_worktree" => Some(Action::FocusExpandWorktree),
-            "focus_expand_explorer" => Some(Action::FocusExpandExplorer),
-            "focus_expand_explorer_diff_list" => Some(Action::FocusExpandExplorerDiffList),
-            "focus_expand_viewer" => Some(Action::FocusExpandViewer),
-            "focus_expand_terminal_claude" => Some(Action::FocusExpandTerminalClaude),
-            "focus_expand_terminal_shell" => Some(Action::FocusExpandTerminalShell),
             "new_claude_code" => Some(Action::NewClaudeCode),
             "new_shell" => Some(Action::NewShell),
             "open_repo" => Some(Action::OpenRepo),
@@ -249,12 +236,6 @@ impl Action {
             Action::FocusViewer => "focus_viewer",
             Action::FocusTerminalClaude => "focus_terminal_claude",
             Action::FocusTerminalShell => "focus_terminal_shell",
-            Action::FocusExpandWorktree => "focus_expand_worktree",
-            Action::FocusExpandExplorer => "focus_expand_explorer",
-            Action::FocusExpandExplorerDiffList => "focus_expand_explorer_diff_list",
-            Action::FocusExpandViewer => "focus_expand_viewer",
-            Action::FocusExpandTerminalClaude => "focus_expand_terminal_claude",
-            Action::FocusExpandTerminalShell => "focus_expand_terminal_shell",
             Action::NewClaudeCode => "new_claude_code",
             Action::NewShell => "new_shell",
             Action::OpenRepo => "open_repo",
@@ -665,8 +646,12 @@ mod tests {
     fn critical_defaults_resolve() {
         let km = default_keymap();
 
+        // Quit moved to ctrl+q; bare q is unbound (passes through) so it can no
+        // longer kill the app by accident.
+        let key_ctrl_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL);
+        assert_eq!(km.resolve(&key_ctrl_q, KeyContext::Global), Some(Action::Quit));
         let key_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty());
-        assert_eq!(km.resolve(&key_q, KeyContext::Global), Some(Action::Quit));
+        assert_eq!(km.resolve(&key_q, KeyContext::Global), None);
 
         let key_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty());
         assert_eq!(
@@ -686,6 +671,21 @@ mod tests {
             km.resolve(&key_ctrl_esc, KeyContext::Terminal),
             Some(Action::LeaveTerminal)
         );
+    }
+
+    #[test]
+    fn worktree_switch_and_zoom_aliases_resolve() {
+        // alt+]/alt+[ are the kitty-protocol-free aliases for ctrl+tab worktree
+        // switching; alt+m zooms the focused panel (replacing alt+shift+digit).
+        let km = default_keymap();
+        let cases = [
+            (KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT), Action::NextWorktree),
+            (KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT), Action::PrevWorktree),
+            (KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT), Action::TogglePanelExpand),
+        ];
+        for (key, action) in cases {
+            assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "{key:?}");
+        }
     }
 
     #[test]
@@ -713,16 +713,51 @@ mod tests {
     fn context_shadows_are_per_context() {
         let km = default_keymap();
 
-        // 'g' = GrabBranch in Worktree, GoToTop in Explorer.
-        let key_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty());
+        // 'c' = CherryPick in Worktree, ShowCommentList in Explorer.
+        let key_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty());
         assert_eq!(
-            km.resolve(&key_g, KeyContext::Worktree),
-            Some(Action::GrabBranch)
+            km.resolve(&key_c, KeyContext::Worktree),
+            Some(Action::CherryPick)
         );
         assert_eq!(
-            km.resolve(&key_g, KeyContext::Explorer),
-            Some(Action::GoToTop)
+            km.resolve(&key_c, KeyContext::Explorer),
+            Some(Action::ShowCommentList)
         );
+    }
+
+    #[test]
+    fn worktree_git_action_keys_resolve() {
+        // The intentional 0.67 remap of the worktree panel's git actions to
+        // more mnemonic chords. Pins the new bindings against silent regression.
+        let km = default_keymap();
+        let cases = [
+            (KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()), Action::PullWorktree),
+            (KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()), Action::CherryPick),
+            (KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()), Action::OpenPullRequest),
+            // 'X' arrives as the resolved glyph 'X' + redundant SHIFT, which
+            // keymap-core folds to match the "X" binding (cf. shift_g test).
+            (KeyEvent::new(KeyCode::Char('X'), KeyModifiers::SHIFT), Action::PruneWorktrees),
+            // g/G are now go_to_top/bottom here too (was grab/ungrab), matching
+            // every other panel; grab/ungrab moved to b/B ("branch", do/undo).
+            (KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty()), Action::GoToTop),
+            (KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT), Action::GoToBottom),
+            (KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()), Action::GrabBranch),
+            (KeyEvent::new(KeyCode::Char('B'), KeyModifiers::SHIFT), Action::UngrabBranch),
+        ];
+        for (key, action) in cases {
+            assert_eq!(km.resolve(&key, KeyContext::Worktree), Some(action), "{key:?}");
+        }
+
+        // The keys vacated by the remap are now unbound in the worktree panel
+        // (no global fallback for bare u/v/P) — a deliberate no-op, not a
+        // surprise reassignment.
+        for key in [
+            KeyEvent::new(KeyCode::Char('u'), KeyModifiers::empty()),
+            KeyEvent::new(KeyCode::Char('v'), KeyModifiers::empty()),
+            KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT),
+        ] {
+            assert_eq!(km.resolve(&key, KeyContext::Worktree), None, "{key:?}");
+        }
     }
 
     #[test]
@@ -733,7 +768,7 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
         assert_eq!(
             km.resolve(&key, KeyContext::Worktree),
-            Some(Action::UngrabBranch)
+            Some(Action::GoToBottom)
         );
     }
 
@@ -872,28 +907,6 @@ mod tests {
     }
 
     #[test]
-    fn option_shift_digit_is_focus_expand() {
-        let km = default_keymap();
-        // Option+Shift+digit (ALT|SHIFT) maximizes; plain Option+digit (ALT)
-        // only focuses. keymap-core keeps SHIFT because ALT is also held.
-        let cases = [
-            ('1', Action::FocusExpandWorktree),
-            ('4', Action::FocusExpandViewer),
-            ('6', Action::FocusExpandTerminalShell),
-        ];
-        for (c, action) in cases {
-            let key = KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT | KeyModifiers::SHIFT);
-            assert_eq!(km.resolve(&key, KeyContext::Terminal), Some(action));
-        }
-
-        let alt_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT);
-        assert_eq!(
-            km.resolve(&alt_1, KeyContext::Global),
-            Some(Action::FocusWorktree)
-        );
-    }
-
-    #[test]
     fn ctrl_f_is_filename_search_in_viewer() {
         let km = default_keymap();
         let key = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL);
@@ -933,15 +946,15 @@ mod tests {
     fn lowercase_char_with_shift_is_not_recased() {
         // Behavior divergence from the old hand-rolled normalizer, locked in:
         // keymap-core trusts the glyph and only drops a redundant sole SHIFT, so
-        // 'g'+SHIFT stays Char('g') and hits the bare 'g' binding (GrabBranch) —
-        // it is NOT re-cased to 'G' (UngrabBranch). A terminal that delivers the
-        // resolved glyph 'G' (the common case) still hits UngrabBranch; see
+        // 'g'+SHIFT stays Char('g') and hits the bare 'g' binding (GoToTop) — it
+        // is NOT re-cased to 'G' (GoToBottom). A terminal that delivers the
+        // resolved glyph 'G' (the common case) still hits GoToBottom; see
         // `shift_g_resolves_uppercase_binding`.
         let km = default_keymap();
         let key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::SHIFT);
         assert_eq!(
             km.resolve(&key, KeyContext::Worktree),
-            Some(Action::GrabBranch)
+            Some(Action::GoToTop)
         );
     }
 
@@ -965,9 +978,11 @@ mod tests {
     }
 
     #[test]
-    fn alt_digit_and_alt_shift_digit_stay_distinct() {
-        // The "keep SHIFT when another modifier is held" rule must keep these
-        // apart, or focus and focus-expand would collapse into one another.
+    fn alt_shift_digit_does_not_fold_into_alt_digit() {
+        // The "keep SHIFT when another modifier is held" rule: alt+1 focuses the
+        // worktree, but alt+shift+1 must NOT drop the SHIFT and collapse onto it.
+        // alt+shift+digit is now unbound (focus+expand was removed), so a correct
+        // resolver returns None rather than folding to FocusWorktree.
         let km = default_keymap();
         let alt_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT);
         let alt_shift_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT | KeyModifiers::SHIFT);
@@ -975,10 +990,7 @@ mod tests {
             km.resolve(&alt_1, KeyContext::Global),
             Some(Action::FocusWorktree)
         );
-        assert_eq!(
-            km.resolve(&alt_shift_1, KeyContext::Global),
-            Some(Action::FocusExpandWorktree)
-        );
+        assert_eq!(km.resolve(&alt_shift_1, KeyContext::Global), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bundled as `0.67.0` (MINOR — breaking keybinding defaults, but pre-1.0 so not MAJOR):

1. **Source the keymap crates from crates.io** instead of a pinned git rev.
2. **Overhaul several non-intuitive default keybindings** (breaking, intentional).
3. **Make terminal key interception keymap-driven** (remove the hardcoded allowlist).

## 1. keymap crates: git -> crates.io

`keymap-core` / `keymap-config` were pinned to a `keymap-rs` git rev; both are now published (`0.1.0`), so we depend on them via crates.io. Kept the two low-level crates rather than adopting the `keymap-suite` facade (conductor already has its own facade in `src/keymap.rs` and deliberately stays sequence-free).

## 2. Keybinding overhaul (breaking)

### Worktree panel — mnemonic git actions
| action | old | new | why |
|---|---|---|---|
| cherry_pick | `p` | `c` | **c**herry |
| pull_worktree | `u` | `p` | **p**ull |
| open_pull_request | `v` | `o` | **o**pen (PR) |
| prune_worktrees | `P` | `X` | pairs with `x`=delete |

> `p` changed meaning (was cherry-pick, now pull). pull flashes `Pulling '<branch>'…` so a mis-press is visible.

### Worktree panel — `g`/`G` consistency
- `g`/`G` are now **go_to_top / go_to_bottom** here too (was grab/ungrab), matching every other panel.
- grab/ungrab moved to **`b`/`B`** (b for "branch", shift for the undo).

### Global
- **Quit**: `q`/`Q` -> **`ctrl+q`** (a stray `q` can no longer kill the app).
- **Worktree switch**: added kitty-protocol-free aliases **`alt+]`=next / `alt+[`=prev** (ctrl+tab still works where the protocol is available).
- **Focus + maximize**: dropped the hard-to-press `alt+shift+1..6` combo (and the 6 `FocusExpand*` actions). Now: focus with `alt+<digit>`, then zoom with **`alt+m`** (`toggle_panel_expand`; `super+space` retained).

## 3. Terminal key interception: keymap-driven, not an allowlist

The terminal panel forwards most keys to the inner PTY (Claude Code / shell) and only steals a few back. That "which keys are stolen" decision was encoded **twice and inconsistently**: `resolve(Terminal)` falls back to the global layer (so every global chord resolved), but a hardcoded `match` allowlist in `event/mod.rs` re-decided which of those actually fired. A globally-bound action like `ctrl+q`=quit *resolved* to `Action::Quit` in the terminal yet was silently forwarded to the PTY — resolution disagreed with behavior, and the command palette advertised chords that don't work there.

This replaces the allowlist with a single source of truth: `Action::fires_in_terminal()`. `resolve` (and `keys_for_action`, for honest help) now filter terminal-context actions through it, and the dispatcher reuses the shared `dispatch_global_action` instead of re-implementing ~15 arms. Behavior is preserved (the `fires_in_terminal` set == the old allowlist); the win is that resolution == behavior == rendered help, with no second source of truth.

- **`ctrl+q` deliberately does NOT quit from the terminal panel** — it reaches the inner program (so Claude/shell keep ctrl+q / XON; leave with `ctrl+esc` first, then quit). This is now an honest, intentional omission rather than an allowlist accident.
- Shell-important chords like `ctrl+r` (reverse-search) correctly pass through to the PTY because `SwitchRepo.fires_in_terminal()` is `false`.

## Tests
- 272 pass, `cargo clippy` clean.
- Keybinding pins: `worktree_git_action_keys_resolve`, `worktree_switch_and_zoom_aliases_resolve`, updated `critical_defaults_resolve` / `alt_shift_digit_does_not_fold_into_alt_digit`.
- Terminal pins: `terminal_intercepts_only_firing_actions` (ctrl+q/ctrl+r pass to PTY; ctrl+p/alt+]/ctrl+esc stolen; help honest) and `terminal_usable_actions_all_resolve_in_terminal` (regression net so a `fires_in_terminal` variant can't drift from its binding).

## Manual verification still needed
- `ctrl+q` actually quits on the target terminal(s) (XON/flow-control caveat) when focus is NOT in the terminal panel.
- `alt+[` / `alt+]` and `alt+m` are delivered by the terminal.
