### PR TITLE
feat: render summary markdown links and GFM (strikethrough, task lists, tables)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.67.1"
+version = "0.68.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.67.1"
+version = "0.68.0"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -3,9 +3,26 @@
 //! Renders a change summary written in Markdown into styled, word-wrapped
 //! ratatui `Line`s. It is deliberately **not** a CommonMark implementation: the
 //! summary is a short, self-authored PR-description-style note, so a small
-//! line-oriented parser covers the useful subset (headings, lists, block
-//! quotes, fenced code blocks, horizontal rules, and inline `code`/**bold**/
-//! *italic*) without pulling in a markdown crate.
+//! line-oriented parser covers the useful subset (headings, lists, task-list
+//! checkboxes, block quotes, fenced code blocks, horizontal rules, GFM tables,
+//! links, and inline `code`/**bold**/*italic*/~~strikethrough~~) without
+//! pulling in a markdown crate.
+//!
+//! - **Links `[text](url)`** render the text as an underlined `info`-coloured
+//!   run followed by the URL in a recessive, muted parenthetical. Terminals
+//!   can't reliably click links, so keeping the URL visible lets the reader
+//!   copy it; a self-titled or empty link collapses to just the URL.
+//! - **Task checkboxes `- [ ]`/`- [x]`** use ASCII brackets (not `☐`/`☑`,
+//!   whose East-Asian *ambiguous* width misaligns in CJK-wide terminals); the
+//!   `[x]` is coloured and completed items' text is muted so the eye lands on
+//!   what's left.
+//! - **Strikethrough `~~x~~`** applies `CROSSED_OUT` *and* a muted colour, so
+//!   the "removed/deprecated" meaning survives even where the terminal ignores
+//!   the SGR 9 escape.
+//! - **Tables** render borderless (bold header, a rule, aligned rows) rather
+//!   than with box-drawing — borders are too width-hungry for the narrow
+//!   summary column. Over-wide cells truncate with `…`. A future refinement
+//!   could fall back to a `key: value` list when even truncation can't fit.
 //!
 //! Design notes:
 //! - **Backward compatible.** Plain text containing no Markdown syntax flows
@@ -46,6 +63,9 @@ enum MdBlock {
         /// `Some("1")` for an ordered item (keeps the author's number), `None`
         /// for a bullet.
         ordered: Option<String>,
+        /// GFM task marker: `None` = plain item, `Some(false)` = `[ ]` (open),
+        /// `Some(true)` = `[x]` (done).
+        checked: Option<bool>,
         text: String,
         /// Leading-whitespace columns before the marker (nesting indent).
         indent: usize,
@@ -57,10 +77,26 @@ enum MdBlock {
         lang: Option<String>,
         lines: Vec<String>,
     },
+    /// A GFM pipe table: a header row, an alignment row, and zero or more body
+    /// rows. `aligns` carries one entry per header column.
+    Table {
+        headers: Vec<String>,
+        aligns: Vec<Align>,
+        rows: Vec<Vec<String>>,
+    },
     /// `---` / `***` / `___` (3+ of the same marker).
     Rule,
     /// A blank source line (preserved as paragraph spacing).
     Blank,
+}
+
+/// Per-column text alignment for a [`MdBlock::Table`], from the delimiter row's
+/// colons (`:--` left, `--:` right, `:-:` center).
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Align {
+    Left,
+    Center,
+    Right,
 }
 
 /// Render Markdown `text` into word-wrapped, styled lines no wider than `width`.
@@ -115,6 +151,15 @@ fn parse_blocks(text: &str) -> Vec<MdBlock> {
                 i += 1;
             }
             blocks.push(MdBlock::CodeBlock { lang, lines: body });
+            continue;
+        }
+
+        // GFM table — a `|`-bearing line immediately followed by a valid
+        // delimiter row. The lookahead helper consumes the whole table (and
+        // returns `None`, eating nothing, when it isn't really a table).
+        if let Some((table, consumed)) = parse_table_at(&lines, i) {
+            blocks.push(table);
+            i += consumed;
             continue;
         }
 
@@ -191,7 +236,8 @@ fn parse_heading(s: &str) -> Option<(u8, String)> {
     Some((hashes as u8, rest.trim_start().to_string()))
 }
 
-/// `- `/`* `/`+ ` (bullet) or `N. `/`N) ` (ordered) → a `ListItem`.
+/// `- `/`* `/`+ ` (bullet) or `N. `/`N) ` (ordered) → a `ListItem`. A leading
+/// GFM task marker (`[ ] `/`[x] `) on the item text is split off into `checked`.
 fn parse_list_item(line: &str) -> Option<MdBlock> {
     let indent = line.len() - line.trim_start().len();
     let s = line.trim_start();
@@ -201,9 +247,11 @@ fn parse_list_item(line: &str) -> Option<MdBlock> {
         .or_else(|| s.strip_prefix("* "))
         .or_else(|| s.strip_prefix("+ "))
     {
+        let (checked, text) = split_task_marker(rest);
         return Some(MdBlock::ListItem {
             ordered: None,
-            text: rest.to_string(),
+            checked,
+            text: text.to_string(),
             indent,
         });
     }
@@ -212,14 +260,109 @@ fn parse_list_item(line: &str) -> Option<MdBlock> {
     if !digits.is_empty() {
         let after = &s[digits.len()..];
         if let Some(rest) = after.strip_prefix(". ").or_else(|| after.strip_prefix(") ")) {
+            let (checked, text) = split_task_marker(rest);
             return Some(MdBlock::ListItem {
                 ordered: Some(digits),
-                text: rest.to_string(),
+                checked,
+                text: text.to_string(),
                 indent,
             });
         }
     }
     None
+}
+
+/// Split a leading GFM task marker off list-item text. `"[ ] foo"` →
+/// `(Some(false), "foo")`; `"[x] foo"`/`"[X] foo"` → `(Some(true), "foo")`; an
+/// empty task `"[ ]"` → `(Some(_), "")`. A marker must be followed by a space or
+/// end-of-string, so `"[ ]x"` and `"[y]"` stay literal `(None, original)`.
+fn split_task_marker(text: &str) -> (Option<bool>, &str) {
+    for (pat, val) in [("[ ]", false), ("[x]", true), ("[X]", true)] {
+        if let Some(rest) = text.strip_prefix(pat) {
+            if rest.is_empty() {
+                return (Some(val), "");
+            }
+            if let Some(after) = rest.strip_prefix(' ') {
+                return (Some(val), after);
+            }
+        }
+    }
+    (None, text)
+}
+
+/// If a GFM pipe table starts at `lines[i]` — a `|`-bearing line immediately
+/// followed by a valid delimiter row — parse it and return the block plus the
+/// number of source lines consumed. Returns `None` (consuming nothing) when it
+/// isn't a real table, so a paragraph like `a | b` is never misread.
+///
+/// The delimiter row is the gate: if it isn't all valid `:?-+:?` cells the whole
+/// candidate is rejected before any line is consumed.
+fn parse_table_at(lines: &[&str], i: usize) -> Option<(MdBlock, usize)> {
+    let header_line = lines.get(i)?;
+    if !header_line.contains('|') {
+        return None;
+    }
+    let delim_line = lines.get(i + 1)?;
+    let aligns = parse_alignments(&split_table_row(delim_line))?;
+    let headers = split_table_row(header_line);
+    if headers.is_empty() {
+        return None;
+    }
+
+    // Body rows: subsequent non-blank `|`-bearing lines.
+    let mut rows = Vec::new();
+    let mut j = i + 2;
+    while let Some(l) = lines.get(j) {
+        if l.trim().is_empty() || !l.contains('|') {
+            break;
+        }
+        rows.push(split_table_row(l));
+        j += 1;
+    }
+
+    Some((
+        MdBlock::Table {
+            headers,
+            aligns,
+            rows,
+        },
+        j - i,
+    ))
+}
+
+/// Split one table row into trimmed cells, dropping the empty cells created by
+/// the surrounding `|`. `"| a | b |"` and `"a | b"` both yield `["a", "b"]`.
+/// (Escaped `\|` and pipes inside `code` are out of scope.)
+fn split_table_row(line: &str) -> Vec<String> {
+    let t = line.trim();
+    let t = t.strip_prefix('|').unwrap_or(t);
+    let t = t.strip_suffix('|').unwrap_or(t);
+    t.split('|').map(|c| c.trim().to_string()).collect()
+}
+
+/// Parse a delimiter row's cells into alignments, or `None` if any cell isn't a
+/// valid `:?-+:?` separator (≥1 dash). Doubles as the "is this a table?" gate.
+fn parse_alignments(cells: &[String]) -> Option<Vec<Align>> {
+    if cells.is_empty() {
+        return None;
+    }
+    cells
+        .iter()
+        .map(|c| {
+            let c = c.trim();
+            let left = c.starts_with(':');
+            let right = c.ends_with(':');
+            let core = c.trim_start_matches(':').trim_end_matches(':');
+            if core.is_empty() || !core.chars().all(|ch| ch == '-') {
+                return None;
+            }
+            Some(match (left, right) {
+                (true, true) => Align::Center,
+                (false, true) => Align::Right,
+                _ => Align::Left,
+            })
+        })
+        .collect()
 }
 
 // ── Rendering ────────────────────────────────────────────────────────
@@ -258,25 +401,44 @@ fn render_block(
         }
         MdBlock::ListItem {
             ordered,
+            checked,
             text,
             indent,
         } => {
             let indent = (*indent).min(8);
-            let marker = match ordered {
-                Some(num) => format!("{num}. "),
-                None => "\u{2022} ".to_string(),
+            // Marker is a truth table over (checked, ordered).
+            let marker = match (checked, ordered) {
+                (Some(true), _) => "[x] ".to_string(),
+                (Some(false), _) => "[ ] ".to_string(),
+                (None, Some(num)) => format!("{num}. "),
+                (None, None) => "\u{2022} ".to_string(),
+            };
+            let marker_color = match checked {
+                Some(true) => theme.success,
+                _ => theme.accent,
+            };
+            // Completed items recede so the eye lands on what's left.
+            let text_color = if *checked == Some(true) {
+                theme.muted
+            } else {
+                theme.fg
             };
             let prefix_w = indent + display_width(&marker);
             let inner = width.saturating_sub(prefix_w).max(1);
-            let cells = spans_to_cells(&inline_spans(text, Style::default().fg(theme.fg), theme));
+            let cells = spans_to_cells(&inline_spans(text, Style::default().fg(text_color), theme));
             let pad = " ".repeat(indent);
-            let first = Span::styled(format!("{pad}{marker}"), Style::default().fg(theme.accent));
+            let first = Span::styled(format!("{pad}{marker}"), Style::default().fg(marker_color));
             let cont = Span::styled(" ".repeat(prefix_w), Style::default());
             with_prefix(wrap_cells(&cells, inner, false), first, cont)
         }
         MdBlock::CodeBlock { lang, lines } => {
             render_code_block(lang.as_deref(), lines, width, theme, syntax_set, syntect_theme)
         }
+        MdBlock::Table {
+            headers,
+            aligns,
+            rows,
+        } => render_table(headers, aligns, rows, width, theme),
     }
 }
 
@@ -329,8 +491,9 @@ fn render_code_block(
 
 // ── Inline parsing ───────────────────────────────────────────────────
 
-/// Parse inline `code`, `**bold**`, and `*italic*` out of `text`, styling the
-/// rest with `base`. Unmatched/space-flanked delimiters stay literal.
+/// Parse inline `code`, `**bold**`, `*italic*`, `~~strikethrough~~`, and
+/// `[text](url)` links out of `text`, styling the rest with `base`.
+/// Unmatched/space-flanked delimiters stay literal.
 fn inline_spans(text: &str, base: Style, theme: &Theme) -> Vec<Span<'static>> {
     let code_style = Style::default().fg(theme.warning);
     let chars: Vec<char> = text.chars().collect();
@@ -381,6 +544,43 @@ fn inline_spans(text: &str, base: Style, theme: &Theme) -> Vec<Span<'static>> {
                 i = j + 1;
                 continue;
             }
+        } else if c == '['
+            && let Some(link) = parse_link_at(&chars, i)
+        {
+            flush(&mut buf, &mut spans, base);
+            let link_style = base.fg(theme.info).add_modifier(Modifier::UNDERLINED);
+            if link.text.is_empty() || link_text_matches_url(&link.text, &link.url) {
+                // Empty or self-titled link: show the URL once, styled.
+                spans.push(Span::styled(link.url, link_style));
+            } else {
+                // Link text (which may itself contain inline markup) plus the
+                // URL in a recessive, footnote-like parenthetical so the
+                // destination stays visible/copyable in a non-clickable TUI.
+                spans.extend(inline_spans(&link.text, link_style, theme));
+                spans.push(Span::styled(
+                    format!(" ({})", link.url),
+                    Style::default().fg(theme.muted),
+                ));
+            }
+            i = link.next_i;
+            continue;
+        } else if c == '~'
+            && i + 2 < n
+            && chars[i + 1] == '~'
+            && !chars[i + 2].is_whitespace()
+            && let Some(j) = find_close_strike(&chars, i + 2)
+        {
+            // Strikethrough `~~text~~`: crossed out AND muted, so the
+            // "removed/deprecated" meaning survives terminals that ignore the
+            // SGR 9 (crossed-out) escape. (A single `~` stays literal; a `~~~`
+            // run at line start is a code fence, handled before inline.)
+            flush(&mut buf, &mut spans, base);
+            spans.push(Span::styled(
+                collect(&chars, i + 2, j),
+                base.fg(theme.muted).add_modifier(Modifier::CROSSED_OUT),
+            ));
+            i = j + 2;
+            continue;
         }
 
         buf.push(c);
@@ -422,6 +622,280 @@ fn find_close_bold(chars: &[char], from: usize) -> Option<usize> {
 /// non-space).
 fn find_close_italic(chars: &[char], from: usize) -> Option<usize> {
     (from..chars.len()).find(|&k| chars[k] == '*' && !chars[k - 1].is_whitespace())
+}
+
+/// Find the closing `~~` at or after `from` (right-flanking: preceded by a
+/// non-space, with non-empty content). Mirrors [`find_close_bold`].
+fn find_close_strike(chars: &[char], from: usize) -> Option<usize> {
+    let n = chars.len();
+    let mut k = from;
+    while k + 1 < n {
+        if chars[k] == '~' && chars[k + 1] == '~' && k > from && !chars[k - 1].is_whitespace() {
+            return Some(k);
+        }
+        k += 1;
+    }
+    None
+}
+
+/// A parsed `[text](url)` inline link.
+struct Link {
+    /// The raw link text (may itself contain inline markup).
+    text: String,
+    url: String,
+    /// Index just past the closing `)`.
+    next_i: usize,
+}
+
+/// Parse a `[text](url)` link whose `[` is at `chars[i]`. Returns `None` when
+/// the link is not well-formed (no `]`, no immediately-following `(`, or no
+/// closing `)`), so the caller leaves the `[` literal.
+///
+/// Deliberate simplification: the first `)` closes the URL, so URLs containing
+/// a literal `)` (e.g. some Wikipedia links) aren't supported — the remainder
+/// falls back to literal text rather than panicking.
+fn parse_link_at(chars: &[char], i: usize) -> Option<Link> {
+    let text_end = find_char_from(chars, i + 1, ']')?;
+    let url_open = text_end + 1;
+    if chars.get(url_open) != Some(&'(') {
+        return None;
+    }
+    let url_end = find_char_from(chars, url_open + 1, ')')?;
+    Some(Link {
+        text: collect(chars, i + 1, text_end),
+        url: collect(chars, url_open + 1, url_end),
+        next_i: url_end + 1,
+    })
+}
+
+/// Index of the first `target` char at or after `from`, if any.
+fn find_char_from(chars: &[char], from: usize, target: char) -> Option<usize> {
+    (from..chars.len()).find(|&k| chars[k] == target)
+}
+
+/// Whether the link text is effectively its own URL, so the URL needn't be
+/// repeated in parentheses. Compared case-insensitively, ignoring a trailing
+/// slash (so `[https://x/](https://x)` collapses).
+fn link_text_matches_url(text: &str, url: &str) -> bool {
+    let norm = |s: &str| s.trim_end_matches('/').to_ascii_lowercase();
+    norm(text) == norm(url)
+}
+
+// ── Tables ───────────────────────────────────────────────────────────
+
+/// Render a GFM table borderless: a bold header row, a horizontal rule, then
+/// aligned body rows with columns separated by two spaces. Box-drawing borders
+/// are intentionally omitted — they cost too much width in the narrow summary
+/// column. Over-wide cells are truncated with `…`. (A future refinement could
+/// fall back to a `key: value` list when even truncation can't fit.)
+fn render_table(
+    headers: &[String],
+    aligns: &[Align],
+    rows: &[Vec<String>],
+    width: usize,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let ncols = headers.len();
+    if ncols == 0 {
+        return vec![Line::from("")];
+    }
+
+    // Normalise alignments and body rows to exactly `ncols` columns so the
+    // render side never indexes past the header column count.
+    let aligns: Vec<Align> = (0..ncols)
+        .map(|k| aligns.get(k).copied().unwrap_or(Align::Left))
+        .collect();
+    let rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| {
+            let mut row: Vec<String> = r.iter().take(ncols).cloned().collect();
+            row.resize(ncols, String::new());
+            row
+        })
+        .collect();
+
+    let widths = fit_col_widths(&natural_col_widths(headers, &rows, theme), width);
+
+    let header_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+    let body_style = Style::default().fg(theme.fg);
+
+    let mut out = Vec::with_capacity(rows.len() + 2);
+    out.push(render_table_row(
+        headers,
+        &widths,
+        &aligns,
+        header_style,
+        width,
+        theme,
+    ));
+    // Rule under the header, clamped to the panel width.
+    let rule_w = (widths.iter().sum::<usize>() + 2 * ncols.saturating_sub(1)).min(width);
+    out.push(Line::from(Span::styled(
+        "\u{2500}".repeat(rule_w),
+        Style::default().fg(theme.muted),
+    )));
+    for row in &rows {
+        out.push(render_table_row(
+            row,
+            &widths,
+            &aligns,
+            body_style,
+            width,
+            theme,
+        ));
+    }
+    out
+}
+
+/// Natural width of each column = max rendered (markup-stripped) display width
+/// over the header and every body cell.
+fn natural_col_widths(headers: &[String], rows: &[Vec<String>], theme: &Theme) -> Vec<usize> {
+    let mut w: Vec<usize> = headers.iter().map(|h| rendered_width(h, theme)).collect();
+    for row in rows {
+        for (k, cell) in row.iter().enumerate() {
+            if let Some(col) = w.get_mut(k) {
+                *col = (*col).max(rendered_width(cell, theme));
+            }
+        }
+    }
+    w
+}
+
+/// Display width of `text` after inline markup is stripped, so column widths
+/// match what actually renders (not the raw `**bold**` source).
+fn rendered_width(text: &str, theme: &Theme) -> usize {
+    cells_width(&spans_to_cells(&inline_spans(text, Style::default(), theme)))
+}
+
+/// Shrink natural column widths so the row (cells + 2-space separators) fits
+/// `width`. Repeatedly trims the widest column by one (not proportional —
+/// overkill for a rare wide table); every column keeps at least 1 column.
+fn fit_col_widths(natural: &[usize], width: usize) -> Vec<usize> {
+    let ncols = natural.len();
+    if ncols == 0 {
+        return vec![];
+    }
+    let seps = 2 * (ncols - 1);
+    let avail = width.saturating_sub(seps).max(ncols); // >= 1 per column
+    let mut w: Vec<usize> = natural.iter().map(|&x| x.max(1).min(avail)).collect();
+    while w.iter().sum::<usize>() > avail {
+        let maxw = *w.iter().max().unwrap();
+        if maxw <= 1 {
+            break; // can't shrink further; the final clip guards the width bound
+        }
+        let idx = w.iter().position(|&x| x == maxw).unwrap();
+        w[idx] -= 1;
+    }
+    w
+}
+
+/// Render one table row into a `Line`: each cell fitted to its column width and
+/// alignment, columns joined by two spaces, then the whole hard-clipped to
+/// `width` as a final guard for degenerate (tiny) widths.
+fn render_table_row(
+    cells: &[String],
+    widths: &[usize],
+    aligns: &[Align],
+    base: Style,
+    width: usize,
+    theme: &Theme,
+) -> Line<'static> {
+    let mut row: Vec<Cell> = Vec::new();
+    for (k, &col_w) in widths.iter().enumerate() {
+        if k > 0 {
+            row.push(Cell { ch: ' ', style: base });
+            row.push(Cell { ch: ' ', style: base });
+        }
+        let text = cells.get(k).map(String::as_str).unwrap_or("");
+        let align = aligns.get(k).copied().unwrap_or(Align::Left);
+        row.extend(fit_cell(text, col_w, align, base, theme));
+    }
+    cells_to_line(&clip_cells(row, width))
+}
+
+/// Fit `text` into exactly `col_w` display columns: render its inline markup,
+/// truncate (with a trailing `…`) when too wide, then pad per `align`. Returns
+/// cells whose total display width is `col_w` (empty when `col_w` is 0).
+/// Works on `Cell`s, so truncation never splits a multibyte char.
+fn fit_cell(text: &str, col_w: usize, align: Align, base: Style, theme: &Theme) -> Vec<Cell> {
+    if col_w == 0 {
+        return Vec::new();
+    }
+    let cells = truncate_cells(spans_to_cells(&inline_spans(text, base, theme)), col_w);
+    let pad = col_w.saturating_sub(cells_width(&cells));
+    let space = |n: usize| -> Vec<Cell> {
+        (0..n).map(|_| Cell { ch: ' ', style: base }).collect()
+    };
+    match align {
+        Align::Left => {
+            let mut out = cells;
+            out.extend(space(pad));
+            out
+        }
+        Align::Right => {
+            let mut out = space(pad);
+            out.extend(cells);
+            out
+        }
+        Align::Center => {
+            let left = pad / 2;
+            let mut out = space(left);
+            out.extend(cells);
+            out.extend(space(pad - left));
+            out
+        }
+    }
+}
+
+/// Truncate `cells` to at most `max_w` display columns, appending `…` (in the
+/// last kept cell's style) only when content was actually cut. Truncates by
+/// display width on char boundaries, so multibyte/CJK content never panics.
+fn truncate_cells(cells: Vec<Cell>, max_w: usize) -> Vec<Cell> {
+    if cells_width(&cells) <= max_w {
+        return cells;
+    }
+    if max_w == 0 {
+        return Vec::new();
+    }
+    let budget = max_w - 1; // reserve one column for the ellipsis
+    let mut out: Vec<Cell> = Vec::new();
+    let mut w = 0;
+    for cell in cells {
+        let cw = char_width(cell.ch);
+        if w + cw > budget {
+            break;
+        }
+        out.push(cell);
+        w += cw;
+    }
+    let style = out.last().map(|c| c.style).unwrap_or_default();
+    out.push(Cell {
+        ch: '\u{2026}',
+        style,
+    });
+    out
+}
+
+/// Hard-clip `cells` to at most `width` display columns (no ellipsis). The final
+/// guard that keeps every table line within the width bound even when the column
+/// math can't fit (e.g. a 4-column table in a 3-wide panel).
+fn clip_cells(cells: Vec<Cell>, width: usize) -> Vec<Cell> {
+    let mut out = Vec::new();
+    let mut w = 0;
+    for cell in cells {
+        let cw = char_width(cell.ch);
+        if w + cw > width {
+            break;
+        }
+        out.push(cell);
+        w += cw;
+    }
+    out
+}
+
+/// Total display width of a cell slice.
+fn cells_width(cells: &[Cell]) -> usize {
+    cells.iter().map(|c| char_width(c.ch)).sum()
 }
 
 // ── Span wrapping ────────────────────────────────────────────────────
@@ -662,10 +1136,10 @@ mod tests {
         assert_eq!(
             parse_blocks("- a\n* b\n1. c\n2) d"),
             vec![
-                MdBlock::ListItem { ordered: None, text: "a".to_string(), indent: 0 },
-                MdBlock::ListItem { ordered: None, text: "b".to_string(), indent: 0 },
-                MdBlock::ListItem { ordered: Some("1".to_string()), text: "c".to_string(), indent: 0 },
-                MdBlock::ListItem { ordered: Some("2".to_string()), text: "d".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: None, checked: None, text: "a".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: None, checked: None, text: "b".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: Some("1".to_string()), checked: None, text: "c".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: Some("2".to_string()), checked: None, text: "d".to_string(), indent: 0 },
             ]
         );
         // No space after the marker → plain paragraph.
@@ -766,10 +1240,282 @@ mod tests {
     fn unclosed_inline_delimiters_stay_literal() {
         let (theme, _, _) = fixtures();
         let base = Style::default().fg(theme.fg);
-        for input in ["a `b", "a *b", "a **b", "*", "`"] {
+        for input in [
+            "a `b", "a *b", "a **b", "*", "`", "a ~~b", "~~", "~", "a ~ b", "~/foo",
+            "a ~~ b ~~ c",
+        ] {
             let spans = inline_spans(input, base, &theme);
             assert_eq!(joined(&spans), input, "input {input:?} should be literal");
         }
+    }
+
+    #[test]
+    fn strikethrough_is_styled_and_muted() {
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+        let spans = inline_spans("keep ~~drop~~ this", base, &theme);
+        assert_eq!(joined(&spans), "keep drop this");
+        let struck = spans.iter().find(|s| s.content == "drop").unwrap();
+        assert!(struck.style.add_modifier.contains(Modifier::CROSSED_OUT));
+        assert_eq!(struck.style.fg, Some(theme.muted));
+    }
+
+    #[test]
+    fn strikethrough_does_not_nest_inner_markup() {
+        // Like bold/italic, strikethrough emits its content literally (no
+        // nesting) — but inline markup OUTSIDE the strike still works.
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+        let spans = inline_spans("~~old **bold**~~ and **real**", base, &theme);
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.content == "old **bold**"
+                    && s.style.add_modifier.contains(Modifier::CROSSED_OUT)),
+            "struck run keeps `**` literal"
+        );
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.content == "real" && s.style.add_modifier.contains(Modifier::BOLD)),
+            "bold outside the strike still applies"
+        );
+    }
+
+    #[test]
+    fn bare_tilde_run_is_fence_not_strikethrough() {
+        // `~~~` at line start is a code fence, parsed before inline strike.
+        assert!(matches!(
+            parse_blocks("~~~\ncode\n~~~").as_slice(),
+            [MdBlock::CodeBlock { .. }]
+        ));
+    }
+
+    // ── Task checkboxes ──
+
+    #[test]
+    fn task_checkboxes_parse() {
+        assert_eq!(
+            parse_blocks("- [ ] todo\n- [x] done\n- [X] also\n1. [ ] num"),
+            vec![
+                MdBlock::ListItem { ordered: None, checked: Some(false), text: "todo".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: None, checked: Some(true), text: "done".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: None, checked: Some(true), text: "also".to_string(), indent: 0 },
+                MdBlock::ListItem { ordered: Some("1".to_string()), checked: Some(false), text: "num".to_string(), indent: 0 },
+            ]
+        );
+    }
+
+    #[test]
+    fn non_checkboxes_stay_plain_items() {
+        // Malformed markers must NOT become checkboxes; text is preserved verbatim.
+        for (input, want_text) in [
+            ("- [y] thing", "[y] thing"),
+            ("- [] thing", "[] thing"),
+            ("- [ ]nospace", "[ ]nospace"),
+            ("- [ x] thing", "[ x] thing"),
+        ] {
+            assert_eq!(
+                parse_blocks(input),
+                vec![MdBlock::ListItem {
+                    ordered: None,
+                    checked: None,
+                    text: want_text.to_string(),
+                    indent: 0,
+                }],
+                "{input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_task_checkbox_parses() {
+        assert_eq!(
+            parse_blocks("- [ ]"),
+            vec![MdBlock::ListItem {
+                ordered: None,
+                checked: Some(false),
+                text: String::new(),
+                indent: 0,
+            }]
+        );
+    }
+
+    #[test]
+    fn checkbox_renders_within_width() {
+        // At widths comfortably above the `[x] ` marker, lines stay in bounds.
+        // (Like all list items, a width narrower than the marker can't be
+        // honoured — that degenerate case is covered by `never_panics`.)
+        for width in [8usize, 20, 40] {
+            for line in render("- [x] done\n- [ ] あいうえお task", width) {
+                assert!(display_width(&line_text(&line)) <= width);
+            }
+        }
+    }
+
+    // ── Tables ──
+
+    #[test]
+    fn table_parses_headers_aligns_rows() {
+        assert_eq!(
+            parse_blocks("| h1 | h2 |\n| --- | :--: |\n| a | b |\n| c | d |"),
+            vec![MdBlock::Table {
+                headers: vec!["h1".to_string(), "h2".to_string()],
+                aligns: vec![Align::Left, Align::Center],
+                rows: vec![
+                    vec!["a".to_string(), "b".to_string()],
+                    vec!["c".to_string(), "d".to_string()],
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn pipe_paragraph_is_not_a_table() {
+        // No delimiter row → not a table; no source line is eaten.
+        assert_eq!(
+            parse_blocks("a | b\nc | d"),
+            vec![
+                MdBlock::Paragraph("a | b".to_string()),
+                MdBlock::Paragraph("c | d".to_string()),
+            ]
+        );
+        // Header-looking line at EOF with no delimiter.
+        assert_eq!(
+            parse_blocks("| h1 | h2 |"),
+            vec![MdBlock::Paragraph("| h1 | h2 |".to_string())]
+        );
+        // Delimiter with zero dashes is not a delimiter.
+        assert_eq!(
+            parse_blocks("| a | b |\n| : | : |").len(),
+            2,
+            "no-dash second line means two paragraphs, not a table"
+        );
+    }
+
+    #[test]
+    fn table_cell_splitting_normalizes_outer_pipes() {
+        assert_eq!(split_table_row("| a | b |"), vec!["a", "b"]);
+        assert_eq!(split_table_row("a | b"), vec!["a", "b"]);
+        assert_eq!(split_table_row("| a | b"), vec!["a", "b"]);
+        assert_eq!(split_table_row("a | b |"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn table_renders_within_width_and_truncates() {
+        // Header + rule + 2 body rows = 4 lines, all within width.
+        let table = "| name | id |\n| --- | --: |\n| alice | 1 |\n| bob | 22 |";
+        for width in [0usize, 1, 2, 3, 8, 20, 80] {
+            let lines = render(table, width);
+            for line in &lines {
+                assert!(
+                    display_width(&line_text(line)) <= width.max(1),
+                    "table line exceeds width {width}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_cell_truncation_never_splits_multibyte() {
+        // Force CJK / accented cells below their content width — must not panic
+        // and must respect the width bound.
+        let table = "| name |\n| ---- |\n| café |\n| 日本語テスト |\n| 🧑‍🤝‍🧑x |";
+        for width in [1usize, 2, 3, 4, 5, 6, 10] {
+            for line in render(table, width) {
+                assert!(display_width(&line_text(&line)) <= width.max(1));
+            }
+        }
+    }
+
+    #[test]
+    fn table_alignment_does_not_change_cell_width() {
+        // Same content under each alignment yields identical column widths.
+        let mk = |delim: &str| render(&format!("| h |\n| {delim} |\n| ab |"), 20);
+        let widths: Vec<usize> = ["---", ":--", "--:", ":-:"]
+            .iter()
+            .map(|d| line_text(&mk(d)[2]).trim_end().chars().count())
+            .collect();
+        // Left/right/center pad differently but the trimmed body content is "ab".
+        for d in ["---", ":--", "--:", ":-:"] {
+            let body = line_text(&mk(d)[2]);
+            assert!(body.contains("ab"), "alignment {d} lost content");
+        }
+        // The full (untrimmed) row width is identical across alignments.
+        let full: Vec<usize> = ["---", ":--", "--:", ":-:"]
+            .iter()
+            .map(|d| display_width(&line_text(&mk(d)[2])))
+            .collect();
+        assert!(full.iter().all(|&w| w == full[0]), "row widths differ: {full:?}");
+        let _ = widths;
+    }
+
+    #[test]
+    fn table_ragged_rows_are_normalized() {
+        // Short and long rows render without panic, padded/truncated to header.
+        let table = "| a | b |\n| - | - |\n| 1 |\n| 1 | 2 | 3 |";
+        let lines = render(table, 40);
+        // header + rule + 2 rows.
+        assert_eq!(lines.len(), 4);
+    }
+
+    #[test]
+    fn links_render_text_and_url() {
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+
+        // Link text shown, URL kept in a recessive parenthetical.
+        let spans = inline_spans("see [the docs](https://example.com) now", base, &theme);
+        assert_eq!(joined(&spans), "see the docs (https://example.com) now");
+        assert!(
+            spans.iter().any(|s| s.content == "the docs"
+                && s.style.add_modifier.contains(Modifier::UNDERLINED)),
+            "link text is underlined"
+        );
+
+        // Inline markup inside the link text is still styled.
+        let spans = inline_spans("[**bold** link](https://x.io)", base, &theme);
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.content == "bold" && s.style.add_modifier.contains(Modifier::BOLD)),
+            "emphasis inside link text is preserved"
+        );
+        assert!(joined(&spans).contains("(https://x.io)"));
+    }
+
+    #[test]
+    fn self_titled_and_empty_links_show_url_once() {
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+
+        let spans = inline_spans("[https://x.com](https://x.com)", base, &theme);
+        assert_eq!(joined(&spans), "https://x.com");
+
+        // Trailing-slash / case differences still collapse.
+        let spans = inline_spans("[https://x.com/](https://x.com)", base, &theme);
+        assert_eq!(joined(&spans), "https://x.com");
+
+        let spans = inline_spans("[](https://x.com)", base, &theme);
+        assert_eq!(joined(&spans), "https://x.com");
+    }
+
+    #[test]
+    fn malformed_links_stay_literal() {
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+        for input in ["[text]", "[text](", "[text(url)", "a [b] c", "["] {
+            let spans = inline_spans(input, base, &theme);
+            assert_eq!(joined(&spans), input, "{input:?} should stay literal");
+        }
+    }
+
+    #[test]
+    fn link_preserves_trailing_text() {
+        let (theme, _, _) = fixtures();
+        let base = Style::default().fg(theme.fg);
+        let spans = inline_spans("[a](b)c", base, &theme);
+        assert_eq!(joined(&spans), "a (b)c");
     }
 
     fn joined(spans: &[Span]) -> String {
@@ -830,6 +1576,23 @@ mod tests {
             "🧑‍🤝‍🧑 *x* `y`",
             "\t\tcode",
             "a\r\nb\r\n```\r\nc",
+            "[",
+            "[](",
+            "[]()",
+            "[x](y",
+            "[**](http://ünïcode.example/path)",
+            "~~",
+            "~~~~",
+            "a ~~b~~ c",
+            "- [ ]",
+            "- [x] あ",
+            "|",
+            "||",
+            "| |",
+            "|---|",
+            "| a |\n|---|",
+            "| 日本 | 🧑‍🤝‍🧑 |\n| :-: | --: |\n| あいうえお | x |",
+            "a | b",
         ];
         for input in inputs {
             for width in [0usize, 1, 2, 3, 8, 80, 1000] {


### PR DESCRIPTION
## Summary

summary（変更サマリ）ビューの Markdown レンダラ（`src/ui/markdown.rs`）にリンクと GFM 機能を追加。既存の見出し/リスト/コードブロック/引用/太字・斜体/インラインコードはそのまま、以下を新規対応。

- **リンク `[text](url)`**: テキストを下線 + `info` 色で表示し、URL を `muted` の括弧で併記（TUI ではクリックできないため URL を可視化してコピー可能に）。自己タイトル/空リンクは URL のみ表示。
- **取り消し線 `~~x~~`**: `CROSSED_OUT` + `muted` 色。SGR 9 非対応端末でも「削除/非推奨」の意図が残る。
- **タスクチェックボックス `- [ ]` / `- [x]`**: ASCII 角括弧を採用（`☐`/`☑` は East-Asian Ambiguous 幅で CJK 環境では崩れるため）。`[x]` は成功色、完了項目のテキストは `muted` で後退。
- **GFM テーブル**: 枠線なし（太字ヘッダ + 罫線 + 2 スペース区切りの整列行）。狭い summary カラムでは箱型枠線が幅を食いすぎるため不採用。`:--:` アラインメント対応、超過セルは `…` で切り詰め。マルチバイト/CJK 安全（バイト境界で panic しない）。

設計上の判断はレビュー時に複数の観点（UX・可読性・スコープ・エッジケース）で検討。テーブルの「2 列を `key: value` リストにフォールバック」は将来の改善として見送り（doc コメントに記載）。

あわせて、`main` ブランチに残っていた stale な `change_summary` レコード（過去のフィーチャーのゴミデータ）を削除済み。

## Test plan

- `cargo test` — markdown 37 件（取り消し線/チェックボックス/テーブルのパース・幅・切り詰め・整列・ラグド行・敵対的入力を含む）+ 全体 290 件パス
- `cargo clippy` — クリーン
- tmux + scratch repo で実機表示確認: 見出し/リスト/コードブロック（syntect ハイライト）/引用/リンク/取り消し線/チェックボックス/テーブルの色・整列を確認
