### PR TITLE
feat: open viewer file in external editor ($EDITOR)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.68.0"
+version = "0.69.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -333,6 +333,11 @@ pub struct App {
     pub main_repo_name: String,
     /// Whether the application should quit on the next tick.
     pub should_quit: bool,
+    /// One-shot request to open a file in an external editor. Set during key
+    /// handling (which has no terminal access) and consumed by the main loop,
+    /// which suspends the TUI and runs `$EDITOR`. `take`n each iteration, so it
+    /// never re-fires — a request, not a persistent mode.
+    pub editor_request: Option<PathBuf>,
     /// Index of the currently selected worktree in the worktree list.
     pub selected_worktree: usize,
     /// Cached list of worktrees discovered in the repository.
@@ -638,6 +643,7 @@ impl App {
             repo_path,
             main_repo_name,
             should_quit: false,
+            editor_request: None,
             selected_worktree: 0,
             worktrees: Vec::new(),
             config,
@@ -990,6 +996,23 @@ impl App {
             mode,
         );
         true
+    }
+
+    /// Queue a request to open the file currently shown in the Viewer in an
+    /// external editor. Resolves the viewer's relative `current_file` against
+    /// the selected worktree; if no file is open, flashes a hint instead of
+    /// queuing. The main loop consumes [`editor_request`](Self::editor_request).
+    pub fn request_open_in_editor(&mut self) {
+        let target = self
+            .worktrees
+            .get(self.selected_worktree)
+            .and_then(|wt| {
+                editor_target(self.viewer_state.content.current_file.as_deref(), &wt.path)
+            });
+        match target {
+            Some(path) => self.editor_request = Some(path),
+            None => self.set_status("No file open to edit".to_string(), StatusLevel::Warning),
+        }
     }
 
     /// Reload the viewer file tree for the currently selected worktree.
@@ -2385,6 +2408,18 @@ fn reselect_worktree_index(
     Some(old_index.min(worktrees.len() - 1))
 }
 
+/// Resolve the absolute path to hand an external editor from the viewer's
+/// relative `current_file` and the worktree root. `None` (no file open, or an
+/// empty path) means "nothing to edit" — the caller flashes a hint rather than
+/// launching an editor on a bogus target.
+fn editor_target(current_file: Option<&str>, worktree_root: &std::path::Path) -> Option<PathBuf> {
+    let rel = current_file?;
+    if rel.is_empty() {
+        return None;
+    }
+    Some(worktree_root.join(rel))
+}
+
 /// Extract the symbol (identifier) at a specific column in a line.
 /// Returns `(symbol_text, start_col, end_col)` where cols are 0-indexed character offsets.
 pub fn extract_symbol_at_column(line: &str, col: usize) -> Option<(String, usize, usize)> {
@@ -2423,6 +2458,26 @@ pub fn extract_symbol_at_column(line: &str, col: usize) -> Option<(String, usize
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn editor_target_resolves_relative_against_worktree() {
+        let root = std::path::Path::new("/repo/wt");
+        assert_eq!(
+            editor_target(Some("src/main.rs"), root),
+            Some(PathBuf::from("/repo/wt/src/main.rs"))
+        );
+    }
+
+    #[test]
+    fn editor_target_is_none_when_no_file_open() {
+        // The load-bearing branch: no current file → no editor launch.
+        assert_eq!(editor_target(None, std::path::Path::new("/repo/wt")), None);
+    }
+
+    #[test]
+    fn editor_target_is_none_for_empty_path() {
+        assert_eq!(editor_target(Some(""), std::path::Path::new("/repo/wt")), None);
+    }
 
     fn wt(branch: &str) -> git_engine::WorktreeInfo {
         git_engine::WorktreeInfo {

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -194,6 +194,9 @@
 "ctrl+f" = "search_filename"
 "c" = "add_comment"
 "C" = "open_comment_list"
+# 'e' for "edit": hand off to $VISUAL/$EDITOR for a quick manual touch-up,
+# then drop back into the viewer (the file reloads on return).
+"e" = "open_in_editor"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 ":" = "command_palette"
@@ -227,6 +230,9 @@
 "J" = "next_changed_file"
 "K" = "prev_changed_file"
 "c" = "add_comment"
+# 'e' for "edit": open the file under review in $VISUAL/$EDITOR for a quick
+# manual fix without leaving the diff workflow (reloads on return).
+"e" = "open_in_editor"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 "enter" = "expand_context"

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -94,6 +94,13 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Hand off to an external editor — before the empty-buffer guard so a
+    // missing file flashes a hint instead of silently doing nothing.
+    if let Some(Action::OpenInEditor) = action {
+        app.request_open_in_editor();
+        return;
+    }
+
     if total == 0 {
         return;
     }
@@ -229,6 +236,13 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
     }
     if let Some(Action::PrevChangedFile) = action {
         app.jump_to_changed_file(false);
+        return;
+    }
+
+    // Hand off the file under review to an external editor for a quick manual
+    // fix — before the empty-buffer guard, so it also works on an empty diff.
+    if let Some(Action::OpenInEditor) = action {
+        app.request_open_in_editor();
         return;
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -92,6 +92,9 @@ pub enum Action {
     PrevSearchMatch,
     AddComment,
     ExitToExplorer,
+    /// Open the file shown in the Viewer in an external editor ($VISUAL /
+    /// $EDITOR): suspend the TUI, run the editor, then restore and reload.
+    OpenInEditor,
 
     // ── Terminal panel ────────────────────────────────────────────
     LeaveTerminal,
@@ -193,6 +196,7 @@ impl Action {
             "prev_search_match" => Some(Action::PrevSearchMatch),
             "add_comment" => Some(Action::AddComment),
             "exit_to_explorer" => Some(Action::ExitToExplorer),
+            "open_in_editor" => Some(Action::OpenInEditor),
             "leave_terminal" => Some(Action::LeaveTerminal),
             "scrollback_up" => Some(Action::ScrollbackUp),
             "scrollback_down" => Some(Action::ScrollbackDown),
@@ -280,6 +284,7 @@ impl Action {
             Action::PrevSearchMatch => "prev_search_match",
             Action::AddComment => "add_comment",
             Action::ExitToExplorer => "exit_to_explorer",
+            Action::OpenInEditor => "open_in_editor",
             Action::LeaveTerminal => "leave_terminal",
             Action::ScrollbackUp => "scrollback_up",
             Action::ScrollbackDown => "scrollback_down",

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,27 +119,10 @@ fn main() -> Result<()> {
     }
 
     // ── Set up crossterm terminal ────────────────────────────────────
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
     let keyboard_enhanced = supports_keyboard_enhancement().unwrap_or(false);
     log::debug!("keyboard_enhanced = {keyboard_enhanced}");
-    execute!(
-        stdout,
-        EnterAlternateScreen,
-        crossterm::event::EnableMouseCapture,
-        crossterm::event::EnableBracketedPaste,
-    )?;
-    if keyboard_enhanced {
-        execute!(
-            stdout,
-            PushKeyboardEnhancementFlags(
-                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-            )
-        )?;
-    }
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    enter_tui(terminal.backend_mut(), keyboard_enhanced)?;
 
     // ── Create application state ─────────────────────────────────────
     let repo_path = match std::env::args().nth(1) {
@@ -163,21 +146,14 @@ fn main() -> Result<()> {
     app.start_symbol_index_build();
 
     // ── Main event loop ──────────────────────────────────────────────
-    let result = run_loop(&mut terminal, &mut app);
+    let result = run_loop(&mut terminal, &mut app, keyboard_enhanced);
 
     // ── Restore terminal (always, even on error) ─────────────────────
-    if keyboard_enhanced {
-        let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
-    }
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        crossterm::event::DisableMouseCapture,
-        crossterm::event::DisableBracketedPaste,
-        SetTitle(""),
-    )?;
-    terminal.show_cursor()?;
+    // Best-effort: attempt every restore step even if an earlier one errors,
+    // so a failure mid-teardown can't strand the user in a half-restored tty.
+    let _ = leave_tui(terminal.backend_mut(), keyboard_enhanced);
+    let _ = execute!(terminal.backend_mut(), SetTitle(""));
+    let _ = terminal.show_cursor();
 
     // ── Persist view state (covers both normal quit and update-restart) ─
     // Must run before the `exec` below: `exec` replaces the process image, so
@@ -223,8 +199,185 @@ fn main() -> Result<()> {
     result
 }
 
+// ── Terminal mode setup / teardown ───────────────────────────────────────
+//
+// `enter_tui` and `leave_tui` are exact inverses, with the enhancement-flag
+// push/pop bracketing the raw-mode + alternate-screen + mouse/paste capture so
+// suspend → restore round-trips cleanly. Keeping both in one place is what lets
+// `main`'s startup/shutdown and the editor-suspend guard share the *same*
+// symmetric sequence — a stray flag added to one but not the other would leave
+// the terminal subtly broken on return.
+
+/// Enter the full-screen TUI terminal mode (raw mode, alternate screen, mouse
+/// and bracketed-paste capture, and — when supported — the kitty keyboard
+/// enhancement flags).
+fn enter_tui<W: io::Write>(w: &mut W, keyboard_enhanced: bool) -> io::Result<()> {
+    enable_raw_mode()?;
+    execute!(
+        w,
+        EnterAlternateScreen,
+        crossterm::event::EnableMouseCapture,
+        crossterm::event::EnableBracketedPaste,
+    )?;
+    if keyboard_enhanced {
+        execute!(
+            w,
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+            )
+        )?;
+    }
+    Ok(())
+}
+
+/// Leave the full-screen TUI terminal mode, returning the terminal to the
+/// cooked / normal-screen baseline. The exact inverse of [`enter_tui`].
+fn leave_tui<W: io::Write>(w: &mut W, keyboard_enhanced: bool) -> io::Result<()> {
+    if keyboard_enhanced {
+        execute!(w, PopKeyboardEnhancementFlags)?;
+    }
+    disable_raw_mode()?;
+    execute!(
+        w,
+        LeaveAlternateScreen,
+        crossterm::event::DisableMouseCapture,
+        crossterm::event::DisableBracketedPaste,
+    )?;
+    Ok(())
+}
+
+/// RAII guard that suspends the TUI so an external full-screen program (vim,
+/// emacs, …) can own the real controlling terminal, then restores it on drop.
+///
+/// Constructing it (`suspend`) tears the TUI down to the baseline; dropping it
+/// re-enters TUI mode. Because the restore lives in `Drop`, it runs even if the
+/// child process errors, the closure panics, or the caller returns early — the
+/// user can never be stranded in a blind (raw-mode, alternate-screen) terminal.
+struct SuspendedTui<'a> {
+    terminal: &'a mut Terminal<CrosstermBackend<io::Stdout>>,
+    keyboard_enhanced: bool,
+}
+
+impl<'a> SuspendedTui<'a> {
+    /// Tear the TUI down to the cooked / normal-screen baseline and show the
+    /// cursor, handing the real tty to whatever runs next.
+    fn suspend(
+        terminal: &'a mut Terminal<CrosstermBackend<io::Stdout>>,
+        keyboard_enhanced: bool,
+    ) -> io::Result<Self> {
+        leave_tui(terminal.backend_mut(), keyboard_enhanced)?;
+        terminal.show_cursor()?;
+        Ok(Self {
+            terminal,
+            keyboard_enhanced,
+        })
+    }
+}
+
+impl Drop for SuspendedTui<'_> {
+    fn drop(&mut self) {
+        if let Err(e) = enter_tui(self.terminal.backend_mut(), self.keyboard_enhanced) {
+            log::warn!("failed to restore the TUI after suspending for an editor: {e}");
+        }
+        // Repaint from scratch: the editor scribbled over the alternate screen.
+        let _ = self.terminal.clear();
+    }
+}
+
+/// Resolve the external editor command line from `$VISUAL` / `$EDITOR`, falling
+/// back to `fallback`. Empty or whitespace-only values are ignored so a stray
+/// `EDITOR=""` doesn't produce an empty command. The chosen value is split on
+/// whitespace into program + arguments (so `"code -w"` works); an editor whose
+/// *path* contains spaces is intentionally not supported (no shell-style
+/// quoting — see the daisy design note: editor-flavor handling is out of scope).
+fn resolve_editor_command(visual: Option<&str>, editor: Option<&str>, fallback: &str) -> Vec<String> {
+    let chosen = [visual, editor]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(fallback);
+    let parts: Vec<String> = chosen.split_whitespace().map(str::to_string).collect();
+    if parts.is_empty() {
+        vec![fallback.to_string()]
+    } else {
+        parts
+    }
+}
+
+/// Suspend the TUI, launch `$EDITOR` on `path`, then restore the TUI and
+/// actively reload the just-edited file so the change is visible immediately
+/// (rather than waiting for the debounced file watcher).
+fn launch_external_editor(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    keyboard_enhanced: bool,
+    app: &mut App,
+    path: &std::path::Path,
+) {
+    use crate::app::StatusLevel;
+
+    let argv = resolve_editor_command(
+        std::env::var("VISUAL").ok().as_deref(),
+        std::env::var("EDITOR").ok().as_deref(),
+        "vi",
+    );
+    // `resolve_editor_command` never returns an empty vec.
+    let (program, args) = argv.split_first().expect("editor command is non-empty");
+
+    // Scope the guard so the TUI is restored before we touch `app` for the
+    // status flash / reload below.
+    let outcome = {
+        let _guard = match SuspendedTui::suspend(terminal, keyboard_enhanced) {
+            Ok(guard) => guard,
+            Err(e) => {
+                app.set_status(
+                    format!("Could not leave the TUI to launch an editor: {e}"),
+                    StatusLevel::Error,
+                );
+                return;
+            }
+        };
+        std::process::Command::new(program)
+            .args(args)
+            .arg(path)
+            .status()
+    };
+
+    match outcome {
+        Ok(status) if status.success() => {
+            app.set_status(format!("Edited {}", path.display()), StatusLevel::Success);
+        }
+        Ok(_) => {
+            app.set_status(
+                format!("Editor exited without success ({})", path.display()),
+                StatusLevel::Info,
+            );
+        }
+        Err(e) => {
+            app.set_status(
+                format!("Failed to launch editor '{program}': {e}"),
+                StatusLevel::Error,
+            );
+        }
+    }
+
+    // Full repaint + active reload of the file we just edited, so the change is
+    // visible immediately instead of waiting for the debounced file watcher.
+    // Mirrors the watcher's own refresh pair so the unified-diff view updates
+    // too when editing from diff mode.
+    app.terminal.needs_clear = true;
+    app.refresh_viewer();
+    app.refresh_diff();
+    app.dirty.mark_all();
+}
+
 /// Drive the draw → poll → handle cycle until the user quits.
-fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> Result<()> {
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+    keyboard_enhanced: bool,
+) -> Result<()> {
     // Set up file watcher for auto-refresh.
     let watch_paths: Vec<std::path::PathBuf> =
         app.worktrees.iter().map(|w| w.path.clone()).collect();
@@ -381,6 +534,16 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
                     break;
                 }
             }
+        }
+
+        // ── 2b. External editor — suspend the TUI, run $EDITOR, restore ──
+        // Consumed as a one-shot request set during key handling (the handler
+        // has no terminal access). Runs synchronously: the main loop blocks
+        // while the editor owns the tty, which is exactly the git-commit-style
+        // hand-off we want, and means background PTYs can't be resized from
+        // under us mid-edit.
+        if let Some(path) = app.editor_request.take() {
+            launch_external_editor(terminal, keyboard_enhanced, app, &path);
         }
 
         // ── 3. RENDER — immediately after events for lowest latency ──
@@ -587,5 +750,64 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
         if app.should_quit {
             return Ok(());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_editor_command;
+
+    #[test]
+    fn falls_back_when_both_unset() {
+        assert_eq!(resolve_editor_command(None, None, "vi"), vec!["vi"]);
+    }
+
+    #[test]
+    fn visual_takes_precedence_over_editor() {
+        assert_eq!(
+            resolve_editor_command(Some("vim"), Some("nano"), "vi"),
+            vec!["vim"]
+        );
+    }
+
+    #[test]
+    fn editor_used_when_visual_unset() {
+        assert_eq!(resolve_editor_command(None, Some("nano"), "vi"), vec!["nano"]);
+    }
+
+    #[test]
+    fn splits_program_and_arguments() {
+        assert_eq!(
+            resolve_editor_command(Some("code -w"), None, "vi"),
+            vec!["code", "-w"]
+        );
+        // tabs and runs of spaces collapse the same way.
+        assert_eq!(
+            resolve_editor_command(Some("code\t-w  -n"), None, "vi"),
+            vec!["code", "-w", "-n"]
+        );
+    }
+
+    #[test]
+    fn empty_or_whitespace_values_are_ignored() {
+        // Empty / whitespace-only VISUAL must not become an empty command; it
+        // is skipped so a stray VISUAL=\"\" still lets EDITOR (or the fallback) win.
+        assert_eq!(resolve_editor_command(Some(""), None, "vi"), vec!["vi"]);
+        assert_eq!(resolve_editor_command(Some("   "), None, "vi"), vec!["vi"]);
+        assert_eq!(
+            resolve_editor_command(Some(""), Some("nano"), "vi"),
+            vec!["nano"]
+        );
+        assert_eq!(resolve_editor_command(Some("  vim  "), None, "vi"), vec!["vim"]);
+    }
+
+    #[test]
+    fn naive_split_does_not_honor_quotes() {
+        // Documented limitation: no shell-style quoting. A quoted argument is
+        // split on its inner spaces. This pins the intentional behavior.
+        assert_eq!(
+            resolve_editor_command(Some("vim -c 'set ft=rust'"), None, "vi"),
+            vec!["vim", "-c", "'set", "ft=rust'"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a lightweight hand-off to an external editor (`$VISUAL` / `$EDITOR`) from the Viewer, so a quick manual touch-up during AI-assisted review doesn't require leaving Conductor — without building any in-app editor.

Press `e` in the Viewer (normal **or** diff mode) to open the file currently shown. Conductor suspends the TUI, runs the editor on the real terminal (git-commit style), and on exit restores the TUI and reloads the file so the change is visible immediately.

### Design highlights
- **`git commit`-style suspend → exec → restore.** The full terminal is handed to the editor (real tty, full fidelity), not embedded in a PTY pane — avoids two-stage vt100 emulation, Esc/key-forwarding loss, and `?1049h` double-emission. The terminal is fully returned to baseline before exec, so the alternate-screen nesting problem can't occur by construction.
- **RAII guard `SuspendedTui`** restores the terminal on `Drop`, so a panic, an early return, or a missing/failed editor binary can never strand the user in a blind (raw-mode, alternate-screen) terminal.
- **Symmetric `enter_tui` / `leave_tui`** helpers, shared by startup/shutdown and the suspend guard, keep the raw-mode + alt-screen + mouse/paste/keyboard-enhancement flag sequence in one place.
- **Synchronous exec** blocks the main loop while the editor owns the tty, so background PTYs aren't resized mid-edit.
- **Active reload on return** (`refresh_viewer` + `refresh_diff`) shows the edit immediately instead of waiting for the debounced file watcher; diff mode updates too.
- **One-shot request field** `App.editor_request: Option<PathBuf>` set during key handling and consumed by the main loop (mirrors the existing `should_restart` idiom).
- Editor resolution: `$VISUAL` → `$EDITOR` → `vi`, empty/whitespace ignored, split on whitespace (so `code -w` works; spaces-in-path / shell quoting intentionally out of scope). Program is spawned via `argv[0]` directly (no `sh -c`), so there is no shell-injection surface.

### Scope deliberately excluded (YAGNI)
`+N` line jump / file+line linking, a GUI (VS Code) detach path, editor-flavor abstraction, and any embedded editor — can be added later if the need appears.

## Test plan

Automated (all 295 tests pass, `clippy` clean):
- `resolve_editor_command`: VISUAL precedence, EDITOR fallback, default fallback, empty/whitespace ignored, whitespace splitting, documented no-quote behavior.
- `editor_target`: relative→absolute resolution, `None` when no file open, `None` for empty path.

Manual (requires a real terminal — not runnable in CI):
- **P0 (blind-state detection):** `$EDITOR` typo / missing binary → returns to TUI with an error flash; `:cq` (non-zero exit) → clean return; editor killed → clean return.
- **P1:** vim round-trip (`:wq`) restores raw mode, mouse, paste, cursor keys, and kitty-keyboard flags; pressing `e` with no file open flashes a hint instead of launching.
- **P2:** edited content / diff updates immediately on return; `code -w`-style waiting editors return cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
