### PR TITLE
feat: 隠しパーティーテーマモードを追加 🎉

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -486,6 +486,13 @@ pub struct App {
     pub show_panel_number_overlay: bool,
     /// Instant when the overlay was activated (for auto-dismiss timer).
     pub panel_overlay_since: Option<std::time::Instant>,
+
+    // ── Party mode (hidden easter egg) ───────────────────────────
+    /// When true, the UI goes full party: the focused panel's border
+    /// glows in a flowing rainbow, syntax tokens turn rainbow, the title
+    /// bar shimmers, and confetti drifts across the screen. Toggled from
+    /// the command palette; not persisted (session-only secret).
+    pub party_mode: bool,
 }
 
 /// Result of a background diff computation.
@@ -700,6 +707,7 @@ impl App {
             new_worktree_paths: HashSet::new(),
             show_panel_number_overlay: false,
             panel_overlay_since: None,
+            party_mode: false,
         };
         app.symbol_index = SymbolIndex::new(app.repo_path.clone());
 
@@ -1495,11 +1503,25 @@ impl App {
             CommandId::OpenPullRequest => self.open_pr_in_browser(),
             CommandId::UpdateAndRestart => self.cmd_update_and_restart(),
             CommandId::SearchFullText => self.cmd_search_full_text(),
+            CommandId::TogglePartyMode => self.cmd_toggle_party_mode(),
             CommandId::Quit => self.should_quit = true,
         }
     }
 
     // ── Command palette handler methods ──────────────────────────────
+
+    /// Toggle the hidden party theme mode (rainbow borders, flashy syntax,
+    /// confetti). A flash message confirms the new state; the whole UI is
+    /// re-rendered so the effect appears/disappears immediately.
+    fn cmd_toggle_party_mode(&mut self) {
+        self.party_mode = !self.party_mode;
+        if self.party_mode {
+            self.set_status("🎉 Party mode ON! 🎉".to_string(), StatusLevel::Success);
+        } else {
+            self.set_status_info("Party mode off.".to_string());
+        }
+        self.dirty.mark_all();
+    }
 
     fn cmd_toggle_panel_expand(&mut self) {
         if self.expanded_panel == Some(self.focus) {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -81,6 +81,7 @@ pub enum CommandId {
 
     // App
     UpdateAndRestart,
+    TogglePartyMode,
     Quit,
 }
 
@@ -444,6 +445,13 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::App,
         action: None,
         keywords: "update upgrade restart download version",
+    },
+    PaletteCommand {
+        id: CommandId::TogglePartyMode,
+        label: "🎉 Party Mode (secret)",
+        category: CommandCategory::App,
+        action: None,
+        keywords: "party rainbow fun secret celebration mode hidden festive disco",
     },
     PaletteCommand {
         id: CommandId::Quit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,6 +491,8 @@ fn run_loop(
                 _ if app.show_panel_number_overlay => TICK_RATE_ACTIVE,
                 _ if last_input_time.elapsed() < ACTIVITY_TIMEOUT => TICK_RATE_ACTIVE,
                 _ if !app.terminal.cc_waiting_worktrees.is_empty() => PULSE_TICK_INTERVAL,
+                // Party mode keeps animating even while idle.
+                _ if app.party_mode => PULSE_TICK_INTERVAL,
                 _ if decoration_active => DECORATION_TICK_INTERVAL,
                 _ => TICK_RATE_IDLE,
             }
@@ -622,6 +624,10 @@ fn run_loop(
                 // regardless of focus or whether decoration is animating.
                 "pulse" if !app.terminal.cc_waiting_worktrees.is_empty() => {
                     app.dirty.mark(crate::app::DirtyPanels::WORKTREE);
+                }
+                // Drive party-mode animations (rainbow border, syntax, confetti).
+                "pulse" if app.party_mode => {
+                    app.dirty.mark_all();
                 }
                 "unfocused_terminal" => {
                     match app.focus {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -345,6 +345,13 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
         &app.repo_path,
         &app.theme,
     );
+
+    // ── Party mode (hidden) ──────────────────────────────────────────
+    // Post-process the finished frame so rainbow borders, a shimmering
+    // title bar, and confetti land on top of everything (including overlays).
+    if app.party_mode {
+        super::party::apply_party_effects(frame, app);
+    }
 }
 
 /// Render a small confirmation overlay for worktree deletion.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod common;
 pub mod decoration;
 pub mod explorer_panel;
 pub mod markdown;
+pub mod party;
 pub mod terminal_claude;
 pub mod terminal_shell;
 pub mod viewer_panel;

--- a/src/ui/party.rs
+++ b/src/ui/party.rs
@@ -1,0 +1,172 @@
+//! Party mode — a hidden, flashy easter-egg overlay.
+//!
+//! When [`crate::app::App::party_mode`] is on, this module post-processes the
+//! rendered frame buffer to add three effects, all animated by `ui_tick`:
+//!
+//! 1. **Rainbow focused border** — every border glyph drawn in the theme's
+//!    focused-border colour is recoloured with a flowing rainbow, so the panel
+//!    that currently has focus glows and swirls.
+//! 2. **Rainbow title bar** — the top title bar's text shimmers.
+//! 3. **Confetti** — sparkles drift down across the main content area.
+//!
+//! The syntax-token rainbow (effect for the Viewer) lives in `viewer_panel.rs`
+//! and reuses [`rainbow`] from here.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier};
+
+use crate::app::App;
+
+/// Convert HSL (h: 0-360, s: 0-1, l: 0-1) to an RGB [`Color`].
+///
+/// Local copy (the equivalent in `common.rs` is private); party mode only ever
+/// needs full-saturation rainbow colours.
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> Color {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let h2 = h / 60.0;
+    let x = c * (1.0 - (h2 % 2.0 - 1.0).abs());
+    let (r1, g1, b1) = match h2 as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = l - c / 2.0;
+    Color::Rgb(
+        ((r1 + m) * 255.0) as u8,
+        ((g1 + m) * 255.0) as u8,
+        ((b1 + m) * 255.0) as u8,
+    )
+}
+
+/// A vivid rainbow colour for the given phase (interpreted as degrees of hue).
+///
+/// Phases that differ by a multiple of 360 produce the same colour, so callers
+/// can freely mix position and time terms to get a flowing gradient.
+pub fn rainbow(phase: f64) -> Color {
+    hsl_to_rgb(phase.rem_euclid(360.0), 1.0, 0.6)
+}
+
+/// Whether `s` begins with a box-drawing glyph (U+2500..=U+257F) — i.e. a panel
+/// border character. Used to target borders without touching text content.
+fn is_border_glyph(s: &str) -> bool {
+    matches!(s.chars().next(), Some(c) if ('\u{2500}'..='\u{257F}').contains(&c))
+}
+
+/// Small deterministic hash for confetti placement — no `rand` dependency, and
+/// stable across frames (the only time term is added by the caller).
+fn pseudo_random(seed: u64) -> u64 {
+    let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    x ^= x >> 16;
+    x = x.wrapping_mul(2246822519);
+    x ^= x >> 13;
+    x
+}
+
+/// Single-cell sparkle glyphs (each exactly one terminal column wide).
+const SPARKLES: &[&str] = &["✦", "✧", "·", "*", "+", "✩"];
+
+/// Apply all party-mode effects to the just-rendered frame buffer.
+///
+/// Called at the very end of `render_ui` when `app.party_mode` is set, so it
+/// recolours whatever is currently on screen (including any open overlay whose
+/// border uses the focused-border colour).
+pub fn apply_party_effects(frame: &mut Frame, app: &App) {
+    let tick = app.ui_tick as f64;
+    let focused = app.theme.border_focused;
+    let area = frame.area();
+    let buf = frame.buffer_mut();
+
+    // ── Effect 1: rainbow focused border ──────────────────────────────
+    // Only the focused panel paints its border in `border_focused`, so matching
+    // that colour automatically scopes the rainbow to the active panel.
+    for y in area.y..area.y.saturating_add(area.height) {
+        for x in area.x..area.x.saturating_add(area.width) {
+            if let Some(cell) = buf.cell_mut((x, y))
+                && cell.fg == focused
+                && is_border_glyph(cell.symbol())
+            {
+                cell.fg = rainbow(x as f64 * 6.0 + y as f64 * 12.0 - tick * 6.0);
+                cell.modifier.insert(Modifier::BOLD);
+            }
+        }
+    }
+
+    // ── Effect 2: rainbow title bar ───────────────────────────────────
+    let title = app.layout_cache.title_area;
+    if title.height >= 1 {
+        let y = title.y;
+        for x in title.x..title.x.saturating_add(title.width) {
+            if let Some(cell) = buf.cell_mut((x, y))
+                && cell.symbol() != " "
+                && !cell.symbol().is_empty()
+            {
+                cell.fg = rainbow(x as f64 * 8.0 - tick * 5.0);
+                cell.modifier.insert(Modifier::BOLD);
+            }
+        }
+    }
+
+    // ── Effect 3: drifting confetti ───────────────────────────────────
+    draw_confetti(buf, app.layout_cache.main_area, tick);
+}
+
+/// Scatter sparkles across `area`, drifting downward as `tick` advances.
+fn draw_confetti(buf: &mut ratatui::buffer::Buffer, area: Rect, tick: f64) {
+    if area.width < 4 || area.height < 3 {
+        return;
+    }
+    let count = (area.width / 12).clamp(4, 24) as u64;
+    let h = area.height as u64;
+    let w = area.width as u64;
+
+    for i in 0..count {
+        let rx = pseudo_random(i.wrapping_mul(2654435761));
+        let x = area.x + (rx % w) as u16;
+        // Each sparkle falls at a slightly different speed and wraps vertically.
+        let speed = 2 + (rx % 3); // ticks-per-row divisor variety
+        let drift = (tick as u64 / speed).wrapping_add(rx >> 8);
+        let y = area.y + (drift % h) as u16;
+        let glyph = SPARKLES[(rx as usize >> 4) % SPARKLES.len()];
+
+        if let Some(cell) = buf.cell_mut((x, y)) {
+            cell.set_symbol(glyph);
+            cell.fg = rainbow(tick * 9.0 + i as f64 * 47.0);
+            cell.modifier.insert(Modifier::BOLD);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rainbow_returns_rgb() {
+        for phase in [0.0, 90.0, 180.0, 359.0, 720.0, -30.0] {
+            assert!(matches!(rainbow(phase), Color::Rgb(_, _, _)));
+        }
+    }
+
+    #[test]
+    fn rainbow_is_periodic_in_360() {
+        assert_eq!(rainbow(10.0), rainbow(370.0));
+    }
+
+    #[test]
+    fn border_glyph_detection() {
+        // Box-drawing characters (plain + thick) are borders.
+        assert!(is_border_glyph("│"));
+        assert!(is_border_glyph("─"));
+        assert!(is_border_glyph("┏"));
+        assert!(is_border_glyph("┃"));
+        // Ordinary text and blanks are not.
+        assert!(!is_border_glyph("a"));
+        assert!(!is_border_glyph(" "));
+        assert!(!is_border_glyph(""));
+        assert!(!is_border_glyph("✦"));
+    }
+}

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -34,6 +34,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // Populate diff annotations cache before taking any shared borrows.
     ensure_diff_annotations_cached(app);
 
+    // Party-mode rainbow phase, advanced by the UI tick (None when off).
+    let party = app.party_mode.then_some(app.ui_tick as f64 * 4.0);
+
     let theme = &app.theme;
     let vs = &app.viewer_state;
     let tab_width = app.config.viewer.tab_width;
@@ -305,10 +308,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                                 diff_bg,
                                 emphasis_bg,
                                 tab_width,
+                                party,
                             )
                         })
                         .unwrap_or_else(|| {
-                            syntax_spans_for_line(vs, line_no, Some(diff_bg), theme.fg)
+                            syntax_spans_for_line(vs, line_no, Some(diff_bg), theme.fg, party)
                         })
                 } else {
                     render_inline_diff_spans(
@@ -326,10 +330,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                     DiffLineTag::Delete => Some(app.theme.diff_del_bg),
                     _ => None,
                 };
-                syntax_spans_for_line(vs, line_no, diff_bg, theme.fg)
+                syntax_spans_for_line(vs, line_no, diff_bg, theme.fg, party)
             }
         } else {
-            syntax_spans_for_line(vs, line_no, gutter_bg, theme.fg)
+            syntax_spans_for_line(vs, line_no, gutter_bg, theme.fg, party)
         };
 
         // Apply horizontal scroll to content spans, clipping to panel width.
@@ -542,6 +546,8 @@ struct DiffLineRenderCtx<'a> {
     area_width: u16,
     comment_lines: &'a std::collections::HashSet<usize>,
     comment_end_lines: &'a std::collections::HashSet<usize>,
+    /// Party-mode rainbow phase (`None` when party mode is off).
+    party: Option<f64>,
 }
 
 /// Build the display line for a single diff content line (context / addition /
@@ -558,6 +564,7 @@ fn render_diff_content_line(
     let theme = ctx.theme;
     let gutter_width = ctx.gutter_width;
     let tab_width = ctx.tab_width;
+    let party = ctx.party;
 
     let is_selected = new_line_no.map(|n| vs.is_line_selected(n)).unwrap_or(false);
     let is_hovered = new_line_no
@@ -675,6 +682,7 @@ fn render_diff_content_line(
                                 diff_bg.unwrap_or(Color::Reset),
                                 emphasis_bg.unwrap_or(Color::Reset),
                                 tab_width,
+                                party,
                             )
                         })
                         .unwrap_or_else(|| {
@@ -705,7 +713,7 @@ fn render_diff_content_line(
             ),
             DiffLineTag::Equal => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg)
+                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg, party)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -719,7 +727,7 @@ fn render_diff_content_line(
         match tag {
             DiffLineTag::Insert => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, diff_bg, theme.fg)
+                    syntax_spans_for_line(vs, line_no - 1, diff_bg, theme.fg, party)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -739,7 +747,7 @@ fn render_diff_content_line(
             }
             DiffLineTag::Equal => {
                 if let Some(line_no) = new_line_no {
-                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg)
+                    syntax_spans_for_line(vs, line_no - 1, None, theme.fg, party)
                 } else {
                     vec![Span::styled(
                         content.to_string(),
@@ -855,6 +863,9 @@ fn render_summary_view(frame: &mut Frame, area: Rect, app: &mut App, focused: bo
 fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'_>) {
     let inner_height = area.height.saturating_sub(2) as usize;
 
+    // Party-mode rainbow phase (None when off); computed before borrowing.
+    let party = app.party_mode.then_some(app.ui_tick as f64 * 4.0);
+
     // Build the visible rows plus the screen-row → comment / entry maps. Inline
     // comment threads are injected after the last line of each commented range
     // (so review comments are visible right in the diff, expanded by default).
@@ -885,6 +896,7 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'
             area_width: area.width,
             comment_lines: &comment_lines,
             comment_end_lines: &comment_end_lines,
+            party,
         };
 
         let mut lines: Vec<Line> = Vec::with_capacity(inner_height);
@@ -1402,6 +1414,7 @@ fn merge_syntax_with_inline(
     diff_bg: Color,
     emphasis_bg: Color,
     tab_width: usize,
+    party: Option<f64>,
 ) -> Option<Vec<Span<'static>>> {
     // Build expanded text and per-byte emphasis flag from inline segments.
     // Tabs are expanded with a *shared* column counter across segments so the
@@ -1463,6 +1476,14 @@ fn merge_syntax_with_inline(
         }
 
         result.push(Span::styled(expanded_text[start..i].to_string(), fg.bg(bg)));
+    }
+
+    // Party mode: recolour the merged tokens with a flowing rainbow while
+    // keeping their diff backgrounds intact.
+    if let Some(phase) = party {
+        for (idx, span) in result.iter_mut().enumerate() {
+            span.style.fg = Some(crate::ui::party::rainbow(phase + idx as f64 * 23.0));
+        }
     }
 
     Some(result)
@@ -1543,17 +1564,26 @@ fn syntax_spans_for_line(
     line_no: usize,
     diff_bg: Option<Color>,
     fg: Color,
+    party: Option<f64>,
 ) -> Vec<Span<'static>> {
     if let Some(tokens) = vs.content.highlighted_lines.get(line_no) {
         tokens
             .iter()
-            .map(|(style, text)| {
-                let s = if let Some(bg) = diff_bg {
+            .enumerate()
+            .map(|(idx, (style, text))| {
+                let mut s = if let Some(bg) = diff_bg {
                     // Keep token fg, override bg with diff colour.
                     style.bg(bg)
                 } else {
                     *style
                 };
+                // Party mode: recolour each token (boundaries preserved) with a
+                // flowing rainbow so the whole line goes flashy.
+                if let Some(phase) = party {
+                    s.fg = Some(crate::ui::party::rainbow(
+                        phase + line_no as f64 * 7.0 + idx as f64 * 23.0,
+                    ));
+                }
                 Span::styled(text.clone(), s)
             })
             .collect()
@@ -1565,7 +1595,11 @@ fn syntax_spans_for_line(
             .get(line_no)
             .cloned()
             .unwrap_or_default();
-        vec![Span::styled(text, Style::default().fg(fg))]
+        let color = match party {
+            Some(phase) => crate::ui::party::rainbow(phase + line_no as f64 * 7.0),
+            None => fg,
+        };
+        vec![Span::styled(text, Style::default().fg(color))]
     }
 }
 
@@ -1851,6 +1885,7 @@ mod tests {
             Color::Rgb(0, 40, 0),
             Color::Rgb(0, 80, 0),
             4,
+            None,
         );
         // Before the tab fix this returned None (texts mismatched on the tab).
         let spans = merged.expect("tabbed line should merge, not fall back to plain");
@@ -1870,6 +1905,7 @@ mod tests {
             Color::Rgb(0, 40, 0),
             Color::Rgb(0, 80, 0),
             4,
+            None,
         );
         assert!(merged.is_none());
     }


### PR DESCRIPTION
## Summary

コマンドパレットから起動する隠し「パーティーテーマモード」を追加しました 🎉

- **focus 中パネルのボーダーが虹色に流れて光る** — 描画後にフレームバッファを後処理し、`border_focused` 色の罫線グリフだけを位置 + tick 由来の虹色に置換。focus 中パネルのみがその色を使う性質を利用して対象を自動で絞り込み（Tab でフォーカス移動すると追従）。
- **Viewer のシンタックスハイライトがトークン単位で虹色に** — トークン境界は保ったまま各トークンを虹色化し、tick で色が流れる。
- **追加演出** — タイトルバー文字の虹色シマー + main 領域を漂う紙吹雪（✦✧·*+）。
- トグルはコマンドパレットの「🎉 Party Mode (secret)」から。デフォルト OFF・設定永続化なし（セッション内のみの隠し機能）。
- アニメは既存の `pulse` タイマー(80ms)で駆動。

### 主な変更
- `src/ui/party.rs`（新規）: 虹色生成・罫線判定・後処理パス（ユニットテスト付き）
- `src/app/mod.rs`: `party_mode` 状態 + `cmd_toggle_party_mode`
- `src/command_palette.rs`: `TogglePartyMode` コマンド
- `src/ui/mod.rs` / `layout.rs`: モジュール登録 + `render_ui` 末尾でフック
- `src/ui/viewer_panel.rs`: トークン単位レインボー
- `src/main.rs`: party モードのアニメ駆動
- `Cargo.toml`: `0.68.0` → `0.69.0`（後方互換の機能追加 = MINOR）

## Test plan

- [x] `cargo build` 成功
- [x] `cargo clippy` 警告なし
- [x] `cargo test` 全 289 件パス（新規 `party` テスト 3 件含む）
- [x] `cargo install --path .` 成功
- [ ] 手動確認: コマンドパレットで「Party」を起動 → focus パネルのボーダーが虹色に流れる / Viewer のコードが虹色になる / タイトルバー虹色・紙吹雪が出る / 再トグルで通常表示へ復帰
