### PR TITLE
fix: route IME-committed paste to active text modal instead of focused PTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.69.0"
+version = "0.69.1"
 edition = "2024"
 
 [dependencies]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -359,12 +359,24 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
 
 // ── Paste event handling ────────────────────────────────────────────────
 
-/// Handle a bracketed paste event. When the terminal panel is focused,
-/// forward the entire pasted text to the PTY in one write, wrapped with
-/// bracketed-paste escape sequences so the shell/application treats it as
-/// a single paste rather than individual keystrokes.
+/// Handle a bracketed paste event. A text-input overlay/modal takes the paste
+/// first (so IME-committed multi-byte text reaches the input field rather than a
+/// terminal sitting behind the modal); otherwise, when a terminal panel is
+/// focused, the entire pasted text is forwarded to the PTY in one write, wrapped
+/// with bracketed-paste escape sequences so the shell/application treats it as a
+/// single paste rather than individual keystrokes.
 pub fn handle_paste_event(app: &mut App, data: String) {
-    if app.focus != Focus::TerminalClaude && app.focus != Focus::TerminalShell {
+    // A text-input overlay/modal owns paste regardless of which panel holds
+    // focus underneath it — the same modal grab that §0 of `handle_key_event`
+    // applies to key events. This matters because macOS terminals deliver
+    // IME-committed multi-byte text (kana/kanji, especially 2+ chars or a
+    // conversion) as a bracketed paste, not as individual key events. Gating on
+    // focus alone would forward that paste into the focused Claude/Shell PTY
+    // sitting behind the modal, so typed Japanese would vanish from the input
+    // field and surface in the terminal instead. Half-width ASCII is unaffected
+    // because it arrives as ordinary key events. Kept in lockstep with
+    // `is_text_input_active`: every destination below is enumerated there.
+    if is_text_input_active(app) {
         // Dispatch paste data to the active overlay input buffer.
         let single_line: String = data.chars().filter(|c| *c != '\n' && *c != '\r').collect();
 


### PR DESCRIPTION
## Summary

Smart worktree モードなどで text-input modal を開いて全角（日本語）を入力すると、2文字以上をまとめて確定したり漢字変換で確定した場合に何も入力されず、裏で開いている Claude パネルに流れてしまう問題を修正する。

### 根本原因

macOS のターミナルは **IME で確定した全角テキストを、個別のキーイベントではなくブラケットペーストイベントとして配信する**（特に2文字以上の同時確定や変換確定時）。`handle_paste_event` は振り分けを `app.focus` のみで判定していたため、modal の裏で Claude/Shell ターミナルパネルにフォーカスが残っている通常状態では、ペーストが modal のバッファではなくフォーカス中の PTY に転送されていた。

- 半角 ASCII は個別キーイベントで届くため常に正しく modal に入る
- 単発のひらがな確定はキーイベントで届くことがあるため「1文字＋Enter なら入る」挙動になっていた
- 2文字以上・変換確定はペーストイベントで届き、フォーカス中 PTY へ誤送されていた

過去2回の修正（#251 / #252）はいずれもキーイベント側（`handle_key_event` のフォーカス横取り）を対象にしており、ペーストイベント側のこの経路は残っていた。

### 修正内容

`handle_paste_event` の振り分けを `app.focus` ではなく `is_text_input_active(app)` で行うようにした。text-input modal がアクティブなら、裏のパネルのフォーカスに関係なくペーストを modal のバッファへ入れる（キーイベント側 §0 が行っている modal グラブと同じ扱いをペースト側にも適用）。`is_text_input_active` はもともとペースト先の列挙と lockstep を保つ判定関数として定義されており、両者の入力先は一致している。

## Test plan

- [ ] `cargo build` / `cargo check` が通る（確認済み）
- [ ] Smart worktree モードの modal で、漢字変換を含む全角を2文字以上まとめて入力できる
- [ ] Claude パネルを開いた状態でも、modal 入力中の全角がパネル側に漏れない
- [ ] 半角 ASCII 入力がこれまで通り modal に入る
- [ ] modal を閉じた状態でのターミナルへのペーストが従来通り動作する
