### PR TITLE
feat: embed editor in a PTY panel instead of suspending the TUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.69.1"
+version = "0.70.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -101,6 +101,9 @@ pub enum Focus {
     Viewer,
     TerminalClaude,
     TerminalShell,
+    /// The embedded editor panel (vim/emacs in a PTY) occupying the merged
+    /// Explorer+Viewer region. Only reachable while [`App::editor`] is `Some`.
+    Editor,
 }
 
 impl Focus {
@@ -114,7 +117,19 @@ impl Focus {
             Focus::Explorer => KeyContext::Explorer,
             Focus::Viewer => KeyContext::Viewer,
             Focus::TerminalClaude | Focus::TerminalShell => KeyContext::Terminal,
+            Focus::Editor => KeyContext::Editor,
         }
+    }
+
+    /// Whether this panel hosts a PTY whose inner program (Claude Code, shell,
+    /// or an editor) should receive raw keystrokes. The event dispatcher routes
+    /// these panels through the PTY-forwarding path; the keymap only steals back
+    /// the chords that [fire in the terminal](crate::keymap::Action).
+    pub fn is_pty(self) -> bool {
+        matches!(
+            self,
+            Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor
+        )
     }
 }
 
@@ -319,6 +334,25 @@ pub struct BackgroundOps {
     pub symbol_index: BackgroundOp<Result<usize, String>>,
 }
 
+/// State for an active embedded editor panel (vim/emacs in a PTY).
+///
+/// Transient: created when the user opens a file in `$EDITOR` and dropped when
+/// the editor process exits. Owns the render cache so the editor panel renders
+/// independently of the Claude/Shell terminal caches.
+pub struct EditorPanel {
+    /// Index of the editor's PTY session in the `PtyManager` session list.
+    /// Kept in sync (shifted/cleared) when other sessions are removed.
+    pub session_idx: usize,
+    /// Absolute path of the file being edited — used for the reload-on-exit and
+    /// the panel title.
+    pub path: PathBuf,
+    /// Cached PTY render output for the editor panel (mirrors the Claude/Shell
+    /// caches in `TerminalState`).
+    pub cache: crate::ui::common::PtyRenderCache,
+    /// Set when the PTY reader thread produced new output to re-render.
+    pub dirty: bool,
+}
+
 /// Top-level application state shared across all UI panels.
 pub struct App {
     /// Tracks which panels need re-rendering.
@@ -333,11 +367,12 @@ pub struct App {
     pub main_repo_name: String,
     /// Whether the application should quit on the next tick.
     pub should_quit: bool,
-    /// One-shot request to open a file in an external editor. Set during key
-    /// handling (which has no terminal access) and consumed by the main loop,
-    /// which suspends the TUI and runs `$EDITOR`. `take`n each iteration, so it
-    /// never re-fires — a request, not a persistent mode.
-    pub editor_request: Option<PathBuf>,
+    /// The embedded editor panel, when active. `Some` ⟺ an editor PTY is running
+    /// and occupying the merged Explorer+Viewer region; `None` is the normal
+    /// (no-editor) layout. Set by [`App::open_in_editor`] and torn down by
+    /// [`App::exit_editor`] (the only two methods that pair this field with
+    /// `Focus::Editor`, keeping the invariant local).
+    pub editor: Option<EditorPanel>,
     /// Index of the currently selected worktree in the worktree list.
     pub selected_worktree: usize,
     /// Cached list of worktrees discovered in the repository.
@@ -650,7 +685,7 @@ impl App {
             repo_path,
             main_repo_name,
             should_quit: false,
-            editor_request: None,
+            editor: None,
             selected_worktree: 0,
             worktrees: Vec::new(),
             config,
@@ -1006,21 +1041,153 @@ impl App {
         true
     }
 
-    /// Queue a request to open the file currently shown in the Viewer in an
-    /// external editor. Resolves the viewer's relative `current_file` against
-    /// the selected worktree; if no file is open, flashes a hint instead of
-    /// queuing. The main loop consumes [`editor_request`](Self::editor_request).
-    pub fn request_open_in_editor(&mut self) {
-        let target = self
-            .worktrees
-            .get(self.selected_worktree)
-            .and_then(|wt| {
-                editor_target(self.viewer_state.content.current_file.as_deref(), &wt.path)
-            });
-        match target {
-            Some(path) => self.editor_request = Some(path),
-            None => self.set_status("No file open to edit".to_string(), StatusLevel::Warning),
+    /// Open the file currently shown in the Viewer in an embedded editor panel
+    /// (`$VISUAL` / `$EDITOR` in a PTY occupying the merged Explorer+Viewer
+    /// region). Resolves the viewer's relative `current_file` against the
+    /// selected worktree; if no file is open, flashes a hint instead. A no-op if
+    /// an editor is already open.
+    pub fn open_in_editor(&mut self) {
+        if self.editor.is_some() {
+            return;
         }
+        // A grabbed worktree's terminals are locked (its sessions run on main),
+        // and §1c would freeze an editor opened here. Refuse rather than trap the
+        // user in an undrivable editor.
+        if self.is_selected_worktree_grabbed() {
+            self.set_status(
+                "Cannot edit while this worktree is grabbed".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+        let (worktree_name, working_dir) = self.selected_worktree_info();
+        let Some(path) =
+            editor_target(self.viewer_state.content.current_file.as_deref(), &working_dir)
+        else {
+            self.set_status("No file open to edit".to_string(), StatusLevel::Warning);
+            return;
+        };
+
+        let argv = resolve_editor_command(
+            std::env::var("VISUAL").ok().as_deref(),
+            std::env::var("EDITOR").ok().as_deref(),
+            "vi",
+        );
+        // `resolve_editor_command` never returns an empty vec.
+        let (program, args) = argv.split_first().expect("editor command is non-empty");
+
+        let (rows, cols) = self.editor_pty_size();
+        match self.terminal.pty_manager.spawn_editor_session(
+            &worktree_name,
+            "editor",
+            &working_dir,
+            rows,
+            cols,
+            program,
+            args,
+            &path,
+        ) {
+            Ok(idx) => {
+                self.terminal.pty_manager.activate_session(idx);
+                let fname = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.display().to_string());
+                self.editor = Some(EditorPanel {
+                    session_idx: idx,
+                    path,
+                    cache: Default::default(),
+                    dirty: true,
+                });
+                self.set_focus(Focus::Editor);
+                // Repaint from scratch so the editor's alternate screen draws
+                // cleanly over the panels it replaces.
+                self.terminal.needs_clear = true;
+                self.dirty.mark_all();
+                self.set_status(
+                    format!("Editing {fname} — Ctrl+Esc: Claude · :q: close · alt+m: zoom"),
+                    StatusLevel::Info,
+                );
+            }
+            Err(e) => {
+                self.set_status(format!("Failed to launch editor: {e}"), StatusLevel::Error);
+            }
+        }
+    }
+
+    /// Tear down the embedded editor panel: kill/remove its PTY session, restore
+    /// focus to the Viewer, and reload the just-edited file so the change is
+    /// visible immediately (mirrors the debounced file-watcher refresh pair).
+    pub fn exit_editor(&mut self) {
+        let Some(path) = self.take_down_editor() else {
+            return;
+        };
+        // Reload the just-edited file immediately (mirror the file-watcher pair).
+        self.refresh_viewer();
+        self.refresh_diff();
+        self.dirty.mark_all();
+        let fname = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+        self.set_status(format!("Edited {fname}"), StatusLevel::Success);
+    }
+
+    /// Tear down the editor PTY and drop the panel, returning the edited path
+    /// (or `None` if no editor was open). Shared core of [`Self::exit_editor`]
+    /// (which adds reload + status) and worktree switching (which discards the
+    /// editor silently because the surrounding context is being reloaded anyway).
+    fn take_down_editor(&mut self) -> Option<PathBuf> {
+        let panel = self.editor.take()?;
+        // Remove the editor PTY (kill is harmless if the child already exited),
+        // adjusting other session indices.
+        self.close_terminal_session(panel.session_idx);
+        // Move focus off the (now-gone) editor only if it was focused — the usual
+        // `:q` flow. If the user had stepped over to Claude and the editor exited
+        // from under them, leave their focus put; just drop any stale "editor
+        // maximized" state. Assigned directly (not via `set_focus`) so callers
+        // control any reload.
+        if self.focus == Focus::Editor {
+            self.focus = Focus::Viewer;
+        }
+        if self.expanded_panel == Some(Focus::Editor) {
+            self.expanded_panel = None;
+        }
+        self.terminal.needs_clear = true;
+        Some(panel.path)
+    }
+
+    /// Discard the editor panel when the worktree it belongs to is being left.
+    /// No reload/flash — the caller ([`on_worktree_changed`]) reloads the new
+    /// worktree's view regardless.
+    pub fn discard_editor_on_worktree_change(&mut self) {
+        self.take_down_editor();
+    }
+
+    /// If an embedded editor is open and its process has exited (e.g. `:q`),
+    /// tear it down and restore the normal layout. Returns `true` if it closed.
+    /// Called every main-loop iteration so the panel disappears promptly rather
+    /// than waiting on the slow dead-session cleanup timer.
+    pub fn poll_editor_exit(&mut self) -> bool {
+        let Some(idx) = self.editor.as_ref().map(|e| e.session_idx) else {
+            return false;
+        };
+        if self.terminal.pty_manager.is_session_alive(idx) {
+            return false;
+        }
+        self.exit_editor();
+        true
+    }
+
+    /// Compute the editor PTY's content size (rows, cols) from the cached
+    /// layout: the editor occupies the merged Explorer+Viewer region, minus the
+    /// title row and borders (which collapse when the panel is maximized).
+    fn editor_pty_size(&self) -> (u16, u16) {
+        let cols = &self.layout_cache.columns;
+        let region_w = cols[1].width.saturating_add(cols[2].width);
+        let region_h = cols[1].height;
+        let expanded = self.expanded_panel == Some(Focus::Editor);
+        editor_content_size(region_w, region_h, expanded)
     }
 
     /// Reload the viewer file tree for the currently selected worktree.
@@ -1161,7 +1328,16 @@ impl App {
     }
 
     /// Set focus to a panel, lazily loading data when first needed.
-    pub fn set_focus(&mut self, focus: Focus) {
+    pub fn set_focus(&mut self, mut focus: Focus) {
+        // While the embedded editor occupies the merged Explorer+Viewer region,
+        // those two panels are hidden — any request to focus them lands on the
+        // editor instead. Centralizing the redirect here keeps every focus path
+        // (Tab cycle, alt+digit, click, palette) honoring the invariant without
+        // each needing to know about the editor.
+        if self.editor.is_some() && matches!(focus, Focus::Explorer | Focus::Viewer) {
+            focus = Focus::Editor;
+        }
+
         // The worktree column became a monitor strip + switcher modal, so
         // "focus the worktree" now opens that modal and leaves focus where it
         // was. This is the single chokepoint every worktree trigger funnels
@@ -1991,10 +2167,14 @@ impl App {
     pub fn cycle_focus_forward(&mut self) {
         // Worktree is no longer a focusable column (it became the top strip +
         // switcher modal), so it's excluded from the Tab cycle.
+        // When the editor is open it stands in for Explorer+Viewer in the cycle;
+        // `set_focus` redirects any Explorer/Viewer target onto it, so the only
+        // explicit arm needed is leaving the editor itself.
         let next = match self.focus {
             Focus::Worktree | Focus::TerminalShell => Focus::Explorer,
             Focus::Explorer => Focus::Viewer,
             Focus::Viewer => Focus::TerminalClaude,
+            Focus::Editor => Focus::TerminalClaude,
             Focus::TerminalClaude => Focus::TerminalShell,
         };
         self.set_focus(next);
@@ -2005,6 +2185,7 @@ impl App {
         let prev = match self.focus {
             Focus::Worktree | Focus::Explorer => Focus::TerminalShell,
             Focus::Viewer => Focus::Explorer,
+            Focus::Editor => Focus::TerminalShell,
             Focus::TerminalClaude => Focus::Viewer,
             Focus::TerminalShell => Focus::TerminalClaude,
         };
@@ -2442,6 +2623,49 @@ fn editor_target(current_file: Option<&str>, worktree_root: &std::path::Path) ->
     Some(worktree_root.join(rel))
 }
 
+/// Content size (rows, cols) for the embedded editor PTY given its region size
+/// and whether it is maximized. The title row is always present; non-maximized
+/// also has a bottom border row and left/right border columns. A zero region
+/// (layout not computed yet) seeds a reasonable default — the per-frame resize
+/// in `sync_pty_sizes` corrects it. Never returns 0 in either dimension (vt100
+/// needs at least 1×1).
+fn editor_content_size(region_w: u16, region_h: u16, expanded: bool) -> (u16, u16) {
+    if region_w == 0 || region_h == 0 {
+        return (24, 80);
+    }
+    let border_rows: u16 = if expanded { 1 } else { 2 };
+    let border_cols: u16 = if expanded { 0 } else { 2 };
+    (
+        region_h.saturating_sub(border_rows).max(1),
+        region_w.saturating_sub(border_cols).max(1),
+    )
+}
+
+/// Resolve the editor command line from `$VISUAL` / `$EDITOR`, falling back to
+/// `fallback`. Empty or whitespace-only values are ignored so a stray
+/// `EDITOR=""` doesn't produce an empty command. The chosen value is split on
+/// whitespace into program + arguments (so `"code -w"` works); an editor whose
+/// *path* contains spaces is intentionally not supported (no shell-style
+/// quoting — editor-flavor handling is out of scope).
+fn resolve_editor_command(
+    visual: Option<&str>,
+    editor: Option<&str>,
+    fallback: &str,
+) -> Vec<String> {
+    let chosen = [visual, editor]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(fallback);
+    let parts: Vec<String> = chosen.split_whitespace().map(str::to_string).collect();
+    if parts.is_empty() {
+        vec![fallback.to_string()]
+    } else {
+        parts
+    }
+}
+
 /// Extract the symbol (identifier) at a specific column in a line.
 /// Returns `(symbol_text, start_col, end_col)` where cols are 0-indexed character offsets.
 pub fn extract_symbol_at_column(line: &str, col: usize) -> Option<(String, usize, usize)> {
@@ -2482,6 +2706,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn focus_is_pty_only_for_pty_panels() {
+        assert!(Focus::TerminalClaude.is_pty());
+        assert!(Focus::TerminalShell.is_pty());
+        assert!(Focus::Editor.is_pty());
+        assert!(!Focus::Worktree.is_pty());
+        assert!(!Focus::Explorer.is_pty());
+        assert!(!Focus::Viewer.is_pty());
+    }
+
+    #[test]
+    fn editor_focus_uses_editor_keymap_context() {
+        assert_eq!(Focus::Editor.key_context(), crate::keymap::KeyContext::Editor);
+    }
+
+    #[test]
     fn editor_target_resolves_relative_against_worktree() {
         let root = std::path::Path::new("/repo/wt");
         assert_eq!(
@@ -2499,6 +2738,84 @@ mod tests {
     #[test]
     fn editor_target_is_none_for_empty_path() {
         assert_eq!(editor_target(Some(""), std::path::Path::new("/repo/wt")), None);
+    }
+
+    #[test]
+    fn resolve_editor_falls_back_when_unset() {
+        assert_eq!(resolve_editor_command(None, None, "vi"), vec!["vi"]);
+    }
+
+    #[test]
+    fn resolve_editor_visual_takes_precedence() {
+        assert_eq!(
+            resolve_editor_command(Some("vim"), Some("nano"), "vi"),
+            vec!["vim"]
+        );
+    }
+
+    #[test]
+    fn resolve_editor_uses_editor_when_visual_unset() {
+        assert_eq!(resolve_editor_command(None, Some("nano"), "vi"), vec!["nano"]);
+    }
+
+    #[test]
+    fn resolve_editor_splits_args() {
+        assert_eq!(
+            resolve_editor_command(Some("code -w"), None, "vi"),
+            vec!["code", "-w"]
+        );
+        assert_eq!(
+            resolve_editor_command(Some("code\t-w  -n"), None, "vi"),
+            vec!["code", "-w", "-n"]
+        );
+    }
+
+    #[test]
+    fn resolve_editor_ignores_blank_values() {
+        // A blank/whitespace-only VISUAL is skipped so EDITOR (or the fallback)
+        // still wins, rather than producing an empty command.
+        assert_eq!(resolve_editor_command(Some(""), None, "vi"), vec!["vi"]);
+        assert_eq!(resolve_editor_command(Some("   "), None, "vi"), vec!["vi"]);
+        assert_eq!(
+            resolve_editor_command(Some(""), Some("nano"), "vi"),
+            vec!["nano"]
+        );
+        assert_eq!(resolve_editor_command(Some("  vim  "), None, "vi"), vec!["vim"]);
+    }
+
+    #[test]
+    fn editor_content_size_subtracts_borders() {
+        // Non-maximized: title row + bottom border (2 rows) and L/R borders (2 cols).
+        assert_eq!(editor_content_size(80, 40, false), (38, 78));
+        // Maximized: only the title row, no borders.
+        assert_eq!(editor_content_size(80, 40, true), (39, 80));
+    }
+
+    #[test]
+    fn editor_content_size_defaults_on_zero_region() {
+        assert_eq!(editor_content_size(0, 40, false), (24, 80));
+        assert_eq!(editor_content_size(80, 0, false), (24, 80));
+    }
+
+    #[test]
+    fn editor_content_size_never_returns_zero() {
+        // Tiny regions clamp to 1×1 rather than underflowing (vt100 needs ≥1).
+        for w in 1..=3u16 {
+            for h in 1..=3u16 {
+                let (rows, c) = editor_content_size(w, h, false);
+                assert!(rows >= 1 && c >= 1, "w={w} h={h} → ({rows},{c})");
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_editor_naive_split_does_not_honor_quotes() {
+        // Documented limitation: no shell-style quoting. A quoted argument is
+        // split on its inner spaces. This pins the intentional behavior.
+        assert_eq!(
+            resolve_editor_command(Some("vim -c 'set ft=rust'"), None, "vi"),
+            vec!["vim", "-c", "'set", "ft=rust'"]
+        );
     }
 
     fn wt(branch: &str) -> git_engine::WorktreeInfo {

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -462,6 +462,7 @@ impl App {
         let kind = match session.kind {
             pty_manager::SessionKind::ClaudeCode => "claude_code",
             pty_manager::SessionKind::Shell => "shell",
+            pty_manager::SessionKind::Editor => "editor",
         };
         let output = self.terminal.pty_manager.get_output(active_idx).join("\n");
 

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -118,6 +118,16 @@ impl App {
             }
         }
 
+        // Keep the embedded editor's session index valid when a lower-indexed
+        // session is removed out from under it. The editor itself is never
+        // closed through this path (it's torn down by `exit_editor`), so it can
+        // only be shifted, never invalidated.
+        if let Some(editor) = self.editor.as_mut()
+            && editor.session_idx > global_idx
+        {
+            editor.session_idx -= 1;
+        }
+
         // Clear invalidated indices and fall back to next available session.
         // The closed session was the displayed one, so the fallback target's
         // content differs — switch through the helper to reset scroll and the
@@ -165,10 +175,23 @@ impl App {
 
         // Walk backwards so removals don't shift indices we haven't checked yet.
         for idx in (0..count).rev() {
+            // The editor's own session is owned by `poll_editor_exit` (which
+            // restores the layout and reloads the file); never reap it here.
+            if self.editor.as_ref().is_some_and(|e| e.session_idx == idx) {
+                continue;
+            }
             if !self.terminal.pty_manager.is_session_alive(idx) {
                 log::info!("removing dead PTY session at index {idx}");
                 self.terminal.pty_manager.remove_session(idx);
                 removed_any = true;
+
+                // Shift the editor's session index when a lower-indexed session
+                // is reaped beneath it.
+                if let Some(editor) = self.editor.as_mut()
+                    && editor.session_idx > idx
+                {
+                    editor.session_idx -= 1;
+                }
 
                 // Adjust deferred prompts.
                 self.terminal.deferred_prompts.remove(&idx);
@@ -484,6 +507,17 @@ impl App {
             {
                 *last_shell_size = (shell_pty_rows, right_cols);
                 self.update_shell_terminal_size(shell_pty_rows, right_cols);
+            }
+        }
+
+        // Keep the embedded editor PTY sized to its (merged Explorer+Viewer)
+        // region. Computed from the cached layout, so it tracks panel resizes
+        // and the maximize toggle.
+        if let Some(idx) = self.editor.as_ref().map(|e| e.session_idx) {
+            let size = self.editor_pty_size();
+            if size != self.terminal.size_editor && size.0 > 0 && size.1 > 0 {
+                self.terminal.size_editor = size;
+                self.terminal.pty_manager.resize_session(idx, size.0, size.1);
             }
         }
     }

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -1410,6 +1410,11 @@ impl App {
     }
 
     pub fn on_worktree_changed(&mut self) {
+        // An embedded editor belongs to the worktree it was opened on; leaving
+        // that worktree would strand it editing the wrong tree, so close it
+        // first. The view reload below covers the new worktree.
+        self.discard_editor_on_worktree_change();
+
         // Reveal the newly selected worktree's chip in the bar on the next
         // render (width-dependent panning happens there, where the area is known).
         // This is only safe to set on *user-initiated* selection changes: if a

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -143,6 +143,7 @@
 "g" = "go_to_top"
 "G" = "go_to_bottom"
 "esc" = "exit_sub_panel"
+"ctrl+esc" = "exit_sub_panel"
 ":" = "command_palette"
 
 # ── Explorer: comment list ──────────────────────────────────────────────────────
@@ -167,6 +168,7 @@
 "R" = "reply_to_comment"
 "space" = "view_comment_detail"
 "esc" = "exit_sub_panel"
+"ctrl+esc" = "exit_sub_panel"
 ":" = "command_palette"
 
 # ── Viewer (file content) ───────────────────────────────────────────────────────
@@ -199,6 +201,10 @@
 "e" = "open_in_editor"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
+# Ctrl+Esc is the app-wide "leave focus" chord (it is the only way out of the
+# PTY panels, where bare Esc is forwarded to the inner program). Bound here too
+# so the same chord works everywhere; bare Esc still works in this panel.
+"ctrl+esc" = "exit_to_explorer"
 ":" = "command_palette"
 "ctrl+o" = "jump_back"
 "ctrl+i" = "jump_forward"
@@ -235,6 +241,7 @@
 "e" = "open_in_editor"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
+"ctrl+esc" = "exit_to_explorer"
 "enter" = "expand_context"
 "shift+enter" = "expand_all_context"
 ":" = "command_palette"
@@ -249,6 +256,7 @@
 "G" = "go_to_bottom"
 "enter" = "select"
 "esc" = "exit_sub_panel"
+"ctrl+esc" = "exit_sub_panel"
 
 # ── Terminal ──────────────────────────────────────────────────────────────────
 [layers.terminal]
@@ -258,3 +266,12 @@
 "shift+home" = "scrollback_top"
 "shift+end" = "snap_to_live"
 "ctrl+g" = "open_file_from_terminal"
+
+# ── Editor (embedded vim/emacs PTY) ───────────────────────────────────────────
+# Almost everything is forwarded to the inner editor — Esc (vim mode changes),
+# Ctrl+G, Shift+PageUp, etc. all reach the program. Only "leave focus" is stolen
+# back, on Ctrl+Esc, matching the terminal panel. (Ctrl+Esc requires the kitty
+# keyboard protocol; on terminals without it, quit the editor with `:q` — the
+# process exit closes the panel automatically. alt+l / alt+h also step away.)
+[layers.editor]
+"ctrl+esc" = "leave_terminal"

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -242,26 +242,32 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // ── 1c. Terminal focus — intercept configurable keys, forward rest to PTY ─
+    // ── 1c. PTY focus — intercept configurable keys, forward rest to PTY ─
+    // Covers the Claude/Shell terminals and the embedded editor: each forwards
+    // unstolen keys to its inner program, using its own keymap context.
 
-    if app.focus == Focus::TerminalClaude || app.focus == Focus::TerminalShell {
+    if app.focus.is_pty() {
+        let pty_context = app.focus.key_context();
+
         // If the selected worktree is grabbed, block all terminal input
         // except navigation keys (focus switching is handled above in §0).
+        // (The editor never opens on a grabbed worktree, so this only guards
+        // the Claude/Shell terminals in practice.)
         if app.is_selected_worktree_grabbed() {
             // Allow Esc to leave terminal, but block everything else.
-            if let Some(Action::LeaveTerminal) = app.keymap.resolve(&key, KeyContext::Terminal) {
+            if let Some(Action::LeaveTerminal) = app.keymap.resolve(&key, pty_context) {
                 app.set_focus(Focus::Explorer);
             }
             return;
         }
 
-        // Resolve via the keymap (terminal layer + global fallback, already
+        // Resolve via the keymap (panel layer + global fallback, already
         // filtered to actions that fire in the terminal). Terminal-only actions
         // need terminal state; everything else reuses the shared global
         // dispatch. A miss falls through to the PTY below — the keymap is the
-        // single source of truth for what the terminal steals from the inner
+        // single source of truth for what the panel steals from the inner
         // program (no hand-maintained allowlist).
-        if let Some(action) = app.keymap.resolve(&key, KeyContext::Terminal)
+        if let Some(action) = app.keymap.resolve(&key, pty_context)
             && (handle_terminal_only_action(app, action) || dispatch_global_action(app, action))
         {
             return;
@@ -271,11 +277,12 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         let session_idx = match app.focus {
             Focus::TerminalClaude => app.terminal.active_claude_session,
             Focus::TerminalShell => app.terminal.active_shell_session,
+            Focus::Editor => app.editor.as_ref().map(|e| e.session_idx),
             _ => unreachable!(),
         };
         if let Some(idx) = session_idx {
             forward_key_to_pty(app, idx, key);
-        } else if key.code == KeyCode::Enter {
+        } else if key.code == KeyCode::Enter && app.focus != Focus::Editor {
             spawn_terminal_session(app);
         }
         return;
@@ -287,7 +294,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         Focus::Worktree => KeyContext::Worktree,
         Focus::Explorer => KeyContext::Explorer,
         Focus::Viewer => KeyContext::Viewer,
-        Focus::TerminalClaude | Focus::TerminalShell => unreachable!(),
+        Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => unreachable!(),
     };
 
     if let Some(action) = app.keymap.resolve(&key, context)
@@ -302,7 +309,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         Focus::Worktree => handle_worktree_key(app, key),
         Focus::Explorer => handle_explorer_key(app, key),
         Focus::Viewer => handle_viewer_key(app, key),
-        Focus::TerminalClaude | Focus::TerminalShell => unreachable!(),
+        Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => unreachable!(),
     }
 }
 
@@ -314,7 +321,21 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
 /// hold.
 fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
     match action {
-        Action::LeaveTerminal => app.set_focus(Focus::Explorer),
+        Action::LeaveTerminal => {
+            // While the editor panel is open, Ctrl+Esc toggles between it and
+            // Claude (the editor stays open so you can chat and return); from
+            // the editor itself it steps over to Claude. Otherwise it leaves a
+            // terminal back to the Explorer as before.
+            let target = if app.editor.is_some() {
+                match app.focus {
+                    Focus::Editor => Focus::TerminalClaude,
+                    _ => Focus::Editor,
+                }
+            } else {
+                Focus::Explorer
+            };
+            app.set_focus(target);
+        }
         Action::ScrollbackUp => {
             let page = match app.focus {
                 Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -413,6 +413,15 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 return;
             }
 
+            // The embedded editor occupies the merged Explorer+Viewer region; a
+            // click anywhere in it just (re)focuses the editor — the Explorer and
+            // Viewer panels behind it are hidden, so their click handlers must
+            // not run. Clicks on the terminal column still fall through.
+            if app.editor.is_some() && col >= left_end && col < viewer_end {
+                app.set_focus(Focus::Editor);
+                return;
+            }
+
             // Check for [<=>] expand button clicks on the top border row.
             if row == main_area.y
                 && let Some(target) = geom.expand_button_at(col) {
@@ -993,6 +1002,20 @@ fn handle_mouse_scroll(
     delta: i32,
 ) {
     if row < main_area.y || row >= main_area.y + main_area.height {
+        return;
+    }
+
+    // The editor occupies the merged Explorer+Viewer region. Translate the wheel
+    // into arrow keys for the inner program (it runs on the alternate screen);
+    // never scroll the hidden Explorer/Viewer state beneath it.
+    if app.editor.is_some() && col >= left_end && col < viewer_end {
+        if let Some(idx) = app.editor.as_ref().map(|e| e.session_idx) {
+            app.terminal.pty_manager.scroll_alt_screen_session(
+                idx,
+                delta.unsigned_abs() as usize,
+                delta < 0,
+            );
+        }
         return;
     }
 

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -97,7 +97,7 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
     // Hand off to an external editor — before the empty-buffer guard so a
     // missing file flashes a hint instead of silently doing nothing.
     if let Some(Action::OpenInEditor) = action {
-        app.request_open_in_editor();
+        app.open_in_editor();
         return;
     }
 
@@ -242,7 +242,7 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
     // Hand off the file under review to an external editor for a quick manual
     // fix — before the empty-buffer guard, so it also works on an empty diff.
     if let Some(Action::OpenInEditor) = action {
-        app.request_open_in_editor();
+        app.open_in_editor();
         return;
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -360,13 +360,18 @@ pub enum KeyContext {
     Viewer,
     ViewerDiffMode,
     Terminal,
+    /// The embedded editor panel. Like `Terminal`, almost every chord is
+    /// forwarded to the inner program (vim/emacs) — its own layer binds only the
+    /// "leave focus" chord; the rest fall through to the global layer (filtered
+    /// to terminal-firing actions) or to the PTY.
+    Editor,
     /// Shared navigation context for overlay popups (list/tree navigation).
     /// Falls back to Global like other contexts.
     Overlay,
 }
 
 /// The non-global contexts, each backed by a named `[layers.<name>]` table.
-const PANEL_CONTEXTS: [KeyContext; 8] = [
+const PANEL_CONTEXTS: [KeyContext; 9] = [
     KeyContext::Worktree,
     KeyContext::Explorer,
     KeyContext::ExplorerDiffList,
@@ -374,6 +379,7 @@ const PANEL_CONTEXTS: [KeyContext; 8] = [
     KeyContext::Viewer,
     KeyContext::ViewerDiffMode,
     KeyContext::Terminal,
+    KeyContext::Editor,
     KeyContext::Overlay,
 ];
 
@@ -390,6 +396,7 @@ impl KeyContext {
             KeyContext::Viewer => "viewer",
             KeyContext::ViewerDiffMode => "viewer_diff_mode",
             KeyContext::Terminal => "terminal",
+            KeyContext::Editor => "editor",
             KeyContext::Overlay => "overlay",
         }
     }
@@ -538,7 +545,12 @@ impl KeyMap {
             None => resolve_layered([&self.global], &input),
         };
         let action = resolved.copied()?;
-        if context == KeyContext::Terminal && !action.fires_in_terminal() {
+        // The editor panel forwards keys to its PTY exactly like the terminal,
+        // so it honors the same "only steal terminal-firing actions" filter —
+        // everything else (Esc, Ctrl+G, …) reaches vim/emacs untouched.
+        if matches!(context, KeyContext::Terminal | KeyContext::Editor)
+            && !action.fires_in_terminal()
+        {
             return None;
         }
         Some(action)
@@ -549,9 +561,12 @@ impl KeyMap {
     /// keymap-core canonical form (e.g. `"ctrl+d"`, `"down"`, `"G"`), which
     /// round-trips back through the config grammar.
     pub fn keys_for_action(&self, context: KeyContext, action: Action) -> Vec<String> {
-        // Keep the rendered help honest with `resolve`: in the terminal context,
-        // a globally-bound action that doesn't fire there has no working chord.
-        if context == KeyContext::Terminal && !action.fires_in_terminal() {
+        // Keep the rendered help honest with `resolve`: in the terminal and
+        // editor contexts, a globally-bound action that doesn't fire there has
+        // no working chord.
+        if matches!(context, KeyContext::Terminal | KeyContext::Editor)
+            && !action.fires_in_terminal()
+        {
             return Vec::new();
         }
 
@@ -817,6 +832,64 @@ mod tests {
                 "{a:?} should have a working chord in the terminal"
             );
         }
+    }
+
+    #[test]
+    fn editor_context_steals_only_leave_and_globals() {
+        // The embedded editor forwards almost everything to vim/emacs. It steals
+        // back only Ctrl+Esc (leave) and the terminal-firing global chords; keys
+        // the editor needs — Esc, Ctrl+G, Shift+PageUp — pass through (None).
+        let km = default_keymap();
+
+        let ctrl_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::CONTROL);
+        assert_eq!(
+            km.resolve(&ctrl_esc, KeyContext::Editor),
+            Some(Action::LeaveTerminal)
+        );
+
+        // Bare Esc → vim mode changes; must not be stolen.
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::empty());
+        assert_eq!(km.resolve(&esc, KeyContext::Editor), None);
+
+        // Ctrl+G is open_file_from_terminal in the *terminal* layer and
+        // search_full_text globally — neither fires in the editor, so it reaches
+        // the inner program instead of being intercepted.
+        let ctrl_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+        assert_eq!(km.resolve(&ctrl_g, KeyContext::Editor), None);
+
+        // Scrollback lives only in the terminal layer, so it does not leak into
+        // the editor.
+        let shift_pgup = KeyEvent::new(KeyCode::PageUp, KeyModifiers::SHIFT);
+        assert_eq!(km.resolve(&shift_pgup, KeyContext::Editor), None);
+
+        // Global focus/zoom chords still work over the editor.
+        let alt_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::ALT);
+        assert_eq!(
+            km.resolve(&alt_l, KeyContext::Editor),
+            Some(Action::CycleFocusForward)
+        );
+        let alt_m = KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT);
+        assert_eq!(
+            km.resolve(&alt_m, KeyContext::Editor),
+            Some(Action::TogglePanelExpand)
+        );
+    }
+
+    #[test]
+    fn ctrl_esc_is_additive_in_viewer() {
+        // The app-wide "leave focus" chord is bound in non-PTY panels too, but
+        // additively: bare Esc keeps working alongside it.
+        let km = default_keymap();
+        let ctrl_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::CONTROL);
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::empty());
+        assert_eq!(
+            km.resolve(&ctrl_esc, KeyContext::Viewer),
+            Some(Action::ExitToExplorer)
+        );
+        assert_eq!(
+            km.resolve(&esc, KeyContext::Viewer),
+            Some(Action::ExitToExplorer)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
     app.start_symbol_index_build();
 
     // ── Main event loop ──────────────────────────────────────────────
-    let result = run_loop(&mut terminal, &mut app, keyboard_enhanced);
+    let result = run_loop(&mut terminal, &mut app);
 
     // ── Restore terminal (always, even on error) ─────────────────────
     // Best-effort: attempt every restore step even if an earlier one errors,
@@ -247,136 +247,10 @@ fn leave_tui<W: io::Write>(w: &mut W, keyboard_enhanced: bool) -> io::Result<()>
     Ok(())
 }
 
-/// RAII guard that suspends the TUI so an external full-screen program (vim,
-/// emacs, …) can own the real controlling terminal, then restores it on drop.
-///
-/// Constructing it (`suspend`) tears the TUI down to the baseline; dropping it
-/// re-enters TUI mode. Because the restore lives in `Drop`, it runs even if the
-/// child process errors, the closure panics, or the caller returns early — the
-/// user can never be stranded in a blind (raw-mode, alternate-screen) terminal.
-struct SuspendedTui<'a> {
-    terminal: &'a mut Terminal<CrosstermBackend<io::Stdout>>,
-    keyboard_enhanced: bool,
-}
-
-impl<'a> SuspendedTui<'a> {
-    /// Tear the TUI down to the cooked / normal-screen baseline and show the
-    /// cursor, handing the real tty to whatever runs next.
-    fn suspend(
-        terminal: &'a mut Terminal<CrosstermBackend<io::Stdout>>,
-        keyboard_enhanced: bool,
-    ) -> io::Result<Self> {
-        leave_tui(terminal.backend_mut(), keyboard_enhanced)?;
-        terminal.show_cursor()?;
-        Ok(Self {
-            terminal,
-            keyboard_enhanced,
-        })
-    }
-}
-
-impl Drop for SuspendedTui<'_> {
-    fn drop(&mut self) {
-        if let Err(e) = enter_tui(self.terminal.backend_mut(), self.keyboard_enhanced) {
-            log::warn!("failed to restore the TUI after suspending for an editor: {e}");
-        }
-        // Repaint from scratch: the editor scribbled over the alternate screen.
-        let _ = self.terminal.clear();
-    }
-}
-
-/// Resolve the external editor command line from `$VISUAL` / `$EDITOR`, falling
-/// back to `fallback`. Empty or whitespace-only values are ignored so a stray
-/// `EDITOR=""` doesn't produce an empty command. The chosen value is split on
-/// whitespace into program + arguments (so `"code -w"` works); an editor whose
-/// *path* contains spaces is intentionally not supported (no shell-style
-/// quoting — see the daisy design note: editor-flavor handling is out of scope).
-fn resolve_editor_command(visual: Option<&str>, editor: Option<&str>, fallback: &str) -> Vec<String> {
-    let chosen = [visual, editor]
-        .into_iter()
-        .flatten()
-        .map(str::trim)
-        .find(|s| !s.is_empty())
-        .unwrap_or(fallback);
-    let parts: Vec<String> = chosen.split_whitespace().map(str::to_string).collect();
-    if parts.is_empty() {
-        vec![fallback.to_string()]
-    } else {
-        parts
-    }
-}
-
-/// Suspend the TUI, launch `$EDITOR` on `path`, then restore the TUI and
-/// actively reload the just-edited file so the change is visible immediately
-/// (rather than waiting for the debounced file watcher).
-fn launch_external_editor(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    keyboard_enhanced: bool,
-    app: &mut App,
-    path: &std::path::Path,
-) {
-    use crate::app::StatusLevel;
-
-    let argv = resolve_editor_command(
-        std::env::var("VISUAL").ok().as_deref(),
-        std::env::var("EDITOR").ok().as_deref(),
-        "vi",
-    );
-    // `resolve_editor_command` never returns an empty vec.
-    let (program, args) = argv.split_first().expect("editor command is non-empty");
-
-    // Scope the guard so the TUI is restored before we touch `app` for the
-    // status flash / reload below.
-    let outcome = {
-        let _guard = match SuspendedTui::suspend(terminal, keyboard_enhanced) {
-            Ok(guard) => guard,
-            Err(e) => {
-                app.set_status(
-                    format!("Could not leave the TUI to launch an editor: {e}"),
-                    StatusLevel::Error,
-                );
-                return;
-            }
-        };
-        std::process::Command::new(program)
-            .args(args)
-            .arg(path)
-            .status()
-    };
-
-    match outcome {
-        Ok(status) if status.success() => {
-            app.set_status(format!("Edited {}", path.display()), StatusLevel::Success);
-        }
-        Ok(_) => {
-            app.set_status(
-                format!("Editor exited without success ({})", path.display()),
-                StatusLevel::Info,
-            );
-        }
-        Err(e) => {
-            app.set_status(
-                format!("Failed to launch editor '{program}': {e}"),
-                StatusLevel::Error,
-            );
-        }
-    }
-
-    // Full repaint + active reload of the file we just edited, so the change is
-    // visible immediately instead of waiting for the debounced file watcher.
-    // Mirrors the watcher's own refresh pair so the unified-diff view updates
-    // too when editing from diff mode.
-    app.terminal.needs_clear = true;
-    app.refresh_viewer();
-    app.refresh_diff();
-    app.dirty.mark_all();
-}
-
 /// Drive the draw → poll → handle cycle until the user quits.
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
-    keyboard_enhanced: bool,
 ) -> Result<()> {
     // Set up file watcher for auto-refresh.
     let watch_paths: Vec<std::path::PathBuf> =
@@ -476,16 +350,26 @@ fn run_loop(
         if pty_dirty {
             app.terminal.dirty_claude = true;
             app.terminal.dirty_shell = true;
+            if let Some(editor) = app.editor.as_mut() {
+                editor.dirty = true;
+            }
             app.dirty.mark(crate::app::DirtyPanels::TERMINAL);
+            // The editor occupies the Explorer/Viewer columns, so its repaint
+            // rides the EXPLORER/VIEWER dirty bits rather than TERMINAL.
+            if app.editor.is_some() {
+                app.dirty.mark(
+                    crate::app::DirtyPanels::EXPLORER | crate::app::DirtyPanels::VIEWER,
+                );
+            }
         }
 
         let tick = if app.dirty.any() || pty_dirty {
             Duration::ZERO
         } else {
             match app.focus {
-                crate::app::Focus::TerminalClaude | crate::app::Focus::TerminalShell => {
-                    TICK_RATE_TERMINAL
-                }
+                crate::app::Focus::TerminalClaude
+                | crate::app::Focus::TerminalShell
+                | crate::app::Focus::Editor => TICK_RATE_TERMINAL,
                 _ if app.update_state != crate::app::UpdateState::Idle => TICK_RATE_ACTIVE,
                 _ if !app.worktree_mgr.pending_worktrees.is_empty() => TICK_RATE_ACTIVE,
                 _ if app.show_panel_number_overlay => TICK_RATE_ACTIVE,
@@ -538,14 +422,12 @@ fn run_loop(
             }
         }
 
-        // ── 2b. External editor — suspend the TUI, run $EDITOR, restore ──
-        // Consumed as a one-shot request set during key handling (the handler
-        // has no terminal access). Runs synchronously: the main loop blocks
-        // while the editor owns the tty, which is exactly the git-commit-style
-        // hand-off we want, and means background PTYs can't be resized from
-        // under us mid-edit.
-        if let Some(path) = app.editor_request.take() {
-            launch_external_editor(terminal, keyboard_enhanced, app, &path);
+        // ── 2b. Embedded editor lifecycle — close the panel once $EDITOR exits ──
+        // The editor runs as an in-panel PTY (not a TUI suspend), so its exit is
+        // detected here every iteration: when the child is gone we tear the panel
+        // down, restore the Explorer/Viewer layout, and reload the edited file.
+        if app.poll_editor_exit() {
+            app.dirty.mark_all();
         }
 
         // ── 3. RENDER — immediately after events for lowest latency ──
@@ -759,61 +641,3 @@ fn run_loop(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::resolve_editor_command;
-
-    #[test]
-    fn falls_back_when_both_unset() {
-        assert_eq!(resolve_editor_command(None, None, "vi"), vec!["vi"]);
-    }
-
-    #[test]
-    fn visual_takes_precedence_over_editor() {
-        assert_eq!(
-            resolve_editor_command(Some("vim"), Some("nano"), "vi"),
-            vec!["vim"]
-        );
-    }
-
-    #[test]
-    fn editor_used_when_visual_unset() {
-        assert_eq!(resolve_editor_command(None, Some("nano"), "vi"), vec!["nano"]);
-    }
-
-    #[test]
-    fn splits_program_and_arguments() {
-        assert_eq!(
-            resolve_editor_command(Some("code -w"), None, "vi"),
-            vec!["code", "-w"]
-        );
-        // tabs and runs of spaces collapse the same way.
-        assert_eq!(
-            resolve_editor_command(Some("code\t-w  -n"), None, "vi"),
-            vec!["code", "-w", "-n"]
-        );
-    }
-
-    #[test]
-    fn empty_or_whitespace_values_are_ignored() {
-        // Empty / whitespace-only VISUAL must not become an empty command; it
-        // is skipped so a stray VISUAL=\"\" still lets EDITOR (or the fallback) win.
-        assert_eq!(resolve_editor_command(Some(""), None, "vi"), vec!["vi"]);
-        assert_eq!(resolve_editor_command(Some("   "), None, "vi"), vec!["vi"]);
-        assert_eq!(
-            resolve_editor_command(Some(""), Some("nano"), "vi"),
-            vec!["nano"]
-        );
-        assert_eq!(resolve_editor_command(Some("  vim  "), None, "vi"), vec!["vim"]);
-    }
-
-    #[test]
-    fn naive_split_does_not_honor_quotes() {
-        // Documented limitation: no shell-style quoting. A quoted argument is
-        // split on its inner spaces. This pins the intentional behavior.
-        assert_eq!(
-            resolve_editor_command(Some("vim -c 'set ft=rust'"), None, "vi"),
-            vec!["vim", "-c", "'set", "ft=rust'"]
-        );
-    }
-}

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -28,6 +28,11 @@ pub enum SessionKind {
     ClaudeCode,
     /// An interactive shell session (e.g. bash, zsh, fish).
     Shell,
+    /// A one-shot external editor (`$VISUAL` / `$EDITOR`) launched on a single
+    /// file. Unlike the persistent Claude/Shell panels this is transient: it
+    /// lives only while the user edits, and is torn down when the editor process
+    /// exits. Excluded from the Claude-output scanner (waiting/active detection).
+    Editor,
 }
 
 // ---------------------------------------------------------------------------
@@ -155,19 +160,9 @@ impl PtyManager {
         repo_root: &Path,
         session_name: Option<&str>,
     ) -> Result<usize> {
-        // 1. Open a new PTY pair with the given size.
-        let pair = self
-            .pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .context("Failed to open PTY pair")?;
-
-        // 2. Build the command depending on the session kind.
-        let mut cmd = match kind {
+        // Build the command depending on the session kind, then hand off to the
+        // shared spawn path.
+        let cmd = match kind {
             SessionKind::ClaudeCode => {
                 let mut c = CommandBuilder::new("claude");
                 if let Some(resume_id) = resume_session_id {
@@ -184,7 +179,62 @@ impl PtyManager {
                 c
             }
             SessionKind::Shell => CommandBuilder::new(shell_path),
+            SessionKind::Editor => {
+                unreachable!("editor sessions are spawned via spawn_editor_session")
+            }
         };
+        self.finish_spawn(kind, worktree, label, working_dir, rows, cols, cmd)
+    }
+
+    /// Spawn an external editor (`$VISUAL` / `$EDITOR`) on a single `file` as a
+    /// transient PTY session. `program` + `args` is the resolved editor command
+    /// line (already split into program and arguments); `file` is appended as
+    /// the final argument.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_editor_session(
+        &mut self,
+        worktree: &str,
+        label: &str,
+        working_dir: &PathBuf,
+        rows: u16,
+        cols: u16,
+        program: &str,
+        args: &[String],
+        file: &Path,
+    ) -> Result<usize> {
+        let mut cmd = CommandBuilder::new(program);
+        for a in args {
+            cmd.arg(a);
+        }
+        cmd.arg(file);
+        self.finish_spawn(SessionKind::Editor, worktree, label, working_dir, rows, cols, cmd)
+    }
+
+    /// Shared tail of the spawn path: open the PTY pair, wire the reader thread
+    /// and vt100 parser, and push the session. `cmd` is the fully built command
+    /// (its working directory is set here).
+    #[allow(clippy::too_many_arguments)]
+    fn finish_spawn(
+        &mut self,
+        kind: SessionKind,
+        worktree: &str,
+        label: &str,
+        working_dir: &PathBuf,
+        rows: u16,
+        cols: u16,
+        mut cmd: CommandBuilder,
+    ) -> Result<usize> {
+        // 1. Open a new PTY pair with the given size.
+        let pair = self
+            .pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("Failed to open PTY pair")?;
+
         cmd.cwd(working_dir);
 
         // 3. Spawn the child process on the slave end.

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -22,6 +22,9 @@ pub struct TerminalState {
     pub size_claude: (u16, u16),
     /// Last known terminal content area size (rows, cols) for Shell PTY.
     pub size_shell: (u16, u16),
+    /// Last applied content area size (rows, cols) for the embedded editor PTY.
+    /// Tracked separately so `sync_pty_sizes` only resizes on an actual change.
+    pub size_editor: (u16, u16),
     /// Scrollback offset for the Claude Code terminal (0 = live view).
     pub scroll_claude: usize,
     /// Scrollback offset for the Shell terminal (0 = live view).
@@ -61,6 +64,7 @@ impl TerminalState {
             active_shell_session: None,
             size_claude: (24, 80),
             size_shell: (6, 80),
+            size_editor: (24, 80),
             scroll_claude: 0,
             scroll_shell: 0,
             cache_claude: Default::default(),

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -682,6 +682,11 @@ fn status_bar_hint(focus: crate::app::Focus, keymap: &crate::keymap::KeyMap) -> 
             ("new shell", &[Action::NewShell]),
             ("palette", &[Action::CommandPalette]),
         ],
+        Focus::Editor => &[
+            ("Claude", &[Action::LeaveTerminal]),
+            ("zoom", &[Action::TogglePanelExpand]),
+            ("panel", &[Action::CycleFocusForward]),
+        ],
     };
 
     let context = focus.key_context();

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -909,6 +909,7 @@ pub fn render_command_palette_overlay(frame: &mut Frame, area: Rect, app: &App) 
         crate::app::Focus::Viewer => "Viewer",
         crate::app::Focus::TerminalClaude => "Claude Code",
         crate::app::Focus::TerminalShell => "Shell",
+        crate::app::Focus::Editor => "Editor",
     };
     let scope_header = |scope: command_palette::CommandScope| match scope {
         command_palette::CommandScope::Current => current_label,
@@ -1506,6 +1507,25 @@ fn help_lines_for(app: &App, focus: crate::app::Focus, theme: &Theme) -> Vec<Lin
             )));
             lines.push(Line::from(Span::styled(
                 "  Use mouse click to switch panels without leaving.",
+                Style::default().fg(theme.muted),
+            )));
+        }
+        Focus::Editor => {
+            let ctx = KeyContext::Editor;
+            help_section(&mut lines, "Editor Panel", theme);
+            help_key_dyn(
+                &mut lines,
+                fmt_keys(app, ctx, Action::LeaveTerminal),
+                "Step over to Claude (editor stays open)",
+                theme,
+            );
+            help_section(&mut lines, "Note", theme);
+            lines.push(Line::from(Span::styled(
+                "  All other keys go to the editor (vim/emacs). Quit it",
+                Style::default().fg(theme.muted),
+            )));
+            lines.push(Line::from(Span::styled(
+                "  (e.g. :q) to close the panel and reload the file.",
                 Style::default().fg(theme.muted),
             )));
         }

--- a/src/ui/editor_panel.rs
+++ b/src/ui/editor_panel.rs
@@ -1,0 +1,115 @@
+//! Embedded editor panel — renders the `$EDITOR` PTY (vim/emacs) in the merged
+//! Explorer+Viewer region while the user edits a file inline.
+//!
+//! A single-session sibling of [`terminal_claude`](super::terminal_claude): no
+//! session tabs, no scrollback (full-screen editors own their own scrolling) —
+//! just a title row with exit hints and the live PTY output.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+
+use crate::app::{App, Focus};
+
+/// Render the embedded editor panel into `area`. No-op if no editor is open.
+pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let Some((session_idx, title)) = app.editor.as_ref().map(|e| {
+        let name = e
+            .path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| e.path.display().to_string());
+        (e.session_idx, name)
+    }) else {
+        return;
+    };
+
+    let focused = app.focus == Focus::Editor;
+    let border_focused = app.theme.border_focused;
+    let border_unfocused = app.theme.border_unfocused;
+    let fg = app.theme.fg;
+    let muted = app.theme.muted;
+    let accent = app.theme.accent;
+
+    let border_color = if focused {
+        border_focused
+    } else {
+        border_unfocused
+    };
+    let border_type = if focused {
+        BorderType::Thick
+    } else {
+        BorderType::Plain
+    };
+    let is_expanded = app.expanded_panel == Some(Focus::Editor);
+
+    // Title row: filename + exit hints. `:q` always works (it ends the process,
+    // which closes the panel); Ctrl+Esc needs the kitty keyboard protocol.
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    let title_style = if focused {
+        Style::default().fg(fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(muted)
+    };
+    let title_line = ratatui::text::Line::from(vec![
+        Span::styled(format!(" EDIT — {title} "), title_style),
+        Span::styled(
+            ":q close · Ctrl+Esc Claude · alt+m zoom",
+            Style::default().fg(muted),
+        ),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title_line).style(Style::default().fg(accent)),
+        chunks[0],
+    );
+
+    let output_area = chunks[1];
+    let output_block = if is_expanded {
+        Block::default()
+    } else {
+        Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+            .border_type(border_type)
+            .border_style(Style::default().fg(border_color))
+    };
+
+    let Some(screen_arc) = app.terminal.pty_manager.get_screen(session_idx) else {
+        frame.render_widget(output_block, output_area);
+        return;
+    };
+    let inner = output_block.inner(output_area);
+    frame.render_widget(output_block, output_area);
+
+    // Rebuild the PTY snapshot only when new output arrived (dirty) or the
+    // cache is empty. Editors run on the alternate screen, so there is no
+    // scrollback offset — always render the live view (offset 0).
+    if let Some(editor) = app.editor.as_mut()
+        && (editor.cache.lines.is_empty() || editor.dirty)
+        && let Some(cache) =
+            crate::ui::common::build_pty_lines(&screen_arc, 0, inner.height, inner.width)
+    {
+        editor.cache = cache;
+        editor.dirty = false;
+    }
+
+    if let Some(editor) = app.editor.as_ref() {
+        crate::ui::common::render_pty_cached(frame, inner, &editor.cache, &app.theme);
+
+        // Place the hardware cursor for IME when focused and unobscured.
+        if focused
+            && !app.is_any_overlay_active()
+            && let Some((row, col)) = editor.cache.cursor_position
+        {
+            let cursor_x = inner.x + col;
+            let cursor_y = inner.y + row;
+            if cursor_x < inner.x + inner.width && cursor_y < inner.y + inner.height {
+                frame.set_cursor_position(ratatui::layout::Position::new(cursor_x, cursor_y));
+            }
+        }
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -122,6 +122,11 @@ pub(crate) fn accordion_widths(
         Some(Focus::Worktree) => (total_width, 0, 0),
         Some(Focus::Explorer) => (0, total_width, 0),
         Some(Focus::Viewer) => (0, 0, total_width),
+        // The maximized editor takes the whole width via the explorer slot;
+        // `render_ui` unions the explorer+viewer columns into one editor area,
+        // so giving the explorer slot the full width (viewer 0) yields a
+        // full-screen editor with the terminal column collapsed.
+        Some(Focus::Editor) => (0, total_width, 0),
         Some(Focus::TerminalClaude | Focus::TerminalShell) => (0, 0, 0),
         None => {
             // Default proportions. The worktree column is gone (its status now
@@ -132,6 +137,21 @@ pub(crate) fn accordion_widths(
             let viewer = ((total_width as u32 * 38 / 100) as u16).max(min_col);
             (0, explorer, viewer)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::accordion_widths;
+    use crate::app::Focus;
+
+    #[test]
+    fn maximized_editor_takes_full_width_via_explorer_slot() {
+        // render_ui unions the explorer+viewer columns into the editor area, so
+        // the maximized editor puts all width on the explorer slot (viewer 0),
+        // collapsing the terminal column to zero remaining.
+        let (left, explorer, viewer) = accordion_widths(Some(Focus::Editor), 120);
+        assert_eq!((left, explorer, viewer), (0, 120, 0));
     }
 }
 
@@ -166,7 +186,7 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // their (bg-transparent) content draws on top; viewer is left alone
     // as a reading pane and the terminal keeps its own PTY background.
     let focused_surface_col = match app.focus {
-        crate::app::Focus::Explorer => Some(1),
+        crate::app::Focus::Explorer if app.editor.is_none() => Some(1),
         _ => None,
     };
     if let Some(col) = focused_surface_col {
@@ -177,21 +197,35 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
 
     // ── Column 0 (worktree) is gone — its status is in the top strip. ──
 
-    // ── Column 1: Explorer (file tree + diff list) ──────────────────
-    super::explorer_panel::render(frame, columns[1], app);
+    if app.editor.is_some() {
+        // The embedded editor replaces the Explorer + Viewer columns with one
+        // merged PTY panel (the terminal column stays put). When maximized,
+        // accordion_widths gives the explorer slot the full width and the
+        // viewer slot zero, so the union below is the whole main area.
+        let region = Rect {
+            x: columns[1].x,
+            y: columns[1].y,
+            width: columns[1].width.saturating_add(columns[2].width),
+            height: columns[1].height,
+        };
+        super::editor_panel::render(frame, region, app);
+    } else {
+        // ── Column 1: Explorer (file tree + diff list) ──────────────────
+        super::explorer_panel::render(frame, columns[1], app);
 
-    // ── Column 2: Viewer (file content) ─────────────────────────────
-    if app.viewer_state.is_current_file_media()
-        && let Some(ref rel_path) = app.viewer_state.content.current_file.clone()
-    {
-        let full_path = app.selected_worktree_path().join(rel_path);
-        let cols = columns[2].width;
-        let rows = columns[2].height;
-        app.viewer_state
-            .media_state
-            .render_if_needed(&full_path, rel_path, cols, rows);
+        // ── Column 2: Viewer (file content) ─────────────────────────────
+        if app.viewer_state.is_current_file_media()
+            && let Some(ref rel_path) = app.viewer_state.content.current_file.clone()
+        {
+            let full_path = app.selected_worktree_path().join(rel_path);
+            let cols = columns[2].width;
+            let rows = columns[2].height;
+            app.viewer_state
+                .media_state
+                .render_if_needed(&full_path, rel_path, cols, rows);
+        }
+        super::viewer_panel::render(frame, columns[2], app);
     }
-    super::viewer_panel::render(frame, columns[2], app);
 
     // ── Column 3: Terminal split (Claude 80% / Shell 20%) ───────────
     let terminal_split = app.layout_cache.terminal_split;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ use crate::theme::Theme;
 
 pub mod common;
 pub mod decoration;
+pub mod editor_panel;
 pub mod explorer_panel;
 pub mod markdown;
 pub mod party;


### PR DESCRIPTION
## Summary

Reworks edit mode from the full-screen "suspend the TUI and hand the terminal to `$EDITOR`" approach to an **embedded editor panel**: pressing `e` in the viewer now opens vim/emacs in a PTY that occupies the merged Explorer+Viewer region, while the Claude/Shell panels stay visible. You can edit and consult Claude side by side, then close the editor to return.

### Behavior
- **Open**: `e` in the viewer/diff opens the editor (resolves `$VISUAL` → `$EDITOR` → `vi`) in the merged Explorer+Viewer area.
- **Hop to Claude and back**: `Ctrl+Esc` toggles between the editor and Claude (the editor stays open); `alt+l` / `alt+h` also step away.
- **Maximize**: `alt+m` (existing panel-zoom) maximizes the editor panel. `super+space` still maps to zoom but is unreliable on macOS (Spotlight), so `alt+m` is the practical key.
- **Close**: quit the editor (e.g. `:q`); the process exit is detected each frame, the panel tears down, and the edited file reloads automatically.
- **Leave-focus key**: `Ctrl+Esc` is now an app-wide "leave focus" chord. It is added to the non-PTY panels too (Viewer/Explorer lists), while bare `Esc` keeps working there — so the same chord works everywhere, and the PTY panels (terminal/editor) which must forward bare `Esc` to the inner program use `Ctrl+Esc` to leave.

### Implementation
- `pty_manager`: new `SessionKind::Editor` + `spawn_editor_session`; shared `finish_spawn` tail.
- `app`: `Focus::Editor` + `Focus::is_pty()`, an `EditorPanel` (session/path/render-cache), `open_in_editor`/`exit_editor`/`poll_editor_exit`, editor-aware `set_focus`/`cycle_focus`, and session-index bookkeeping so the editor survives other sessions closing.
- `keymap`: dedicated `KeyContext::Editor` that only steals `Ctrl+Esc` (so `Esc`, `Ctrl+G`, `Shift+PageUp` etc. reach the editor); additive `Ctrl+Esc` in non-PTY panels.
- `ui`: new `editor_panel` renderer; the layout unions the Explorer+Viewer columns into the editor area; PTY sizing follows the merged region and the maximize toggle.
- `main`: removed the old `SuspendedTui` / `launch_external_editor` suspend path; the main loop now polls for editor exit.
- Guards: refuses to open on a grabbed worktree; closes the editor when switching worktrees so it can't edit the wrong tree.

## Test plan

- `cargo test` — 306 passing, including new coverage for the editor keymap context (`Ctrl+Esc` steals leave, `Esc`/`Ctrl+G`/`Shift+PageUp` pass through, globals still fire), additive `Ctrl+Esc` in the viewer, `Focus::is_pty`, `editor_content_size` boundary/clamp behavior, and the maximized-editor accordion width.
- `cargo clippy` clean; `cargo check` clean after rebase onto latest main.
- Manual: open `e` on a file → edit in vim → `:q` returns and reloads; `Ctrl+Esc` hops to Claude and back; `alt+m` zooms; switching worktrees closes the editor. (TUI rendering is not auto-tested.)
