### PR TITLE
feat: worktree barの余白ダブルクリックで新規worktree作成

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.69.1"
+version = "0.70.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -35,6 +35,18 @@ fn register_double_click_on(
     register_double_click(last, now) && same_idx
 }
 
+/// Open the new-worktree creation dialog. Shared by the worktree bar's `[+]`
+/// button and its blank-area double-click so the two entry points can't drift.
+fn start_worktree_creation(app: &mut App) {
+    use crate::app::{StatusLevel, WorktreeInputMode};
+    app.worktree_mgr.input_mode = WorktreeInputMode::CreatingWorktree;
+    app.worktree_mgr.input_buffer.clear();
+    app.set_status(
+        "New branch name (Tab: Smart Mode, Enter to continue, Esc to cancel):".to_string(),
+        StatusLevel::Info,
+    );
+}
+
 /// Send all pending comments to Claude via /conductor:address-conductor-comment (no ID = bulk mode).
 fn ask_claude_all_comments(app: &mut App) {
     let prompt = "/conductor:address-conductor-comment\n".to_string();
@@ -269,14 +281,7 @@ fn handle_wtbar_click(
         Some(WtbarAction::ScrollRight) => {
             app.wtbar_scroll = app.wtbar_scroll.saturating_add(1);
         }
-        Some(WtbarAction::Add) => {
-            app.worktree_mgr.input_mode = WorktreeInputMode::CreatingWorktree;
-            app.worktree_mgr.input_buffer.clear();
-            app.set_status(
-                "New branch name (Tab: Smart Mode, Enter to continue, Esc to cancel):".to_string(),
-                StatusLevel::Info,
-            );
-        }
+        Some(WtbarAction::Add) => start_worktree_creation(app),
         Some(WtbarAction::Delete(i)) => {
             if let Some(wt) = app.worktrees.get(i) {
                 if wt.is_main {
@@ -300,7 +305,19 @@ fn handle_wtbar_click(
                 }
             }
         }
-        _ => {}
+        // Blank area of the bar: a double-click acts as the `[+]` button. A
+        // single click has nothing to do (the bar holds no focus), so it is
+        // just consumed.
+        None => {
+            if register_double_click(
+                &mut app.worktree_mgr.wtbar_blank_last_click,
+                std::time::Instant::now(),
+            ) {
+                start_worktree_creation(app);
+            }
+        }
+        // Stale/out-of-range `Select` hit from a prior render: ignore.
+        Some(WtbarAction::Select(_)) => {}
     }
     true
 }

--- a/src/worktree_ops.rs
+++ b/src/worktree_ops.rs
@@ -16,6 +16,11 @@ pub struct WorktreeManager {
     pub input_buffer: TextInput,
     /// Timestamp of the last click on worktree blank space (for double-click detection).
     pub blank_last_click: std::time::Instant,
+    /// Timestamp of the last click on the worktree bar's blank area (for
+    /// double-click-to-create detection). Kept separate from `blank_last_click`
+    /// so a click on the column's blank space and one on the bar's blank space
+    /// can't falsely combine into a double-click.
+    pub wtbar_blank_last_click: std::time::Instant,
     /// Timestamp of the last click on a worktree list item (for double-click detection).
     pub item_last_click: std::time::Instant,
     /// Index of the last clicked worktree list item.
@@ -54,6 +59,7 @@ impl Default for WorktreeManager {
             input_mode: WorktreeInputMode::Normal,
             input_buffer: TextInput::new(),
             blank_last_click: std::time::Instant::now(),
+            wtbar_blank_last_click: std::time::Instant::now(),
             item_last_click: std::time::Instant::now(),
             item_last_click_idx: usize::MAX,
             pending_branch: String::new(),


### PR DESCRIPTION
## Summary

worktree bar（画面上部の全幅ストリップ）の余白部分をダブルクリックすると、`[+]` ボタンと同じ新規 worktree 作成ダイアログが起動するようにしました。`[+]` ボタンの単クリック動作は従来どおり維持しています。

- `WtbarAction::Add` の起動ロジックを共有ヘルパ `start_worktree_creation()` に抽出し、`[+]` ボタン経路と余白ダブルクリック経路の両方から呼ぶことで重複を排除。
- worktree bar 専用のダブルクリック判定用タイムスタンプ `wtbar_blank_last_click` を追加。左カラムの `blank_last_click` とは分離し、別領域のクリックが誤って 1 つのダブルクリックに合体しないようにした。
- 余白の単クリックは無反応（消費のみ）を維持（bar はフォーカスを持たないため）。`⎇` マーカーを含むどのヒット領域にも当たらない箇所が対象。
- `handle_wtbar_click` の `match` から `_ => {}` ワイルドカードを排除し、`None`（余白）/ `Some(WtbarAction::Select(_))`（古い範囲外 index は no-op）を明示。将来 `WtbarAction` に variant を追加した際にコンパイルエラーで検知できるようにした。
- `Cargo.toml` のバージョンを `0.69.1` → `0.70.0` に更新（後方互換の機能追加 = MINOR）。

## Test plan

- [x] `cargo build` — 成功
- [x] `cargo clippy` — 警告なし
- [x] `cargo test` — 298 passed, 0 failed
- [ ] 実機（マウス対応端末）で worktree bar の余白をダブルクリックし、作成ダイアログが開くことを確認
