### PR TITLE
docs: refresh README and CLAUDE.md for current layout, config, and module structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,31 +27,42 @@ Node.js MCP server that exposes review DB tools to Claude Code sessions.
 
 ### Application Structure
 
-Single-struct state model: `App` in `app.rs` holds all application state as flat fields. No ECS or component architecture.
+Single-struct state model: `App` in `app/` (`app/mod.rs`, with logic split across `app/review.rs`, `app/terminal.rs`, `app/worktree.rs`) holds all application state as flat fields. No ECS or component architecture.
 
 **Main loop** (`main.rs`): 60fps event loop — polls crossterm events at 16ms, handles keys/mouse, checks file watcher, refreshes worktrees periodically (3s), scans Claude Code PTY output for file-change patterns.
 
-**Event dispatch** (`event.rs`): Overlay modes (worktree input, cherry-pick, branch switch, review input, etc.) take absolute priority and consume all keys. Otherwise, the `Focus` enum routes input to the focused panel. Terminal panels forward all keys except Esc directly to PTY.
+**Event dispatch** (`event/`, dispatched from `event/mod.rs` into per-context submodules `global`/`explorer`/`viewer`/`terminal`/`worktree`/`overlay`/`mouse`): Overlay modes (worktree input, cherry-pick, branch switch, review input, etc.) take absolute priority and consume all keys. Otherwise, the `Focus` enum routes input to the focused panel. Terminal panels forward all keys except Esc directly to PTY.
 
-### Four-Column Layout
+### Layout
 
 ```
-Worktree | Explorer | Viewer | Terminal (Claude Code / Shell)
+Title bar
+Worktree monitor strip (full width)
+Explorer | Viewer | Terminal (Claude Code / Shell)
+Status bar
 ```
 
-- Worktree column shrinks when not focused
-- Terminal column is split 80/20 vertically (Claude Code top, Shell bottom)
+- The worktree list is **not** a column: it lives in a full-width monitor strip
+  along the top (`ui/worktree_bar.rs`), showing every worktree's branch, dirty
+  count, ahead/behind, and Claude Code waiting/active state. Hidden while a panel
+  is maximized.
+- The main area is a three-column accordion (`ui/layout.rs`): Explorer | Viewer |
+  Terminal, with focus-driven widths. Any panel can be maximized (`Alt+m`).
+- Explorer column is split 50/50 (file tree top, diff/comment list bottom).
+- Terminal column is split 80/20 vertically (Claude Code top, Shell bottom).
+- When the embedded editor is active (`Focus::Editor`), it merges the
+  Explorer+Viewer columns into one PTY panel.
 - Tab cycles focus; panel-specific vim-style keys (j/k, h/l, g/G, /)
 
 ### Key Modules
 
 | Module | Role |
 |--------|------|
-| `app.rs` | All application state and business logic methods |
-| `event.rs` | Keyboard/mouse event dispatch based on Focus and overlay state |
+| `app/` | All application state and business logic methods (`mod.rs` + `review.rs`, `terminal.rs`, `worktree.rs`) |
+| `event/` | Keyboard/mouse event dispatch based on Focus and overlay state (per-context submodules) |
 | `git_engine.rs` | All git operations via `git2` (no shell-out) — worktrees, diffs, branches, cherry-pick, merge |
 | `diff_state.rs` | Diff data model (file diffs, hunks, lines) using `similar` crate |
-| `viewer_state.rs` | File tree model and file content buffer |
+| `viewer/` | File tree model (`file_tree.rs`) and file content buffer (`file_view.rs`) |
 | `review_store.rs` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
 | `pty_manager.rs` | PTY session management — spawn, read/write, resize; vt100 parser for rendering; output scanner for Claude Code |
 | `file_watcher.rs` | Filesystem change detection via `notify` crate, debounced at 500ms |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.70.2"
+version = "0.70.3"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.70.2"
+version = "0.70.3"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cd conductor
 make install
 ```
 
-`make install` installs the `conductor` binary to `~/.cargo/bin/` (`cargo install --path .`) and installs MCP server dependencies (`npm install`).
+`make install` installs the `conductor` binary to `~/.cargo/bin/` (`cargo install --path .`) and installs MCP server dependencies (`npm ci`).
 
 ### 2. Install the Claude Code plugin
 
@@ -61,22 +61,46 @@ make dev
 ## Layout
 
 ```
-Worktree | Explorer | Viewer | Terminal (Claude Code / Shell)
+┌────────────────────────────────────────────────────────┐
+│ Title bar                                               │
+├────────────────────────────────────────────────────────┤
+│ Worktree monitor strip (full width)                     │
+├──────────────┬──────────────┬──────────────────────────┤
+│              │              │ Claude Code              │
+│  Explorer    │   Viewer     ├──────────────────────────┤
+│ (tree + diff)│ (file/diff)  │ Shell                    │
+├──────────────┴──────────────┴──────────────────────────┤
+│ Status bar                                              │
+└────────────────────────────────────────────────────────┘
 ```
+
+The main area is a three-column accordion — **Explorer | Viewer | Terminal** —
+with focus-driven widths. The worktree list is no longer a column: every
+worktree (branch, dirty count, ahead/behind, and Claude Code waiting/active
+state) is shown in the full-width **worktree monitor strip** along the top, so
+multiple parallel sessions can be watched at a glance. Click a worktree to jump
+to it, `[+]` to create one, or open the switcher modal for the full list/detail
+view.
+
+- **Explorer** column is split 50/50: file tree (top) and diff / comment list (bottom).
+- **Terminal** column is split 80/20: Claude Code (top) and Shell (bottom).
+- Any panel can be maximized (`Alt+m`) to take the full main area.
 
 ### Keybindings
 
-- **Tab** — cycle focus between panels
-- **j/k** — navigate up/down
-- **h/l** — collapse/expand
-- **g/G** — jump to top/bottom
-- **/** — search
-- **?** — show help
-- **Esc** — back / close overlay
+- **Tab / Shift+Tab** — cycle panel focus (non-terminal panels)
+- **Alt+h / Alt+l** — cycle panel focus from anywhere, including terminals
+- **Alt+1…6** (or **⌘+1…6**) — focus a specific panel
+- **Alt+m** — maximize / restore the focused panel
+- **Ctrl+Tab / Ctrl+Shift+Tab** (or **Alt+] / Alt+[**) — switch the selected worktree
+- **Ctrl+n** — new Claude Code session · **Ctrl+t** — new shell
+- **j/k** — navigate up/down · **h/l** — collapse/expand · **g/G** — top/bottom
+- **/** — search · **Ctrl+g** — full-text (grep) search
+- **?** — show help · **Esc** — back / close overlay · **Ctrl+q** — quit
 
 ### Command Palette
 
-**Ctrl+.** (any panel, including terminal) or **:** (non-terminal panels) to open the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
+**Ctrl+p** (any panel, including terminals) or **:** (non-terminal panels) opens the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
 
 ## MCP Server
 
@@ -111,6 +135,8 @@ main_branch = "main"                    # main/trunk branch name (default: "main
 decoration = "aquarium"                 # worktree panel decoration
                                         #   aquarium | space | garden | city | none
 # auto_resume = true                    # automatically resume Claude Code sessions on startup
+# auto_resume_main = false              # also resume the session on the main worktree
+                                        #   (grabbed sessions are always resumed regardless)
 
 [terminal]
 # inactive_scrollback = 1000            # scrollback lines for background sessions
@@ -139,7 +165,7 @@ theme = "catppuccin-mocha"              # syntax highlighting theme
 # maps a key chord to an action name and LAYERS OVER the built-in defaults
 # per-chord. [keybinds.keys] is the global layer; each [keybinds.layers.<name>]
 # is a per-panel layer (worktree, explorer, explorer_diff_list,
-# explorer_comment_list, viewer, viewer_diff_mode, terminal, overlay).
+# explorer_comment_list, viewer, viewer_diff_mode, terminal, editor, overlay).
 #
 # [keybinds.keys]
 # "ctrl+q" = "quit"
@@ -149,8 +175,6 @@ theme = "catppuccin-mocha"              # syntax highlighting theme
 # "down" = "navigate_down"
 # "w" = "create_worktree"
 
-[notification]
-
 [ccusage]
 # enabled = false                       # token usage display in the title bar (requires ccusage)
 # poll_interval_secs = 120              # polling interval in seconds
@@ -158,6 +182,16 @@ theme = "catppuccin-mocha"              # syntax highlighting theme
 [updates]
 # check_on_startup = true               # check for new versions on startup
 # check_interval_secs = 3600            # minimum interval between checks (default: 1h)
+
+[api]
+# LLM provider for smart-worktree generation (turn a task description into a
+# branch name + initial Claude Code prompt). Each provider stands alone — a
+# failure surfaces to the user rather than falling back to another.
+# provider = "gemini"                   # "gemini" (Gemini API) | "claude" (claude -p CLI) | "command" (external)
+# model = "gemini-2.5-flash"            # model used by the "gemini" provider
+# command = ["ollama", "run", "llama3"] # external command for provider = "command"
+                                        #   (prompt on stdin, completion on stdout)
+# command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
 ```
 
 ## Data Paths


### PR DESCRIPTION
## Summary

実態とズレていた README.md と CLAUDE.md をコードベースに合わせて更新しました。

### Layout（最も古かった箇所）
- 旧 `Worktree | Explorer | Viewer | Terminal` の4カラム表記を、現行の実装（`src/ui/layout.rs`, `src/ui/worktree_bar.rs`）に合わせて修正。
- Worktree カラムは廃止され、上部の**全幅 worktree monitor strip** に移行。メインは **Explorer | Viewer | Terminal** の3カラムアコーディオン。

### README.md
- コマンドパレットのキーを修正: `Ctrl+.`（存在しない）→ `Ctrl+p`（global）/ `:`（非ターミナル）。
- Keybindings を実バインド（`src/default_keybinds.toml`）に合わせて拡充（`Alt+h/l`, `Alt+1…6`, `Alt+m`, `Ctrl+Tab`, `Ctrl+n/t`, `Ctrl+g`, `Ctrl+q` 等）。
- Config: 構造体に存在しない `[notification]` セクションを削除。smart-worktree 生成用の `[api]` セクション（gemini/claude/command プロバイダ）を追加。`[general]` に `auto_resume_main` を追記。`[keybinds]` のレイヤー一覧に `editor` を追加。
- `make install` の説明を `npm install` → `npm ci`（実際の Makefile）に修正。

### CLAUDE.md
- "Four-Column Layout" を現行レイアウトに更新。
- ディレクトリ化されたモジュールのパスを修正: `app.rs`→`app/`、`event.rs`→`event/`、`viewer_state.rs`→`viewer/`。

### Versioning
- ドキュメント修正のため `Cargo.toml` を PATCH バンプ（0.70.2 → 0.70.3）。

## Test plan

- [x] `cargo update -p conductor` で Cargo.lock を同期（0.70.2 → 0.70.3）。
- [x] README の config 例は全行コメント＋セクションヘッダのみで TOML として有効（`config.rs` の `generated_default_config_is_valid_toml` テストと同等構造）。
- [x] 記載したモジュールパス・キーバインド・config フィールドはすべて該当ソース（`layout.rs`, `default_keybinds.toml`, `config.rs`, `src/` ディレクトリ構成）で実在を確認。
- ドキュメントのみの変更のためコードへの影響なし。
