### PR TITLE
feat: show explorer entries in non-git dirs and fix new-file refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.72.0"
+version = "0.73.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.72.0"
+version = "0.73.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1216,18 +1216,22 @@ impl App {
     ///
     /// Preserves the currently open file and scroll position so that
     /// file-watcher refreshes don't disrupt the user's view.
-    pub fn refresh_viewer(&mut self) {
-        if let Some(wt) = self.worktrees.get(self.selected_worktree) {
-            let path = wt.path.clone();
-            let tab_width = self.config.viewer.tab_width;
-            self.viewer_state.load_file_tree(&path, tab_width);
-            // Startup restore: this is the lazy (synchronous) tree-load path
-            // (e.g. first time the viewer is focused), so re-open any pending
-            // file here. The async worktree-switch path does this in
-            // `poll_worktree_switch_ops`.
-            self.consume_pending_view_restore();
-            self.rehighlight_viewer();
-        }
+    ///
+    /// Returns `true` when the file tree's visible entries changed. Uses
+    /// [`Self::selected_worktree_path`], which falls back to `repo_path` when
+    /// there is no worktree, so the Explorer still shows the current folder's
+    /// contents in a plain (non-git) directory.
+    pub fn refresh_viewer(&mut self) -> bool {
+        let path = self.selected_worktree_path();
+        let tab_width = self.config.viewer.tab_width;
+        let changed = self.viewer_state.load_file_tree(&path, tab_width);
+        // Startup restore: this is the lazy (synchronous) tree-load path
+        // (e.g. first time the viewer is focused), so re-open any pending
+        // file here. The async worktree-switch path does this in
+        // `poll_worktree_switch_ops`.
+        self.consume_pending_view_restore();
+        self.rehighlight_viewer();
+        changed
     }
 
     /// Restore the previously selected worktree and seed its saved view

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,15 +297,28 @@ fn leave_tui<W: io::Write>(w: &mut W, keyboard_enhanced: bool) -> io::Result<()>
     Ok(())
 }
 
+/// Paths the file watcher should monitor: every worktree's path, or — when
+/// there are no worktrees (e.g. a plain non-git directory) — the repo path
+/// itself, so the Explorer still auto-refreshes on file changes there.
+fn watch_paths_for(app: &App) -> Vec<std::path::PathBuf> {
+    if app.worktrees.is_empty() {
+        vec![app.repo_path.clone()]
+    } else {
+        app.worktrees.iter().map(|w| w.path.clone()).collect()
+    }
+}
+
 /// Drive the draw → poll → handle cycle until the user quits.
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
 ) -> Result<()> {
-    // Set up file watcher for auto-refresh.
-    let watch_paths: Vec<std::path::PathBuf> =
-        app.worktrees.iter().map(|w| w.path.clone()).collect();
-    let file_watcher = crate::file_watcher::FileWatcher::new(&watch_paths).ok();
+    // Set up file watcher for auto-refresh. The watched set is rebuilt later
+    // (in the worktree_poll timer) whenever it changes — e.g. the user runs
+    // `git init` in a plain folder, or adds/removes a worktree — so newly
+    // created files keep showing up instead of going unnoticed.
+    let mut current_watch_paths = watch_paths_for(app);
+    let mut file_watcher = crate::file_watcher::FileWatcher::new(&current_watch_paths).ok();
 
     // Set up socket listener for CC state notifications (instant delivery).
     let cc_notify = crate::cc_notify::CcNotifyListener::new(&app.repo_path).ok();
@@ -581,6 +594,24 @@ fn run_loop(
                     if app.refresh_worktrees() {
                         app.dirty.mark(
                             crate::app::DirtyPanels::WORKTREE | crate::app::DirtyPanels::EXPLORER,
+                        );
+                    }
+                    // Rebuild the file watcher if the set of paths to watch
+                    // changed (e.g. `git init` created the first worktree, or a
+                    // worktree was added/removed). Without this the watcher would
+                    // keep monitoring a stale set and miss new files.
+                    let desired = watch_paths_for(app);
+                    if desired != current_watch_paths {
+                        current_watch_paths = desired;
+                        file_watcher =
+                            crate::file_watcher::FileWatcher::new(&current_watch_paths).ok();
+                    }
+                    // Periodic fallback: re-walk the file tree so newly created
+                    // files appear even if a watcher event was missed. Cheap
+                    // (lazy child loading) and only repaints when it changed.
+                    if app.refresh_viewer() {
+                        app.dirty.mark(
+                            crate::app::DirtyPanels::EXPLORER | crate::app::DirtyPanels::VIEWER,
                         );
                     }
                     app.check_diff_viewer_staleness();

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -306,7 +306,10 @@ impl ViewerState {
     /// expansion state so that file-watcher refreshes don't disrupt the
     /// user's view. If the previously open file was deleted, the viewer
     /// naturally resets to "no file selected".
-    pub fn load_file_tree(&mut self, worktree_path: &Path, tab_width: usize) {
+    ///
+    /// Returns `true` when the set of visible entries changed, so callers can
+    /// skip a repaint when a periodic refresh found nothing new.
+    pub fn load_file_tree(&mut self, worktree_path: &Path, tab_width: usize) -> bool {
         // Save state before clearing.
         let prev_file = self.content.current_file.clone();
         let prev_file_scroll = self.content.file_scroll;
@@ -318,6 +321,15 @@ impl ViewerState {
             .filter(|e| e.is_dir && e.is_expanded)
             .map(|e| e.path.clone())
             .collect();
+        // Remember the cursor's entry and the full path set so we can restore
+        // the cursor and detect whether the rebuilt tree actually changed.
+        let prev_selected_path = self
+            .tree
+            .file_tree
+            .get(self.tree.tree_selected)
+            .map(|e| e.path.clone());
+        let prev_paths: Vec<String> =
+            self.tree.file_tree.iter().map(|e| e.path.clone()).collect();
 
         // Build (or rebuild) the gitignore matcher for this worktree.
         self.tree.gitignore = Some(Arc::new(Self::build_gitignore(worktree_path)));
@@ -382,6 +394,29 @@ impl ViewerState {
             }
             // If the file was deleted, we naturally stay at "no file selected".
         }
+
+        // Keep the tree cursor anchored across rebuilds. When a file is open the
+        // block above already pointed the cursor at it; otherwise restore the
+        // previously selected entry so watcher/periodic refreshes don't snap the
+        // cursor back to the top.
+        let anchored_to_open_file = prev_file.as_ref().is_some_and(|f| {
+            self.tree.file_tree.get(self.tree.tree_selected).map(|e| &e.path) == Some(f)
+        });
+        if !anchored_to_open_file
+            && let Some(path) = prev_selected_path
+            && let Some(idx) = self.tree.file_tree.iter().position(|e| e.path == path)
+        {
+            self.tree.tree_selected = idx;
+        }
+        if self.tree.tree_selected >= self.tree.file_tree.len() {
+            self.tree.tree_selected = self.tree.file_tree.len().saturating_sub(1);
+        }
+
+        self.tree
+            .file_tree
+            .iter()
+            .map(|e| &e.path)
+            .ne(prev_paths.iter())
     }
 
     /// Open (read) a file and store its lines in `file_content`.


### PR DESCRIPTION
## Summary

- **非gitフォルダでもExplorerにファイルが表示されるようになった**: `refresh_viewer` が `selected_worktree_path()` 経由に変わり、worktreeが無い場合は `repo_path` にフォールバックして `walk_dir` を実行する。`git init` 前でも現在フォルダの中身をそのまま表示する
- **新規ファイルが出てこない問題を修正**: file watcher の監視パスを `worktree_poll` タイマーで動的に再構築するようにした（worktree が増減/初期化された場合に監視対象を更新）。また同タイマーで `refresh_viewer` も呼び、watcher イベントが拾えなくても3秒ごとにツリーを再walkする安全網を追加
- **不要な再描画を抑制**: `load_file_tree` がエントリの変化有無を `bool` で返すようになり、変化がなければ dirty フラグを立てない
- **カーソル位置の保持**: 定期/watcher リフレッシュでカーソルが先頭に飛ばないよう、ファイルを開いていない時も path で位置を保持する

## Test plan

- [ ] 非gitディレクトリで `conductor` を起動し、Explorerにファイル一覧が表示されることを確認
- [ ] 非gitディレクトリで新規ファイルを作成し、3秒以内にExplorerに反映されることを確認
- [ ] gitリポジトリで新規ファイルを作成し、Explorerに反映されることを確認
- [ ] gitリポジトリで `git worktree add` し、worktree切り替えが正常に動作することを確認
- [ ] Explorerでファイルを選択中に定期リフレッシュが走ってもカーソルが動かないことを確認
- [ ] `cargo test` が341件すべてpass することを確認
