### PR TITLE
fix: fall back to local base branch when repo has no remote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.75.0"
+version = "0.75.1"
 edition = "2024"
 
 [dependencies]

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -804,8 +804,15 @@ impl App {
     pub fn start_smart_worktree_async(&mut self, description: &str) {
         let desc = description.to_string();
         let main_branch = self.config.general.main_branch.clone();
-        let base_ref = format!("origin/{main_branch}");
         let repo_path = self.repo_path.clone();
+        // Resolve to a ref that actually exists: origin/<main> if there is a
+        // remote, otherwise the local <main> branch (or HEAD). Without this,
+        // worktree creation fails with "invalid reference: origin/main" in a
+        // local-only repo and the smart worktree never materializes.
+        let base_ref = match git_engine::GitEngine::open(&repo_path) {
+            Ok(engine) => engine.resolve_base_ref(&main_branch),
+            Err(_) => format!("origin/{main_branch}"),
+        };
         let wt_dir = self.config.general.worktree_dir.clone();
 
         let cancel_token = Arc::new(AtomicBool::new(false));
@@ -1187,18 +1194,28 @@ impl App {
     pub fn load_base_branches(&mut self) {
         match git_engine::GitEngine::open(&self.repo_path) {
             Ok(engine) => {
-                match engine.list_remote_branches() {
+                // Prefer remote-tracking branches; fall back to local branches
+                // when the repo has no remote (e.g. a local-only project),
+                // otherwise the picker would be empty and nothing is selectable.
+                let branches = match engine.list_remote_branches() {
+                    Ok(remote) if !remote.is_empty() => Ok(remote),
+                    Ok(_) => engine.list_local_branches(),
+                    Err(e) => Err(e),
+                };
+                match branches {
                     Ok(branches) => {
                         self.worktree_mgr.base_branch_list = branches;
                         self.worktree_mgr.base_branch_selected = 0;
                         self.worktree_mgr.base_branch_filter.clear();
-                        // Pre-select origin/<main_branch> if it exists.
-                        let default_base = format!("origin/{}", self.config.general.main_branch);
+                        // Pre-select origin/<main_branch>, or the local
+                        // <main_branch> when there is no remote.
+                        let main_branch = self.config.general.main_branch.clone();
+                        let remote_base = format!("origin/{main_branch}");
                         if let Some(pos) = self
                             .worktree_mgr
                             .base_branch_list
                             .iter()
-                            .position(|b| b == &default_base)
+                            .position(|b| b == &remote_base || b == &main_branch)
                         {
                             self.worktree_mgr.base_branch_selected = pos;
                         }

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -272,6 +272,24 @@ impl GitEngine {
         Ok(names)
     }
 
+    /// Resolve the best existing starting ref for a new worktree branching off
+    /// `main_branch`.
+    ///
+    /// Prefers the remote-tracking branch `origin/<main_branch>`, falls back to
+    /// the local branch `<main_branch>`, then to `HEAD`. The returned ref is
+    /// guaranteed to resolve, so `git worktree add ... <ref>` won't fail with an
+    /// "invalid reference" error in a repo that has no remote.
+    pub fn resolve_base_ref(&self, main_branch: &str) -> String {
+        let remote = format!("origin/{main_branch}");
+        if self.repo.revparse_single(&remote).is_ok() {
+            return remote;
+        }
+        if self.repo.revparse_single(main_branch).is_ok() {
+            return main_branch.to_string();
+        }
+        String::from("HEAD")
+    }
+
     /// Create a worktree from a remote branch (wt switch equivalent).
     ///
     /// `remote_branch` should be like "origin/feature-x".


### PR DESCRIPTION
## Summary

remote を持たないローカル専用リポジトリで worktree 作成が壊れていた問題を修正する。Conductor は base ブランチを remote (`origin/main`) 前提で扱っていたため、remote の無いリポジトリで以下の2つが同じ根本原因で壊れていた。

- **手動 worktree 作成で base branch が選べない**: `load_base_branches` が remote ブランチのみを列挙していたため、remote が無いとピッカーが空になっていた。
- **smart worktree がぐるぐる回って何も生まれない**: `start_smart_worktree_async` が base_ref を `origin/main` にハードコードしており、Phase 2 の `git worktree add ... origin/main` が `fatal: invalid reference: origin/main` で必ず失敗していた（LLM 生成 Phase 1 は成功していた）。

### 変更点

- `git_engine.rs`: `resolve_base_ref(main_branch)` を追加。`origin/<main>` → 無ければ local `<main>` → `HEAD` の順で必ず解決する ref を返す。
- `app/worktree.rs` `load_base_branches`: remote ブランチが空なら local ブランチにフォールバック。デフォルト選択も `origin/<main>` か local `<main>` を拾う。
- `app/worktree.rs` `start_smart_worktree_async`: `origin/{main}` ハードコードを `resolve_base_ref()` に置換。
- バージョン `0.75.0` → `0.75.1` (PATCH: バグ修正)。

## Test plan

- [x] `cargo build` / `cargo clippy` がクリーン（`resolve_base_ref` の dead_code 警告も解消）
- [x] remote 無しリポジトリで `git worktree add -b X path origin/main` が `fatal: invalid reference` で失敗することを再現 → 修正後の base（local `main`）では exit 0 で worktree 作成成功を確認（テスト用 worktree/branch は削除済み）
- [ ] remote 無しリポジトリで手動 worktree 作成時に base branch ピッカーに local ブランチが表示され選択できること
- [ ] remote 無しリポジトリで smart worktree が worktree とセッションを生成すること
