### PR TITLE
feat: 背景画像ユーザー向けのテーマ切替・ライトテーマ・透明化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.75.2"
+version = "0.76.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.75.2"
+version = "0.76.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -383,6 +383,10 @@ pub struct App {
     pub keymap: KeyMap,
     /// UI color theme.
     pub theme: Theme,
+    /// Active theme name — the canonical key used to resolve `theme`.
+    /// Kept in sync by `set_theme`; used to find the current selection in the
+    /// theme picker and to build the config layer when persisting.
+    pub theme_name: String,
     /// State for the Explorer/Viewer panel (file tree + file content).
     pub viewer_state: ViewerState,
     /// State for the Diff data (used for inline highlights in Viewer).
@@ -681,7 +685,14 @@ impl App {
             .and_then(|store| store.get_today_stats().ok());
 
         let (keymap, keybind_warnings) = KeyMap::with_warnings(&config.keybinds);
-        let theme = Theme::from_name(&config.viewer.theme);
+        // [ui] theme takes precedence; fall back to [viewer] theme for compatibility.
+        let theme_name = config
+            .ui
+            .theme
+            .as_deref()
+            .unwrap_or(&config.viewer.theme)
+            .to_string();
+        let theme = Theme::from_name(&theme_name);
         let auto_resume = config.general.auto_resume;
 
         // Derive the main repo display name from the main worktree path.
@@ -712,6 +723,7 @@ impl App {
             config,
             keymap,
             theme,
+            theme_name,
             viewer_state: ViewerState::default(),
             diff_state,
             review_store,
@@ -1428,6 +1440,26 @@ impl App {
         self.set_status(text, StatusLevel::Info);
     }
 
+    /// Switch the active UI theme at runtime.
+    ///
+    /// When `persist` is `true`, the selection is written to the config file
+    /// (`~/.config/conductor/config.toml`) so it survives restarts. A write
+    /// failure is non-fatal: it is logged and surfaced as a warning flash.
+    pub fn set_theme(&mut self, name: &str, persist: bool) {
+        self.theme = Theme::from_name(name);
+        self.theme_name = name.to_string();
+        self.config.ui.theme = Some(name.to_string());
+        if persist
+            && let Err(e) = crate::config::persist_ui_theme(name)
+        {
+            log::warn!("failed to persist theme '{name}': {e}");
+            self.set_status(
+                format!("Theme saved in session but could not write config: {e}"),
+                StatusLevel::Warning,
+            );
+        }
+    }
+
     // ── Code navigation helpers ────────────────────────────────────
 
     /// Extract the symbol under the cursor from the current viewer line.
@@ -1712,7 +1744,29 @@ impl App {
             CommandId::TogglePartyMode => self.cmd_toggle_party_mode(),
             CommandId::ToggleRichMode => self.cmd_toggle_rich_mode(),
             CommandId::Quit => self.should_quit = true,
+            CommandId::SwitchTheme => self.cmd_open_theme_picker(),
         }
+    }
+
+    /// Open the theme picker overlay.
+    ///
+    /// Captures `theme_name` as the revert target so Esc can restore the theme
+    /// that was active when the picker opened (even after live-preview moves).
+    pub fn cmd_open_theme_picker(&mut self) {
+        let themes: Vec<String> = crate::theme::Theme::all_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let selected = themes
+            .iter()
+            .position(|t| t == &self.theme_name)
+            .unwrap_or(0);
+        self.overlays.theme_picker = crate::overlay::ThemePickerOverlay {
+            themes,
+            selected,
+            original: self.theme_name.clone(),
+        };
+        self.overlays.active = ActiveOverlay::ThemePicker;
     }
 
     // ── Command palette handler methods ──────────────────────────────

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -84,6 +84,9 @@ pub enum CommandId {
     TogglePartyMode,
     ToggleRichMode,
     Quit,
+
+    // UI
+    SwitchTheme,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -467,6 +470,14 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::App,
         action: Some(Action::Quit),
         keywords: "exit close",
+    },
+    // UI
+    PaletteCommand {
+        id: CommandId::SwitchTheme,
+        label: "Switch Theme",
+        category: CommandCategory::View,
+        action: Some(Action::OpenThemePicker),
+        keywords: "theme color light dark appearance palette catppuccin solarized github",
     },
 ];
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,9 @@ pub struct Config {
     pub api: ApiConfig,
     /// `[rich]` -- rich mode (terminal graphics) settings.
     pub rich: RichConfig,
+    /// `[ui]` -- UI appearance settings (theme, etc.).
+    #[serde(default)]
+    pub ui: UiConfig,
 }
 
 impl Config {
@@ -327,6 +330,16 @@ impl Default for RichConfig {
     }
 }
 
+/// `[ui]` section — UI appearance overrides.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UiConfig {
+    /// UI color theme name. When `None`, falls back to `[viewer] theme` for
+    /// backward compatibility. Light theme options: `catppuccin-latte`,
+    /// `solarized-light`, `github-light`. Dark: see `Theme::all_names()`.
+    pub theme: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -443,8 +456,110 @@ pub fn generate_default_config() -> String {
 # model = "gemini-2.5-flash"            # model for smart worktree generation (Gemini API)
 # command = ["ollama", "run", "llama3"] # external command for provider = "command" (prompt on stdin, completion on stdout)
 # command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
+
+[ui]
+# theme = "catppuccin-mocha"            # UI color theme (overrides [viewer] theme when set)
+#                                       #   dark:  catppuccin-mocha | dracula | nord | solarized-dark
+#                                       #          tokyo-night | gruvbox | rose-pine | kanagawa
+#                                       #   light: catppuccin-latte | solarized-light | github-light
+#                                       # Light themes work best on terminals with a light/white background.
+#                                       # When unset, conductor auto-detects a light background via OSC 11
+#                                       # and switches to catppuccin-latte for that session (no file write).
 "#,
     )
+}
+
+/// Persist a theme selection to `~/.config/conductor/config.toml`.
+///
+/// Uses text-based minimal editing to preserve existing comments and structure:
+/// - If the `[ui]` section already has an uncommented `theme = ...` line, it is
+///   replaced in place.
+/// - If the `[ui]` section exists but has no uncommented `theme` line (e.g. only
+///   comments), the line is inserted immediately after the `[ui]` header.
+/// - If no `[ui]` section exists, `\n[ui]\ntheme = "..."\n` is appended.
+pub fn persist_ui_theme(name: &str) -> Result<()> {
+    let path = config_file_path();
+    let contents = if path.exists() {
+        std::fs::read_to_string(&path)?
+    } else {
+        // Config file doesn't exist yet; generate defaults and proceed.
+        generate_default_config()
+    };
+    let updated = upsert_ui_theme(&contents, name);
+    std::fs::write(&path, updated)?;
+    Ok(())
+}
+
+/// Pure function: upsert `theme = "<name>"` in the `[ui]` section of a
+/// config file string, preserving all comments and surrounding content.
+///
+/// Extracted as a testable helper so file I/O in `persist_ui_theme` can be
+/// tested independently. Called transitively via `set_theme`.
+/// Return `true` when `line` is a `[ui]` TOML section header, possibly followed
+/// by whitespace and/or an inline comment (e.g. `[ui]  # colors`).
+/// Sub-sections like `[ui.fonts]` are deliberately excluded.
+fn is_ui_section_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    // Must start with exactly `[ui]` (not `[ui.something]`).
+    if !trimmed.starts_with("[ui]") {
+        return false;
+    }
+    // After `[ui]` only whitespace and/or a `#` comment may follow.
+    let after = trimmed["[ui]".len()..].trim_start();
+    after.is_empty() || after.starts_with('#')
+}
+
+fn upsert_ui_theme(contents: &str, name: &str) -> String {
+    let theme_line = format!("theme = \"{name}\"");
+    let lines: Vec<&str> = contents.lines().collect();
+
+    // Locate the [ui] section header.
+    // Match `[ui]` with optional trailing whitespace/comment, e.g. `[ui]  # colors`,
+    // but NOT sub-sections like `[ui.colors]`.
+    let ui_start = lines.iter().position(|l| is_ui_section_header(l));
+
+    if let Some(ui_idx) = ui_start {
+        // End of section = next bare `[...]` header (not a comment).
+        let ui_end = lines[ui_idx + 1..]
+            .iter()
+            .position(|l| {
+                let t = l.trim();
+                t.starts_with('[') && !t.starts_with('#')
+            })
+            .map(|i| ui_idx + 1 + i)
+            .unwrap_or(lines.len());
+
+        // Look for an existing uncommented `theme = ...` key within the section.
+        let existing_theme_idx = lines[ui_idx + 1..ui_end]
+            .iter()
+            .position(|l| {
+                let t = l.trim();
+                !t.starts_with('#') && (t.starts_with("theme =") || t.starts_with("theme="))
+            })
+            .map(|i| ui_idx + 1 + i);
+
+        let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        if let Some(idx) = existing_theme_idx {
+            result_lines[idx] = theme_line;
+        } else {
+            // No uncommented theme line in the section — insert right after [ui].
+            result_lines.insert(ui_idx + 1, theme_line);
+        }
+
+        let mut result = result_lines.join("\n");
+        if contents.ends_with('\n') {
+            result.push('\n');
+        }
+        result
+    } else {
+        // No [ui] section at all — append one.
+        let mut result = contents.to_string();
+        if !result.ends_with('\n') && !result.is_empty() {
+            result.push('\n');
+        }
+        result.push_str(&format!("\n[ui]\n{theme_line}\n"));
+        result
+    }
 }
 
 /// Default review prompt template (Japanese).
@@ -574,5 +689,112 @@ check_interval_secs = 3600"#,
         assert_eq!(cfg.terminal.inactive_scrollback, 1000);
         assert_eq!(cfg.viewer.tab_width, 2);
         assert!(cfg.updates.check_on_startup);
+    }
+
+    #[test]
+    fn ui_config_default_has_no_theme() {
+        let cfg = Config::default();
+        assert!(cfg.ui.theme.is_none());
+    }
+
+    #[test]
+    fn ui_config_round_trips_through_toml() {
+        let toml_str = r#"[ui]
+theme = "catppuccin-latte"
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.ui.theme.as_deref(), Some("catppuccin-latte"));
+
+        // Serialize and deserialize again.
+        let serialized = toml::to_string_pretty(&cfg).expect("serialize");
+        let cfg2: Config = toml::from_str(&serialized).expect("round-trip");
+        assert_eq!(cfg2.ui.theme.as_deref(), Some("catppuccin-latte"));
+    }
+
+    #[test]
+    fn upsert_ui_theme_appends_when_no_ui_section() {
+        let contents = "[general]\nmain_branch = \"main\"\n";
+        let result = upsert_ui_theme(contents, "nord");
+        assert!(result.contains("[ui]"));
+        assert!(result.contains("theme = \"nord\""));
+        // Original content preserved.
+        assert!(result.contains("[general]"));
+    }
+
+    #[test]
+    fn upsert_ui_theme_replaces_existing_theme_line() {
+        let contents = "[ui]\ntheme = \"dracula\"\n";
+        let result = upsert_ui_theme(contents, "github-light");
+        assert_eq!(
+            result,
+            "[ui]\ntheme = \"github-light\"\n",
+            "existing theme line must be replaced in place"
+        );
+    }
+
+    #[test]
+    fn upsert_ui_theme_inserts_after_ui_header_when_only_comments() {
+        let contents = "[ui]\n# theme = \"catppuccin-mocha\"\n";
+        let result = upsert_ui_theme(contents, "catppuccin-latte");
+        // Should have the new line inserted after [ui], before the comment.
+        assert!(result.contains("theme = \"catppuccin-latte\""));
+        // Comment must be preserved.
+        assert!(result.contains("# theme = \"catppuccin-mocha\""));
+    }
+
+    #[test]
+    fn upsert_ui_theme_preserves_other_sections_after_ui() {
+        let contents = "[viewer]\ntheme = \"dracula\"\n\n[ui]\n# theme placeholder\n\n[general]\n";
+        let result = upsert_ui_theme(contents, "nord");
+        assert!(result.contains("theme = \"nord\""));
+        assert!(result.contains("[viewer]"));
+        assert!(result.contains("[general]"));
+    }
+
+    #[test]
+    fn upsert_ui_theme_trailing_newline_preserved() {
+        let with_newline = "[ui]\ntheme = \"dracula\"\n";
+        let without_newline = "[ui]\ntheme = \"dracula\"";
+        assert!(upsert_ui_theme(with_newline, "nord").ends_with('\n'));
+        assert!(!upsert_ui_theme(without_newline, "nord").ends_with('\n'));
+    }
+
+    // inline-comment [ui] header detection.
+
+    #[test]
+    fn upsert_ui_theme_handles_inline_comment_on_ui_header() {
+        // `[ui]  # color settings` must be recognised as the [ui] section.
+        let contents = "[general]\n\n[ui]  # color settings\ntheme = \"dracula\"\n";
+        let result = upsert_ui_theme(contents, "nord");
+        assert_eq!(
+            result.matches("[ui]").count(),
+            1,
+            "must not append a duplicate [ui] section"
+        );
+        assert!(result.contains("theme = \"nord\""));
+    }
+
+    #[test]
+    fn upsert_ui_theme_does_not_match_ui_subsection() {
+        // `[ui.colors]` is NOT the `[ui]` section; a new `[ui]` block must be appended.
+        let contents = "[ui.colors]\nfoo = \"bar\"\n";
+        let result = upsert_ui_theme(contents, "nord");
+        assert!(
+            result.contains("[ui]\n"),
+            "a new [ui] section should be appended, not matched"
+        );
+        // The subsection must still be present.
+        assert!(result.contains("[ui.colors]"));
+    }
+
+    #[test]
+    fn is_ui_section_header_cases() {
+        assert!(super::is_ui_section_header("[ui]"));
+        assert!(super::is_ui_section_header("[ui]  "));
+        assert!(super::is_ui_section_header("[ui]  # comment"));
+        assert!(super::is_ui_section_header("  [ui]"));
+        assert!(!super::is_ui_section_header("[ui.sub]"));
+        assert!(!super::is_ui_section_header("[ui.colors]"));
+        assert!(!super::is_ui_section_header("[viewer]"));
     }
 }

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -77,6 +77,10 @@
 "alt+/" = "toggle_panel_overlay"
 # macOS Unicode fallback (Option+/ = '÷', US layout).
 "÷" = "toggle_panel_overlay"
+# Alt+t — open the theme picker (t for "theme").
+# macOS Unicode fallback (Option+t = '†', dagger, US layout).
+"alt+t" = "open_theme_picker"
+"†" = "open_theme_picker"
 
 # ── Worktree ──────────────────────────────────────────────────────────────────
 [layers.worktree]

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -147,6 +147,10 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.toggle_panel_overlay();
             true
         }
+        Action::OpenThemePicker => {
+            app.cmd_open_theme_picker();
+            true
+        }
         _ => false, // Not a global action — let panel-specific handler try.
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -201,6 +201,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
                 ActiveOverlay::CommandPalette => handle_command_palette_key(app, key),
                 ActiveOverlay::WorktreeSwitcher => handle_worktree_key(app, key),
                 ActiveOverlay::CommentList => handle_explorer_comment_list_key(app, key),
+                ActiveOverlay::ThemePicker => handle_theme_picker_key(app, key),
                 ActiveOverlay::None => unreachable!(),
             }
             return;

--- a/src/event/overlay.rs
+++ b/src/event/overlay.rs
@@ -1596,6 +1596,52 @@ fn jump_to_symbol_implementation(app: &mut App, symbol: &str, screen_row: usize)
     }
 }
 
+// ── Overlay: theme picker ────────────────────────────────────────────────
+
+/// Handle keys for the theme picker overlay.
+///
+/// Up/Down (or j/k) browse the list with live preview — each movement calls
+/// `set_theme(name, false)` so the UI updates immediately without persisting.
+/// Enter confirms and persists the selected theme; Esc reverts to the theme
+/// that was active when the picker was opened.
+pub(super) fn handle_theme_picker_key(app: &mut App, key: KeyEvent) {
+    let count = app.overlays.theme_picker.themes.len();
+
+    if overlay_list_nav(&app.keymap, &key, &mut app.overlays.theme_picker.selected, count) {
+        // Live preview: apply the newly highlighted theme without persisting.
+        let name = app
+            .overlays
+            .theme_picker
+            .themes
+            .get(app.overlays.theme_picker.selected)
+            .cloned()
+            .unwrap_or_default();
+        app.set_theme(&name, false);
+        return;
+    }
+
+    match key.code {
+        KeyCode::Enter => {
+            let name = app
+                .overlays
+                .theme_picker
+                .themes
+                .get(app.overlays.theme_picker.selected)
+                .cloned()
+                .unwrap_or_default();
+            app.overlays.active = ActiveOverlay::None;
+            app.set_theme(&name, true);
+            app.set_status(format!("Theme: {name}"), StatusLevel::Success);
+        }
+        KeyCode::Esc => {
+            let orig = app.overlays.theme_picker.original.clone();
+            app.overlays.active = ActiveOverlay::None;
+            app.set_theme(&orig, false);
+        }
+        _ => {}
+    }
+}
+
 fn jump_to_symbol_references(app: &mut App, symbol: &str) {
     let root = app.symbol_index.root();
     let refs = app.symbol_index.find_references(symbol, &root);

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -145,6 +145,10 @@ pub enum Action {
     // ── Panel layout ────────────────────────────────────────────
     TogglePanelExpand,
     TogglePanelOverlay,
+
+    // ── UI ──────────────────────────────────────────────────────
+    /// Open the theme picker overlay to switch the UI color theme at runtime.
+    OpenThemePicker,
 }
 
 impl Action {
@@ -231,6 +235,7 @@ impl Action {
             "inline_reply" => Some(Action::InlineReply),
             "toggle_panel_expand" => Some(Action::TogglePanelExpand),
             "toggle_panel_overlay" => Some(Action::TogglePanelOverlay),
+            "open_theme_picker" => Some(Action::OpenThemePicker),
             _ => None,
         }
     }
@@ -319,6 +324,7 @@ impl Action {
             Action::InlineReply => "inline_reply",
             Action::TogglePanelExpand => "toggle_panel_expand",
             Action::TogglePanelOverlay => "toggle_panel_overlay",
+            Action::OpenThemePicker => "open_theme_picker",
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,26 @@ fn main() -> Result<()> {
     let window_title = format!("conductor - {}", app.main_repo_name);
     execute!(io::stdout(), SetTitle(&window_title))?;
 
+    // ── OSC11 background auto-detection ──────────────────────────────
+    // The query must run while in raw mode and before the event loop starts
+    // reading stdin (same requirement as the graphics-protocol probe below).
+    // `auto_theme_for_background` handles the "only when unconfigured" guard
+    // and the light/dark threshold, so main.rs stays free of inline logic.
+    if let Some(lum) = term_caps::query_background_luminance() {
+        let configured = app.config.ui.theme.as_deref();
+        if let Some(theme) = term_caps::auto_theme_for_background(lum, configured) {
+            // Session-only (persist=false); user can override via theme picker.
+            app.set_theme(theme, false);
+            log::info!(
+                "OSC11 auto-detected light background (luminance={lum:.2}): switched to {theme}"
+            );
+        } else {
+            log::info!(
+                "OSC11 auto-detected background (luminance={lum:.2}): keeping current theme"
+            );
+        }
+    }
+
     // ── Rich mode capability detection ───────────────────────────────
     // Runs after entering the alternate screen but before the event loop
     // starts reading stdin: the graphics probe (when it runs) must read the

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -37,6 +37,20 @@ pub enum ActiveOverlay {
     /// Full-screen comment list — overview of all review comments on the branch
     /// with jump-to-location. Reuses the comment list state + handler.
     CommentList,
+    /// Theme picker — Up/Down to browse, live preview on each move, Enter to
+    /// persist, Esc to revert to the theme that was active when the picker opened.
+    ThemePicker,
+}
+
+/// Theme picker overlay state.
+#[derive(Default)]
+pub struct ThemePickerOverlay {
+    /// All available theme names in display order (see `Theme::all_names`).
+    pub themes: Vec<String>,
+    /// Currently highlighted index within `themes`.
+    pub selected: usize,
+    /// The `theme_name` active when the picker was opened — used to revert on Esc.
+    pub original: String,
 }
 
 /// Switch-branch overlay state.
@@ -220,4 +234,5 @@ pub struct OverlayManager {
     pub grep_search: GrepSearchOverlay,
     pub help: HelpOverlay,
     pub command_palette: CommandPaletteOverlay,
+    pub theme_picker: ThemePickerOverlay,
 }

--- a/src/term_caps.rs
+++ b/src/term_caps.rs
@@ -17,6 +17,8 @@
 //! the crossterm event loop starts reading stdin, or the query response would
 //! be swallowed as input events.
 
+use std::io::Write;
+
 use ratatui_image::picker::ProtocolType;
 
 /// Resolved rich-mode tier for this session.
@@ -150,6 +152,148 @@ pub fn resolve_rich_tier(
     }
 }
 
+/// Query the terminal for its background color via OSC 11 and return the
+/// relative luminance (0.0 = black, 1.0 = white, linear scale).
+///
+/// **How it works:** sends `ESC ] 11 ; ? ST` to stdout while in raw mode, then
+/// polls fd 0 (stdin) on the **main thread** with `libc::poll` and a 150 ms
+/// deadline. Reading happens only when the fd is reported readable, so the call
+/// never blocks longer than the deadline. The response is drained completely
+/// before returning so no bytes leak into the subsequent graphics-protocol probe
+/// (`Picker::from_query_stdio`).
+///
+/// **tmux:** when `TERM` starts with `"tmux"` or `TERM_PROGRAM == "tmux"`,
+/// the passthrough is typically disabled and no response arrives; the function
+/// returns `None` immediately without sending the query.
+///
+/// Returns `None` when the terminal does not respond within the timeout or the
+/// response cannot be parsed.
+pub fn query_background_luminance() -> Option<f64> {
+    // Skip when running inside tmux (passthrough usually disabled).
+    let term = std::env::var("TERM").unwrap_or_default();
+    let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+    if term.starts_with("tmux") || term_program.eq_ignore_ascii_case("tmux") {
+        return None;
+    }
+
+    // Send the OSC 11 query to stdout. Raw mode is already active and the
+    // crossterm event loop has not started yet, so there is no concurrent reader.
+    {
+        let mut stdout = std::io::stdout().lock();
+        // OSC 11 query: ESC ] 11 ; ? ST  (ST = ESC \)
+        if stdout.write_all(b"\x1b]11;?\x1b\\").is_err() {
+            return None;
+        }
+        if stdout.flush().is_err() {
+            return None;
+        }
+    }
+
+    // Read the response on the main thread using libc::poll so we never block
+    // longer than the deadline even on terminals that don't support OSC 11.
+    const TIMEOUT_MS: i32 = 150;
+    let deadline = std::time::Instant::now()
+        + std::time::Duration::from_millis(TIMEOUT_MS as u64);
+
+    let mut buf: Vec<u8> = Vec::with_capacity(64);
+    loop {
+        // Compute remaining time for this poll call.
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .map(|d| d.as_millis().min(TIMEOUT_MS as u128) as i32)
+            .unwrap_or(0);
+        if remaining <= 0 {
+            return None; // Timed out.
+        }
+
+        // SAFETY: poll is a simple syscall with a plain-old-data pollfd struct.
+        let ready = unsafe {
+            let mut pfd = libc::pollfd {
+                fd: libc::STDIN_FILENO,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            libc::poll(&mut pfd, 1, remaining)
+        };
+
+        if ready <= 0 {
+            return None; // Timeout or error.
+        }
+
+        // Read one byte at a time to detect the OSC terminator precisely.
+        let mut byte = [0u8; 1];
+        // SAFETY: reading one byte from fd 0 (stdin) which we know is readable.
+        let n = unsafe {
+            libc::read(
+                libc::STDIN_FILENO,
+                byte.as_mut_ptr().cast::<libc::c_void>(),
+                1,
+            )
+        };
+        if n <= 0 {
+            return None;
+        }
+        buf.push(byte[0]);
+
+        // OSC terminators: ST (ESC \) or BEL (0x07).
+        let ended = buf.ends_with(b"\x1b\\") || buf.ends_with(b"\x07");
+        if ended {
+            return std::str::from_utf8(&buf)
+                .ok()
+                .and_then(parse_osc11_luminance);
+        }
+
+        // Bail if the response grows unreasonably large.
+        if buf.len() > 256 {
+            return None;
+        }
+    }
+}
+
+/// Choose a theme name based on the terminal background luminance.
+///
+/// Returns `Some(name)` only when the caller should switch themes automatically:
+/// - `configured` is `None` (user has not pinned a theme in the config), and
+/// - `lum > 0.5` (light background detected).
+///
+/// Returns `None` when a theme is already configured, or the background is dark
+/// (keep whatever theme is already active).
+pub fn auto_theme_for_background(lum: f64, configured: Option<&str>) -> Option<&'static str> {
+    if configured.is_some() {
+        return None; // Explicit config always wins.
+    }
+    if lum > 0.5 {
+        Some("catppuccin-latte")
+    } else {
+        None // Dark background — keep the default dark theme.
+    }
+}
+
+/// Parse `ESC ] 11 ; rgb:RRRR/GGGG/BBBB ST` and return the relative luminance.
+///
+/// Each channel is a 4-hex-digit value (0000–FFFF); we use the high byte (first
+/// two hex digits) for the luminance calculation, matching common practice.
+fn parse_osc11_luminance(response: &str) -> Option<f64> {
+    // Strip the OSC prefix and suffix, then extract the rgb:…/…/… part.
+    let inner = response
+        .trim_start_matches('\x1b')
+        .trim_start_matches(']')
+        .trim_end_matches('\x1b')
+        .trim_end_matches('\\')
+        .trim_end_matches('\x07');
+    // Expected: "11;rgb:RRRR/GGGG/BBBB"
+    let rgb_part = inner.strip_prefix("11;rgb:")?;
+    let parts: Vec<&str> = rgb_part.split('/').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    // Each part is a 4-digit hex value; take the first two digits (high byte).
+    let r = u8::from_str_radix(parts[0].get(..2)?, 16).ok()? as f64 / 255.0;
+    let g = u8::from_str_radix(parts[1].get(..2)?, 16).ok()? as f64 / 255.0;
+    let b = u8::from_str_radix(parts[2].get(..2)?, 16).ok()? as f64 / 255.0;
+    Some(0.299 * r + 0.587 * g + 0.114 * b)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,5 +393,92 @@ mod tests {
         assert!(RichTier::TierB.is_rich());
         assert!(!RichTier::TierA.has_graphics());
         assert!(RichTier::TierB.has_graphics());
+    }
+
+    // auto_theme_for_background pure-function tests.
+
+    #[test]
+    fn auto_theme_configured_always_returns_none() {
+        // User has pinned a theme — auto-detection must not override it.
+        assert!(super::auto_theme_for_background(0.9, Some("dracula")).is_none());
+        assert!(super::auto_theme_for_background(0.9, Some("catppuccin-mocha")).is_none());
+        assert!(super::auto_theme_for_background(0.1, Some("github-light")).is_none());
+    }
+
+    #[test]
+    fn auto_theme_light_background_selects_latte() {
+        // Light background (luminance > 0.5) with no configured theme.
+        let t = super::auto_theme_for_background(0.9, None);
+        assert_eq!(t, Some("catppuccin-latte"));
+        // Exactly on the threshold (0.5) counts as dark.
+        assert!(super::auto_theme_for_background(0.5, None).is_none());
+        // Just above threshold.
+        let t2 = super::auto_theme_for_background(0.501, None);
+        assert_eq!(t2, Some("catppuccin-latte"));
+    }
+
+    #[test]
+    fn auto_theme_dark_background_returns_none() {
+        assert!(super::auto_theme_for_background(0.1, None).is_none());
+        assert!(super::auto_theme_for_background(0.0, None).is_none());
+        assert!(super::auto_theme_for_background(0.499, None).is_none());
+    }
+
+    // OSC11 parser tests (no terminal I/O needed).
+
+    #[test]
+    fn parse_osc11_black_background() {
+        // Black background: all channels 0x00.
+        let lum = super::parse_osc11_luminance("\x1b]11;rgb:0000/0000/0000\x1b\\");
+        assert!(lum.is_some());
+        assert!((lum.unwrap() - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_osc11_white_background() {
+        // White background: all channels 0xFF.
+        let lum = super::parse_osc11_luminance("\x1b]11;rgb:ffff/ffff/ffff\x1b\\");
+        assert!(lum.is_some());
+        assert!((lum.unwrap() - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_osc11_catppuccin_mocha_bg() {
+        // Catppuccin Mocha base: #1e1e2e → 0x1e1e ≈ 30, 0x1e1e ≈ 30, 0x2e2e ≈ 46
+        let lum = super::parse_osc11_luminance("\x1b]11;rgb:1e1e/1e1e/2e2e\x1b\\");
+        assert!(lum.is_some());
+        let v = lum.unwrap();
+        // Expect a dark background — luminance well below 0.5.
+        assert!(v < 0.2, "expected dark bg, got {v}");
+    }
+
+    #[test]
+    fn parse_osc11_malformed_returns_none() {
+        assert!(super::parse_osc11_luminance("garbage").is_none());
+        assert!(super::parse_osc11_luminance("\x1b]11;rgb:ZZ/GG/HH\x1b\\").is_none());
+        assert!(super::parse_osc11_luminance("\x1b]11;rgb:ffff/ffff\x1b\\").is_none());
+    }
+
+    // additional parser coverage.
+
+    #[test]
+    fn parse_osc11_bel_terminator() {
+        // Some terminals (e.g. old xterm) use BEL (0x07) as the OSC terminator.
+        let lum = super::parse_osc11_luminance("\x1b]11;rgb:ffff/ffff/ffff\x07");
+        assert!(lum.is_some());
+        assert!((lum.unwrap() - 1.0).abs() < 0.01, "white bg via BEL terminator");
+    }
+
+    #[test]
+    fn parse_osc11_8bit_channels() {
+        // Some terminals reply with 8-bit (2-digit) channel values: `rgb:RR/GG/BB`.
+        // The parser reads the first two hex digits, so this is handled naturally.
+        let lum = super::parse_osc11_luminance("\x1b]11;rgb:ff/ff/ff\x1b\\");
+        assert!(lum.is_some());
+        assert!((lum.unwrap() - 1.0).abs() < 0.01, "white bg via 8-bit channels");
+
+        let dark = super::parse_osc11_luminance("\x1b]11;rgb:1e/1e/2e\x1b\\");
+        assert!(dark.is_some());
+        assert!(dark.unwrap() < 0.2, "dark bg via 8-bit channels");
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -8,6 +8,16 @@ use ratatui::style::Color;
 /// A color theme for the application.
 #[derive(Debug, Clone)]
 pub struct Theme {
+    // ── Meta ─────────────────────────────────────────────────────────
+    /// The canonical name of this theme (matches the key used in `from_name`
+    /// and returned by `all_names`). Primarily used to detect registration
+    /// drift between `from_name` and `all_names` at test time.
+    #[allow(dead_code)]
+    pub name: &'static str,
+    /// Whether this is a light (true) or dark (false) background theme.
+    /// Used by OSC 11 auto-detection and by the theme-picker light/dark tag.
+    pub light: bool,
+
     // ── Core ─────────────────────────────────────────────────────────
     /// Foreground color for normal text.
     pub fg: Color,
@@ -132,10 +142,11 @@ pub struct Theme {
     pub code_fg: Color,
 
     // ── Panel surface ────────────────────────────────────────────────
-    /// Subtle background filled behind the currently focused list panel
-    /// (worktree / explorer) to lift it out of the surrounding columns.
-    /// A gentle step above each theme's base so focus reads in peripheral
-    /// vision without straining the eye on long sessions.
+    /// Subtle background for the focused list panel (worktree / explorer).
+    /// Retained in the struct for theme compatibility; the layout.rs surface
+    /// fill was removed in the transparency sweep so the terminal background
+    /// shows through instead.
+    #[allow(dead_code)]
     pub panel_focused_bg: Color,
 }
 
@@ -151,8 +162,29 @@ impl Theme {
             "gruvbox" => Self::gruvbox(),
             "rose-pine" => Self::rose_pine(),
             "kanagawa" => Self::kanagawa(),
+            "catppuccin-latte" => Self::catppuccin_latte(),
+            "solarized-light" => Self::solarized_light(),
+            "github-light" => Self::github_light(),
             _ => Self::default(),
         }
+    }
+
+    /// All built-in theme names in display order: dark themes first, then light.
+    /// Used by the theme-picker UI and OSC11 auto-detection switch.
+    pub fn all_names() -> &'static [&'static str] {
+        &[
+            "catppuccin-mocha",
+            "dracula",
+            "nord",
+            "solarized-dark",
+            "tokyo-night",
+            "gruvbox",
+            "rose-pine",
+            "kanagawa",
+            "catppuccin-latte",
+            "solarized-light",
+            "github-light",
+        ]
     }
 
     /// Darken an RGB color by the given factor (0.0 = black, 1.0 = unchanged).
@@ -179,6 +211,8 @@ impl Theme {
     /// Yellow #f9e2af, Peach #fab387.
     fn catppuccin_mocha() -> Self {
         Self {
+            name: "catppuccin-mocha",
+            light: false,
             fg: Color::Rgb(205, 214, 244),      // Text
             accent: Color::Rgb(203, 166, 247),  // Mauve
             muted: Color::Rgb(69, 71, 90),      // Surface1
@@ -243,6 +277,8 @@ impl Theme {
 
     fn dracula() -> Self {
         Self {
+            name: "dracula",
+            light: false,
             fg: Color::Rgb(248, 248, 242),
             accent: Color::Rgb(255, 121, 198),
             muted: Color::Rgb(68, 71, 90),
@@ -307,6 +343,8 @@ impl Theme {
 
     fn nord() -> Self {
         Self {
+            name: "nord",
+            light: false,
             fg: Color::Rgb(216, 222, 233),
             accent: Color::Rgb(136, 192, 208),
             muted: Color::Rgb(59, 66, 82),
@@ -373,6 +411,8 @@ impl Theme {
 
     fn solarized_dark() -> Self {
         Self {
+            name: "solarized-dark",
+            light: false,
             fg: Color::Rgb(131, 148, 150),
             accent: Color::Rgb(181, 137, 0),
             muted: Color::Rgb(0, 43, 54),
@@ -437,6 +477,8 @@ impl Theme {
 
     fn tokyo_night() -> Self {
         Self {
+            name: "tokyo-night",
+            light: false,
             fg: Color::Rgb(192, 202, 245),
             accent: Color::Rgb(122, 162, 247),
             muted: Color::Rgb(59, 66, 97),
@@ -501,6 +543,8 @@ impl Theme {
 
     fn gruvbox() -> Self {
         Self {
+            name: "gruvbox",
+            light: false,
             fg: Color::Rgb(235, 219, 178),
             accent: Color::Rgb(250, 189, 47),
             muted: Color::Rgb(60, 56, 54),
@@ -565,6 +609,8 @@ impl Theme {
 
     fn rose_pine() -> Self {
         Self {
+            name: "rose-pine",
+            light: false,
             fg: Color::Rgb(224, 222, 244),
             accent: Color::Rgb(235, 188, 186),
             muted: Color::Rgb(57, 53, 82),
@@ -629,6 +675,8 @@ impl Theme {
 
     fn kanagawa() -> Self {
         Self {
+            name: "kanagawa",
+            light: false,
             fg: Color::Rgb(220, 215, 186),
             accent: Color::Rgb(127, 180, 202),
             muted: Color::Rgb(54, 54, 70),
@@ -690,10 +738,304 @@ impl Theme {
             panel_focused_bg: Color::Rgb(34, 34, 46),
         }
     }
+
+    /// Catppuccin Latte — the official light variant of Catppuccin.
+    ///
+    /// Palette reference (https://catppuccin.com/palette): Base #eff1f5,
+    /// Mantle #e6e9ef, Surface0 #ccd0da, Surface1 #bcc0cc, Surface2 #acb0be,
+    /// Overlay0 #9ca0b0, Overlay1 #8c8fa1, Text #4c4f69, Subtext0 #6c6f85,
+    /// Mauve #8839ef, Blue #1e66f5, Sky #04a5e5, Green #40a02b, Red #d20f39,
+    /// Yellow #df8e1d, Peach #fe640b, Pink #ea76cb.
+    fn catppuccin_latte() -> Self {
+        Self {
+            name: "catppuccin-latte",
+            light: true,
+            fg: Color::Rgb(76, 79, 105),       // Text
+            accent: Color::Rgb(136, 57, 239),  // Mauve
+            muted: Color::Rgb(188, 192, 204),  // Surface1
+            success: Color::Rgb(64, 160, 43),  // Green
+            error: Color::Rgb(210, 15, 57),    // Red
+            warning: Color::Rgb(223, 142, 29), // Yellow
+            info: Color::Rgb(4, 165, 229),     // Sky
+
+            diff_add: Color::Rgb(64, 160, 43),
+            diff_add_bg: Color::Rgb(220, 245, 210),
+            diff_del: Color::Rgb(210, 15, 57),
+            diff_del_bg: Color::Rgb(252, 220, 228),
+            diff_add_bg_emphasis: Color::Rgb(196, 236, 182),
+            diff_del_bg_emphasis: Color::Rgb(248, 196, 210),
+            diff_section_header: Color::Rgb(140, 143, 161), // Overlay1
+
+            border_focused: Color::Rgb(136, 57, 239), // Mauve
+            border_unfocused: Color::Rgb(188, 192, 204), // Surface1
+            border_secondary: Color::Rgb(172, 176, 190), // Surface2
+
+            selected_bg: Color::Rgb(136, 57, 239),  // Mauve
+            selected_fg: Color::Rgb(239, 241, 245), // Base (near-white)
+            selected_bg_inactive: Color::Rgb(204, 208, 218), // Surface0
+            selected_fg_inactive: Color::Rgb(76, 79, 105),   // Text
+
+            line_selected_bg: Color::Rgb(204, 208, 218), // Surface0
+            line_selected_fg: Color::Rgb(76, 79, 105),   // Text
+
+            gutter_selected_bg: Color::Rgb(30, 102, 245), // Blue
+            gutter_selected_fg: Color::Rgb(239, 241, 245), // Base
+            gutter_hover_fg: Color::Rgb(140, 143, 161),   // Overlay1
+            gutter_hover_bg: Color::Rgb(224, 227, 236),   // between Base and Surface0
+            gutter_pending_bg: Color::Rgb(189, 211, 252), // light blue
+            line_pending_bg: Color::Rgb(236, 240, 252),   // very light blue
+
+            hint: Color::Rgb(156, 160, 176),            // Overlay0
+            search_match_fg: Color::Rgb(223, 142, 29),  // Yellow
+            search_match_bg: Color::Rgb(252, 238, 190), // light yellow
+            search_current_fg: Color::Rgb(76, 79, 105), // Text
+
+            waiting_primary: Color::Rgb(254, 100, 11),  // Peach
+            waiting_secondary: Color::Rgb(212, 82, 9),
+
+            titlebar_bg: Color::Rgb(230, 233, 239), // Mantle
+            dir_fg: Color::Rgb(156, 160, 176),      // Overlay0
+
+            status_bg_success: Color::Rgb(210, 240, 200),
+            status_bg_error: Color::Rgb(252, 212, 220),
+            status_bg_warning: Color::Rgb(252, 232, 196),
+            status_bg_info: Color::Rgb(208, 232, 252),
+
+            comment_preview_bg: Color::Rgb(204, 208, 218), // Surface0
+            comment_user_bg: Color::Rgb(196, 228, 220),    // teal-tinted light
+            reply_text: Color::Rgb(108, 111, 133),         // Subtext0
+
+            code_bg: Color::Rgb(230, 233, 239),  // Mantle
+            code_fg: Color::Rgb(234, 118, 203),  // Pink
+
+            panel_focused_bg: Color::Rgb(220, 223, 232), // between Base and Surface0
+        }
+    }
+
+    /// Solarized Light — Ethan Schoonover's light variant.
+    ///
+    /// Palette reference (https://ethanschoonover.com/solarized/): base3 #fdf6e3,
+    /// base2 #eee8d5, base1 #93a1a1, base0 #839496, base00 #657b83,
+    /// base01 #586e75, yellow #b58900, orange #cb4b16, red #dc322f,
+    /// magenta #d33682, violet #6c71c4, blue #268bd2, cyan #2aa198, green #859900.
+    fn solarized_light() -> Self {
+        Self {
+            name: "solarized-light",
+            light: true,
+            fg: Color::Rgb(101, 123, 131),     // base00 — body text
+            accent: Color::Rgb(38, 139, 210),  // blue
+            muted: Color::Rgb(147, 161, 161),  // base1 — medium gray for separators
+            success: Color::Rgb(133, 153, 0),  // green
+            error: Color::Rgb(220, 50, 47),    // red
+            warning: Color::Rgb(181, 137, 0),  // yellow
+            info: Color::Rgb(42, 161, 152),    // cyan
+
+            diff_add: Color::Rgb(133, 153, 0),
+            diff_add_bg: Color::Rgb(232, 244, 210),
+            diff_del: Color::Rgb(220, 50, 47),
+            diff_del_bg: Color::Rgb(252, 228, 224),
+            diff_add_bg_emphasis: Color::Rgb(212, 236, 184),
+            diff_del_bg_emphasis: Color::Rgb(248, 206, 200),
+            diff_section_header: Color::Rgb(147, 161, 161), // base1
+
+            border_focused: Color::Rgb(38, 139, 210),  // blue
+            border_unfocused: Color::Rgb(147, 161, 161), // base1
+            border_secondary: Color::Rgb(131, 148, 150), // base0
+
+            selected_bg: Color::Rgb(38, 139, 210),   // blue
+            selected_fg: Color::Rgb(253, 246, 227),  // base3 (lightest)
+            selected_bg_inactive: Color::Rgb(238, 232, 213), // base2
+            selected_fg_inactive: Color::Rgb(101, 123, 131), // base00
+
+            line_selected_bg: Color::Rgb(238, 232, 213), // base2
+            line_selected_fg: Color::Rgb(101, 123, 131), // base00
+
+            gutter_selected_bg: Color::Rgb(42, 161, 152), // cyan
+            gutter_selected_fg: Color::Rgb(253, 246, 227), // base3
+            gutter_hover_fg: Color::Rgb(131, 148, 150),   // base0
+            gutter_hover_bg: Color::Rgb(245, 238, 218),   // between base3 and base2
+            gutter_pending_bg: Color::Rgb(196, 224, 244), // light blue
+            line_pending_bg: Color::Rgb(240, 248, 253),   // very light blue
+
+            hint: Color::Rgb(131, 148, 150),             // base0
+            search_match_fg: Color::Rgb(181, 137, 0),    // yellow
+            search_match_bg: Color::Rgb(253, 240, 184),  // light yellow
+            search_current_fg: Color::Rgb(253, 246, 227), // base3
+
+            waiting_primary: Color::Rgb(203, 75, 22),   // orange
+            waiting_secondary: Color::Rgb(160, 60, 18),
+
+            titlebar_bg: Color::Rgb(238, 232, 213), // base2
+            dir_fg: Color::Rgb(131, 148, 150),      // base0
+
+            status_bg_success: Color::Rgb(220, 240, 192),
+            status_bg_error: Color::Rgb(252, 224, 220),
+            status_bg_warning: Color::Rgb(252, 232, 192),
+            status_bg_info: Color::Rgb(208, 232, 248),
+
+            comment_preview_bg: Color::Rgb(238, 232, 213), // base2
+            comment_user_bg: Color::Rgb(216, 236, 232),    // teal-tinted light
+            reply_text: Color::Rgb(88, 110, 117),          // base01
+
+            code_bg: Color::Rgb(228, 222, 200),  // slightly darker than base2
+            code_fg: Color::Rgb(211, 54, 130),   // magenta
+
+            panel_focused_bg: Color::Rgb(232, 226, 208), // between base3 and base2
+        }
+    }
+
+    /// GitHub Light — inspired by GitHub's web UI color system.
+    ///
+    /// Palette reference (https://primer.style/primitives/colors): bg #ffffff,
+    /// fg #24292f, blue #0969da, green #1a7f37, red #cf222e,
+    /// amber #9a6700, border #d0d7de, neutral #6e7781.
+    fn github_light() -> Self {
+        Self {
+            name: "github-light",
+            light: true,
+            fg: Color::Rgb(36, 41, 47),         // fg.default
+            accent: Color::Rgb(9, 105, 218),    // accent.fg
+            muted: Color::Rgb(208, 215, 222),   // border.default — visible separator on white
+            success: Color::Rgb(26, 127, 55),   // success.fg
+            error: Color::Rgb(207, 34, 46),     // danger.fg
+            warning: Color::Rgb(154, 103, 0),   // attention.fg (amber)
+            info: Color::Rgb(9, 105, 218),      // accent.fg
+
+            diff_add: Color::Rgb(26, 127, 55),
+            diff_add_bg: Color::Rgb(230, 255, 237),  // GitHub addition bg
+            diff_del: Color::Rgb(207, 34, 46),
+            diff_del_bg: Color::Rgb(255, 235, 233),  // GitHub deletion bg
+            diff_add_bg_emphasis: Color::Rgb(204, 255, 220), // stronger addition
+            diff_del_bg_emphasis: Color::Rgb(255, 193, 186), // stronger deletion
+            diff_section_header: Color::Rgb(110, 119, 129),  // fg.muted
+
+            border_focused: Color::Rgb(9, 105, 218),    // accent.fg
+            border_unfocused: Color::Rgb(208, 215, 222), // border.default
+            border_secondary: Color::Rgb(175, 184, 193), // border.muted
+
+            selected_bg: Color::Rgb(9, 105, 218),    // accent.fg
+            selected_fg: Color::Rgb(255, 255, 255),  // white
+            selected_bg_inactive: Color::Rgb(234, 238, 242), // neutral.subtle
+            selected_fg_inactive: Color::Rgb(36, 41, 47),    // fg.default
+
+            line_selected_bg: Color::Rgb(234, 238, 242), // neutral.subtle
+            line_selected_fg: Color::Rgb(36, 41, 47),    // fg.default
+
+            gutter_selected_bg: Color::Rgb(9, 105, 218),  // accent.fg
+            gutter_selected_fg: Color::Rgb(255, 255, 255), // white
+            gutter_hover_fg: Color::Rgb(110, 119, 129),   // fg.muted
+            gutter_hover_bg: Color::Rgb(246, 248, 250),   // canvas.subtle
+            gutter_pending_bg: Color::Rgb(182, 212, 251), // accent.subtle darker
+            line_pending_bg: Color::Rgb(240, 245, 255),   // very light blue
+
+            hint: Color::Rgb(110, 119, 129),            // fg.muted
+            search_match_fg: Color::Rgb(154, 103, 0),   // attention.fg
+            search_match_bg: Color::Rgb(255, 248, 197), // attention.subtle
+            search_current_fg: Color::Rgb(36, 41, 47),  // fg.default
+
+            waiting_primary: Color::Rgb(225, 111, 36),  // orange
+            waiting_secondary: Color::Rgb(184, 92, 30),
+
+            titlebar_bg: Color::Rgb(246, 248, 250), // canvas.subtle
+            dir_fg: Color::Rgb(110, 119, 129),      // fg.muted
+
+            status_bg_success: Color::Rgb(218, 251, 225),
+            status_bg_error: Color::Rgb(255, 228, 225),
+            status_bg_warning: Color::Rgb(255, 248, 197),
+            status_bg_info: Color::Rgb(221, 244, 255),
+
+            comment_preview_bg: Color::Rgb(246, 248, 250), // canvas.subtle
+            comment_user_bg: Color::Rgb(232, 245, 241),    // teal-tinted light
+            reply_text: Color::Rgb(110, 119, 129),         // fg.muted
+
+            code_bg: Color::Rgb(246, 248, 250),  // canvas.subtle — GitHub inline code bg
+            code_fg: Color::Rgb(149, 56, 0),     // brown-red for inline code
+
+            panel_focused_bg: Color::Rgb(240, 243, 246), // between white and canvas.subtle
+        }
+    }
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self::catppuccin_mocha()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_light_themes_have_light_true() {
+        assert!(Theme::from_name("catppuccin-latte").light);
+        assert!(Theme::from_name("solarized-light").light);
+        assert!(Theme::from_name("github-light").light);
+    }
+
+    #[test]
+    fn from_name_dark_themes_have_light_false() {
+        assert!(!Theme::from_name("catppuccin-mocha").light);
+        assert!(!Theme::from_name("dracula").light);
+        assert!(!Theme::from_name("nord").light);
+        assert!(!Theme::from_name("solarized-dark").light);
+        assert!(!Theme::from_name("tokyo-night").light);
+        assert!(!Theme::from_name("gruvbox").light);
+        assert!(!Theme::from_name("rose-pine").light);
+        assert!(!Theme::from_name("kanagawa").light);
+    }
+
+    #[test]
+    fn all_names_contains_all_eleven_themes() {
+        let names = Theme::all_names();
+        assert_eq!(names.len(), 11);
+        assert!(names.contains(&"catppuccin-mocha"));
+        assert!(names.contains(&"dracula"));
+        assert!(names.contains(&"nord"));
+        assert!(names.contains(&"solarized-dark"));
+        assert!(names.contains(&"tokyo-night"));
+        assert!(names.contains(&"gruvbox"));
+        assert!(names.contains(&"rose-pine"));
+        assert!(names.contains(&"kanagawa"));
+        assert!(names.contains(&"catppuccin-latte"));
+        assert!(names.contains(&"solarized-light"));
+        assert!(names.contains(&"github-light"));
+    }
+
+    #[test]
+    fn all_names_dark_before_light() {
+        let names = Theme::all_names();
+        let last_dark = names
+            .iter()
+            .rposition(|n| !Theme::from_name(n).light)
+            .expect("at least one dark theme");
+        let first_light = names
+            .iter()
+            .position(|n| Theme::from_name(n).light)
+            .expect("at least one light theme");
+        assert!(last_dark < first_light, "dark themes must precede light themes");
+    }
+
+    #[test]
+    fn unknown_name_falls_back_to_default() {
+        // Unknown names return the default (catppuccin-mocha), which is dark.
+        let theme = Theme::from_name("does-not-exist");
+        assert!(!theme.light);
+    }
+
+    /// Every name in `all_names()` must round-trip through `from_name` and
+    /// return the same canonical `name` field. A mismatch means a theme was
+    /// registered in one list but omitted or renamed in the other.
+    #[test]
+    fn all_names_round_trip_through_from_name() {
+        for &n in Theme::all_names() {
+            let theme = Theme::from_name(n);
+            assert_eq!(
+                theme.name, n,
+                "Theme::from_name(\"{n}\").name == \"{}\", expected \"{n}\" — \
+                 check that from_name has a match arm for this theme",
+                theme.name
+            );
+        }
     }
 }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -312,7 +312,9 @@ pub fn render_title_bar(frame: &mut Frame, area: Rect, app: &mut crate::app::App
 
     let (badge_bg, badge_fg, branch_fg) = name_to_color(&app.main_repo_name);
 
-    let bar_bg = theme.titlebar_bg;
+    // Use Color::Reset so the terminal's own background (including any
+    // background image) shows through the title bar.
+    let bar_bg = Color::Reset;
     let conductor_bg = badge_bg;
     let conductor_fg = badge_fg;
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -179,22 +179,6 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // ── Accordion column widths (from cache) ───────────────────────
     let columns = app.layout_cache.columns;
 
-    // ── Focused-panel surface ───────────────────────────────────────
-    // Lift the focused list panel (worktree / explorer) out of its
-    // neighbours with a subtle surface fill, so the active column reads
-    // at a glance in peripheral vision. Painted before the panels so
-    // their (bg-transparent) content draws on top; viewer is left alone
-    // as a reading pane and the terminal keeps its own PTY background.
-    let focused_surface_col = match app.focus {
-        crate::app::Focus::Explorer if app.editor.is_none() => Some(1),
-        _ => None,
-    };
-    if let Some(col) = focused_surface_col {
-        let fill = ratatui::widgets::Block::default()
-            .style(ratatui::style::Style::default().bg(app.theme.panel_focused_bg));
-        frame.render_widget(fill, columns[col]);
-    }
-
     // ── Column 0 (worktree) is gone — its status is in the top strip. ──
 
     if app.editor.is_some() {
@@ -349,6 +333,9 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
         }
         crate::overlay::ActiveOverlay::CommentList => {
             super::explorer_panel::render_comment_list_overlay(frame, main_area, app);
+        }
+        crate::overlay::ActiveOverlay::ThemePicker => {
+            super::theme_picker::render_theme_picker_overlay(frame, main_area, app);
         }
     }
     // Fuzzy filename-search ("jump to file") modal — rendered at the top level

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,6 +28,7 @@ pub mod panel_overlay;
 pub mod references;
 pub mod review;
 pub mod symbol_action;
+pub mod theme_picker;
 
 /// Shared read-only context extracted from `App` for UI rendering.
 ///

--- a/src/ui/theme_picker.rs
+++ b/src/ui/theme_picker.rs
@@ -1,0 +1,70 @@
+//! Theme picker overlay — a compact list popup for switching UI themes at runtime.
+//!
+//! Each entry shows the theme name and a light/dark tag. Up/Down moves the
+//! selection with a live preview; Enter confirms and persists; Esc reverts.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+
+use crate::app::App;
+use crate::theme::Theme;
+
+/// Render the theme picker overlay as a centered modal popup.
+pub fn render_theme_picker_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let themes = &app.overlays.theme_picker.themes;
+
+    // Size the popup to fit all themes comfortably.
+    let popup_height = (themes.len() as u16 + 2).min(area.height.saturating_sub(4));
+    let popup_width = 38_u16.min(area.width.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Switch Theme  ↑/↓ preview  Enter confirm  Esc revert ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent));
+
+    let list_inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let selected = app.overlays.theme_picker.selected;
+    let items: Vec<ListItem> = themes
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let tag = if Theme::from_name(name).light {
+                " ☀ light"
+            } else {
+                " 🌙 dark"
+            };
+            let label = format!("  {name}{tag}");
+            let style = if i == selected {
+                Style::default()
+                    .fg(theme.selected_fg)
+                    .bg(theme.selected_bg)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.fg)
+            };
+            ListItem::new(Line::from(Span::styled(label, style)))
+        })
+        .collect();
+
+    let list = List::new(items).highlight_style(
+        Style::default()
+            .bg(theme.selected_bg)
+            .fg(theme.selected_fg)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, list_inner, &mut state);
+}


### PR DESCRIPTION
## Summary

ターミナルに背景画像を設定しているユーザー向けに、テキストが背景に埋もれて読めなくなる問題へ対応する。TUI では端末の背景画像ピクセルを読めずアルファも無いため、ピクセル単位の自動コントラスト調整は原理的に不可。そこで現実解として「透明化 + テーマ切替 + ライトテーマ + OSC11 による粗い自動判定」を実装した。

- **透明化スイープ（既定ON）**: フォーカスパネルの全カラム塗り（`panel_focused_bg`）とタイトルバー背景を `Color::Reset` 化し、端末の背景画像が透けるようにした。フォーカス表示は枠線（`border_focused`）が担う。選択・diff・検索・gutter・status フラッシュ・CC waiting アラート・モーダルポップアップなど意味のあるハイライトは維持。
- **ライトテーマ追加**: `catppuccin-latte` / `solarized-light` / `github-light` を追加。`Theme` に `light: bool` と `name` を追加。
- **ランタイムのテーマ切替 UI**: コマンドパレットの "Switch Theme"、または `Alt+t` でテーマピッカーを開く。上下キーでライブプレビュー、Enter で確定して永続化、Esc で元に戻す。
- **設定の永続化**: 新設 `[ui] theme` セクションへテキストベースで最小編集して保存（コメント保持）。未設定時は従来どおり `viewer.theme` にフォールバック。
- **OSC11 ライト/ダーク自動判定**: 起動時に OSC 11 で端末のベース背景色を問い合わせ、相対輝度から明背景ならライトテーマを初期既定に。`libc::poll` でメインスレッド処理しスレッドリークを回避、tmux はスキップ。明示設定・ユーザー選択が常に優先。

semver: 後方互換の機能追加につき MINOR bump（0.75.x → 0.76.0）。

## Test plan

- [x] `cargo build` / `cargo clippy`（警告ゼロ）/ `cargo test`（375 passed）
- [x] テーマモデル: `from_name` ↔ `all_names` のラウンドトリップ、ライトテーマ名解決のテスト
- [x] 設定: `[ui] theme` の追記/置換、`[ui]  # comment` 付きヘッダでも重複セクション破損しないテスト
- [x] OSC11: パーサ（BEL/8bit ターミネータ）と `auto_theme_for_background` の輝度しきい値テスト
- [x] `cargo install --path .` 成功
- [ ] 明るい背景画像・暗い背景画像の両方で文字が読めること、タイトルバー／フォーカスパネル背後に画像が透けることを目視確認（手動）
