### PR TITLE
feat: live-reload appearance config via fsevents with restart/live separation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.76.0"
+version = "0.77.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -569,6 +569,18 @@ pub struct CcusageInfo {
     pub total_cost: f64,
 }
 
+/// Resolve the active UI theme name from config.
+///
+/// `[ui] theme` takes precedence; when absent, `[viewer] theme` is used for
+/// backward compatibility with configs that predate the `[ui]` section.
+fn resolve_theme_name(cfg: &config::Config) -> String {
+    cfg.ui
+        .theme
+        .as_deref()
+        .unwrap_or(&cfg.viewer.theme)
+        .to_string()
+}
+
 impl App {
     /// Returns `true` when the panel number overlay should be rendered.
     /// Activated by Alt+/ and auto-dismisses after 2 seconds.
@@ -631,39 +643,7 @@ impl App {
         // Initialize syntect syntax set and theme.
         let syntax_set = two_face::syntax::extra_newlines();
         let ts = ThemeSet::load_defaults();
-        let syntect_theme = if let Some(ref path) = config.viewer.syntax_theme_file {
-            match ThemeSet::get_theme(path) {
-                Ok(theme) => theme,
-                Err(e) => {
-                    log::warn!(
-                        "failed to load syntax theme file {path}: {e}; falling back to built-in theme"
-                    );
-                    let name = match config.viewer.theme.as_str() {
-                        "catppuccin-mocha" => "base16-mocha.dark",
-                        "dracula" => "base16-eighties.dark",
-                        "nord" => "base16-ocean.dark",
-                        "solarized-dark" => "Solarized (dark)",
-                        _ => "base16-mocha.dark",
-                    };
-                    ts.themes
-                        .get(name)
-                        .cloned()
-                        .unwrap_or_else(|| ts.themes["base16-mocha.dark"].clone())
-                }
-            }
-        } else {
-            let syntect_theme_name = match config.viewer.theme.as_str() {
-                "catppuccin-mocha" => "base16-mocha.dark",
-                "dracula" => "base16-eighties.dark",
-                "nord" => "base16-ocean.dark",
-                "solarized-dark" => "Solarized (dark)",
-                _ => "base16-mocha.dark",
-            };
-            ts.themes
-                .get(syntect_theme_name)
-                .cloned()
-                .unwrap_or_else(|| ts.themes["base16-mocha.dark"].clone())
-        };
+        let syntect_theme = config::syntect_theme_for(&config.viewer, &ts);
 
         // Build the list of known repositories: current repo first, then extras from config.
         let mut repo_list = vec![repo_path.clone()];
@@ -685,13 +665,7 @@ impl App {
             .and_then(|store| store.get_today_stats().ok());
 
         let (keymap, keybind_warnings) = KeyMap::with_warnings(&config.keybinds);
-        // [ui] theme takes precedence; fall back to [viewer] theme for compatibility.
-        let theme_name = config
-            .ui
-            .theme
-            .as_deref()
-            .unwrap_or(&config.viewer.theme)
-            .to_string();
+        let theme_name = resolve_theme_name(&config);
         let theme = Theme::from_name(&theme_name);
         let auto_resume = config.general.auto_resume;
 
@@ -1457,6 +1431,125 @@ impl App {
                 format!("Theme saved in session but could not write config: {e}"),
                 StatusLevel::Warning,
             );
+        }
+    }
+
+    // ── Live config reload ─────────────────────────────────────────
+
+    /// Apply appearance (live-reloadable) fields from `new` to the running app.
+    ///
+    /// Only the fields classified as LIVE are copied; restart-required fields
+    /// (shell, scrollback limits, API settings, etc.) are intentionally left
+    /// untouched so that `refresh_diff`, which reads `config.general.main_branch`
+    /// on every call, never sees a stale or transitional value.
+    ///
+    /// ## LIVE fields applied here
+    /// - `ui.theme` / `viewer.theme` → theme + theme_name + syntect rebuild
+    /// - `viewer.syntax_theme_file`  → syntect rebuild (same path as theme)
+    /// - `viewer.tab_width`          → config copy + refresh_viewer + refresh_diff
+    /// - `diff.word_diff`            → config copy + refresh_diff
+    /// - `diff.default_view`         → diff_state.view_mode + refresh_diff
+    /// - `general.decoration`        → config copy (drawn directly each frame)
+    /// - `layout.*`                  → config copy; LayoutCache auto-invalidates
+    ///
+    /// `viewer.word_wrap` is copied into config via `adopt_appearance` but is not
+    /// in `AppearanceSnapshot` and has no rendering effect until the render path
+    /// is implemented.
+    pub fn apply_appearance(&mut self, new: &config::Config) {
+        // ── UI / syntax theme ──────────────────────────────────────
+        let new_theme_name = resolve_theme_name(new);
+        if new_theme_name != self.theme_name {
+            self.theme = Theme::from_name(&new_theme_name);
+            self.theme_name = new_theme_name;
+        }
+
+        // Rebuild syntect theme when either the viewer theme or the custom
+        // theme file changes (the two are bundled into a single re-construction
+        // so there is never a half-updated state).
+        let ts = ThemeSet::load_defaults();
+        self.syntect_theme = config::syntect_theme_for(&new.viewer, &ts);
+
+        // Clear the Markdown cache so code blocks inside review comments pick
+        // up the new syntect theme. The cache fingerprints the UI colour palette
+        // only; a syntax-only change would otherwise leave stale highlighted spans.
+        self.markdown_cache.clear();
+
+        // ── Diff view mode ──────────────────────────────────────────
+        // Apply view_mode directly. `diff_state.view_mode` is written only in
+        // `DiffState::new` and here — there is no runtime interactive toggle —
+        // so overwriting it is safe.
+        self.diff_state.view_mode = crate::diff_state::DiffViewMode::from(new.diff.default_view);
+
+        // Copy all live config fields (no-op for restart-required fields).
+        // LayoutCache keyed on layout proportions detects changes automatically
+        // and recomputes on the next frame; no explicit invalidation needed.
+        self.config.adopt_appearance(new);
+
+        // Refresh the viewer file tree + diff to pick up tab_width / word_diff.
+        // refresh_viewer calls rehighlight_viewer unconditionally, so the new
+        // syntect theme is applied to the open file as part of this call.
+        self.refresh_viewer();
+        self.refresh_diff();
+
+        // Trigger a full redraw.
+        self.dirty.mark_all();
+    }
+
+    /// Reload the config file and apply any appearance changes.
+    ///
+    /// 1. Guards against the config file being absent (e.g., a remove event from
+    ///    a delete-then-write atomic save): skips loading to avoid `Config::load()`
+    ///    writing a default file and clobbering the user's in-progress edits.
+    /// 2. Loads `~/.config/conductor/config.toml`; on parse error, flashes an
+    ///    error message and returns without modifying the running config.
+    /// 3. Computes whether appearance fields and/or restart-required fields changed.
+    ///    True no-op (neither changed) → returns silently, which is also the guard
+    ///    that absorbs the self-write loop from the in-app theme picker.
+    /// 4. If restart-required fields changed, flashes a warning.
+    /// 5. If appearance fields changed, calls `apply_appearance` and (when no
+    ///    restart warning was issued) flashes an info confirmation.
+    pub fn reload_appearance_config(&mut self) {
+        // Guard: skip if the file was just deleted (remove event from an atomic
+        // editor save). Config::load() on a missing file would write defaults and
+        // return Config::default(), clobbering the user's work.
+        if !config::config_file_path().exists() {
+            return;
+        }
+
+        let new = match config::Config::load() {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("config reload: failed to parse config file: {e}");
+                self.set_status(
+                    format!("Config error — kept previous settings: {e}"),
+                    StatusLevel::Error,
+                );
+                return;
+            }
+        };
+
+        let appearance_changed = new.appearance_snapshot() != self.config.appearance_snapshot();
+        let restart_changed = config::has_restart_changes(&self.config, &new);
+
+        // True no-op: nothing changed. This absorbs the FS event from the in-app
+        // theme picker (ui.theme is appearance-only, so both flags are false when
+        // the picker persists a theme that the running config already reflects).
+        if !appearance_changed && !restart_changed {
+            return;
+        }
+
+        if restart_changed {
+            self.set_status(
+                String::from("Config updated — some changes require a restart to take effect"),
+                StatusLevel::Warning,
+            );
+        }
+
+        if appearance_changed {
+            self.apply_appearance(&new);
+            if !restart_changed {
+                self.set_status_info(String::from("Config reloaded"));
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ pub struct Config {
     /// `[ui]` -- UI appearance settings (theme, etc.).
     #[serde(default)]
     pub ui: UiConfig,
+    /// `[layout]` -- panel proportion overrides.
+    #[serde(default)]
+    pub layout: LayoutConfig,
 }
 
 impl Config {
@@ -330,6 +333,35 @@ impl Default for RichConfig {
     }
 }
 
+/// `[layout]` section — panel proportion overrides.
+///
+/// Values are percentages (0–100). The worktree column is always 0-width
+/// (the worktree monitor lives in the top strip); the terminal column gets
+/// whatever width remains after explorer and viewer. These proportions apply
+/// only in the default (non-maximized) layout; maximizing a panel overrides
+/// them as before.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LayoutConfig {
+    /// Explorer column width as a percentage of the total frame width.
+    pub explorer_width_pct: u16,
+    /// Viewer column width as a percentage of the total frame width.
+    pub viewer_width_pct: u16,
+    /// Claude Code area height as a percentage of the terminal column height.
+    /// The shell area receives the remainder.
+    pub terminal_split_pct: u16,
+}
+
+impl Default for LayoutConfig {
+    fn default() -> Self {
+        Self {
+            explorer_width_pct: 24,
+            viewer_width_pct: 38,
+            terminal_split_pct: 80,
+        }
+    }
+}
+
 /// `[ui]` section — UI appearance overrides.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -341,16 +373,166 @@ pub struct UiConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Snapshot types
+// ---------------------------------------------------------------------------
+
+/// A point-in-time capture of all "live-reloadable" (appearance) fields.
+///
+/// Equality is used as an idempotency guard in `App::reload_appearance_config`:
+/// when the snapshot matches the running state, no work is done, which naturally
+/// absorbs the self-write loop from the in-app theme picker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppearanceSnapshot {
+    pub ui_theme: Option<String>,
+    pub viewer_theme: String,
+    pub viewer_syntax_theme_file: Option<String>,
+    pub viewer_tab_width: usize,
+    // viewer.word_wrap is intentionally absent — the rendering path is not yet
+    // implemented, so saving word_wrap should not trigger a "Config reloaded"
+    // flash or any visual change. Re-add here when the render path is wired.
+    pub diff_word_diff: bool,
+    pub diff_default_view: DiffView,
+    pub general_decoration: String,
+    pub layout_explorer_width_pct: u16,
+    pub layout_viewer_width_pct: u16,
+    pub layout_terminal_split_pct: u16,
+}
+
+impl Config {
+    /// Capture a snapshot of the appearance (live-reloadable) fields.
+    pub fn appearance_snapshot(&self) -> AppearanceSnapshot {
+        AppearanceSnapshot {
+            ui_theme: self.ui.theme.clone(),
+            viewer_theme: self.viewer.theme.clone(),
+            viewer_syntax_theme_file: self.viewer.syntax_theme_file.clone(),
+            viewer_tab_width: self.viewer.tab_width,
+            diff_word_diff: self.diff.word_diff,
+            diff_default_view: self.diff.default_view,
+            general_decoration: self.general.decoration.clone(),
+            layout_explorer_width_pct: self.layout.explorer_width_pct,
+            layout_viewer_width_pct: self.layout.viewer_width_pct,
+            layout_terminal_split_pct: self.layout.terminal_split_pct,
+        }
+    }
+
+    /// Copy all live-reloadable appearance fields from `new` into `self`.
+    ///
+    /// Only the fields tracked by [`AppearanceSnapshot`] (plus `viewer.word_wrap`
+    /// which is tracked in config but not yet in the snapshot) are updated;
+    /// restart-required fields (shell, scrollback, API settings, keybinds, etc.)
+    /// are intentionally left untouched. Called by `App::apply_appearance` before
+    /// rebuilding derived state (syntect theme, diff, layout cache, etc.).
+    pub fn adopt_appearance(&mut self, new: &Config) {
+        self.ui.theme = new.ui.theme.clone();
+        self.viewer.theme = new.viewer.theme.clone();
+        self.viewer.syntax_theme_file = new.viewer.syntax_theme_file.clone();
+        self.viewer.tab_width = new.viewer.tab_width;
+        // word_wrap: copy into config so it persists, but not in AppearanceSnapshot
+        // because the rendering path is not yet implemented.
+        self.viewer.word_wrap = new.viewer.word_wrap;
+        self.diff.word_diff = new.diff.word_diff;
+        self.diff.default_view = new.diff.default_view;
+        self.general.decoration = new.general.decoration.clone();
+        self.layout = new.layout.clone();
+    }
+}
+
+/// Return `true` when `new` differs from `old` in any restart-required field.
+///
+/// Restart-required fields are those NOT covered by `AppearanceSnapshot`:
+/// `general.{repo, repos, worktree_dir, shell, main_branch, auto_resume,
+/// auto_resume_main}`, `terminal.{active_scrollback, inactive_scrollback}`,
+/// `rich.mode`, `api.*`, `updates.*`, `ccusage.*`, `review.*`, `keybinds`.
+pub fn has_restart_changes(old: &Config, new: &Config) -> bool {
+    old.general.shell != new.general.shell
+        || old.general.repo != new.general.repo
+        || old.general.repos != new.general.repos
+        || old.general.worktree_dir != new.general.worktree_dir
+        || old.general.main_branch != new.general.main_branch
+        || old.general.auto_resume != new.general.auto_resume
+        || old.general.auto_resume_main != new.general.auto_resume_main
+        || old.terminal.inactive_scrollback != new.terminal.inactive_scrollback
+        || old.terminal.active_scrollback != new.terminal.active_scrollback
+        || old.rich.mode != new.rich.mode
+        || old.api.model != new.api.model
+        || old.api.provider != new.api.provider
+        || old.api.command != new.api.command
+        || old.api.command_timeout_secs != new.api.command_timeout_secs
+        || old.updates.check_on_startup != new.updates.check_on_startup
+        || old.updates.check_interval_secs != new.updates.check_interval_secs
+        || old.ccusage.enabled != new.ccusage.enabled
+        || old.ccusage.poll_interval_secs != new.ccusage.poll_interval_secs
+        || old.review.prompt_template != new.review.prompt_template
+        || old.review.prompt_action != new.review.prompt_action
+        || old.keybinds != new.keybinds
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /// Return the canonical path to the configuration file.
-fn config_file_path() -> PathBuf {
+pub fn config_file_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".config")
         .join("conductor")
         .join("config.toml")
+}
+
+/// Resolve the syntect syntax-highlighting theme for a given viewer config.
+///
+/// When `viewer.syntax_theme_file` is set, the file is loaded directly
+/// (falling back to a built-in theme on error). Otherwise, the built-in
+/// syntect theme that best matches `viewer.theme` is returned.
+///
+/// The mapping from conductor UI theme names to syntect names covers the four
+/// original dark themes; all other names fall back to `base16-mocha.dark`
+/// (the same drift that existed before this helper was extracted — expanding
+/// the mapping table is out of scope here).
+pub fn syntect_theme_for(
+    viewer: &ViewerConfig,
+    ts: &syntect::highlighting::ThemeSet,
+) -> syntect::highlighting::Theme {
+    // Map the conductor viewer theme name to the corresponding syntect key.
+    // Dark themes map to matching dark syntect themes; light themes map to
+    // light syntect built-ins so code blocks remain readable on a light UI.
+    let builtin_name = |theme: &str| -> &str {
+        match theme {
+            // Dark themes
+            "catppuccin-mocha" => "base16-mocha.dark",
+            "dracula" => "base16-eighties.dark",
+            "nord" => "base16-ocean.dark",
+            "solarized-dark" => "Solarized (dark)",
+            // Light themes — map to light syntect built-ins to preserve
+            // readability on a light background.
+            "catppuccin-latte" => "base16-ocean.light",
+            "solarized-light" => "Solarized (light)",
+            "github-light" => "InspiredGitHub",
+            _ => "base16-mocha.dark",
+        }
+    };
+    let fallback = || {
+        let name = builtin_name(&viewer.theme);
+        ts.themes
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| ts.themes["base16-mocha.dark"].clone())
+    };
+
+    if let Some(ref path) = viewer.syntax_theme_file {
+        match syntect::highlighting::ThemeSet::get_theme(path) {
+            Ok(theme) => theme,
+            Err(e) => {
+                log::warn!(
+                    "failed to load syntax theme file {path}: {e}; falling back to built-in theme"
+                );
+                fallback()
+            }
+        }
+    } else {
+        fallback()
+    }
 }
 
 /// Detect the user's shell from `$SHELL`, falling back to `/bin/sh`.
@@ -374,6 +556,8 @@ pub fn generate_default_config() -> String {
     String::from(
         r#"# Conductor configuration file
 # All fields are optional with sensible defaults.
+# Appearance settings (theme, viewer, diff, decoration, layout) take effect
+# immediately on file save — no restart required. All other settings need a restart.
 
 [general]
 # repo = "/path/to/default/repo"       # default repository to open on startup
@@ -465,6 +649,15 @@ pub fn generate_default_config() -> String {
 #                                       # Light themes work best on terminals with a light/white background.
 #                                       # When unset, conductor auto-detects a light background via OSC 11
 #                                       # and switches to catppuccin-latte for that session (no file write).
+
+[layout]
+# explorer_width_pct = 24               # explorer column width % (default: 24)
+# viewer_width_pct = 38                 # viewer column width % (default: 38)
+#                                       # terminal column gets the remaining width
+# terminal_split_pct = 80              # Claude Code area height % within terminal column (default: 80)
+#                                       # shell area receives the remainder
+#                                       # These proportions apply in the default layout only;
+#                                       # maximizing a panel (Alt+m) overrides them temporarily.
 "#,
     )
 }
@@ -490,11 +683,6 @@ pub fn persist_ui_theme(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Pure function: upsert `theme = "<name>"` in the `[ui]` section of a
-/// config file string, preserving all comments and surrounding content.
-///
-/// Extracted as a testable helper so file I/O in `persist_ui_theme` can be
-/// tested independently. Called transitively via `set_theme`.
 /// Return `true` when `line` is a `[ui]` TOML section header, possibly followed
 /// by whitespace and/or an inline comment (e.g. `[ui]  # colors`).
 /// Sub-sections like `[ui.fonts]` are deliberately excluded.
@@ -509,6 +697,11 @@ fn is_ui_section_header(line: &str) -> bool {
     after.is_empty() || after.starts_with('#')
 }
 
+/// Pure function: upsert `theme = "<name>"` in the `[ui]` section of a
+/// config file string, preserving all comments and surrounding content.
+///
+/// Extracted as a testable helper so file I/O in `persist_ui_theme` can be
+/// tested independently. Called transitively via `set_theme`.
 fn upsert_ui_theme(contents: &str, name: &str) -> String {
     let theme_line = format!("theme = \"{name}\"");
     let lines: Vec<&str> = contents.lines().collect();
@@ -796,5 +989,353 @@ theme = "catppuccin-latte"
         assert!(!super::is_ui_section_header("[ui.sub]"));
         assert!(!super::is_ui_section_header("[ui.colors]"));
         assert!(!super::is_ui_section_header("[viewer]"));
+    }
+
+    #[test]
+    fn layout_config_defaults() {
+        let cfg = LayoutConfig::default();
+        assert_eq!(cfg.explorer_width_pct, 24);
+        assert_eq!(cfg.viewer_width_pct, 38);
+        assert_eq!(cfg.terminal_split_pct, 80);
+    }
+
+    #[test]
+    fn layout_config_round_trips_through_toml() {
+        let toml_str = r#"[layout]
+explorer_width_pct = 30
+viewer_width_pct = 40
+terminal_split_pct = 75
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.layout.explorer_width_pct, 30);
+        assert_eq!(cfg.layout.viewer_width_pct, 40);
+        assert_eq!(cfg.layout.terminal_split_pct, 75);
+
+        let serialized = toml::to_string_pretty(&cfg).expect("serialize");
+        let cfg2: Config = toml::from_str(&serialized).expect("round-trip");
+        assert_eq!(cfg2.layout.explorer_width_pct, 30);
+        assert_eq!(cfg2.layout.viewer_width_pct, 40);
+        assert_eq!(cfg2.layout.terminal_split_pct, 75);
+    }
+
+    #[test]
+    fn layout_config_empty_toml_gives_defaults() {
+        let cfg: Config = toml::from_str("").expect("empty toml");
+        assert_eq!(cfg.layout.explorer_width_pct, 24);
+        assert_eq!(cfg.layout.viewer_width_pct, 38);
+        assert_eq!(cfg.layout.terminal_split_pct, 80);
+    }
+
+    #[test]
+    fn appearance_snapshot_includes_layout() {
+        let mut cfg = Config::default();
+        cfg.layout.explorer_width_pct = 30;
+        let snap = cfg.appearance_snapshot();
+        assert_eq!(snap.layout_explorer_width_pct, 30);
+        assert_eq!(snap.layout_viewer_width_pct, 38);
+        assert_eq!(snap.layout_terminal_split_pct, 80);
+    }
+
+    // ── adopt_appearance / appearance_snapshot invariants / has_restart_changes ──
+
+    /// AC4 往復不変条件: adopt_appearance 後に snapshot が new と一致すること。
+    /// AppearanceSnapshot に足してadopt_appearance のコピーに足し忘れた場合を検出する。
+    #[test]
+    fn adopt_appearance_round_trip_invariant() {
+        let mut cur = Config::default();
+        let mut new = Config::default();
+        // Change every live field to a non-default value.
+        new.ui.theme = Some(String::from("dracula"));
+        new.viewer.theme = String::from("dracula");
+        new.viewer.syntax_theme_file = Some(String::from("/tmp/custom.tmTheme"));
+        new.viewer.tab_width = 4;        // default is 2
+        new.viewer.word_wrap = true;     // default is false
+        new.diff.word_diff = false;      // default is true
+        new.diff.default_view = DiffView::SideBySide; // default is Unified
+        new.general.decoration = String::from("space");
+        new.layout.explorer_width_pct = 30;
+        new.layout.viewer_width_pct = 42;
+        new.layout.terminal_split_pct = 70;
+
+        cur.adopt_appearance(&new);
+
+        assert_eq!(
+            cur.appearance_snapshot(),
+            new.appearance_snapshot(),
+            "adopt_appearance must copy all snapshot-tracked live fields"
+        );
+    }
+
+    /// snapshot 等価: 同一 config は等価。
+    #[test]
+    fn appearance_snapshot_equal_for_identical_configs() {
+        let cfg = Config::default();
+        assert_eq!(cfg.appearance_snapshot(), cfg.appearance_snapshot());
+    }
+
+    /// snapshot 不等価: 各 live フィールドを 1 つ変えると != になること。
+    #[test]
+    fn appearance_snapshot_detects_each_live_field_change() {
+        let base = Config::default();
+
+        let mut c = base.clone();
+        c.ui.theme = Some(String::from("dracula"));
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "ui.theme");
+
+        let mut c = base.clone();
+        c.viewer.theme = String::from("nord");
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "viewer.theme");
+
+        let mut c = base.clone();
+        c.viewer.syntax_theme_file = Some(String::from("/custom.tmTheme"));
+        assert_ne!(
+            c.appearance_snapshot(),
+            base.appearance_snapshot(),
+            "viewer.syntax_theme_file"
+        );
+
+        let mut c = base.clone();
+        c.viewer.tab_width = 4; // default is 2
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "viewer.tab_width");
+
+        let mut c = base.clone();
+        c.diff.word_diff = false; // default is true
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "diff.word_diff");
+
+        let mut c = base.clone();
+        c.diff.default_view = DiffView::SideBySide; // default is Unified
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "diff.default_view");
+
+        let mut c = base.clone();
+        c.general.decoration = String::from("space");
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "general.decoration");
+
+        let mut c = base.clone();
+        c.layout.explorer_width_pct = 30;
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.explorer_width_pct");
+
+        let mut c = base.clone();
+        c.layout.viewer_width_pct = 42;
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.viewer_width_pct");
+
+        let mut c = base.clone();
+        c.layout.terminal_split_pct = 70;
+        assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.terminal_split_pct");
+    }
+
+    /// has_restart_changes: live フィールドのみ変えたら false。
+    #[test]
+    fn has_restart_changes_false_for_live_only_diff() {
+        let old = Config::default();
+        let mut new = Config::default();
+        new.ui.theme = Some(String::from("dracula"));
+        new.viewer.theme = String::from("nord");
+        new.viewer.tab_width = 4;        // default is 2
+        new.diff.word_diff = false;      // default is true
+        new.general.decoration = String::from("space");
+        new.layout.explorer_width_pct = 30;
+        assert!(!has_restart_changes(&old, &new));
+    }
+
+    /// has_restart_changes: 各 restart フィールドを 1 つ変えたら true。
+    #[test]
+    fn has_restart_changes_true_for_each_restart_field() {
+        let base = Config::default();
+
+        let mut c = base.clone();
+        c.general.shell = String::from("/bin/fish");
+        assert!(has_restart_changes(&base, &c), "general.shell");
+
+        let mut c = base.clone();
+        c.general.main_branch = String::from("master");
+        assert!(has_restart_changes(&base, &c), "general.main_branch");
+
+        let mut c = base.clone();
+        c.general.repo = Some(PathBuf::from("/other/repo"));
+        assert!(has_restart_changes(&base, &c), "general.repo");
+
+        let mut c = base.clone();
+        c.general.auto_resume = false; // default is true
+        assert!(has_restart_changes(&base, &c), "general.auto_resume");
+
+        let mut c = base.clone();
+        c.general.auto_resume_main = true;
+        assert!(has_restart_changes(&base, &c), "general.auto_resume_main");
+
+        let mut c = base.clone();
+        c.terminal.active_scrollback = 99999;
+        assert!(has_restart_changes(&base, &c), "terminal.active_scrollback");
+
+        let mut c = base.clone();
+        c.api.provider = String::from("claude"); // default is "gemini"
+        assert!(has_restart_changes(&base, &c), "api.provider");
+
+        let mut c = base.clone();
+        c.ccusage.enabled = true;
+        assert!(has_restart_changes(&base, &c), "ccusage.enabled");
+    }
+
+    /// Partition test: すべてのフィールドが live か restart のどちらかに必ず属する。
+    /// フィールドを 1 つ変えた new で snapshot != か has_restart_changes が必ず true になること。
+    #[test]
+    fn every_field_is_either_live_or_restart() {
+        let base = Config::default();
+
+        // general
+        {
+            let mut c = base.clone();
+            c.general.repo = Some(PathBuf::from("/p"));
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.repo");
+        }
+        {
+            let mut c = base.clone();
+            c.general.main_branch = String::from("master");
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.main_branch");
+        }
+        {
+            let mut c = base.clone();
+            c.general.shell = String::from("/bin/fish");
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.shell");
+        }
+        {
+            let mut c = base.clone();
+            c.general.repos = vec![PathBuf::from("/p")];
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.repos");
+        }
+        {
+            let mut c = base.clone();
+            c.general.worktree_dir = Some(PathBuf::from("/wt"));
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.worktree_dir");
+        }
+        {
+            let mut c = base.clone();
+            c.general.decoration = String::from("space");
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.decoration");
+        }
+        {
+            let mut c = base.clone();
+            c.general.auto_resume = false; // default is true
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.auto_resume");
+        }
+        {
+            let mut c = base.clone();
+            c.general.auto_resume_main = true;
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.auto_resume_main");
+        }
+        // terminal
+        {
+            let mut c = base.clone();
+            c.terminal.active_scrollback = 9999;
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "terminal.active_scrollback");
+        }
+        // viewer (live)
+        {
+            let mut c = base.clone();
+            c.viewer.theme = String::from("nord");
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "viewer.theme");
+        }
+        {
+            let mut c = base.clone();
+            c.viewer.tab_width = 4; // default is 2
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "viewer.tab_width");
+        }
+        // diff (live)
+        {
+            let mut c = base.clone();
+            c.diff.word_diff = false; // default is true
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "diff.word_diff");
+        }
+        // api
+        {
+            let mut c = base.clone();
+            c.api.provider = String::from("claude"); // default is "gemini"
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "api.provider");
+        }
+        // ccusage
+        {
+            let mut c = base.clone();
+            c.ccusage.enabled = true;
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "ccusage.enabled");
+        }
+        // layout (live)
+        {
+            let mut c = base.clone();
+            c.layout.explorer_width_pct = 30;
+            assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "layout.explorer_width_pct");
+        }
+    }
+
+    /// Helper: estimate background luminance of a syntect theme (0–255 range).
+    fn theme_bg_luma(theme: &syntect::highlighting::Theme) -> f32 {
+        theme
+            .settings
+            .background
+            .map(|c| 0.299 * c.r as f32 + 0.587 * c.g as f32 + 0.114 * c.b as f32)
+            .unwrap_or(0.0)
+    }
+
+    /// syntect_theme_for: dark UI テーマは暗い syntect テーマを返すこと。
+    #[test]
+    fn syntect_theme_for_dark_themes_return_dark_syntect() {
+        let ts = syntect::highlighting::ThemeSet::load_defaults();
+        let viewer_with = |theme: &str| ViewerConfig {
+            theme: theme.to_string(),
+            syntax_theme_file: None,
+            ..Default::default()
+        };
+
+        for name in &["catppuccin-mocha", "dracula", "nord", "solarized-dark"] {
+            let theme = syntect_theme_for(&viewer_with(name), &ts);
+            assert!(
+                theme_bg_luma(&theme) < 128.0,
+                "dark conductor theme '{name}' must map to a dark syntect theme (luma={:.0})",
+                theme_bg_luma(&theme)
+            );
+        }
+    }
+
+    /// syntect_theme_for: ライトテーマがライト系 syntect テーマを返すこと。
+    #[test]
+    fn syntect_theme_for_light_themes_use_light_syntect() {
+        let ts = syntect::highlighting::ThemeSet::load_defaults();
+        let viewer_with = |theme: &str| ViewerConfig {
+            theme: theme.to_string(),
+            syntax_theme_file: None,
+            ..Default::default()
+        };
+
+        // Light UI themes must map to light syntect built-ins.
+        for name in &["catppuccin-latte", "solarized-light", "github-light"] {
+            let theme = syntect_theme_for(&viewer_with(name), &ts);
+            assert!(
+                theme_bg_luma(&theme) >= 128.0,
+                "light conductor theme '{name}' must map to a light syntect theme (luma={:.0})",
+                theme_bg_luma(&theme)
+            );
+        }
+    }
+
+    /// syntect_theme_for: 未知テーマ名はパニックせず mocha フォールバック。
+    #[test]
+    fn syntect_theme_for_unknown_falls_back_without_panic() {
+        let ts = syntect::highlighting::ThemeSet::load_defaults();
+        let viewer = ViewerConfig {
+            theme: String::from("nonexistent-theme-xyz"),
+            syntax_theme_file: None,
+            ..Default::default()
+        };
+        let _ = syntect_theme_for(&viewer, &ts); // must not panic
+    }
+
+    /// syntect_theme_for: 存在しないパスの syntax_theme_file はパニックしないこと。
+    #[test]
+    fn syntect_theme_for_missing_theme_file_falls_back_without_panic() {
+        let ts = syntect::highlighting::ThemeSet::load_defaults();
+        let viewer = ViewerConfig {
+            theme: String::from("catppuccin-mocha"),
+            syntax_theme_file: Some(String::from("/nonexistent/path/theme.tmTheme")),
+            ..Default::default()
+        };
+        let _ = syntect_theme_for(&viewer, &ts); // must not panic
     }
 }

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -1,0 +1,140 @@
+//! Configuration file watcher.
+//!
+//! Monitors the parent directory of `config.toml` for file-system events and
+//! forwards only events that match the config file name. Using the parent
+//! directory instead of the file directly avoids losing the watch when an
+//! editor saves atomically via a write-then-rename (which replaces the inode).
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::sync::mpsc;
+
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+/// Events sent from the config watcher to the main loop.
+#[derive(Debug)]
+pub enum ConfigEvent {
+    /// The config file was created, modified, or replaced.
+    Changed,
+}
+
+/// File system watcher for the conductor configuration file.
+///
+/// Watches the *parent directory* of the config file in non-recursive mode so
+/// that write-then-rename atomic saves (common in editors like Vim, neovim,
+/// and most $EDITOR wrappers) still deliver events after an inode swap.
+pub struct ConfigWatcher {
+    _watcher: RecommendedWatcher,
+    rx: mpsc::Receiver<ConfigEvent>,
+}
+
+impl ConfigWatcher {
+    /// Create a new watcher for `config_path`.
+    ///
+    /// The parent directory of `config_path` is monitored; only events whose
+    /// path matches the config file name produce a [`ConfigEvent`].
+    pub fn new(config_path: &Path) -> anyhow::Result<Self> {
+        let config_filename = config_path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("config path has no filename"))?
+            .to_os_string();
+        let watch_dir = config_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("config path has no parent directory"))?
+            .to_path_buf();
+
+        let (tx, rx) = mpsc::channel();
+
+        let sender = tx.clone();
+        let mut watcher = RecommendedWatcher::new(
+            move |result: Result<Event, notify::Error>| {
+                if let Ok(event) = result
+                    && (event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove())
+                    && event
+                        .paths
+                        .iter()
+                        .any(|p| matches_config_file(p, &config_filename))
+                {
+                    let _ = sender.send(ConfigEvent::Changed);
+                }
+            },
+            Config::default(),
+        )?;
+
+        if watch_dir.exists() {
+            watcher.watch(&watch_dir, RecursiveMode::NonRecursive)?;
+        }
+
+        Ok(Self {
+            _watcher: watcher,
+            rx,
+        })
+    }
+
+    /// Check for a pending config-change event (non-blocking).
+    pub fn poll(&self) -> Option<ConfigEvent> {
+        self.rx.try_recv().ok()
+    }
+}
+
+/// Return `true` when `path` refers to the given config file name.
+///
+/// Extracted as a pure function so the filename-matching logic can be unit
+/// tested independently of the file system.
+fn matches_config_file(path: &Path, config_filename: &OsStr) -> bool {
+    path.file_name() == Some(config_filename)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use super::matches_config_file;
+
+    #[test]
+    fn matches_exact_filename() {
+        let filename = OsStr::new("config.toml");
+        assert!(matches_config_file(
+            Path::new("/home/user/.config/conductor/config.toml"),
+            filename
+        ));
+    }
+
+    #[test]
+    fn does_not_match_with_extension() {
+        let filename = OsStr::new("config.toml");
+        assert!(!matches_config_file(
+            Path::new("/home/user/.config/conductor/config.toml.tmp"),
+            filename
+        ));
+    }
+
+    #[test]
+    fn does_not_match_different_filename() {
+        let filename = OsStr::new("config.toml");
+        assert!(!matches_config_file(
+            Path::new("/home/user/.config/conductor/other.toml"),
+            filename
+        ));
+    }
+
+    #[test]
+    fn does_not_match_parent_dir_only() {
+        let filename = OsStr::new("config.toml");
+        assert!(!matches_config_file(
+            Path::new("/home/user/.config/conductor/"),
+            filename
+        ));
+    }
+
+    #[test]
+    fn matches_when_path_is_just_filename() {
+        let filename = OsStr::new("config.toml");
+        assert!(matches_config_file(Path::new("config.toml"), filename));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod ccusage_cache;
 mod claude_sessions;
 mod command_palette;
 mod config;
+mod config_watcher;
 mod diff_state;
 mod event;
 mod file_watcher;
@@ -340,6 +341,13 @@ fn run_loop(
     let mut current_watch_paths = watch_paths_for(app);
     let mut file_watcher = crate::file_watcher::FileWatcher::new(&current_watch_paths).ok();
 
+    // Set up a dedicated watcher for the conductor config file. Separate from
+    // the worktree file watcher: the worktree watcher is rebuilt each time the
+    // worktree set changes, which would break config monitoring if they shared
+    // the same watcher instance.
+    let config_watcher =
+        crate::config_watcher::ConfigWatcher::new(&crate::config::config_file_path()).ok();
+
     // Set up socket listener for CC state notifications (instant delivery).
     let cc_notify = crate::cc_notify::CcNotifyListener::new(&app.repo_path).ok();
 
@@ -356,6 +364,12 @@ fn run_loop(
     const FS_DEBOUNCE: Duration = Duration::from_millis(500);
     let mut fs_pending = false;
     let mut fs_first_seen: Option<Instant> = None;
+
+    // Separate debounce for config-file changes. Shorter than FS_DEBOUNCE and
+    // isolated so worktree-poll rebuilds don't reset it.
+    const CONFIG_DEBOUNCE: Duration = Duration::from_millis(300);
+    let mut cfg_pending = false;
+    let mut cfg_first_seen: Option<Instant> = None;
 
     // Periodic timers — consolidated into a single registry.
     let mut timers = timer::TimerRegistry::new();
@@ -698,6 +712,26 @@ fn run_loop(
                     app.start_symbol_index_build();
                 }
                 app.dirty.mark_all();
+            }
+        }
+
+        // Config file change events (debounced). Shorter debounce than FS events
+        // because the two event streams are independent — a worktree-poll rebuild
+        // must not reset the config debounce timer.
+        if let Some(ref watcher) = config_watcher {
+            while watcher.poll().is_some() {
+                if !cfg_pending {
+                    cfg_first_seen = Some(Instant::now());
+                }
+                cfg_pending = true;
+            }
+            if cfg_pending
+                && let Some(t) = cfg_first_seen
+                && t.elapsed() >= CONFIG_DEBOUNCE
+            {
+                cfg_pending = false;
+                cfg_first_seen = None;
+                app.reload_appearance_config();
             }
         }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -18,6 +18,12 @@ pub struct LayoutCache {
     pub expanded_panel: Option<crate::app::Focus>,
     /// Whether notification bar was visible (cache key).
     pub has_notifications: bool,
+    /// Explorer column width % used when computing this cache (cache key).
+    pub explorer_width_pct: u16,
+    /// Viewer column width % used when computing this cache (cache key).
+    pub viewer_width_pct: u16,
+    /// Claude Code area height % within the terminal column (cache key).
+    pub terminal_split_pct: u16,
     /// Title bar area.
     pub title_area: Rect,
     /// Notification bar area.
@@ -43,10 +49,14 @@ impl LayoutCache {
         frame_area: Rect,
         expanded_panel: Option<crate::app::Focus>,
         has_notifications: bool,
+        layout: &crate::config::LayoutConfig,
     ) -> bool {
         if self.frame_area == frame_area
             && self.expanded_panel == expanded_panel
             && self.has_notifications == has_notifications
+            && self.explorer_width_pct == layout.explorer_width_pct
+            && self.viewer_width_pct == layout.viewer_width_pct
+            && self.terminal_split_pct == layout.terminal_split_pct
         {
             return false;
         }
@@ -54,6 +64,9 @@ impl LayoutCache {
         self.frame_area = frame_area;
         self.expanded_panel = expanded_panel;
         self.has_notifications = has_notifications;
+        self.explorer_width_pct = layout.explorer_width_pct;
+        self.viewer_width_pct = layout.viewer_width_pct;
+        self.terminal_split_pct = layout.terminal_split_pct;
 
         // The notification bar is gone — Claude-waiting state is now shown by
         // the worktree strip (the waiting worktree is highlighted there).
@@ -77,7 +90,12 @@ impl LayoutCache {
         self.main_area = outer[3];
         self.status_area = outer[4];
 
-        let (left_w, explorer_w, viewer_w) = accordion_widths(expanded_panel, self.main_area.width);
+        let (left_w, explorer_w, viewer_w) = accordion_widths(
+            expanded_panel,
+            self.main_area.width,
+            layout.explorer_width_pct,
+            layout.viewer_width_pct,
+        );
         let right_w = self
             .main_area
             .width
@@ -99,10 +117,14 @@ impl LayoutCache {
                 .split(self.columns[1]);
         self.explorer_mid_y = explorer_split[1].y;
 
-        // Terminal 80/20 vertical split
-        let terminal_split =
-            Layout::vertical([Constraint::Percentage(80), Constraint::Percentage(20)])
-                .split(self.columns[3]);
+        // Terminal vertical split: Claude Code gets `terminal_split_pct`%,
+        // shell gets the remainder.
+        let shell_pct = 100u16.saturating_sub(layout.terminal_split_pct);
+        let terminal_split = Layout::vertical([
+            Constraint::Percentage(layout.terminal_split_pct),
+            Constraint::Percentage(shell_pct),
+        ])
+        .split(self.columns[3]);
         self.terminal_split = [terminal_split[0], terminal_split[1]];
 
         true
@@ -111,10 +133,14 @@ impl LayoutCache {
 
 /// Calculate accordion panel widths based on panel expansion state.
 ///
-/// Returns `(left_width, explorer_width, viewer_width)`. The right panel gets whatever remains.
+/// Returns `(left_width, explorer_width, viewer_width)`. The right panel gets
+/// whatever remains. `explorer_pct` and `viewer_pct` are the configured
+/// percentages (0–100) used only in the default (non-maximized) layout.
 pub(crate) fn accordion_widths(
     expanded_panel: Option<crate::app::Focus>,
     total_width: u16,
+    explorer_pct: u16,
+    viewer_pct: u16,
 ) -> (u16, u16, u16) {
     use crate::app::Focus;
 
@@ -133,8 +159,9 @@ pub(crate) fn accordion_widths(
             // lives in the top strip), so it gets width 0 and the freed space
             // goes to the explorer and viewer review panes.
             let min_col = 3_u16;
-            let explorer = ((total_width as u32 * 24 / 100) as u16).max(min_col);
-            let viewer = ((total_width as u32 * 38 / 100) as u16).max(min_col);
+            let explorer =
+                ((total_width as u32 * explorer_pct as u32 / 100) as u16).max(min_col);
+            let viewer = ((total_width as u32 * viewer_pct as u32 / 100) as u16).max(min_col);
             (0, explorer, viewer)
         }
     }
@@ -142,16 +169,118 @@ pub(crate) fn accordion_widths(
 
 #[cfg(test)]
 mod tests {
-    use super::accordion_widths;
+    use ratatui::layout::Rect;
+
+    use super::{LayoutCache, accordion_widths};
     use crate::app::Focus;
+    use crate::config::LayoutConfig;
+
+    /// Build a minimal LayoutConfig with the given proportions.
+    fn layout(explorer: u16, viewer: u16, terminal: u16) -> LayoutConfig {
+        LayoutConfig {
+            explorer_width_pct: explorer,
+            viewer_width_pct: viewer,
+            terminal_split_pct: terminal,
+        }
+    }
+
+    /// A non-zero Rect large enough to produce non-trivial layout splits.
+    fn rect(w: u16, h: u16) -> Rect {
+        Rect::new(0, 0, w, h)
+    }
+
+    // ── LayoutCache::update ──────────────────────────────────────────
+
+    #[test]
+    fn layout_cache_update_returns_true_first_call() {
+        let mut cache = LayoutCache::default();
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
+        assert!(changed, "first update must recompute");
+    }
+
+    #[test]
+    fn layout_cache_update_returns_false_on_identical_second_call() {
+        let mut cache = LayoutCache::default();
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg);
+        let changed = cache.update(rect(200, 50), None, false, &cfg);
+        assert!(!changed, "identical inputs must not recompute");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_frame_area_change() {
+        let mut cache = LayoutCache::default();
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg);
+        let changed = cache.update(rect(201, 50), None, false, &cfg);
+        assert!(changed, "frame_area change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_explorer_pct_change() {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
+        let changed = cache.update(rect(200, 50), None, false, &layout(30, 38, 80));
+        assert!(changed, "explorer_width_pct change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_viewer_pct_change() {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 42, 80));
+        assert!(changed, "viewer_width_pct change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_terminal_split_change() {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 70));
+        assert!(changed, "terminal_split_pct change must invalidate");
+    }
+
+    // ── accordion_widths: abnormal percentages ───────────────────────
+
+    #[test]
+    fn accordion_widths_does_not_panic_on_large_percentages() {
+        // Percentages exceeding 100 must not panic (Percentage constraint clamps).
+        let _ = accordion_widths(None, 200, 240, 0);
+        let _ = accordion_widths(None, 100, 60, 60);
+    }
+
+    #[test]
+    fn terminal_split_pct_over_100_does_not_panic() {
+        // terminal_split_pct > 100 makes shell_pct saturate to 0; must not panic.
+        let mut cache = LayoutCache::default();
+        let _ = cache.update(rect(200, 50), None, false, &layout(24, 38, 200));
+    }
 
     #[test]
     fn maximized_editor_takes_full_width_via_explorer_slot() {
         // render_ui unions the explorer+viewer columns into the editor area, so
         // the maximized editor puts all width on the explorer slot (viewer 0),
         // collapsing the terminal column to zero remaining.
-        let (left, explorer, viewer) = accordion_widths(Some(Focus::Editor), 120);
+        let (left, explorer, viewer) = accordion_widths(Some(Focus::Editor), 120, 24, 38);
         assert_eq!((left, explorer, viewer), (0, 120, 0));
+    }
+
+    #[test]
+    fn default_layout_uses_configured_percentages() {
+        // With default percentages (24/38) and 200-column terminal.
+        let (left, explorer, viewer) = accordion_widths(None, 200, 24, 38);
+        assert_eq!(left, 0, "worktree column is always hidden");
+        assert_eq!(explorer, 48, "200 * 24 / 100 = 48");
+        assert_eq!(viewer, 76, "200 * 38 / 100 = 76");
+    }
+
+    #[test]
+    fn custom_percentages_are_respected() {
+        // Wider explorer (30%) and narrower viewer (30%).
+        let (left, explorer, viewer) = accordion_widths(None, 100, 30, 30);
+        assert_eq!(left, 0);
+        assert_eq!(explorer, 30);
+        assert_eq!(viewer, 30);
     }
 }
 
@@ -161,8 +290,10 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     let has_notifications = !app.terminal.cc_waiting_worktrees.is_empty();
 
     // Update layout cache (no-op if nothing changed).
+    // Disjoint field borrows: `app.layout_cache` mutably, `app.config.layout`
+    // immutably — Rust allows this because they are separate struct fields.
     app.layout_cache
-        .update(area, app.expanded_panel, has_notifications);
+        .update(area, app.expanded_panel, has_notifications, &app.config.layout);
 
     let title_area = app.layout_cache.title_area;
     let wtbar_area = app.layout_cache.wtbar_area;

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -159,6 +159,17 @@ impl MarkdownCache {
         Self::default()
     }
 
+    /// Clear all cached entries.
+    ///
+    /// Called by `App::apply_appearance` after the syntect theme is replaced so
+    /// that the next render re-highlights code blocks with the new theme. The
+    /// cache fingerprint only tracks the UI theme colour palette; a syntect-only
+    /// change (e.g. `[viewer] syntax_theme_file`) would otherwise leave stale
+    /// highlighted spans in the cache.
+    pub fn clear(&self) {
+        self.entries.borrow_mut().clear();
+    }
+
     /// Cached lines for `key` when body/width/theme are unchanged, else render
     /// and store. Returned lines carry no explicit background.
     pub fn render(


### PR DESCRIPTION
## Summary

設定の外部化を仕上げ、見た目(appearance)設定をアプリ再起動なしで即時反映するライブリロード機構を追加した。

- **即時反映 (live reload)**: `App::apply_appearance` / `reload_appearance_config` を新設。theme・syntect構文テーマ・`viewer.tab_width`・`diff.word_diff`・`diff.default_view`・`general.decoration`・`[layout]` をファイル保存で再起動なしに反映する。
- **イベント駆動監視 (no polling)**: 新規 `src/config_watcher.rs` が `notify` (macOS=FSEvents) で `~/.config/conductor/` の親ディレクトリを `NonRecursive` 監視し、`config.toml` をファイル名でフィルタ。エディタの atomic-rename 保存に耐える。`main.rs` で worktree 監視とは独立した 300ms デバウンスを掛ける。
- **live / restart の明確な分離**: `Config::appearance_snapshot()`（live集合）と `has_restart_changes()`（restart集合）で表現。`Config::adopt_appearance` はライブ対象フィールドのみをフィールド単位コピーし、restartフィールド（repo/shell/main_branch/scrollback 等）には一切触れない。restart設定の変更検知時は「再起動が必要」を flash する。
- **自己書き込みループ防止**: appearance スナップショットの等価ガードで、in-appテーマピッカーの保存によるFS再発火を無音 no-op に吸収する。
- **`[layout]` の新規externalize**: パネル列幅比（explorer/viewer/terminal split）を設定可能にした。内部フレームタイミング定数は意図的に据え置き。
- **ライトテーマのsyntect対応**: ライトUIテーマ選択時に構文ハイライトが暗色のままになる問題を修正。
- **不正TOML / remove イベント耐性**: パースエラー時は現状維持＋error flash、ファイル不在時はデフォルト上書きを避けて no-op。

## Test plan

- `cargo build` — clean (0 warnings)
- `cargo clippy` — clean (0 warnings)
- `cargo test` — 404 passed; 0 failed（live/restart分類の往復不変条件・syntectマッピング・LayoutCacheキャッシュキー・異常値の網羅テストを追加）
- `cargo install --path .` — success (0.76.0 → 0.77.0)
- 手動: 起動中に `config.toml` の `[ui] theme` 等を保存し即時反映を目視確認（推奨）
