### PR TITLE
feat: fix shell panel paste/scroll/arrow handling and add grow/shrink-shell resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.77.0"
+version = "0.78.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.77.0"
+version = "0.78.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -423,6 +423,12 @@ pub struct App {
     /// `None` means no panel is expanded (default layout).
     pub expanded_panel: Option<Focus>,
 
+    /// Runtime height percentage for the Claude Code area within the terminal
+    /// column (the Shell gets the remainder). Seeded from
+    /// `config.layout.terminal_split_pct` at startup and adjusted live by the
+    /// grow/shrink-shell actions; not persisted back to the config file.
+    pub terminal_split_pct: u16,
+
     /// Frame counter for UI animations (e.g. waiting-state pulse).
     pub ui_tick: u64,
     /// Independent tick counter for decoration animation (incremented at fixed interval).
@@ -627,6 +633,9 @@ impl App {
     /// Create a new `App` rooted at the given repository path.
     pub fn new(repo_path: PathBuf) -> Self {
         let config = config::Config::load().unwrap_or_default();
+        // Snapshot the configured terminal split before `config` is moved into
+        // the struct; this seeds the runtime-adjustable `terminal_split_pct`.
+        let config_terminal_split_pct = config.layout.terminal_split_pct;
         let view_mode = DiffViewMode::from(config.diff.default_view);
         let diff_state = DiffState::new(&config.general.main_branch, view_mode);
 
@@ -713,6 +722,7 @@ impl App {
             syntect_theme,
             markdown_cache: crate::ui::markdown::MarkdownCache::new(),
             expanded_panel: None,
+            terminal_split_pct: config_terminal_split_pct,
             ui_tick: 0,
             decoration_tick: 0,
             notification_bar_badges: Vec::new(),
@@ -1796,6 +1806,8 @@ impl App {
             CommandId::NextWorktree => self.select_next_worktree(),
             CommandId::PrevWorktree => self.select_prev_worktree(),
             CommandId::TogglePanelExpand => self.cmd_toggle_panel_expand(),
+            CommandId::GrowShell => self.grow_shell(),
+            CommandId::ShrinkShell => self.shrink_shell(),
             CommandId::CreateWorktree => self.cmd_create_worktree(),
             CommandId::DeleteWorktree => self.cmd_delete_worktree(),
             CommandId::SwitchBranch => self.cmd_switch_branch(),
@@ -1902,6 +1914,45 @@ impl App {
         } else {
             self.expanded_panel = Some(self.focus);
         }
+    }
+
+    /// Grow the Shell area within the terminal column by one step (the Claude
+    /// area shrinks). Bound to the grow-shell action.
+    pub fn grow_shell(&mut self) {
+        self.adjust_terminal_split(-(Self::TERMINAL_SPLIT_STEP as i16));
+    }
+
+    /// Shrink the Shell area within the terminal column by one step (the Claude
+    /// area grows). Bound to the shrink-shell action.
+    pub fn shrink_shell(&mut self) {
+        self.adjust_terminal_split(Self::TERMINAL_SPLIT_STEP as i16);
+    }
+
+    /// Step (percentage points) each grow/shrink-shell action moves the
+    /// Claude/Shell divider.
+    const TERMINAL_SPLIT_STEP: u16 = 5;
+    /// Bounds for the runtime Claude-area percentage, leaving at least this much
+    /// for each of the two terminal panes so neither can vanish.
+    const TERMINAL_SPLIT_MIN: u16 = 20;
+    const TERMINAL_SPLIT_MAX: u16 = 80;
+
+    /// Adjust the runtime Claude-area height percentage by `delta` points,
+    /// clamped so both the Claude and Shell panes keep a usable minimum. A
+    /// positive `delta` enlarges the Claude pane (shrinks the Shell); negative
+    /// enlarges the Shell. Flashes the resulting split as a status message.
+    fn adjust_terminal_split(&mut self, delta: i16) {
+        let next = (self.terminal_split_pct as i16 + delta)
+            .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
+            as u16;
+        if next == self.terminal_split_pct {
+            return;
+        }
+        self.terminal_split_pct = next;
+        self.dirty.mark_all();
+        self.set_status_info(format!(
+            "Terminal split: Claude {next}% / Shell {}%",
+            100 - next
+        ));
     }
 
     fn cmd_create_worktree(&mut self) {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -19,6 +19,8 @@ pub enum CommandId {
     NextWorktree,
     PrevWorktree,
     TogglePanelExpand,
+    GrowShell,
+    ShrinkShell,
 
     // Worktree
     CreateWorktree,
@@ -202,6 +204,20 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Navigation,
         action: Some(Action::TogglePanelExpand),
         keywords: "resize maximize fullscreen",
+    },
+    PaletteCommand {
+        id: CommandId::GrowShell,
+        label: "Layout: Grow Shell Area",
+        category: CommandCategory::Navigation,
+        action: Some(Action::GrowShell),
+        keywords: "resize terminal shell split bigger taller",
+    },
+    PaletteCommand {
+        id: CommandId::ShrinkShell,
+        label: "Layout: Shrink Shell Area",
+        category: CommandCategory::Navigation,
+        action: Some(Action::ShrinkShell),
+        keywords: "resize terminal shell split smaller shorter claude",
     },
     // Worktree
     PaletteCommand {

--- a/src/config.rs
+++ b/src/config.rs
@@ -655,7 +655,8 @@ pub fn generate_default_config() -> String {
 # viewer_width_pct = 38                 # viewer column width % (default: 38)
 #                                       # terminal column gets the remaining width
 # terminal_split_pct = 80              # Claude Code area height % within terminal column (default: 80)
-#                                       # shell area receives the remainder
+#                                       # shell area receives the remainder; the initial split only —
+#                                       # adjust it live with Ctrl+Alt+Up / Ctrl+Alt+Down (grow/shrink shell)
 #                                       # These proportions apply in the default layout only;
 #                                       # maximizing a panel (Alt+m) overrides them temporarily.
 "#,

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -74,6 +74,11 @@
 # alt+m — maximize/zoom the focused panel. Reliable everywhere (super+space's
 # Cmd is eaten by macOS/terminals); the easy half of "focus then zoom".
 "alt+m" = "toggle_panel_expand"
+# Resize the Claude/Shell vertical split at runtime (the Shell starts small).
+# Ctrl+Alt+Up grows the Shell (divider up); Ctrl+Alt+Down shrinks it. These fire
+# even with the Shell (a terminal) focused, so you can resize while typing in it.
+"ctrl+alt+up" = "grow_shell"
+"ctrl+alt+down" = "shrink_shell"
 "alt+/" = "toggle_panel_overlay"
 # macOS Unicode fallback (Option+/ = '÷', US layout).
 "÷" = "toggle_panel_overlay"

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -147,6 +147,14 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.toggle_panel_overlay();
             true
         }
+        Action::GrowShell => {
+            app.grow_shell();
+            true
+        }
+        Action::ShrinkShell => {
+            app.shrink_shell();
+            true
+        }
         Action::OpenThemePicker => {
             app.cmd_open_theme_picker();
             true

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -1038,10 +1038,16 @@ fn handle_mouse_scroll(
     // never scroll the hidden Explorer/Viewer state beneath it.
     if app.editor.is_some() && col >= left_end && col < viewer_end {
         if let Some(idx) = app.editor.as_ref().map(|e| e.session_idx) {
-            app.terminal.pty_manager.scroll_alt_screen_session(
+            // PTY grid is 1-based; the merged editor region starts at left_end
+            // (left border) with content one cell in and one row down.
+            let pty_col = col.saturating_sub(left_end).max(1);
+            let pty_row = row.saturating_sub(main_area.y).max(1);
+            app.terminal.pty_manager.forward_scroll_to_session(
                 idx,
                 delta.unsigned_abs() as usize,
                 delta < 0,
+                pty_col,
+                pty_row,
             );
         }
         return;
@@ -1145,20 +1151,25 @@ fn handle_mouse_scroll(
         let abs_delta = delta.unsigned_abs() as usize;
         // ScrollUp (delta < 0) moves toward older content / into history.
         let up = delta < 0;
-        let session_idx = if row < terminal_split_y {
-            app.terminal.active_claude_session
+        let (session_idx, content_y) = if row < terminal_split_y {
+            (app.terminal.active_claude_session, main_area.y + 1)
         } else {
-            app.terminal.active_shell_session
+            (app.terminal.active_shell_session, terminal_split_y + 1)
         };
 
-        // Pagers (less/bat/man) run on the alternate screen, which has no
-        // scrollback — translate the wheel into arrow keys for the child
-        // instead of bumping the (ignored) local scrollback offset.
+        // Full-screen apps that own the screen handle the wheel themselves:
+        // apps with mouse reporting on (vim/neovim, `less --mouse`) get an
+        // encoded mouse event; alt-screen pagers without mouse reporting get
+        // arrow keys. Either way the local scrollback offset is left alone.
+        // PTY grid is 1-based; the terminal column starts at `viewer_end` (left
+        // border) and the panel content starts at `content_y`.
+        let pty_col = col.saturating_sub(viewer_end).max(1);
+        let pty_row = row.saturating_sub(content_y).saturating_add(1);
         if let Some(idx) = session_idx
             && app
                 .terminal
                 .pty_manager
-                .scroll_alt_screen_session(idx, abs_delta, up)
+                .forward_scroll_to_session(idx, abs_delta, up, pty_col, pty_row)
         {
             return;
         }

--- a/src/event/terminal.rs
+++ b/src/event/terminal.rs
@@ -8,7 +8,15 @@ use crate::terminal_link;
 
 /// Forward a key event to the PTY session at the given index.
 pub(super) fn forward_key_to_pty(app: &mut App, session_idx: usize, key: KeyEvent) {
-    let Some(data) = key_event_to_ansi(&key) else {
+    // Programs that enable application cursor keys mode (DECCKM) — pagers like
+    // `less`/`bat`, editors like `vim` — expect arrow/Home/End as SS3 (`ESC O`)
+    // rather than CSI (`ESC [`); honor the session's current mode so the keys
+    // actually register (e.g. arrow-key scrolling in `bat`).
+    let app_cursor = app
+        .terminal
+        .pty_manager
+        .session_application_cursor(session_idx);
+    let Some(data) = key_event_to_ansi(&key, app_cursor) else {
         return;
     };
 
@@ -39,7 +47,7 @@ pub(super) fn forward_key_to_pty(app: &mut App, session_idx: usize, key: KeyEven
 ///
 /// Returns `None` for key events that have no meaningful byte representation
 /// (e.g. bare modifier key presses like Shift alone).
-fn key_event_to_ansi(key: &KeyEvent) -> Option<Vec<u8>> {
+fn key_event_to_ansi(key: &KeyEvent, app_cursor: bool) -> Option<Vec<u8>> {
     let mods = key.modifiers;
     let data = match key.code {
         // ── Character keys ───────────────────────────────────────
@@ -86,16 +94,22 @@ fn key_event_to_ansi(key: &KeyEvent) -> Option<Vec<u8>> {
         KeyCode::Esc => vec![0x1b],
 
         // ── Arrow keys ───────────────────────────────────────────
-        KeyCode::Up => arrow_with_modifiers(b'A', &mods),
-        KeyCode::Down => arrow_with_modifiers(b'B', &mods),
-        KeyCode::Right => arrow_with_modifiers(b'C', &mods),
-        KeyCode::Left => arrow_with_modifiers(b'D', &mods),
+        KeyCode::Up => arrow_with_modifiers(b'A', &mods, app_cursor),
+        KeyCode::Down => arrow_with_modifiers(b'B', &mods, app_cursor),
+        KeyCode::Right => arrow_with_modifiers(b'C', &mods, app_cursor),
+        KeyCode::Left => arrow_with_modifiers(b'D', &mods, app_cursor),
 
         // ── Home / End ───────────────────────────────────────────
+        // DECCKM applies to the unmodified form: SS3 (`ESC O H`) when the
+        // application has application-cursor-keys mode on, CSI otherwise.
         KeyCode::Home => {
             let p = xterm_modifier_param(&mods);
             if p == 1 {
-                b"\x1b[H".to_vec()
+                if app_cursor {
+                    b"\x1bOH".to_vec()
+                } else {
+                    b"\x1b[H".to_vec()
+                }
             } else {
                 format!("\x1b[1;{p}H").into_bytes()
             }
@@ -103,7 +117,11 @@ fn key_event_to_ansi(key: &KeyEvent) -> Option<Vec<u8>> {
         KeyCode::End => {
             let p = xterm_modifier_param(&mods);
             if p == 1 {
-                b"\x1b[F".to_vec()
+                if app_cursor {
+                    b"\x1bOF".to_vec()
+                } else {
+                    b"\x1b[F".to_vec()
+                }
             } else {
                 format!("\x1b[1;{p}F").into_bytes()
             }
@@ -405,7 +423,13 @@ fn xterm_modifier_param(modifiers: &KeyModifiers) -> u8 {
 ///
 /// For Cmd (Super) on macOS, we map to the same behaviour as common
 /// terminals: Cmd+Left/Right → Home/End, Cmd+Up/Down → PageUp/PageDown.
-fn arrow_with_modifiers(dir: u8, modifiers: &KeyModifiers) -> Vec<u8> {
+///
+/// `app_cursor` reflects the target program's application-cursor-keys mode
+/// (DECCKM). When it is on and no modifiers are pressed, arrow keys are sent as
+/// SS3 (`ESC O A`) instead of CSI (`ESC [ A`) — what pagers/editors bind to
+/// (this is what makes arrow-key scrolling work in `less`/`bat`). With
+/// modifiers, xterm always uses the CSI `1;<param>` form regardless of DECCKM.
+fn arrow_with_modifiers(dir: u8, modifiers: &KeyModifiers, app_cursor: bool) -> Vec<u8> {
     // Cmd+Arrow → Home/End/PageUp/PageDown (macOS convention).
     if modifiers.contains(KeyModifiers::SUPER) {
         return match dir {
@@ -419,7 +443,11 @@ fn arrow_with_modifiers(dir: u8, modifiers: &KeyModifiers) -> Vec<u8> {
 
     let param = xterm_modifier_param(modifiers);
     if param == 1 {
-        vec![0x1b, b'[', dir]
+        if app_cursor {
+            vec![0x1b, b'O', dir]
+        } else {
+            vec![0x1b, b'[', dir]
+        }
     } else {
         format!("\x1b[1;{param}{}", dir as char).into_bytes()
     }
@@ -482,5 +510,48 @@ fn f_key_to_ansi(n: u8, modifiers: &KeyModifiers) -> Vec<u8> {
         } else {
             format!("\x1b[1;{param}{code}").into_bytes()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn arrows_use_csi_in_normal_cursor_mode() {
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Up), false), Some(b"\x1b[A".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Down), false), Some(b"\x1b[B".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Right), false), Some(b"\x1b[C".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Left), false), Some(b"\x1b[D".to_vec()));
+    }
+
+    #[test]
+    fn arrows_use_ss3_in_application_cursor_mode() {
+        // DECCKM on: pagers/editors (less, bat, vim) expect SS3 — this is what
+        // makes arrow-key scrolling register in `bat`.
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Up), true), Some(b"\x1bOA".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Down), true), Some(b"\x1bOB".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Right), true), Some(b"\x1bOC".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Left), true), Some(b"\x1bOD".to_vec()));
+    }
+
+    #[test]
+    fn home_end_honor_application_cursor_mode() {
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Home), false), Some(b"\x1b[H".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::End), false), Some(b"\x1b[F".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::Home), true), Some(b"\x1bOH".to_vec()));
+        assert_eq!(key_event_to_ansi(&key(KeyCode::End), true), Some(b"\x1bOF".to_vec()));
+    }
+
+    #[test]
+    fn modified_arrows_stay_csi_regardless_of_cursor_mode() {
+        // With a modifier, xterm uses the CSI `1;<param>` form even under DECCKM.
+        let shift_up = KeyEvent::new(KeyCode::Up, KeyModifiers::SHIFT);
+        assert_eq!(key_event_to_ansi(&shift_up, true), Some(b"\x1b[1;2A".to_vec()));
+        assert_eq!(key_event_to_ansi(&shift_up, false), Some(b"\x1b[1;2A".to_vec()));
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -145,6 +145,10 @@ pub enum Action {
     // ── Panel layout ────────────────────────────────────────────
     TogglePanelExpand,
     TogglePanelOverlay,
+    /// Grow the Shell area (move the Claude/Shell divider up).
+    GrowShell,
+    /// Shrink the Shell area (move the Claude/Shell divider down).
+    ShrinkShell,
 
     // ── UI ──────────────────────────────────────────────────────
     /// Open the theme picker overlay to switch the UI color theme at runtime.
@@ -235,6 +239,8 @@ impl Action {
             "inline_reply" => Some(Action::InlineReply),
             "toggle_panel_expand" => Some(Action::TogglePanelExpand),
             "toggle_panel_overlay" => Some(Action::TogglePanelOverlay),
+            "grow_shell" => Some(Action::GrowShell),
+            "shrink_shell" => Some(Action::ShrinkShell),
             "open_theme_picker" => Some(Action::OpenThemePicker),
             _ => None,
         }
@@ -324,6 +330,8 @@ impl Action {
             Action::InlineReply => "inline_reply",
             Action::TogglePanelExpand => "toggle_panel_expand",
             Action::TogglePanelOverlay => "toggle_panel_overlay",
+            Action::GrowShell => "grow_shell",
+            Action::ShrinkShell => "shrink_shell",
             Action::OpenThemePicker => "open_theme_picker",
         }
     }
@@ -360,6 +368,10 @@ impl Action {
                 | Action::PrevWorktree
                 | Action::TogglePanelExpand
                 | Action::TogglePanelOverlay
+                // Resizing the Claude/Shell split is most useful with the Shell
+                // (a terminal) focused, so these must fire over a PTY too.
+                | Action::GrowShell
+                | Action::ShrinkShell
         )
     }
 }

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -396,25 +396,39 @@ impl PtyManager {
         Ok(())
     }
 
-    /// Translate a mouse-wheel scroll into arrow-key presses for a session
-    /// that is showing the **alternate screen** (e.g. pagers like `less`,
-    /// `bat`, `man`).
+    /// Forward a mouse-wheel scroll to a PTY session that owns the screen,
+    /// returning `true` when the scroll was handled (the caller must then **not**
+    /// adjust the local scrollback offset).
     ///
-    /// The alternate screen has no scrollback of its own, so the local
-    /// scrollback offset is meaningless there — the user must scroll the
-    /// child program instead. This mirrors the "alternate-scroll" behavior
-    /// of tmux / iTerm2: each wheel notch becomes `lines` Up/Down arrow
-    /// presses sent to the child.
+    /// Three cases, matching how tmux / iTerm2 behave:
     ///
-    /// Returns `true` if the scroll was handled by injecting arrow keys, in
-    /// which case the caller must **not** also adjust the local scrollback
-    /// offset. Returns `false` when the session is not on the alternate
-    /// screen, or when the child has enabled mouse reporting (in which case
-    /// it captures the wheel itself and synthesizing arrows would fight it).
-    pub fn scroll_alt_screen_session(&mut self, idx: usize, lines: usize, up: bool) -> bool {
+    /// 1. **Child requested mouse reporting** (vim/neovim with `mouse=`,
+    ///    `less --mouse`, fzf, …): forward the wheel as a properly encoded mouse
+    ///    event (SGR `1006` or legacy X10) at `col`/`row` so the application
+    ///    scrolls itself. This is the fix for full-screen apps where the wheel
+    ///    used to be swallowed entirely. Applies on both the normal and
+    ///    alternate screen — if the app turned mouse reporting on, it wants the
+    ///    event.
+    /// 2. **Alternate screen, no mouse reporting** (pagers like `less`, `bat`,
+    ///    `man`): the alternate screen has no scrollback of its own, so translate
+    ///    each wheel notch into `lines` Up/Down arrow presses sent to the child
+    ///    (the classic "alternate-scroll").
+    /// 3. **Normal screen, no mouse reporting**: not handled here — return
+    ///    `false` so the caller scrolls the panel's local scrollback buffer.
+    ///
+    /// `col` / `row` are 1-based coordinates within the PTY grid, used only for
+    /// the mouse-event encoding in case 1.
+    pub fn forward_scroll_to_session(
+        &mut self,
+        idx: usize,
+        lines: usize,
+        up: bool,
+        col: u16,
+        row: u16,
+    ) -> bool {
         // Read the relevant terminal modes, then drop the session/parser
         // borrow before writing (write_to_session needs &mut self).
-        let (is_alt, app_cursor, mouse_on) = {
+        let (is_alt, app_cursor, mouse_mode, mouse_encoding) = {
             let Some(session) = self.sessions.get(idx) else {
                 return false;
             };
@@ -423,14 +437,27 @@ impl PtyManager {
             (
                 screen.alternate_screen(),
                 screen.application_cursor(),
-                screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None,
+                screen.mouse_protocol_mode(),
+                screen.mouse_protocol_encoding(),
             )
         };
 
-        if !is_alt || mouse_on {
+        // Case 1: the child captures the wheel itself — hand it an encoded event.
+        if mouse_mode != vt100::MouseProtocolMode::None {
+            let seq = encode_mouse_wheel(up, col, row, mouse_encoding);
+            if let Err(e) = self.write_to_session(idx, &seq) {
+                log::warn!("failed to forward wheel event to PTY session: {e}");
+            }
+            return true;
+        }
+
+        // Case 3: ordinary screen with no mouse reporting → caller scrolls
+        // the local scrollback buffer.
+        if !is_alt {
             return false;
         }
 
+        // Case 2: alternate-screen pager → synthesize arrow keys.
         let arrow = scroll_arrow_sequence(up, app_cursor);
         let mut buf = Vec::with_capacity(arrow.len() * lines);
         for _ in 0..lines {
@@ -477,30 +504,57 @@ impl PtyManager {
         Ok(())
     }
 
-    /// Send a large text payload to the PTY using bracketed paste mode and
+    /// Send a clipboard paste payload to the PTY, sanitizing it first and using
     /// chunked writes to avoid hitting the kernel's PTY input buffer limit
     /// (typically 4096 bytes on macOS / Linux).
+    ///
+    /// Two safety steps mirror what a well-behaved terminal does with a paste:
+    ///
+    /// 1. **Sanitize** (`sanitize_pasted_text`): clipboard content can carry
+    ///    ANSI escape sequences and other non-printable control bytes (copied
+    ///    from a colorized terminal, a web page, etc.). Forwarding those raw
+    ///    lets them move the cursor, change modes, or — worst — smuggle a
+    ///    `\x1b[201~` that ends bracketed paste early so the remainder runs as
+    ///    typed commands. We strip escape sequences and control characters,
+    ///    keeping only tabs and newlines (CR is normalized to LF).
+    /// 2. **Conditional bracketing**: the `\x1b[200~` / `\x1b[201~` markers are
+    ///    only emitted when the foreground application has actually enabled
+    ///    bracketed paste (DECSET 2004), exactly as a real terminal gates them.
+    ///    Wrapping unconditionally would dump literal `[200~` / `[201~` text
+    ///    into apps that never asked for it (a bare prompt, `cat`, …).
     pub fn write_paste_to_session(&mut self, idx: usize, text: &str) -> Result<()> {
         const CHUNK_SIZE: usize = 1024;
         const CHUNK_DELAY: Duration = Duration::from_millis(5);
+
+        let cleaned = sanitize_pasted_text(text);
 
         let session = self
             .sessions
             .get_mut(idx)
             .context("Session index out of bounds")?;
+
+        // Read the bracketed-paste mode flag under the screen lock, then drop it
+        // before taking the writer lock.
+        let bracketed = {
+            let parser = session.screen.lock().unwrap_or_else(|e| e.into_inner());
+            parser.screen().bracketed_paste()
+        };
+
         let mut writer = session.writer.lock().unwrap_or_else(|e| e.into_inner());
 
-        // Begin bracketed paste mode.
-        writer
-            .write_all(b"\x1b[200~")
-            .context("Failed to write paste-start to PTY")?;
-        writer.flush().context("Failed to flush PTY writer")?;
+        // Begin bracketed paste mode (only if the app understands it).
+        if bracketed {
+            writer
+                .write_all(b"\x1b[200~")
+                .context("Failed to write paste-start to PTY")?;
+            writer.flush().context("Failed to flush PTY writer")?;
+        }
 
         // Write the payload in small chunks. Split on UTF-8 character
         // boundaries so a flushed chunk never ends with a truncated multi-byte
         // sequence (see `utf8_chunks`) — otherwise full-width / multi-byte text
         // split across the 1 KiB boundary can be mis-decoded by the receiver.
-        for chunk in utf8_chunks(text, CHUNK_SIZE) {
+        for chunk in utf8_chunks(&cleaned, CHUNK_SIZE) {
             writer
                 .write_all(chunk.as_bytes())
                 .context("Failed to write chunk to PTY")?;
@@ -511,10 +565,12 @@ impl PtyManager {
         }
 
         // End bracketed paste mode.
-        writer
-            .write_all(b"\x1b[201~")
-            .context("Failed to write paste-end to PTY")?;
-        writer.flush().context("Failed to flush PTY writer")?;
+        if bracketed {
+            writer
+                .write_all(b"\x1b[201~")
+                .context("Failed to write paste-end to PTY")?;
+            writer.flush().context("Failed to flush PTY writer")?;
+        }
 
         Ok(())
     }
@@ -545,6 +601,18 @@ impl PtyManager {
                 buf.clone()
             })
             .unwrap_or_default()
+    }
+
+    /// Whether the session at `idx` has application cursor keys mode (DECCKM)
+    /// enabled. Full-screen programs on the alternate screen — pagers (`less`,
+    /// `bat`), editors (`vim`) — commonly turn this on, after which they expect
+    /// the arrow keys as SS3 (`ESC O A`) and ignore the default CSI (`ESC [ A`)
+    /// form. Key forwarding consults this so the arrows actually drive them.
+    pub fn session_application_cursor(&self, idx: usize) -> bool {
+        self.sessions.get(idx).is_some_and(|s| {
+            let parser = s.screen.lock().unwrap_or_else(|e| e.into_inner());
+            parser.screen().application_cursor()
+        })
     }
 
     /// Get the vt100 screen parser for the session at the given index.
@@ -1074,6 +1142,116 @@ fn utf8_chunks(text: &str, max: usize) -> Vec<&str> {
     chunks
 }
 
+/// Sanitize clipboard text before it is written to a PTY as a paste.
+///
+/// Clipboard content frequently carries bytes that are unsafe to forward
+/// verbatim into a terminal's input stream:
+/// * **ANSI escape sequences** (copied from a colorized terminal, a TUI, a web
+///   page that styled its text): these move the cursor, switch modes, or — most
+///   dangerously — can contain a `\x1b[201~` that prematurely *ends* bracketed
+///   paste, after which the rest of the clipboard is interpreted as typed
+///   commands. Whole escape sequences are dropped.
+/// * **Other C0/C1 control characters and DEL**: forwarded raw they can ring
+///   bells, send signals (via the line discipline), or corrupt the input.
+///
+/// What is preserved: ordinary printable text, **tabs** (`\t`), and **newlines**
+/// (`\n`). Carriage returns are normalized — `\r\n` and lone `\r` both become a
+/// single `\n` — so multi-line pastes keep their line structure without
+/// injecting bare CRs.
+fn sanitize_pasted_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // ESC introduces an escape sequence — drop the whole thing.
+            '\u{1b}' => skip_escape_sequence(&mut chars),
+            '\t' | '\n' => out.push(c),
+            // Normalize CR / CRLF to a single LF.
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                out.push('\n');
+            }
+            // Drop every other control character (remaining C0, DEL, C1).
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Consume the remainder of an ANSI escape sequence whose introducing `ESC` has
+/// already been read from `chars`. Handles the common sequence shapes so that no
+/// stray bytes of a dropped sequence leak into the sanitized output:
+/// * `CSI` (`ESC [`) — parameters/intermediates up to a final byte `0x40..=0x7E`.
+/// * String sequences `OSC/DCS/SOS/PM/APC` (`ESC ] P X ^ _`) — up to `BEL` or
+///   the String Terminator `ESC \`.
+/// * `SS2/SS3` (`ESC N` / `ESC O`) — exactly one following byte.
+/// * Anything else (`ESC` + a single byte, e.g. `ESC 7`) — already consumed.
+fn skip_escape_sequence(chars: &mut std::iter::Peekable<std::str::Chars>) {
+    match chars.next() {
+        Some('[') => {
+            for c in chars.by_ref() {
+                if ('\u{40}'..='\u{7e}').contains(&c) {
+                    break;
+                }
+            }
+        }
+        Some(']') | Some('P') | Some('X') | Some('^') | Some('_') => {
+            while let Some(c) = chars.next() {
+                if c == '\u{07}' {
+                    break;
+                }
+                if c == '\u{1b}' {
+                    if chars.peek() == Some(&'\\') {
+                        chars.next();
+                    }
+                    break;
+                }
+            }
+        }
+        Some('N') | Some('O') => {
+            // Single-shift: skip the one character it selects.
+            chars.next();
+        }
+        _ => {}
+    }
+}
+
+/// Encode a single mouse-wheel notch as the byte sequence a terminal sends to a
+/// child program that has enabled mouse reporting.
+///
+/// `up` selects wheel-up (xterm button 64) vs wheel-down (65). `col` / `row` are
+/// 1-based cell coordinates. The `encoding` follows the child's requested mode:
+/// SGR (`1006`, the modern default that has no 223-column limit) emits
+/// `CSI < b ; col ; row M`; otherwise the legacy X10 form `CSI M Cb Cx Cy` is
+/// used, with each value offset by 32 and clamped to one byte.
+fn encode_mouse_wheel(
+    up: bool,
+    col: u16,
+    row: u16,
+    encoding: vt100::MouseProtocolEncoding,
+) -> Vec<u8> {
+    let button: u16 = if up { 64 } else { 65 };
+    let col = col.max(1);
+    let row = row.max(1);
+    match encoding {
+        vt100::MouseProtocolEncoding::Sgr => {
+            format!("\x1b[<{button};{col};{row}M").into_bytes()
+        }
+        // Default (X10) and Utf8: CSI M Cb Cx Cy, each byte offset by 32.
+        // Values above 223 cannot be represented in the legacy form; clamp so
+        // we never emit a byte that wraps the coordinate.
+        _ => {
+            let cb = (32 + button).min(255) as u8;
+            let cx = (32 + col).min(255) as u8;
+            let cy = (32 + row).min(255) as u8;
+            vec![0x1b, b'[', b'M', cb, cx, cy]
+        }
+    }
+}
+
 /// Count the number of Cursor Position Report requests (`CSI 6 n` = `\x1b[6n`)
 /// in a byte slice.  Programs send this to ask the terminal "where is the
 /// cursor?" and expect a `CSI row ; col R` response.
@@ -1113,6 +1291,90 @@ mod tests {
         // Normal mode → CSI (ESC [).
         assert_eq!(scroll_arrow_sequence(true, false), b"\x1b[A");
         assert_eq!(scroll_arrow_sequence(false, false), b"\x1b[B");
+    }
+
+    // ── sanitize_pasted_text ─────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_keeps_plain_text_tabs_and_newlines() {
+        let input = "echo hello\tworld\nsecond line\n";
+        assert_eq!(sanitize_pasted_text(input), input);
+    }
+
+    #[test]
+    fn sanitize_normalizes_crlf_and_lone_cr_to_lf() {
+        assert_eq!(sanitize_pasted_text("a\r\nb\rc"), "a\nb\nc");
+    }
+
+    #[test]
+    fn sanitize_strips_csi_escape_sequences() {
+        // SGR color codes around the word must be removed, leaving plain text.
+        let input = "\x1b[31mred\x1b[0m text";
+        assert_eq!(sanitize_pasted_text(input), "red text");
+    }
+
+    #[test]
+    fn sanitize_removes_embedded_bracketed_paste_end_marker() {
+        // The load-bearing security case: a clipboard that smuggles a paste-end
+        // marker (`\x1b[201~`) followed by a command must not be able to break
+        // out of bracketed paste. The whole CSI sequence (incl. the `~` final
+        // byte) is dropped, so no `201~` survives.
+        let input = "safe\x1b[201~rm -rf /\n";
+        let out = sanitize_pasted_text(input);
+        assert_eq!(out, "saferm -rf /\n");
+        assert!(!out.contains("201~"));
+        assert!(!out.contains('\x1b'));
+    }
+
+    #[test]
+    fn sanitize_strips_osc_string_sequence() {
+        // OSC (window title) terminated by BEL — the whole thing is removed.
+        let input = "before\x1b]0;evil title\x07after";
+        assert_eq!(sanitize_pasted_text(input), "beforeafter");
+    }
+
+    #[test]
+    fn sanitize_drops_bare_control_bytes_but_keeps_text() {
+        // NUL, BEL, backspace, DEL all dropped; surrounding text intact.
+        let input = "a\x00b\x07c\x08d\x7fe";
+        assert_eq!(sanitize_pasted_text(input), "abcde");
+    }
+
+    #[test]
+    fn sanitize_preserves_multibyte_text() {
+        let input = "こんにちは\tworld\n";
+        assert_eq!(sanitize_pasted_text(input), input);
+    }
+
+    // ── encode_mouse_wheel ───────────────────────────────────────────────
+
+    #[test]
+    fn encode_mouse_wheel_sgr_up_and_down() {
+        // SGR: wheel up = button 64, down = 65; coordinates inline, final 'M'.
+        assert_eq!(
+            encode_mouse_wheel(true, 5, 9, vt100::MouseProtocolEncoding::Sgr),
+            b"\x1b[<64;5;9M".to_vec()
+        );
+        assert_eq!(
+            encode_mouse_wheel(false, 1, 1, vt100::MouseProtocolEncoding::Sgr),
+            b"\x1b[<65;1;1M".to_vec()
+        );
+    }
+
+    #[test]
+    fn encode_mouse_wheel_x10_offsets_by_32() {
+        // Legacy X10: CSI M Cb Cx Cy with each value +32. Up = 64+32 = 96 = '`'.
+        let seq = encode_mouse_wheel(true, 2, 3, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(seq, vec![0x1b, b'[', b'M', 96, 34, 35]);
+    }
+
+    #[test]
+    fn encode_mouse_wheel_clamps_coordinates_to_at_least_one() {
+        // 0 coordinates are clamped to 1 so the SGR form stays well-formed.
+        assert_eq!(
+            encode_mouse_wheel(true, 0, 0, vt100::MouseProtocolEncoding::Sgr),
+            b"\x1b[<64;1;1M".to_vec()
+        );
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -50,13 +50,14 @@ impl LayoutCache {
         expanded_panel: Option<crate::app::Focus>,
         has_notifications: bool,
         layout: &crate::config::LayoutConfig,
+        terminal_split_pct: u16,
     ) -> bool {
         if self.frame_area == frame_area
             && self.expanded_panel == expanded_panel
             && self.has_notifications == has_notifications
             && self.explorer_width_pct == layout.explorer_width_pct
             && self.viewer_width_pct == layout.viewer_width_pct
-            && self.terminal_split_pct == layout.terminal_split_pct
+            && self.terminal_split_pct == terminal_split_pct
         {
             return false;
         }
@@ -66,7 +67,9 @@ impl LayoutCache {
         self.has_notifications = has_notifications;
         self.explorer_width_pct = layout.explorer_width_pct;
         self.viewer_width_pct = layout.viewer_width_pct;
-        self.terminal_split_pct = layout.terminal_split_pct;
+        // The terminal split is runtime-adjustable (grow/shrink shell), so it
+        // comes in as a parameter rather than straight from the config.
+        self.terminal_split_pct = terminal_split_pct;
 
         // The notification bar is gone — Claude-waiting state is now shown by
         // the worktree strip (the waiting worktree is highlighted there).
@@ -119,9 +122,9 @@ impl LayoutCache {
 
         // Terminal vertical split: Claude Code gets `terminal_split_pct`%,
         // shell gets the remainder.
-        let shell_pct = 100u16.saturating_sub(layout.terminal_split_pct);
+        let shell_pct = 100u16.saturating_sub(terminal_split_pct);
         let terminal_split = Layout::vertical([
-            Constraint::Percentage(layout.terminal_split_pct),
+            Constraint::Percentage(terminal_split_pct),
             Constraint::Percentage(shell_pct),
         ])
         .split(self.columns[3]);
@@ -194,7 +197,7 @@ mod tests {
     #[test]
     fn layout_cache_update_returns_true_first_call() {
         let mut cache = LayoutCache::default();
-        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
         assert!(changed, "first update must recompute");
     }
 
@@ -202,8 +205,8 @@ mod tests {
     fn layout_cache_update_returns_false_on_identical_second_call() {
         let mut cache = LayoutCache::default();
         let cfg = layout(24, 38, 80);
-        cache.update(rect(200, 50), None, false, &cfg);
-        let changed = cache.update(rect(200, 50), None, false, &cfg);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(200, 50), None, false, &cfg, 80);
         assert!(!changed, "identical inputs must not recompute");
     }
 
@@ -211,32 +214,35 @@ mod tests {
     fn layout_cache_invalidates_on_frame_area_change() {
         let mut cache = LayoutCache::default();
         let cfg = layout(24, 38, 80);
-        cache.update(rect(200, 50), None, false, &cfg);
-        let changed = cache.update(rect(201, 50), None, false, &cfg);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(201, 50), None, false, &cfg, 80);
         assert!(changed, "frame_area change must invalidate");
     }
 
     #[test]
     fn layout_cache_invalidates_on_explorer_pct_change() {
         let mut cache = LayoutCache::default();
-        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
-        let changed = cache.update(rect(200, 50), None, false, &layout(30, 38, 80));
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+        let changed = cache.update(rect(200, 50), None, false, &layout(30, 38, 80), 80);
         assert!(changed, "explorer_width_pct change must invalidate");
     }
 
     #[test]
     fn layout_cache_invalidates_on_viewer_pct_change() {
         let mut cache = LayoutCache::default();
-        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
-        let changed = cache.update(rect(200, 50), None, false, &layout(24, 42, 80));
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 42, 80), 80);
         assert!(changed, "viewer_width_pct change must invalidate");
     }
 
     #[test]
     fn layout_cache_invalidates_on_terminal_split_change() {
+        // The terminal split now arrives as a runtime parameter (grow/shrink
+        // shell), so vary that argument rather than the config field.
         let mut cache = LayoutCache::default();
-        cache.update(rect(200, 50), None, false, &layout(24, 38, 80));
-        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 70));
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(200, 50), None, false, &cfg, 70);
         assert!(changed, "terminal_split_pct change must invalidate");
     }
 
@@ -253,7 +259,7 @@ mod tests {
     fn terminal_split_pct_over_100_does_not_panic() {
         // terminal_split_pct > 100 makes shell_pct saturate to 0; must not panic.
         let mut cache = LayoutCache::default();
-        let _ = cache.update(rect(200, 50), None, false, &layout(24, 38, 200));
+        let _ = cache.update(rect(200, 50), None, false, &layout(24, 38, 200), 200);
     }
 
     #[test]
@@ -292,8 +298,13 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // Update layout cache (no-op if nothing changed).
     // Disjoint field borrows: `app.layout_cache` mutably, `app.config.layout`
     // immutably — Rust allows this because they are separate struct fields.
-    app.layout_cache
-        .update(area, app.expanded_panel, has_notifications, &app.config.layout);
+    app.layout_cache.update(
+        area,
+        app.expanded_panel,
+        has_notifications,
+        &app.config.layout,
+        app.terminal_split_pct,
+    );
 
     let title_area = app.layout_cache.title_area;
     let wtbar_area = app.layout_cache.wtbar_area;


### PR DESCRIPTION
## Summary

Shell パネル（および埋め込みターミナル全般）の paste / scroll / 矢印キー周りの不具合を修正し、Claude/Shell の縦分割をランタイムでリサイズできる機能を追加。

- **Paste のサニタイズ**: クリップボード内容を PTY に流す前に ANSI エスケープ列・制御文字を除去（`\x1b[201~` による bracketed paste の早期終了＝コマンド注入を防止）。CR/CRLF は LF に正規化。bracketed paste マーカーはアプリが DECSET 2004 を有効にしている時だけ付与。
- **マウスホイールスクロール**: マウスレポートを有効にしているフルスクリーンアプリ（vim/neovim, `less --mouse`, fzf 等）にはホイールを SGR(1006)/X10 のエンコード済みマウスイベントとして転送。alt-screen のページャ（`less`/`bat`/`man`）には従来通り矢印キーへ変換。`scroll_alt_screen_session` → `forward_scroll_to_session` にリネームし col/row を受け取るよう変更。
- **矢印 / Home / End キー**: セッションの application cursor keys mode (DECCKM) を見て、有効なら SS3 (`ESC O`) を、無効なら CSI (`ESC [`) を送出。`bat`/`less`/`vim` での矢印スクロールが効くように。
- **Claude/Shell 分割のランタイムリサイズ**: `Ctrl+Alt+Up` で Shell を拡大 / `Ctrl+Alt+Down` で縮小（コマンドパレットにも `Layout: Grow/Shrink Shell Area` を追加）。20〜80% でクランプ。設定ファイルには永続化せず、起動時に `terminal_split_pct` をシードするのみ。

## Test plan

- `cargo test` — `key_event_to_ansi`（CSI/SS3、修飾キー付き矢印）、`sanitize_pasted_text`（プレーン/CRLF/CSI/OSC/制御文字/マルチバイト/201~ 注入）、`encode_mouse_wheel`（SGR/X10/クランプ）、`layout_cache` のランタイム split パラメータを追加・更新済み
- 手動: Shell で `bat`/`less` を開き矢印・ホイールでスクロール、色付きテキストや `201~` を含むテキストの paste、`Ctrl+Alt+Up/Down` での分割リサイズを確認
