### PR TITLE
feat: infinite-scrollback width-reflow transcript view for Claude sessions

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -559,6 +559,73 @@ pub struct App {
     /// the redraw rate, which varies from ~2fps (idle pulses) to ~60fps
     /// (active input).
     pub rich_epoch: std::time::Instant,
+
+    // ── Reflow transcript view ───────────────────────────────────────────
+    /// State for the read-only, word-wrapped session-log viewer that
+    /// overlays the Claude PTY panel during infinite-scrollback mode.
+    pub reflow: ReflowView,
+}
+
+/// Direction of the reflow view entry/exit sweep animation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepDir {
+    /// Sweep front moves top-to-bottom (entering the transcript view).
+    In,
+    /// Sweep front moves bottom-to-top (returning to the live PTY).
+    Out,
+}
+
+/// Active sweep animation for the reflow transcript view.
+///
+/// Holds the direction and the `Instant` the animation started so that
+/// `reflow_view::render` can compute progress via elapsed time without any
+/// frame-counter dependency.
+pub struct Sweep {
+    pub dir: SweepDir,
+    pub start: std::time::Instant,
+}
+
+/// State for the reflow transcript view.
+///
+/// When `active` is `true`, this view overlays the Claude PTY panel and renders
+/// the Claude Code session log as a scrollable, word-wrapped Markdown display.
+/// Width changes trigger a full re-render of `cached_lines`; otherwise the
+/// cached lines are reused each frame.
+#[derive(Default)]
+pub struct ReflowView {
+    /// Whether the reflow view is currently overlaying the Claude PTY panel.
+    pub active: bool,
+    /// Parsed and normalised log entries from the session file.
+    ///
+    /// Wrapped in `Rc` so that `build_lines` can cheaply clone the handle
+    /// (refcount increment only) and release its borrow on `self` before
+    /// calling `cache.render` — avoiding a deep copy of all entry strings on
+    /// every resize.
+    pub entries: std::rc::Rc<Vec<crate::claude_log::LogEntry>>,
+    /// Vertical scroll offset — number of rendered lines from the top to skip.
+    pub scroll: usize,
+    /// Total number of lines in `cached_lines` (kept in sync after each render).
+    pub total_lines: usize,
+    /// Panel inner width at the last render — used to detect size changes for reflow.
+    pub last_width: u16,
+    /// When `true`, the next render pins scroll to the bottom (most recent turn).
+    pub pending_bottom: bool,
+    /// Pre-rendered, width-reflowed lines; rebuilt only when `last_width` changes.
+    pub cached_lines: Vec<ratatui::text::Line<'static>>,
+    /// Inner panel height at the last render — used for page-scroll sizing.
+    pub last_inner_height: u16,
+    /// Per-session Markdown render cache.
+    ///
+    /// Kept separate from `App::markdown_cache` so it does not pollute the
+    /// shared cache with reflow keys and is automatically invalidated when a new
+    /// session is opened (the whole `ReflowView` is replaced by `open_reflow`).
+    pub cache: crate::ui::markdown::MarkdownCache,
+    /// In-progress entry/exit sweep animation, or `None` when idle.
+    ///
+    /// `Option<Sweep>` defaults to `None` — `Sweep` itself does not need
+    /// `Default` because `Option<T>: Default` is always `None` without a
+    /// `T: Default` bound.
+    pub sweep: Option<Sweep>,
 }
 
 /// Result of a background diff computation.
@@ -613,6 +680,114 @@ impl App {
             self.show_panel_number_overlay = true;
             self.panel_overlay_since = Some(std::time::Instant::now());
         }
+    }
+
+    // ── Reflow transcript view ────────────────────────────────────────────
+
+    /// Enter the reflow transcript view for the focused worktree's latest session.
+    ///
+    /// Resolves the focused worktree's working directory, looks up the most
+    /// recent Claude Code session via history, loads and parses the `.jsonl`
+    /// file, and activates the overlay. If no session is found or the log is
+    /// empty, a status flash is shown and the view stays inactive.
+    pub fn open_reflow(&mut self) {
+        let working_dir = match self.worktrees.get(self.selected_worktree) {
+            Some(wt) => wt.path.clone(),
+            None => {
+                self.set_status(
+                    "No worktree selected for transcript view".to_string(),
+                    StatusLevel::Warning,
+                );
+                return;
+            }
+        };
+
+        let canonical =
+            std::fs::canonicalize(&working_dir).unwrap_or_else(|_| working_dir.clone());
+        let session = match crate::claude_sessions::find_latest_sessions_for_paths(
+            std::slice::from_ref(&working_dir),
+        ) {
+            Ok(mut map) => map.remove(&canonical),
+            Err(e) => {
+                log::warn!("reflow: cannot look up session: {e}");
+                None
+            }
+        };
+        let session = match session {
+            Some(s) => s,
+            None => {
+                self.set_status(
+                    "No Claude session found for this worktree".to_string(),
+                    StatusLevel::Info,
+                );
+                return;
+            }
+        };
+
+        let jsonl_path =
+            match crate::claude_sessions::session_jsonl_path(&working_dir, &session.session_id) {
+                Some(p) => p,
+                None => {
+                    self.set_status(
+                        "Cannot resolve session file path".to_string(),
+                        StatusLevel::Warning,
+                    );
+                    return;
+                }
+            };
+
+        let entries = crate::claude_log::load_session(&jsonl_path);
+        if entries.is_empty() {
+            self.set_status(
+                "Session log is empty or unreadable".to_string(),
+                StatusLevel::Info,
+            );
+            return;
+        }
+
+        // TODO(background): load_session is currently synchronous; for very
+        // large files (5MB+) this may block the UI for a frame or two.
+        // A future version should spawn the parse on a background thread and
+        // show a "Loading…" placeholder while the entries arrive.
+        self.reflow = ReflowView {
+            active: true,
+            entries: std::rc::Rc::new(entries),
+            scroll: 0,
+            total_lines: 0,
+            last_width: 0, // Forces a full line rebuild on first render.
+            pending_bottom: true,
+            cached_lines: Vec::new(),
+            last_inner_height: 0,
+            cache: crate::ui::markdown::MarkdownCache::new(),
+            // Start the entry transition: the border glides from the accent to
+            // its complement over TRANSITION_DURATION_MS, masking the initial
+            // build_lines latency.
+            sweep: Some(Sweep {
+                dir: SweepDir::In,
+                start: std::time::Instant::now(),
+            }),
+        };
+    }
+
+    /// Leave the reflow transcript view and return to the live PTY display.
+    pub fn close_reflow(&mut self) {
+        self.reflow.active = false;
+        self.reflow.sweep = None;
+        // Reset Claude scrollback so the live tail is shown immediately.
+        self.terminal.scroll_claude = 0;
+    }
+
+    /// Begin the exit sweep animation rather than closing immediately.
+    ///
+    /// Sets `sweep` to a `SweepDir::Out` animation so `reflow_view::render`
+    /// plays the bottom-to-top wipe before calling `close_reflow()` once the
+    /// animation completes. Focus-loss closes the view immediately via
+    /// `set_focus` without a sweep (the panel disappears anyway).
+    pub fn request_close_reflow(&mut self) {
+        self.reflow.sweep = Some(Sweep {
+            dir: SweepDir::Out,
+            start: std::time::Instant::now(),
+        });
     }
 
     /// Returns `true` when any overlay popup is visible on top of the main panels.
@@ -765,6 +940,7 @@ impl App {
             rich_picker: None,
             rich_tier_available: crate::term_caps::RichTier::Off,
             rich_epoch: std::time::Instant::now(),
+            reflow: ReflowView::default(),
         };
         app.symbol_index = SymbolIndex::new(app.repo_path.clone());
 
@@ -1386,6 +1562,14 @@ impl App {
                 self.expanded_panel = None;
             }
         }
+        // Leaving the Claude terminal while the reflow view is active orphans it:
+        // the keyboard gate checks `focus == TerminalClaude`, so Esc would stop
+        // working and the transcript would float invisibly behind other panels.
+        // Close it here so the panel always returns to a clean live-PTY state.
+        if self.reflow.active && focus != Focus::TerminalClaude {
+            self.close_reflow();
+        }
+
         match focus {
             Focus::Explorer | Focus::Viewer => {
                 if self.viewer_state.tree.file_tree.is_empty() {
@@ -1483,6 +1667,13 @@ impl App {
         // up the new syntect theme. The cache fingerprints the UI colour palette
         // only; a syntax-only change would otherwise leave stale highlighted spans.
         self.markdown_cache.clear();
+
+        // Force a full rebuild of the reflow transcript on the next render so
+        // that Markdown spans pick up the new theme colours and syntect palette.
+        // Setting last_width=0 makes build_lines run on the next frame regardless
+        // of whether the panel width changed.
+        self.reflow.last_width = 0;
+        self.reflow.cache.clear();
 
         // ── Diff view mode ──────────────────────────────────────────
         // Apply view_mode directly. `diff_state.view_mode` is written only in

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -10,6 +10,23 @@ use std::path::PathBuf;
 const SESSION_ICONS: &[&str] = &["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
 impl App {
+    /// Switch the Claude panel to display the session at `idx`.
+    ///
+    /// Closes any active reflow transcript first: the reflow view is bound to
+    /// whichever session was showing when it was opened, so switching sessions
+    /// makes that transcript stale and it must be torn down here. This mirrors
+    /// the scroll/cache reset inside [`TerminalState::switch_claude_session`]
+    /// (same "the panel now shows a different session" invariant), but reflow
+    /// state lives on `App`, so the close has to happen one level up. Routing
+    /// every Claude session switch through this wrapper keeps the panel from
+    /// rendering the previous session's transcript after a tab/strip switch.
+    pub fn switch_claude_session(&mut self, idx: usize) {
+        if self.reflow.active {
+            self.close_reflow();
+        }
+        self.terminal.switch_claude_session(idx);
+    }
+
     /// Spawn a new Claude Code PTY session for the currently selected worktree.
     pub fn spawn_claude_code(&mut self) -> anyhow::Result<usize> {
         self.spawn_claude_code_with_name(None)
@@ -50,7 +67,7 @@ impl App {
             &self.repo_path,
             session_name,
         )?;
-        self.terminal.switch_claude_session(idx);
+        self.switch_claude_session(idx);
         self.rebuild_worktree_list_rows();
         Ok(idx)
     }
@@ -139,7 +156,7 @@ impl App {
                 .first()
                 .map(|(idx, _)| *idx)
             {
-                Some(idx) => self.terminal.switch_claude_session(idx),
+                Some(idx) => self.switch_claude_session(idx),
                 None => {
                     self.terminal.active_claude_session = None;
                     self.terminal.scroll_claude = 0;
@@ -308,7 +325,7 @@ impl App {
             &self.repo_path,
             None,
         )?;
-        self.terminal.switch_claude_session(idx);
+        self.switch_claude_session(idx);
         Ok(idx)
     }
 
@@ -375,7 +392,7 @@ impl App {
                     Ok(idx) => {
                         resumed_count += 1;
                         if wt.path == selected_wt_path {
-                            self.terminal.switch_claude_session(idx);
+                            self.switch_claude_session(idx);
                         }
                     }
                     Err(e) => {
@@ -422,7 +439,7 @@ impl App {
                     resumed_count += 1;
                     // Only switch to this session for the currently selected worktree.
                     if wt.path == selected_wt_path {
-                        self.terminal.switch_claude_session(idx);
+                        self.switch_claude_session(idx);
                     }
                 }
                 Err(e) => {

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -350,7 +350,7 @@ impl App {
             &self.repo_path,
             None,
         )?;
-        self.terminal.switch_claude_session(idx);
+        self.switch_claude_session(idx);
         Ok(idx)
     }
 
@@ -1427,6 +1427,12 @@ impl App {
     }
 
     pub fn on_worktree_changed(&mut self) {
+        // A reflow transcript belongs to the previous worktree's session;
+        // switching worktrees must reset it before new session state loads.
+        if self.reflow.active {
+            self.close_reflow();
+        }
+
         // An embedded editor belongs to the worktree it was opened on; leaving
         // that worktree would strand it editing the wrong tree, so close it
         // first. The view reload below covers the new worktree.

--- a/src/claude_log.rs
+++ b/src/claude_log.rs
@@ -1,0 +1,431 @@
+//! Claude Code session log parser.
+//!
+//! Reads a Claude Code `.jsonl` session file and normalises its records into
+//! a flat list of [`LogEntry`] values for display in the reflow transcript view.
+//!
+//! Parsing is line-oriented and lenient: malformed lines are silently skipped,
+//! unknown `type` values are ignored, and sidechain records are excluded.
+//! The module never panics regardless of input.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+// ── Raw serde types (one-to-one with the JSONL schema) ────────────────────────
+
+/// One record from a Claude Code `.jsonl` session file.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogRecord {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub is_sidechain: bool,
+    #[serde(default)]
+    pub message: Option<Message>,
+}
+
+/// The `message` field present on `user` and `assistant` records.
+#[derive(Deserialize)]
+pub struct Message {
+    #[serde(default)]
+    pub role: Option<String>,
+    /// Model name, present on `assistant` messages.
+    #[serde(default)]
+    pub model: Option<String>,
+    pub content: Content,
+}
+
+/// `content` is either a bare string or an array of typed blocks.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum Content {
+    Text(String),
+    Blocks(Vec<Block>),
+}
+
+/// A single typed block within an array-form `content`.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Block {
+    Text {
+        text: String,
+    },
+    /// Thinking block — shown as a stub; body is empty in published logs.
+    Thinking,
+    ToolUse {
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    ToolResult {
+        #[serde(default)]
+        content: ToolResultContent,
+    },
+    /// Any block type not explicitly handled above.
+    #[serde(other)]
+    Other,
+}
+
+/// The `content` field of a `tool_result` block, which may be a bare string,
+/// an array of text-only objects, or absent.
+#[derive(Deserialize, Default)]
+#[serde(untagged)]
+pub enum ToolResultContent {
+    #[default]
+    None,
+    Text(String),
+    Blocks(Vec<TextOnly>),
+}
+
+/// A `{ "text": "..." }` object as found in `tool_result` content arrays.
+#[derive(Deserialize)]
+pub struct TextOnly {
+    #[serde(default)]
+    pub text: String,
+}
+
+// ── Display-layer types ────────────────────────────────────────────────────────
+
+/// Speaker of a conversation turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Role {
+    User,
+    Assistant,
+}
+
+/// A display-ready conversation entry normalised from one raw log record.
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub role: Role,
+    /// Model name, when present on an assistant message.
+    /// Retained for future use (e.g. per-entry model display); not rendered in the
+    /// current CLI-style glyph layout.
+    #[allow(dead_code)]
+    pub model: Option<String>,
+    pub blocks: Vec<DisplayBlock>,
+}
+
+/// A display-ready content fragment within a [`LogEntry`].
+#[derive(Debug, Clone)]
+pub enum DisplayBlock {
+    /// Markdown prose (user input or assistant text response).
+    Text(String),
+    /// A tool invocation — rendered as `▸ {name}: {summary}`.
+    ToolUse { name: String, summary: String },
+    /// The result returned by a tool — rendered as a line-count summary.
+    ToolResult { lines: usize },
+    /// A thinking block — rendered as a placeholder stub.
+    Thinking,
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Extract a one-line summary from a tool call's `input` JSON.
+///
+/// Tries the most common argument keys in priority order (`command`,
+/// `file_path`, `path`, `pattern`) and returns an empty string if none match.
+fn summarise_tool_input(input: &serde_json::Value) -> String {
+    const KEYS: &[&str] = &["command", "file_path", "path", "pattern"];
+    let Some(obj) = input.as_object() else {
+        return String::new();
+    };
+    for key in KEYS {
+        if let Some(v) = obj.get(*key)
+            && let Some(s) = v.as_str()
+        {
+            return s.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Count the total number of output lines in a `ToolResultContent`.
+fn count_result_lines(content: &ToolResultContent) -> usize {
+    match content {
+        ToolResultContent::None => 0,
+        ToolResultContent::Text(s) => s.lines().count(),
+        ToolResultContent::Blocks(blocks) => blocks.iter().map(|b| b.text.lines().count()).sum(),
+    }
+}
+
+/// Convert a [`Content`] value into display blocks, normalising the two surface
+/// forms (bare string and typed block array) into the same flat representation.
+fn content_to_display_blocks(content: Content) -> Vec<DisplayBlock> {
+    match content {
+        Content::Text(s) if !s.is_empty() => vec![DisplayBlock::Text(s)],
+        Content::Text(_) => vec![],
+        Content::Blocks(blocks) => blocks
+            .into_iter()
+            .filter_map(|b| match b {
+                Block::Text { text } if !text.is_empty() => Some(DisplayBlock::Text(text)),
+                Block::Text { .. } => None,
+                Block::Thinking => Some(DisplayBlock::Thinking),
+                Block::ToolUse { name, input } => {
+                    let summary = summarise_tool_input(&input);
+                    Some(DisplayBlock::ToolUse { name, summary })
+                }
+                Block::ToolResult { content } => {
+                    let lines = count_result_lines(&content);
+                    Some(DisplayBlock::ToolResult { lines })
+                }
+                Block::Other => None,
+            })
+            .collect(),
+    }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/// Parse a Claude Code `.jsonl` session file and return display entries.
+///
+/// Malformed lines and unknown record types are silently skipped.
+/// Sidechain records (`isSidechain == true`) are excluded.
+/// This function never panics regardless of file contents.
+pub fn load_session(path: &Path) -> Vec<LogEntry> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) => {
+            log::warn!("reflow: cannot read session file {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+
+    let mut entries = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let record: LogRecord = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("reflow: skipping malformed jsonl line: {e}");
+                continue;
+            }
+        };
+
+        // Only process `user` and `assistant` turns; skip sidechain records.
+        if record.kind != "user" && record.kind != "assistant" {
+            continue;
+        }
+        if record.is_sidechain {
+            continue;
+        }
+
+        let Some(msg) = record.message else {
+            continue;
+        };
+
+        let role = match msg.role.as_deref() {
+            Some("user") => Role::User,
+            Some("assistant") => Role::Assistant,
+            _ => continue,
+        };
+
+        let blocks = content_to_display_blocks(msg.content);
+        if blocks.is_empty() {
+            continue;
+        }
+
+        entries.push(LogEntry {
+            role,
+            model: msg.model,
+            blocks,
+        });
+    }
+    entries
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_msg_content(json: &str) -> Vec<DisplayBlock> {
+        let r: LogRecord = serde_json::from_str(json).expect("valid test json");
+        content_to_display_blocks(r.message.unwrap().content)
+    }
+
+    #[test]
+    fn string_content_becomes_single_text_block() {
+        let blocks = parse_msg_content(
+            r#"{"type":"user","message":{"role":"user","content":"hello world"}}"#,
+        );
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(blocks[0], DisplayBlock::Text(_)));
+    }
+
+    #[test]
+    fn array_content_multiple_block_types() {
+        let blocks = parse_msg_content(
+            r#"{
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-opus-4",
+                    "content": [
+                        {"type":"text","text":"Here is the plan."},
+                        {"type":"thinking","thinking":"","signature":"abc"},
+                        {"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"ls -la"}},
+                        {"type":"tool_result","tool_use_id":"tu1","content":"file1\nfile2\nfile3"}
+                    ]
+                }
+            }"#,
+        );
+        assert_eq!(blocks.len(), 4);
+        assert!(matches!(blocks[0], DisplayBlock::Text(_)));
+        assert!(matches!(blocks[1], DisplayBlock::Thinking));
+        assert!(matches!(blocks[2], DisplayBlock::ToolUse { .. }));
+        assert!(matches!(blocks[3], DisplayBlock::ToolResult { lines: 3 }));
+    }
+
+    #[test]
+    fn sidechain_flag_is_parsed() {
+        let r: LogRecord = serde_json::from_str(
+            r#"{"type":"user","isSidechain":true,"message":{"role":"user","content":"secret"}}"#,
+        )
+        .unwrap();
+        assert!(r.is_sidechain);
+    }
+
+    #[test]
+    fn tool_use_summary_picks_command_key() {
+        let input = serde_json::json!({"command": "cargo build", "cwd": "/project"});
+        assert_eq!(summarise_tool_input(&input), "cargo build");
+    }
+
+    #[test]
+    fn tool_use_summary_falls_back_to_file_path() {
+        let input = serde_json::json!({"file_path": "/src/main.rs"});
+        assert_eq!(summarise_tool_input(&input), "/src/main.rs");
+    }
+
+    #[test]
+    fn tool_use_summary_falls_back_to_pattern() {
+        let input = serde_json::json!({"pattern": "fn open_reflow"});
+        assert_eq!(summarise_tool_input(&input), "fn open_reflow");
+    }
+
+    #[test]
+    fn tool_result_string_counts_lines() {
+        let content = ToolResultContent::Text("a\nb\nc".to_string());
+        assert_eq!(count_result_lines(&content), 3);
+    }
+
+    #[test]
+    fn tool_result_block_array_counts_lines() {
+        let content = ToolResultContent::Blocks(vec![
+            TextOnly {
+                text: "a\nb\nc".to_string(),
+            },
+            TextOnly {
+                text: "d\ne".to_string(),
+            },
+        ]);
+        assert_eq!(count_result_lines(&content), 5);
+    }
+
+    #[test]
+    fn empty_text_block_excluded() {
+        let blocks = parse_msg_content(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":""}]}}"#,
+        );
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn unknown_block_type_is_skipped() {
+        let blocks = parse_msg_content(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[
+                {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}},
+                {"type":"text","text":"done"}
+            ]}}"#,
+        );
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(blocks[0], DisplayBlock::Text(_)));
+    }
+
+    // ── load_session integration tests (write a temp .jsonl, call load_session) ──
+
+    fn write_jsonl(lines: &[&str]) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("tmp file");
+        for line in lines {
+            writeln!(f, "{line}").expect("write");
+        }
+        f
+    }
+
+    #[test]
+    fn load_session_skips_non_user_assistant_types() {
+        let f = write_jsonl(&[
+            r#"{"type":"system","message":{"role":"system","content":"sys prompt"}}"#,
+            r#"{"type":"summary","message":{"role":"assistant","content":"summary"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"hello"}}"#,
+        ]);
+        let entries = load_session(f.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].role, Role::User);
+    }
+
+    #[test]
+    fn load_session_skips_sidechain_records() {
+        let f = write_jsonl(&[
+            r#"{"type":"user","isSidechain":true,"message":{"role":"user","content":"hidden"}}"#,
+            r#"{"type":"assistant","isSidechain":false,"message":{"role":"assistant","content":"visible"}}"#,
+        ]);
+        let entries = load_session(f.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].role, Role::Assistant);
+    }
+
+    #[test]
+    fn load_session_skips_role_mismatch() {
+        // A record with type=user but role=system should be silently dropped.
+        let f = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"system","content":"not a user turn"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"real user"}}"#,
+        ]);
+        let entries = load_session(f.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].role, Role::User);
+    }
+
+    #[test]
+    fn load_session_skips_empty_blocks() {
+        // A message whose content produces zero display blocks is not emitted.
+        let f = write_jsonl(&[
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":""}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"valid"}}"#,
+        ]);
+        let entries = load_session(f.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].role, Role::User);
+    }
+
+    #[test]
+    fn load_session_mixed_records_correct_count() {
+        let f = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":"q1"}}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"a1"}}"#,
+            r#"{"type":"system","message":{"role":"system","content":"noise"}}"#,
+            r#"{"type":"user","isSidechain":true,"message":{"role":"user","content":"chain"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"q2"}}"#,
+            r#"not-json-at-all"#,
+        ]);
+        let entries = load_session(f.path());
+        // system noise, sidechain, and malformed line are excluded → 3 remain.
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].role, Role::User);
+        assert_eq!(entries[1].role, Role::Assistant);
+        assert_eq!(entries[2].role, Role::User);
+    }
+
+    #[test]
+    fn load_session_missing_file_returns_empty() {
+        let entries = load_session(std::path::Path::new("/nonexistent/path.jsonl"));
+        assert!(entries.is_empty());
+    }
+}

--- a/src/claude_sessions.rs
+++ b/src/claude_sessions.rs
@@ -246,6 +246,15 @@ pub fn find_latest_sessions_for_paths(
     Ok(result)
 }
 
+/// Return the `.jsonl` path for the given working directory and session ID.
+///
+/// Mirrors the path that `session_file_exists` checks so callers can open
+/// the file directly. Returns `None` if the home directory is unavailable.
+pub fn session_jsonl_path(working_dir: &Path, session_id: &str) -> Option<PathBuf> {
+    let dir = projects_dir_for(working_dir)?;
+    Some(dir.join(format!("{session_id}.jsonl")))
+}
+
 /// Return the Claude projects directory for a given working directory path.
 /// E.g. `/Users/foo/project` → `~/.claude/projects/-Users-foo-project/`.
 fn projects_dir_for(working_dir: &Path) -> Option<PathBuf> {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -9,6 +9,7 @@ mod explorer;
 mod global;
 mod mouse;
 mod overlay;
+pub mod reflow;
 mod terminal;
 mod viewer;
 mod worktree;
@@ -243,6 +244,13 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // ── 1b4. Reflow transcript view — consume all keys while active ──────────
+    // Must sit before the PTY-forward path so keys are not forwarded to Claude.
+    if app.reflow.active && app.focus == Focus::TerminalClaude {
+        handle_reflow_key(app, key);
+        return;
+    }
+
     // ── 1c. PTY focus — intercept configurable keys, forward rest to PTY ─
     // Covers the Claude/Shell terminals and the embedded editor: each forwards
     // unstolen keys to its inner program, using its own keymap context.
@@ -338,6 +346,16 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
             app.set_focus(target);
         }
         Action::ScrollbackUp => {
+            // Intercept the first upward scroll on the live Claude terminal
+            // (scroll_claude == 0) to enter the infinite-scrollback reflow view
+            // instead of the limited vt100 scrollback buffer.
+            if app.focus == Focus::TerminalClaude
+                && app.terminal.scroll_claude == 0
+                && !app.reflow.active
+            {
+                app.open_reflow();
+                return true;
+            }
             let page = match app.focus {
                 Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
                 Focus::TerminalShell => app.terminal.size_shell.0 as usize / 2,
@@ -363,11 +381,21 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
             };
             *scroll = scroll.saturating_sub(page.max(1));
         }
-        Action::ScrollbackTop => match app.focus {
-            Focus::TerminalClaude => app.terminal.scroll_claude = 1000,
-            Focus::TerminalShell => app.terminal.scroll_shell = 1000,
-            _ => unreachable!(),
-        },
+        Action::ScrollbackTop => {
+            // Same hijack as ScrollbackUp: jump straight to reflow on Claude live view.
+            if app.focus == Focus::TerminalClaude
+                && app.terminal.scroll_claude == 0
+                && !app.reflow.active
+            {
+                app.open_reflow();
+                return true;
+            }
+            match app.focus {
+                Focus::TerminalClaude => app.terminal.scroll_claude = 1000,
+                Focus::TerminalShell => app.terminal.scroll_shell = 1000,
+                _ => unreachable!(),
+            }
+        }
         Action::SnapToLive => match app.focus {
             Focus::TerminalClaude => app.terminal.scroll_claude = 0,
             Focus::TerminalShell => app.terminal.scroll_shell = 0,
@@ -377,6 +405,90 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
         _ => return false,
     }
     true
+}
+
+// ── Reflow key handling ─────────────────────────────────────────────────
+
+/// Handle a key event while the reflow transcript view is active.
+///
+/// All keys are consumed here and never forwarded to the PTY — the reflow
+/// view is a pure read-only overlay. Navigation:
+///
+/// * `j` / Down — scroll down one line.
+/// * `k` / Up — scroll up one line.
+/// * `Ctrl-d` / PageDown — scroll down half a page.
+/// * `Ctrl-u` / PageUp — scroll up half a page.
+/// * `g` / Home — jump to the oldest turn (top).
+/// * `G` / End — jump to the newest turn (bottom) without leaving.
+/// * `Esc` — close reflow view and return to live PTY.
+/// * `j` / Down / PageDown at the bottom — close reflow (live return).
+fn handle_reflow_key(app: &mut App, key: KeyEvent) {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use crate::event::reflow::{at_bottom, clamp_scroll};
+
+    let inner = app.reflow.last_inner_height as usize;
+    let total = app.reflow.total_lines;
+    let page: usize = (inner / 2).max(1);
+    let bottom = at_bottom(app.reflow.scroll, total, inner);
+
+    match key.code {
+        // ── Line scroll ─────────────────────────────────────────────────────
+        KeyCode::Char('j') | KeyCode::Down => {
+            if bottom {
+                // Bottom + discrete down-key → begin exit sweep back to live PTY.
+                app.request_close_reflow();
+                return;
+            }
+            app.reflow.scroll = app.reflow.scroll.saturating_add(1);
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.reflow.scroll = app.reflow.scroll.saturating_sub(1);
+        }
+
+        // ── Page scroll ──────────────────────────────────────────────────────
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            if bottom {
+                app.request_close_reflow();
+                return;
+            }
+            app.reflow.scroll = app.reflow.scroll.saturating_add(page);
+        }
+        KeyCode::PageDown => {
+            if bottom {
+                app.request_close_reflow();
+                return;
+            }
+            app.reflow.scroll = app.reflow.scroll.saturating_add(page);
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.reflow.scroll = app.reflow.scroll.saturating_sub(page);
+        }
+        KeyCode::PageUp => {
+            app.reflow.scroll = app.reflow.scroll.saturating_sub(page);
+        }
+
+        // ── Jump to top / bottom ─────────────────────────────────────────────
+        KeyCode::Char('g') | KeyCode::Home => {
+            app.reflow.scroll = 0;
+        }
+        KeyCode::Char('G') | KeyCode::End => {
+            // Snap to the newest turn (logical bottom) without leaving the view.
+            app.reflow.scroll = total.saturating_sub(inner);
+        }
+
+        // ── Leave ────────────────────────────────────────────────────────────
+        KeyCode::Esc => {
+            // Play the exit sweep before returning to the live PTY.
+            app.request_close_reflow();
+            return;
+        }
+
+        _ => {} // All other keys are silently consumed.
+    }
+
+    // Clamp scroll after any adjustment.  Upper bound is total - inner, not
+    // total - 1: aligns with the render path and at_bottom logic.
+    app.reflow.scroll = clamp_scroll(app.reflow.scroll, total, inner);
 }
 
 // ── Paste event handling ────────────────────────────────────────────────

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -540,7 +540,7 @@ fn handle_worktree_column_click(app: &mut App, row: u16, geom: &ClickGeometry) {
         match app.worktree_list_rows[item_row] {
             crate::app::WorktreeListRow::Session { pty_idx, .. } => {
                 app.on_worktree_changed();
-                app.terminal.switch_claude_session(pty_idx);
+                app.switch_claude_session(pty_idx);
                 // Single click: keep focus on worktree panel.
                 // Double click: move focus to terminal.
                 if is_double {
@@ -1148,6 +1148,21 @@ fn handle_mouse_scroll(
         }
     } else {
         // Terminal panels (right column).
+        //
+        // Focus the panel being scrolled so that wheel events take immediate
+        // effect even when the panel does not currently hold keyboard focus.
+        // This also satisfies the `focus == TerminalClaude` render guard in
+        // terminal_claude.rs so reflow entry and display are consistent.
+        // Note: set_focus(TerminalShell) closes reflow if it was active, which
+        // is intentional — the user is deliberately scrolling away from Claude.
+        if row < terminal_split_y {
+            if app.focus != Focus::TerminalClaude {
+                app.set_focus(Focus::TerminalClaude);
+            }
+        } else if app.focus != Focus::TerminalShell {
+            app.set_focus(Focus::TerminalShell);
+        }
+
         let abs_delta = delta.unsigned_abs() as usize;
         // ScrollUp (delta < 0) moves toward older content / into history.
         let up = delta < 0;
@@ -1175,8 +1190,53 @@ fn handle_mouse_scroll(
         }
 
         if row < terminal_split_y {
-            if up {
-                app.terminal.scroll_claude = app.terminal.scroll_claude.saturating_add(abs_delta);
+            if app.reflow.active {
+                // While the reflow view is active, route wheel events into its
+                // scroll offset.
+                //
+                // Scroll convention: scroll=0 is the oldest/top content; max is
+                // newest/bottom. Wheel-up moves toward older content (subtract).
+                //
+                // Wheel-down past the logical bottom begins the exit sweep so
+                // trackpad inertia carries the user naturally back to the live
+                // tail (same experience as scrolling past the end of a document).
+                // Wheel-up and wheel-down above the bottom adjust scroll normally.
+                if up {
+                    app.reflow.scroll = app.reflow.scroll.saturating_sub(abs_delta);
+                } else {
+                    let inner = app.reflow.last_inner_height as usize;
+                    if crate::event::reflow::at_bottom(
+                        app.reflow.scroll,
+                        app.reflow.total_lines,
+                        inner,
+                    ) {
+                        // Already at the bottom — exit sweep on further down scroll.
+                        app.request_close_reflow();
+                        return;
+                    }
+                    app.reflow.scroll = app.reflow.scroll.saturating_add(abs_delta);
+                }
+                let inner = app.reflow.last_inner_height as usize;
+                let max_scroll = app.reflow.total_lines.saturating_sub(inner);
+                app.reflow.scroll = app.reflow.scroll.min(max_scroll);
+            } else if up {
+                // Enter the reflow transcript view on the first upward scroll
+                // from the live tail (scroll_claude == 0) instead of the
+                // limited vt100 scrollback buffer. Wheel-down never triggers
+                // entry; accidental upward inertia still opens the view but
+                // the user can Esc back immediately.
+                //
+                // Skip entry when the worktree is grabbed: the visible PTY
+                // runs on the main worktree's session while open_reflow would
+                // look up the grabbed (source) worktree's history, producing a
+                // mismatch.  Keyboard entry is already blocked by the grabbed-
+                // worktree gate in handle_terminal_only_action.
+                if app.terminal.scroll_claude == 0 && !app.is_selected_worktree_grabbed() {
+                    app.open_reflow();
+                } else {
+                    app.terminal.scroll_claude =
+                        app.terminal.scroll_claude.saturating_add(abs_delta);
+                }
             } else {
                 app.terminal.scroll_claude = app.terminal.scroll_claude.saturating_sub(abs_delta);
             }

--- a/src/event/reflow.rs
+++ b/src/event/reflow.rs
@@ -1,0 +1,191 @@
+//! Pure scroll arithmetic for the reflow transcript view.
+//!
+//! Extracted as a module so these functions can be unit-tested independently
+//! of the full `App` state and confirmed against the core invariant:
+//! **1 logical line == 1 visual row** (no `Paragraph::wrap`) therefore
+//! `max_scroll == total_lines.saturating_sub(inner_height)`.
+
+/// Clamp `scroll` to the valid range `[0, total.saturating_sub(inner)]`.
+///
+/// `inner` is the height of the panel's visible area in terminal rows.
+/// When the total number of lines is less than or equal to `inner` (the whole
+/// log fits in the panel), the function returns `0`, keeping the view pinned
+/// to the top with no blank rows below the last line.
+pub fn clamp_scroll(scroll: usize, total: usize, inner: usize) -> usize {
+    scroll.min(total.saturating_sub(inner))
+}
+
+/// Return `true` when `scroll` is at or past the logical bottom of the content.
+///
+/// `inner` is the visible height.  A scroll position at `total - inner` means
+/// the last content line is on the last visual row — this is "at bottom".
+pub fn at_bottom(scroll: usize, total: usize, inner: usize) -> bool {
+    scroll >= total.saturating_sub(inner)
+}
+
+// ── Transition animation ──────────────────────────────────────────────────────
+
+/// Total duration of the entry/exit transition animation in milliseconds.
+///
+/// 500 ms lets the border hue glide gently from the accent to its complement
+/// (and back on exit) as a single smooth gradient — calm rather than the old
+/// rapid flicker — while still being short enough that leaving read mode feels
+/// responsive.
+pub const TRANSITION_DURATION_MS: u64 = 500;
+
+/// Compute how far a transition animation has progressed, clamped to `[0.0, 1.0]`.
+///
+/// `start` is the `Instant` the animation began.  Returns `0.0` at the moment
+/// of creation and `1.0` at or after `duration_ms` milliseconds have elapsed.
+/// A `duration_ms` of zero is treated as instantly complete (returns `1.0`) to
+/// avoid a division-by-zero.
+pub fn sweep_progress(start: &std::time::Instant, duration_ms: u64) -> f64 {
+    if duration_ms == 0 {
+        return 1.0;
+    }
+    let elapsed_ms = start.elapsed().as_millis() as f64;
+    (elapsed_ms / duration_ms as f64).clamp(0.0, 1.0)
+}
+
+/// Smoothstep easing for the entry/exit border-color transition.
+///
+/// Maps linear `progress` in `[0, 1]` to an eased `[0, 1]` value via the
+/// classic `3p² − 2p³` curve, which has zero slope at both ends. Callers use
+/// the result to interpolate the border between the accent color and its
+/// complement, so the hue change starts and settles gently instead of
+/// flickering — `0.0` keeps the start color, `1.0` reaches the target.
+pub fn transition_eased(progress: f64) -> f64 {
+    let p = progress.clamp(0.0, 1.0);
+    p * p * (3.0 - 2.0 * p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── clamp_scroll ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn clamp_allows_zero() {
+        assert_eq!(clamp_scroll(0, 100, 20), 0);
+    }
+
+    #[test]
+    fn clamp_pins_to_max() {
+        // max = 100 - 20 = 80
+        assert_eq!(clamp_scroll(200, 100, 20), 80);
+    }
+
+    #[test]
+    fn clamp_at_exact_max() {
+        assert_eq!(clamp_scroll(80, 100, 20), 80);
+    }
+
+    #[test]
+    fn clamp_within_range_unchanged() {
+        assert_eq!(clamp_scroll(40, 100, 20), 40);
+    }
+
+    #[test]
+    fn clamp_when_log_shorter_than_panel_returns_zero() {
+        // total(10) < inner(20): whole log fits → max_scroll = 0
+        assert_eq!(clamp_scroll(5, 10, 20), 0);
+        assert_eq!(clamp_scroll(0, 10, 20), 0);
+    }
+
+    #[test]
+    fn clamp_when_total_equals_inner_returns_zero() {
+        assert_eq!(clamp_scroll(0, 20, 20), 0);
+        assert_eq!(clamp_scroll(1, 20, 20), 0);
+    }
+
+    #[test]
+    fn clamp_total_zero_returns_zero() {
+        assert_eq!(clamp_scroll(0, 0, 20), 0);
+    }
+
+    // ── at_bottom ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn at_bottom_when_scroll_equals_max() {
+        assert!(at_bottom(80, 100, 20));
+    }
+
+    #[test]
+    fn at_bottom_when_scroll_exceeds_max() {
+        assert!(at_bottom(90, 100, 20));
+    }
+
+    #[test]
+    fn not_at_bottom_when_scroll_below_max() {
+        assert!(!at_bottom(79, 100, 20));
+    }
+
+    #[test]
+    fn at_bottom_when_log_fits_in_panel() {
+        // total(10) <= inner(20): max_scroll = 0, any scroll >= 0 is at bottom
+        assert!(at_bottom(0, 10, 20));
+    }
+
+    // ── sweep_progress ───────────────────────────────────────────────────────
+
+    #[test]
+    fn sweep_progress_zero_duration_returns_complete() {
+        let t = std::time::Instant::now();
+        assert_eq!(sweep_progress(&t, 0), 1.0);
+    }
+
+    #[test]
+    fn sweep_progress_fresh_instant_is_near_zero() {
+        let t = std::time::Instant::now();
+        let p = sweep_progress(&t, TRANSITION_DURATION_MS);
+        // A just-started animation must be well under 10 % complete.
+        assert!(p < 0.1, "expected near 0.0, got {p}");
+    }
+
+    // ── transition_eased ─────────────────────────────────────────────────────
+
+    #[test]
+    fn transition_eased_endpoints_are_exact() {
+        // Smoothstep pins to 0 at the start and 1 at the end so the border
+        // begins at the accent and settles exactly on the complement.
+        assert_eq!(transition_eased(0.0), 0.0);
+        assert_eq!(transition_eased(1.0), 1.0);
+    }
+
+    #[test]
+    fn transition_eased_midpoint_is_half() {
+        // 3(0.5)² − 2(0.5)³ = 0.5 — symmetric curve passes through its center.
+        assert!((transition_eased(0.5) - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn transition_eased_is_monotonic_within_unit_range() {
+        // A single smooth ramp: never decreasing, always within [0, 1].
+        let mut prev = 0.0;
+        for i in 0..=100 {
+            let p = i as f64 / 100.0;
+            let v = transition_eased(p);
+            assert!((0.0..=1.0).contains(&v), "transition_eased({p}) = {v} out of range");
+            assert!(v >= prev - 1e-12, "transition_eased must be monotonic non-decreasing");
+            prev = v;
+        }
+    }
+
+    #[test]
+    fn transition_eased_clamps_out_of_range_input() {
+        assert_eq!(transition_eased(-0.5), 0.0);
+        assert_eq!(transition_eased(1.5), 1.0);
+    }
+
+    // ── Integration: pending_bottom pin ─────────────────────────────────────
+
+    #[test]
+    fn pending_bottom_pin_matches_clamp_max() {
+        let total = 150usize;
+        let inner = 30usize;
+        let pinned = total.saturating_sub(inner); // 120
+        assert_eq!(clamp_scroll(pinned, total, inner), pinned);
+        assert!(at_bottom(pinned, total, inner));
+    }
+}

--- a/src/event/terminal.rs
+++ b/src/event/terminal.rs
@@ -289,7 +289,7 @@ pub(super) fn handle_terminal_tab_click(
             // Otherwise, switch to the session (resets scroll + render cache
             // so the panel re-renders the newly selected session).
             if is_claude {
-                app.terminal.switch_claude_session(global_idx);
+                app.switch_claude_session(global_idx);
             } else {
                 app.terminal.switch_shell_session(global_idx);
             }

--- a/src/event/worktree.rs
+++ b/src/event/worktree.rs
@@ -51,7 +51,7 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                 .copied()
             {
                 Some(WorktreeListRow::Session { pty_idx, .. }) => {
-                    app.terminal.switch_claude_session(pty_idx);
+                    app.switch_claude_session(pty_idx);
                     app.set_focus(Focus::TerminalClaude);
                 }
                 Some(WorktreeListRow::Worktree(_)) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod app;
 mod background;
 mod cc_notify;
 mod ccusage_cache;
+mod claude_log;
 mod claude_sessions;
 mod command_palette;
 mod config;
@@ -543,6 +544,12 @@ fn run_loop(
         }
         if !app.worktree_mgr.pending_worktrees.is_empty() {
             app.dirty.mark(crate::app::DirtyPanels::WORKTREE);
+        }
+        // Drive the reflow sweep animation: keep the terminal panel dirty for
+        // every frame while a sweep is in progress (focus==TerminalClaude so the
+        // tick rate is already 8ms; no additional wake-up source needed).
+        if app.reflow.sweep.is_some() {
+            app.dirty.mark(crate::app::DirtyPanels::TERMINAL);
         }
 
         if app.dirty.any() {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -200,6 +200,37 @@ impl Theme {
         }
     }
 
+    /// Return the complementary color: the hue rotated 180° in HSL space while
+    /// preserving saturation and lightness. This yields an equally-bright
+    /// opposite hue (a green-ish complement for a purple accent, etc.) rather
+    /// than the muddy result of a raw RGB inversion. Non-RGB colors are
+    /// returned unchanged.
+    pub fn complement(color: Color) -> Color {
+        match color {
+            Color::Rgb(r, g, b) => {
+                let (h, s, l) = rgb_to_hsl(r, g, b);
+                let (r, g, b) = hsl_to_rgb((h + 0.5) % 1.0, s, l);
+                Color::Rgb(r, g, b)
+            }
+            other => other,
+        }
+    }
+
+    /// Linearly interpolate between two RGB colors by `t`, clamped to `[0, 1]`
+    /// (`0.0` = `from`, `1.0` = `to`). Used to glide the reflow border between
+    /// the accent and its complement. If either color is non-RGB, `from` is
+    /// returned unchanged.
+    pub fn lerp(from: Color, to: Color, t: f64) -> Color {
+        match (from, to) {
+            (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => {
+                let t = t.clamp(0.0, 1.0);
+                let mix = |a: u8, b: u8| (a as f64 + (b as f64 - a as f64) * t).round() as u8;
+                Color::Rgb(mix(r1, r2), mix(g1, g2), mix(b1, b2))
+            }
+            _ => from,
+        }
+    }
+
     // ── Built-in themes ──────────────────────────────────────────────
 
     /// Default theme — the official Catppuccin Mocha palette.
@@ -956,6 +987,73 @@ impl Theme {
     }
 }
 
+/// Convert an 8-bit RGB triple to HSL with all components in `[0, 1]`.
+///
+/// Used by [`Theme::complement`] to rotate hue while keeping saturation and
+/// lightness. Achromatic inputs (r == g == b) report hue and saturation of 0.
+fn rgb_to_hsl(r: u8, g: u8, b: u8) -> (f64, f64, f64) {
+    let r = r as f64 / 255.0;
+    let g = g as f64 / 255.0;
+    let b = b as f64 / 255.0;
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let l = (max + min) / 2.0;
+    let d = max - min;
+    if d.abs() < f64::EPSILON {
+        return (0.0, 0.0, l); // achromatic: hue is undefined, report 0
+    }
+    let s = if l > 0.5 {
+        d / (2.0 - max - min)
+    } else {
+        d / (max + min)
+    };
+    let h = if max == r {
+        ((g - b) / d + if g < b { 6.0 } else { 0.0 }) / 6.0
+    } else if max == g {
+        ((b - r) / d + 2.0) / 6.0
+    } else {
+        ((r - g) / d + 4.0) / 6.0
+    };
+    (h, s, l)
+}
+
+/// Convert HSL components in `[0, 1]` back to an 8-bit RGB triple.
+///
+/// Inverse of [`rgb_to_hsl`]; `s == 0` short-circuits to a neutral gray.
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    if s.abs() < f64::EPSILON {
+        let v = (l * 255.0).round() as u8;
+        return (v, v, v);
+    }
+    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    let p = 2.0 * l - q;
+    let hue_to_rgb = |p: f64, q: f64, mut t: f64| -> f64 {
+        if t < 0.0 {
+            t += 1.0;
+        }
+        if t > 1.0 {
+            t -= 1.0;
+        }
+        if t < 1.0 / 6.0 {
+            p + (q - p) * 6.0 * t
+        } else if t < 1.0 / 2.0 {
+            q
+        } else if t < 2.0 / 3.0 {
+            p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        } else {
+            p
+        }
+    };
+    let r = hue_to_rgb(p, q, h + 1.0 / 3.0);
+    let g = hue_to_rgb(p, q, h);
+    let b = hue_to_rgb(p, q, h - 1.0 / 3.0);
+    (
+        (r * 255.0).round() as u8,
+        (g * 255.0).round() as u8,
+        (b * 255.0).round() as u8,
+    )
+}
+
 impl Default for Theme {
     fn default() -> Self {
         Self::catppuccin_mocha()
@@ -965,6 +1063,44 @@ impl Default for Theme {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn complement_rotates_hue_180_and_round_trips() {
+        // Pure red (h=0) → cyan (h=0.5) at the same saturation/lightness.
+        assert_eq!(Theme::complement(Color::Rgb(255, 0, 0)), Color::Rgb(0, 255, 255));
+        // Applying complement twice returns (approximately) the original hue.
+        let original = Color::Rgb(203, 166, 247); // Catppuccin Mauve accent
+        let twice = Theme::complement(Theme::complement(original));
+        let (Color::Rgb(r, g, b), Color::Rgb(r2, g2, b2)) = (original, twice) else {
+            unreachable!()
+        };
+        // Allow ±2 per channel for HSL round-trip rounding.
+        assert!((r as i16 - r2 as i16).abs() <= 2);
+        assert!((g as i16 - g2 as i16).abs() <= 2);
+        assert!((b as i16 - b2 as i16).abs() <= 2);
+    }
+
+    #[test]
+    fn complement_leaves_non_rgb_unchanged() {
+        assert_eq!(Theme::complement(Color::Reset), Color::Reset);
+    }
+
+    #[test]
+    fn lerp_endpoints_and_midpoint() {
+        let a = Color::Rgb(0, 0, 0);
+        let b = Color::Rgb(100, 200, 50);
+        assert_eq!(Theme::lerp(a, b, 0.0), a);
+        assert_eq!(Theme::lerp(a, b, 1.0), b);
+        assert_eq!(Theme::lerp(a, b, 0.5), Color::Rgb(50, 100, 25));
+    }
+
+    #[test]
+    fn lerp_clamps_out_of_range_t() {
+        let a = Color::Rgb(10, 20, 30);
+        let b = Color::Rgb(200, 200, 200);
+        assert_eq!(Theme::lerp(a, b, -1.0), a);
+        assert_eq!(Theme::lerp(a, b, 2.0), b);
+    }
 
     #[test]
     fn from_name_light_themes_have_light_true() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod editor_panel;
 pub mod explorer_panel;
 pub mod markdown;
 pub mod party;
+pub mod reflow_view;
 pub mod rich;
 pub mod terminal_claude;
 pub mod terminal_shell;

--- a/src/ui/reflow_view.rs
+++ b/src/ui/reflow_view.rs
@@ -1,0 +1,397 @@
+//! Reflow transcript view — read-only, word-wrapped rendering of a Claude Code
+//! session log inside the Claude PTY panel.
+//!
+//! `render` is called from `terminal_claude::render` whenever `app.reflow.active`
+//! is true.  It maintains a `cached_lines` vector inside `app.reflow` and
+//! rebuilds it only when the panel width changes, so there is no per-frame
+//! re-parse of the `.jsonl` file or re-invocation of the Markdown renderer.
+//!
+//! ## Layout grammar
+//!
+//! Each conversation block is rendered in a two-column gutter layout:
+//!
+//! ```text
+//! ⏺ assistant text line 1
+//!   continuation line 2
+//! ⏺ Bash(cargo build)
+//!   ⎿  12 lines
+//! > user text line 1
+//!   continuation line 2
+//! ```
+//!
+//! The gutter (`MARKER_COLS = 2`) is always 2 display columns: marker glyph
+//! padded to 2 cols for the first line, two spaces for continuations.
+//! Markdown content is rendered at `width - MARKER_COLS` so the combined width
+//! is exactly `width`, preserving the "1 logical line = 1 visual row" invariant.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::{App, SweepDir};
+use crate::claude_log::{DisplayBlock, Role};
+
+// ── Glyph constants ───────────────────────────────────────────────────────────
+
+/// Display columns reserved for the left-hand marker gutter.
+const MARKER_COLS: usize = 2;
+
+/// Bullet/record marker for assistant messages and tool invocations (U+23FA ⏺).
+const ASSISTANT_MARKER: &str = "\u{23fa}";
+
+/// Corner glyph for tool result lines (U+23BF ⎿).
+const TOOL_RESULT_GLYPH: &str = "\u{23bf}";
+
+// ── Public render entry point ─────────────────────────────────────────────────
+
+/// Render the reflow transcript view into `area` (the Claude panel's inner rect).
+///
+/// `app` is taken as `&mut` so the render can write updated scroll / cache state
+/// back to `app.reflow` after building or scrolling the line list.
+pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let inner_width = area.width as usize;
+    let inner_height = area.height as usize;
+
+    // ── (Re)build cached lines when the panel width changed ──────────────────
+    if app.reflow.last_width != area.width {
+        let new_lines = build_lines(app, inner_width);
+        let total = new_lines.len();
+
+        app.reflow.cached_lines = new_lines;
+        app.reflow.total_lines = total;
+        app.reflow.last_width = area.width;
+    }
+
+    app.reflow.last_inner_height = area.height;
+
+    // ── Pin to bottom on first open ───────────────────────────────────────────
+    if app.reflow.pending_bottom {
+        app.reflow.scroll = app
+            .reflow
+            .total_lines
+            .saturating_sub(inner_height);
+        app.reflow.pending_bottom = false;
+    }
+
+    // ── Clamp scroll to valid range ───────────────────────────────────────────
+    // Upper bound is total - inner_height, not total - 1: when pinned to the
+    // logical bottom, the last content line sits at the last visual row, not
+    // one row above.  total < inner_height (short log) collapses to 0 via
+    // saturating_sub so the view stays at the top and shows no blank rows.
+    app.reflow.scroll =
+        crate::event::reflow::clamp_scroll(app.reflow.scroll, app.reflow.total_lines, inner_height);
+
+    // ── Slice visible lines ───────────────────────────────────────────────────
+    let scroll = app.reflow.scroll;
+    let visible: Vec<Line<'static>> = app
+        .reflow
+        .cached_lines
+        .iter()
+        .skip(scroll)
+        .take(inner_height)
+        .cloned()
+        .collect();
+
+    // ── Transition completion ─────────────────────────────────────────────────
+    // Drive the entry/exit transition timer. `SweepDir` is Copy so we snapshot
+    // direction and progress before dropping the borrow on `app.reflow`, then
+    // apply any completion side-effects. The border color transition is painted
+    // in `terminal_claude::render`, not here.
+    let transition_state = app.reflow.sweep.as_ref().map(|s| {
+        (
+            s.dir,
+            crate::event::reflow::sweep_progress(
+                &s.start,
+                crate::event::reflow::TRANSITION_DURATION_MS,
+            ),
+        )
+    });
+
+    if let Some((dir, p)) = transition_state
+        && p >= 1.0
+    {
+        match dir {
+            SweepDir::In => {
+                app.reflow.sweep = None;
+            }
+            SweepDir::Out => {
+                // close_reflow sets active=false; the next frame renders
+                // the live PTY instead of this view.
+                app.close_reflow();
+            }
+        }
+    }
+
+    // No .wrap(): `markdown_cache.render` already produces lines ≤ `body_width`
+    // columns, and each line then receives a `MARKER_COLS`-wide prefix, keeping
+    // total width ≤ `area.width`.  1 logical line == 1 visual row means scroll
+    // arithmetic is exact with no invisible over-height rows.
+    frame.render_widget(Paragraph::new(visible), area);
+}
+
+// ── Line builder ─────────────────────────────────────────────────────────────
+
+/// Rebuild the full `Vec<Line<'static>>` from `app.reflow.entries`.
+///
+/// Called only when the panel width changes.  Uses an `Rc` clone of the
+/// entries (refcount bump only, no deep copy) to release the immutable borrow
+/// on `app.reflow` before calling `app.reflow.cache.render`, which also needs
+/// `&app.reflow.cache` (another field of `app.reflow`).
+fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
+    // Rc clone: O(1), releases the borrow on app.reflow.entries.
+    let entries = std::rc::Rc::clone(&app.reflow.entries);
+
+    // Cache theme colors up front (Color is Copy); this lets us call
+    // app.reflow.cache.render() later without conflicting borrows.
+    let style_assistant = Style::default().fg(app.theme.success);
+    let style_user = Style::default().fg(app.theme.muted);
+    let style_name = Style::default().fg(app.theme.info);
+    let style_dim = Style::default()
+        .fg(app.theme.muted)
+        .add_modifier(Modifier::DIM);
+    let style_thinking = Style::default()
+        .fg(app.theme.muted)
+        .add_modifier(Modifier::DIM | Modifier::ITALIC);
+
+    // Content width after reserving the marker gutter.
+    let body_width = width.saturating_sub(MARKER_COLS);
+
+    let mut all_lines: Vec<Line<'static>> = Vec::new();
+
+    for (ei, entry) in entries.iter().enumerate() {
+        let is_user = entry.role == Role::User;
+
+        // ── Content blocks (no role header; marker glyphs carry the role) ────
+        for (bi, block) in entry.blocks.iter().enumerate() {
+            match block {
+                DisplayBlock::Text(text) => {
+                    let key = format!("{ei}:{bi}");
+                    // app.reflow.cache and app.theme/syntax_set/syntect_theme are
+                    // disjoint fields — shared borrows of different struct members
+                    // are fine simultaneously in Rust 2021+ (NLL).
+                    let md_lines = app.reflow.cache.render(
+                        &key,
+                        text,
+                        body_width,
+                        &app.theme,
+                        &app.syntax_set,
+                        &app.syntect_theme,
+                    );
+                    let (glyph, marker_style) = if is_user {
+                        (">", style_user)
+                    } else {
+                        (ASSISTANT_MARKER, style_assistant)
+                    };
+                    all_lines.extend(with_marker(md_lines, glyph, marker_style));
+                }
+                DisplayBlock::ToolUse { name, summary } => {
+                    // ⏺ Name(summary) — single line, marker width + body truncated.
+                    let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
+                    let remaining = width.saturating_sub(MARKER_COLS);
+                    let line = if summary.is_empty() {
+                        // ⏺ Name
+                        let name_display = truncate_to_width(name, remaining);
+                        Line::from(vec![
+                            Span::styled(marker_prefix, style_assistant),
+                            Span::styled(name_display, style_name),
+                        ])
+                    } else {
+                        // ⏺ Name(summary)
+                        let name_cols = name.width();
+                        // Budget for summary: remaining minus name cols and two parens.
+                        let summary_budget = remaining.saturating_sub(name_cols + 2);
+                        let summary_display = truncate_to_width(summary, summary_budget);
+                        Line::from(vec![
+                            Span::styled(marker_prefix, style_assistant),
+                            Span::styled(name.clone(), style_name),
+                            Span::styled(format!("({summary_display})"), style_dim),
+                        ])
+                    };
+                    all_lines.push(line);
+                }
+                DisplayBlock::ToolResult { lines } => {
+                    // "  ⎿  {n} lines" — 2-space indent + corner glyph + 2 spaces + count.
+                    let result_str = format!("  {TOOL_RESULT_GLYPH}  {lines} lines");
+                    let result_display = truncate_to_width(&result_str, width);
+                    all_lines.push(Line::from(vec![Span::styled(result_display, style_dim)]));
+                }
+                DisplayBlock::Thinking => {
+                    // ⏺ Thinking… — italic dim body, assistant-colored marker.
+                    let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
+                    all_lines.push(Line::from(vec![
+                        Span::styled(marker_prefix, style_assistant),
+                        Span::styled("Thinking\u{2026}", style_thinking),
+                    ]));
+                }
+            }
+        }
+
+        // ── Blank separator between entries ──────────────────────────────────
+        all_lines.push(Line::from(""));
+    }
+
+    all_lines
+}
+
+// ── Marker/indent helpers (pure, testable independently of App) ───────────────
+
+/// Prepend a `MARKER_COLS`-wide marker to the first line of `lines` and a
+/// same-width blank indent to all continuation lines.
+///
+/// `glyph` is measured with `unicode_width` and padded with spaces to exactly
+/// `MARKER_COLS` display columns before being inserted as the leading span.
+/// Content spans on each line keep their original styling.
+fn with_marker(
+    lines: Vec<Line<'static>>,
+    glyph: &str,
+    marker_style: Style,
+) -> Vec<Line<'static>> {
+    let marker_prefix = pad_glyph_to(glyph, MARKER_COLS);
+    let cont_prefix = " ".repeat(MARKER_COLS);
+
+    lines
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut line)| {
+            let prefix = if i == 0 {
+                Span::styled(marker_prefix.clone(), marker_style)
+            } else {
+                Span::raw(cont_prefix.clone())
+            };
+            line.spans.insert(0, prefix);
+            line
+        })
+        .collect()
+}
+
+/// Pad `glyph` with trailing spaces until it occupies exactly `target_cols`
+/// display columns.  If the glyph is already `target_cols` wide or wider,
+/// returns it unchanged.
+fn pad_glyph_to(glyph: &str, target_cols: usize) -> String {
+    let w = UnicodeWidthStr::width(glyph);
+    if w >= target_cols {
+        glyph.to_string()
+    } else {
+        let mut s = glyph.to_string();
+        for _ in 0..(target_cols - w) {
+            s.push(' ');
+        }
+        s
+    }
+}
+
+/// Truncate `s` to at most `max_cols` display columns, appending `…` if cut.
+///
+/// Walks Unicode scalar values, accumulates display width, and cuts before the
+/// first character that would overflow.  Returns a `String` (owned) so callers
+/// can pass it directly to `Span::styled`.
+fn truncate_to_width(s: &str, max_cols: usize) -> String {
+    if max_cols == 0 {
+        return String::new();
+    }
+    let mut width = 0usize;
+    // Reserve one column for the ellipsis so the indicator fits within max_cols.
+    let budget = max_cols.saturating_sub(1);
+    for (i, ch) in s.char_indices() {
+        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + cw > budget {
+            let mut out = s[..i].to_string();
+            out.push('\u{2026}'); // …
+            return out;
+        }
+        width += cw;
+    }
+    // String fits within max_cols without truncation.
+    s.to_string()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Color;
+
+    // ── pad_glyph_to ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn pad_glyph_ascii_pads_to_target() {
+        // ">" is 1 col wide; padded to 2 should give "> ".
+        assert_eq!(pad_glyph_to(">", 2), "> ");
+    }
+
+    #[test]
+    fn pad_glyph_already_at_target_unchanged() {
+        assert_eq!(pad_glyph_to("=>", 2), "=>");
+    }
+
+    #[test]
+    fn pad_glyph_wider_than_target_unchanged() {
+        assert_eq!(pad_glyph_to("abc", 2), "abc");
+    }
+
+    #[test]
+    fn pad_glyph_assistant_marker_produces_two_cols() {
+        // ⏺ (U+23FA) has unicode_width of 1; padded to 2 should append one space.
+        let padded = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
+        assert_eq!(UnicodeWidthStr::width(padded.as_str()), MARKER_COLS);
+    }
+
+    // ── with_marker ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn with_marker_prepends_glyph_to_first_line() {
+        let style = Style::default().fg(Color::Green);
+        let lines = vec![
+            Line::from("hello"),
+            Line::from("world"),
+        ];
+        let result = with_marker(lines, ">", style);
+        assert_eq!(result.len(), 2);
+        // First span of first line is the marker.
+        assert_eq!(result[0].spans[0].content, "> ");
+        // Second line gets a blank indent.
+        assert_eq!(result[1].spans[0].content, "  ");
+    }
+
+    #[test]
+    fn with_marker_empty_input_returns_empty() {
+        let style = Style::default();
+        let result = with_marker(vec![], ">", style);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn with_marker_single_line_no_continuation() {
+        let style = Style::default();
+        let result = with_marker(vec![Line::from("only")], ">", style);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].spans[0].content, "> ");
+    }
+
+    // ── truncate_to_width ────────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_fits_returns_unchanged() {
+        assert_eq!(truncate_to_width("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_over_limit_appends_ellipsis() {
+        let result = truncate_to_width("hello world", 6);
+        assert!(result.ends_with('\u{2026}'));
+        assert!(UnicodeWidthStr::width(result.as_str()) <= 6);
+    }
+
+    #[test]
+    fn truncate_zero_budget_returns_empty() {
+        assert_eq!(truncate_to_width("anything", 0), "");
+    }
+}

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -166,11 +166,49 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let output_block = if is_expanded {
         Block::default()
     } else {
+        // Border color while reflow is active: the complement of the accent is
+        // the persistent read-mode cue. During the entry/exit transition the
+        // border glides smoothly between the accent and that complement (a
+        // single gentle gradient, no flicker); otherwise it's the normal
+        // focus/unfocus color.
+        let effective_border = if app.reflow.active {
+            let complement = crate::theme::Theme::complement(theme.accent);
+            if let Some(sweep) = &app.reflow.sweep {
+                let p = crate::event::reflow::sweep_progress(
+                    &sweep.start,
+                    crate::event::reflow::TRANSITION_DURATION_MS,
+                );
+                let t = crate::event::reflow::transition_eased(p);
+                match sweep.dir {
+                    // Entering read mode: accent → complement.
+                    crate::app::SweepDir::In => crate::theme::Theme::lerp(theme.accent, complement, t),
+                    // Leaving read mode: complement → accent, then close_reflow.
+                    crate::app::SweepDir::Out => crate::theme::Theme::lerp(complement, theme.accent, t),
+                }
+            } else {
+                // Steady read mode: rest on the complement.
+                complement
+            }
+        } else {
+            border_color
+        };
         Block::default()
             .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
             .border_type(border_type)
-            .border_style(Style::default().fg(border_color))
+            .border_style(Style::default().fg(effective_border))
     };
+
+    // If the reflow transcript view is active *and* this panel has focus,
+    // hand off rendering to the reflow view.  The focus guard prevents a
+    // stale reflow from rendering after a worktree switch or focus move that
+    // didn't go through close_reflow (belt-and-suspenders; F4 closes it in
+    // set_focus/on_worktree_changed, but the guard keeps rendering safe).
+    if app.reflow.active && app.focus == Focus::TerminalClaude {
+        let inner = output_block.inner(output_area);
+        frame.render_widget(output_block, output_area);
+        crate::ui::reflow_view::render(frame, inner, app);
+        return;
+    }
 
     if let Some(active_idx) = app.terminal.active_claude_session {
         if let Some(screen_arc) = app.terminal.pty_manager.get_screen(active_idx) {


### PR DESCRIPTION
## Summary

Claude パネルに、`.jsonl` セッションログを読み取り専用で表示する無限スクロールバック・リフロービューを追加します。ライブ PTY の上スクロールで突入し、パネル幅に追従してワードラップ（1論理行=1視覚行）、Markdown をキャッシュ描画します。

- 新規モジュール: `claude_log`（jsonl パース）、`event/reflow`（スクロール算術・遷移）、`ui/reflow_view`（2カラムガター描画）
- ガターレイアウト（`⏺` assistant / `>` user / `⎿` tool result / Thinking）、幅変化時のみ行を再構築するキャッシュ
- 入退場時のボーダー演出

### Fixes in this PR

- **別 Claude セッションへ切替えても画面が変わらないバグ**: reflow ビューはセッションに紐づくが、`switch_claude_session` が `reflow.active` をリセットしていなかったため、タブ切替・ストリップ選択・新規セッション作成等で前セッションの transcript が描画され続けていた。`App::switch_claude_session` ラッパーを新設し、切替前に reflow を畳むよう全 call site を一本化。
- **入退場アニメーションのチカチカ解消**: 明暗を3周期振動させる `flicker_intensity` を撤廃。`Theme::complement`（HSL で色相180°回転）＋ `Theme::lerp` ＋ smoothstep で、accent から補色へ一方向に滑らかに変化（読み取りモード中は補色で静止）。遷移時間 360ms→500ms。

## Test plan

- `cargo build` / `cargo clippy` クリーン
- `cargo test` 全パス（452件）。`event::reflow`（`transition_eased` ほか）、`theme`（`complement`/`lerp` 往復・補間）、`terminal_state`（セッション切替時のスクロール/キャッシュリセット）を含む
- 起動して reflow 突入→別セッション切替で画面が更新されること、ボーダーが補色へ穏やかに遷移することを目視確認
