### PR TITLE
fix: isolate Claude panel scrollback per session and match Claude Code transcript styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.78.0"
+version = "0.79.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -684,48 +684,67 @@ impl App {
 
     // ── Reflow transcript view ────────────────────────────────────────────
 
-    /// Enter the reflow transcript view for the focused worktree's latest session.
+    /// Enter the reflow transcript view for the active Claude panel's session.
     ///
-    /// Resolves the focused worktree's working directory, looks up the most
-    /// recent Claude Code session via history, loads and parses the `.jsonl`
-    /// file, and activates the overlay. If no session is found or the log is
-    /// empty, a status flash is shown and the view stays inactive.
+    /// Resolves the session backing the currently displayed Claude panel (via
+    /// its pinned `claude_session_id`), loads and parses that `.jsonl` file, and
+    /// activates the overlay. Falls back to the selected worktree's most recent
+    /// session only when the panel has no tracked id. If no session is found or
+    /// the log is empty, a status flash is shown and the view stays inactive.
     pub fn open_reflow(&mut self) {
-        let working_dir = match self.worktrees.get(self.selected_worktree) {
-            Some(wt) => wt.path.clone(),
-            None => {
-                self.set_status(
-                    "No worktree selected for transcript view".to_string(),
-                    StatusLevel::Warning,
-                );
-                return;
-            }
-        };
+        // Prefer the session backing the *currently displayed* Claude panel. A
+        // worktree can host several Claude panels (CC:1, CC:2, …), so resolving
+        // "the worktree's latest session" would open whichever log was written
+        // most recently regardless of which panel is on screen — that is the
+        // cross-panel scroll bleed this view used to suffer from. The pinned
+        // per-session id (see `PtySession::claude_session_id`) ties the
+        // transcript to the panel the user is actually looking at.
+        let resolved = self
+            .terminal
+            .active_claude_session
+            .and_then(|idx| self.terminal.pty_manager.claude_session_ref(idx));
 
-        let canonical =
-            std::fs::canonicalize(&working_dir).unwrap_or_else(|_| working_dir.clone());
-        let session = match crate::claude_sessions::find_latest_sessions_for_paths(
-            std::slice::from_ref(&working_dir),
-        ) {
-            Ok(mut map) => map.remove(&canonical),
-            Err(e) => {
-                log::warn!("reflow: cannot look up session: {e}");
-                None
-            }
-        };
-        let session = match session {
-            Some(s) => s,
+        let (working_dir, session_id) = match resolved {
+            Some(pair) => pair,
             None => {
-                self.set_status(
-                    "No Claude session found for this worktree".to_string(),
-                    StatusLevel::Info,
-                );
-                return;
+                // Fallback for panels without a tracked id (e.g. sessions that
+                // predate id pinning): use the selected worktree's latest log.
+                let working_dir = match self.worktrees.get(self.selected_worktree) {
+                    Some(wt) => wt.path.clone(),
+                    None => {
+                        self.set_status(
+                            "No worktree selected for transcript view".to_string(),
+                            StatusLevel::Warning,
+                        );
+                        return;
+                    }
+                };
+                let canonical =
+                    std::fs::canonicalize(&working_dir).unwrap_or_else(|_| working_dir.clone());
+                let session = match crate::claude_sessions::find_latest_sessions_for_paths(
+                    std::slice::from_ref(&working_dir),
+                ) {
+                    Ok(mut map) => map.remove(&canonical),
+                    Err(e) => {
+                        log::warn!("reflow: cannot look up session: {e}");
+                        None
+                    }
+                };
+                match session {
+                    Some(s) => (working_dir, s.session_id),
+                    None => {
+                        self.set_status(
+                            "No Claude session found for this worktree".to_string(),
+                            StatusLevel::Info,
+                        );
+                        return;
+                    }
+                }
             }
         };
 
         let jsonl_path =
-            match crate::claude_sessions::session_jsonl_path(&working_dir, &session.session_id) {
+            match crate::claude_sessions::session_jsonl_path(&working_dir, &session_id) {
                 Some(p) => p,
                 None => {
                     self.set_status(
@@ -1562,13 +1581,16 @@ impl App {
                 self.expanded_panel = None;
             }
         }
-        // Leaving the Claude terminal while the reflow view is active orphans it:
-        // the keyboard gate checks `focus == TerminalClaude`, so Esc would stop
-        // working and the transcript would float invisibly behind other panels.
-        // Close it here so the panel always returns to a clean live-PTY state.
-        if self.reflow.active && focus != Focus::TerminalClaude {
-            self.close_reflow();
-        }
+        // Note: we deliberately do NOT close the reflow transcript here on a
+        // plain focus change. Both the key handler (`event`) and the renderer
+        // (`ui::terminal_claude`) gate reflow on `focus == TerminalClaude`, so
+        // while another panel is focused the transcript neither captures keys
+        // nor renders (the Claude panel falls back to the live PTY). Tearing it
+        // down here would also reset the scroll offset, snapping the user back to
+        // the live tail when they merely glanced at another panel. Reflow is
+        // still closed on the transitions where the transcript becomes stale —
+        // session switch (`switch_claude_session`) and worktree change
+        // (`on_worktree_changed`) — and by Esc/F4 in the reflow key handler.
 
         match focus {
             Focus::Explorer | Focus::Viewer => {

--- a/src/claude_log.rs
+++ b/src/claude_log.rs
@@ -51,8 +51,12 @@ pub enum Block {
     Text {
         text: String,
     },
-    /// Thinking block — shown as a stub; body is empty in published logs.
-    Thinking,
+    /// Thinking block. Local session logs carry the full reasoning text in the
+    /// `thinking` field (unlike the redacted published logs), so capture it.
+    Thinking {
+        #[serde(default)]
+        thinking: String,
+    },
     ToolUse {
         name: String,
         #[serde(default)]
@@ -61,6 +65,10 @@ pub enum Block {
     ToolResult {
         #[serde(default)]
         content: ToolResultContent,
+        /// Set when the tool reported an error. Rendered with an error-colored
+        /// connector to mirror Claude Code's transcript.
+        #[serde(default)]
+        is_error: bool,
     },
     /// Any block type not explicitly handled above.
     #[serde(other)]
@@ -111,13 +119,25 @@ pub struct LogEntry {
 pub enum DisplayBlock {
     /// Markdown prose (user input or assistant text response).
     Text(String),
-    /// A tool invocation — rendered as `▸ {name}: {summary}`.
+    /// A tool invocation — rendered as `⏺ {name}({summary})`.
     ToolUse { name: String, summary: String },
-    /// The result returned by a tool — rendered as a line-count summary.
-    ToolResult { lines: usize },
-    /// A thinking block — rendered as a placeholder stub.
-    Thinking,
+    /// The result returned by a tool — a capped preview of the actual output
+    /// plus the total line count, mirroring Claude Code's collapsed `⎿` block.
+    ToolResult {
+        /// First [`TOOL_RESULT_PREVIEW_LINES`] lines of output (already capped).
+        preview: Vec<String>,
+        /// Total number of output lines, for the `… +N lines` summary.
+        total_lines: usize,
+        /// Whether the tool reported an error.
+        is_error: bool,
+    },
+    /// A thinking block — the assistant's reasoning text (may be empty).
+    Thinking { text: String },
 }
+
+/// Maximum number of tool-result output lines shown before collapsing into a
+/// `… +N lines` summary, matching Claude Code's transcript preview.
+pub const TOOL_RESULT_PREVIEW_LINES: usize = 4;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -140,12 +160,15 @@ fn summarise_tool_input(input: &serde_json::Value) -> String {
     String::new()
 }
 
-/// Count the total number of output lines in a `ToolResultContent`.
-fn count_result_lines(content: &ToolResultContent) -> usize {
+/// Split a `ToolResultContent` into its individual output lines.
+fn result_lines(content: &ToolResultContent) -> Vec<String> {
     match content {
-        ToolResultContent::None => 0,
-        ToolResultContent::Text(s) => s.lines().count(),
-        ToolResultContent::Blocks(blocks) => blocks.iter().map(|b| b.text.lines().count()).sum(),
+        ToolResultContent::None => Vec::new(),
+        ToolResultContent::Text(s) => s.lines().map(str::to_string).collect(),
+        ToolResultContent::Blocks(blocks) => blocks
+            .iter()
+            .flat_map(|b| b.text.lines().map(str::to_string))
+            .collect(),
     }
 }
 
@@ -160,14 +183,20 @@ fn content_to_display_blocks(content: Content) -> Vec<DisplayBlock> {
             .filter_map(|b| match b {
                 Block::Text { text } if !text.is_empty() => Some(DisplayBlock::Text(text)),
                 Block::Text { .. } => None,
-                Block::Thinking => Some(DisplayBlock::Thinking),
+                Block::Thinking { thinking } => Some(DisplayBlock::Thinking { text: thinking }),
                 Block::ToolUse { name, input } => {
                     let summary = summarise_tool_input(&input);
                     Some(DisplayBlock::ToolUse { name, summary })
                 }
-                Block::ToolResult { content } => {
-                    let lines = count_result_lines(&content);
-                    Some(DisplayBlock::ToolResult { lines })
+                Block::ToolResult { content, is_error } => {
+                    let lines = result_lines(&content);
+                    let total_lines = lines.len();
+                    let preview = lines.into_iter().take(TOOL_RESULT_PREVIEW_LINES).collect();
+                    Some(DisplayBlock::ToolResult {
+                        preview,
+                        total_lines,
+                        is_error,
+                    })
                 }
                 Block::Other => None,
             })
@@ -276,9 +305,15 @@ mod tests {
         );
         assert_eq!(blocks.len(), 4);
         assert!(matches!(blocks[0], DisplayBlock::Text(_)));
-        assert!(matches!(blocks[1], DisplayBlock::Thinking));
+        assert!(matches!(blocks[1], DisplayBlock::Thinking { .. }));
         assert!(matches!(blocks[2], DisplayBlock::ToolUse { .. }));
-        assert!(matches!(blocks[3], DisplayBlock::ToolResult { lines: 3 }));
+        assert!(matches!(
+            blocks[3],
+            DisplayBlock::ToolResult {
+                total_lines: 3,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -311,7 +346,7 @@ mod tests {
     #[test]
     fn tool_result_string_counts_lines() {
         let content = ToolResultContent::Text("a\nb\nc".to_string());
-        assert_eq!(count_result_lines(&content), 3);
+        assert_eq!(result_lines(&content).len(), 3);
     }
 
     #[test]
@@ -324,7 +359,60 @@ mod tests {
                 text: "d\ne".to_string(),
             },
         ]);
-        assert_eq!(count_result_lines(&content), 5);
+        assert_eq!(result_lines(&content).len(), 5);
+    }
+
+    #[test]
+    fn tool_result_preview_caps_and_reports_total() {
+        // 10 output lines → preview capped at TOOL_RESULT_PREVIEW_LINES,
+        // total_lines retains the real count for the "+N lines" summary.
+        let body: String = (0..10)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let json = format!(
+            r#"{{"type":"user","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"t","content":{body:?}}}]}}}}"#
+        );
+        let blocks = parse_msg_content(&json);
+        match &blocks[0] {
+            DisplayBlock::ToolResult {
+                preview,
+                total_lines,
+                is_error,
+            } => {
+                assert_eq!(*total_lines, 10);
+                assert_eq!(preview.len(), TOOL_RESULT_PREVIEW_LINES);
+                assert_eq!(preview[0], "line0");
+                assert!(!*is_error);
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_result_error_flag_is_captured() {
+        let blocks = parse_msg_content(
+            r#"{"type":"user","message":{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"t","is_error":true,"content":"boom"}
+            ]}}"#,
+        );
+        assert!(matches!(
+            blocks[0],
+            DisplayBlock::ToolResult { is_error: true, .. }
+        ));
+    }
+
+    #[test]
+    fn thinking_text_is_captured() {
+        let blocks = parse_msg_content(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[
+                {"type":"thinking","thinking":"let me reason","signature":"x"}
+            ]}}"#,
+        );
+        match &blocks[0] {
+            DisplayBlock::Thinking { text } => assert_eq!(text, "let me reason"),
+            other => panic!("expected Thinking, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -60,6 +60,14 @@ pub struct PtySession {
     pub worktree: String,
     /// The working directory this session was spawned in.
     pub working_dir: PathBuf,
+    /// The Claude Code session id (`<id>.jsonl` under the project dir) backing
+    /// this panel, when known. Set for `ClaudeCode` sessions: a fresh spawn
+    /// forces a generated id via `--session-id`, and a resumed spawn records the
+    /// id it resumed. `None` for Shell/Editor sessions, and for any Claude
+    /// session whose id could not be determined. Lets the reflow transcript view
+    /// open *this* panel's log instead of merely the worktree's latest session —
+    /// essential when one worktree hosts multiple Claude panels (CC:1, CC:2, …).
+    pub claude_session_id: Option<String>,
     /// Whether this session is the currently displayed (active) session.
     pub is_active: bool,
 
@@ -184,14 +192,25 @@ impl PtyManager {
         session_name: Option<&str>,
     ) -> Result<usize> {
         // Build the command depending on the session kind, then hand off to the
-        // shared spawn path.
-        let cmd = match kind {
+        // shared spawn path. For Claude sessions we also pin down the session id
+        // so the reflow transcript view can later open this exact panel's log.
+        let (cmd, claude_session_id) = match kind {
             SessionKind::ClaudeCode => {
                 let mut c = CommandBuilder::new("claude");
-                if let Some(resume_id) = resume_session_id {
+                // Resume keeps the existing session id (Claude appends to the
+                // same `<id>.jsonl`); a fresh spawn forces a generated id via
+                // `--session-id` so we know the file name up front instead of
+                // having to guess "the worktree's most recent session".
+                let session_id = if let Some(resume_id) = resume_session_id {
                     c.arg("--resume");
                     c.arg(resume_id);
-                }
+                    resume_id.to_string()
+                } else {
+                    let new_id = Uuid::new_v4().to_string();
+                    c.arg("--session-id");
+                    c.arg(&new_id);
+                    new_id
+                };
                 if let Some(name) = session_name {
                     c.arg("--name");
                     c.arg(name);
@@ -199,14 +218,18 @@ impl PtyManager {
                 // Let the conductor MCP server find the review database.
                 let db_path = repo_root.join(".conductor").join("conductor.db");
                 c.env("CONDUCTOR_DB_PATH", db_path);
-                c
+                (c, Some(session_id))
             }
-            SessionKind::Shell => CommandBuilder::new(shell_path),
+            SessionKind::Shell => (CommandBuilder::new(shell_path), None),
             SessionKind::Editor => {
                 unreachable!("editor sessions are spawned via spawn_editor_session")
             }
         };
-        self.finish_spawn(kind, worktree, label, working_dir, rows, cols, cmd)
+        let idx = self.finish_spawn(kind, worktree, label, working_dir, rows, cols, cmd)?;
+        if let Some(session) = self.sessions.get_mut(idx) {
+            session.claude_session_id = claude_session_id;
+        }
+        Ok(idx)
     }
 
     /// Spawn an external editor (`$VISUAL` / `$EDITOR`) on a single `file` as a
@@ -360,6 +383,9 @@ impl PtyManager {
             kind,
             worktree: worktree.to_string(),
             working_dir: working_dir.clone(),
+            // Populated by `spawn_session` for Claude panels after this returns;
+            // Shell/Editor sessions keep it `None`.
+            claude_session_id: None,
             is_active: false,
             master: pair.master,
             writer,
@@ -755,6 +781,17 @@ impl PtyManager {
     /// Return the number of sessions.
     pub fn session_count(&self) -> usize {
         self.sessions.len()
+    }
+
+    /// The Claude session id and working directory for the session at `idx`,
+    /// when it is a Claude panel with a known id. Used by the reflow transcript
+    /// view to open the log for a *specific* panel rather than the worktree's
+    /// most recently written session. Returns `None` for out-of-range indices,
+    /// non-Claude sessions, or Claude sessions whose id is unknown.
+    pub fn claude_session_ref(&self, idx: usize) -> Option<(PathBuf, String)> {
+        let session = self.sessions.get(idx)?;
+        let id = session.claude_session_id.as_ref()?;
+        Some((session.working_dir.clone(), id.clone()))
     }
 
     /// Read-only access to the sessions slice.

--- a/src/ui/reflow_view.rs
+++ b/src/ui/reflow_view.rs
@@ -26,13 +26,14 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, SweepDir};
 use crate::claude_log::{DisplayBlock, Role};
+use crate::theme::Theme;
 
 // ── Glyph constants ───────────────────────────────────────────────────────────
 
@@ -42,8 +43,59 @@ const MARKER_COLS: usize = 2;
 /// Bullet/record marker for assistant messages and tool invocations (U+23FA ⏺).
 const ASSISTANT_MARKER: &str = "\u{23fa}";
 
+/// Prompt marker for user turns (Claude Code shows `>` before user input).
+const USER_MARKER: &str = ">";
+
 /// Corner glyph for tool result lines (U+23BF ⎿).
 const TOOL_RESULT_GLYPH: &str = "\u{23bf}";
+
+/// Marker for thinking blocks (U+273B ✻), matching Claude Code's spinner glyph.
+const THINKING_GLYPH: &str = "\u{273b}";
+
+// ── Claude Code fixed palette (dark theme) ─────────────────────────────────────
+//
+// Lifted verbatim from the Claude Code CLI's hardcoded dark theme so the
+// transcript reads like the real thing regardless of the user's conductor theme.
+// (Conductor's own theme drives every other panel; only this overlay pins the
+// Claude palette.)
+mod palette {
+    use ratatui::style::Color;
+
+    /// Claude's signature coral/orange accent — `claude` token.
+    pub const CLAUDE: Color = Color::Rgb(215, 119, 87);
+    /// Primary text — `text` token (white).
+    pub const TEXT: Color = Color::Rgb(255, 255, 255);
+    /// Tool-invocation bullet — `success` token (green).
+    pub const SUCCESS: Color = Color::Rgb(78, 186, 101);
+    /// Error connector — `error` token (coral red).
+    pub const ERROR: Color = Color::Rgb(255, 107, 128);
+    /// Dimmed/secondary text — `inactive` token (grey).
+    pub const INACTIVE: Color = Color::Rgb(153, 153, 153);
+    /// Accent for headings/links — `permission` token (periwinkle).
+    pub const PERMISSION: Color = Color::Rgb(177, 185, 249);
+    /// Inline-code / very dim — `subtle` token.
+    pub const SUBTLE: Color = Color::Rgb(80, 80, 80);
+}
+
+/// Build a Claude-flavored [`Theme`] for the Markdown renderer so prose,
+/// headings, links and code in the transcript adopt Claude Code's palette
+/// instead of the active conductor theme. Only the fields the Markdown
+/// renderer consults are overridden; the rest are inherited from `base`.
+fn claude_markdown_theme(base: &Theme) -> Theme {
+    let mut t = base.clone();
+    t.fg = palette::TEXT;
+    t.muted = palette::INACTIVE;
+    t.hint = palette::INACTIVE;
+    t.accent = palette::CLAUDE;
+    t.info = palette::PERMISSION;
+    t.success = palette::SUCCESS;
+    t.error = palette::ERROR;
+    t.warning = Color::Rgb(255, 193, 7);
+    t.border_secondary = palette::SUBTLE;
+    t.code_fg = palette::TEXT;
+    t.code_bg = Color::Rgb(43, 43, 43);
+    t
+}
 
 // ── Public render entry point ─────────────────────────────────────────────────
 
@@ -148,17 +200,23 @@ fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
     // Rc clone: O(1), releases the borrow on app.reflow.entries.
     let entries = std::rc::Rc::clone(&app.reflow.entries);
 
-    // Cache theme colors up front (Color is Copy); this lets us call
-    // app.reflow.cache.render() later without conflicting borrows.
-    let style_assistant = Style::default().fg(app.theme.success);
-    let style_user = Style::default().fg(app.theme.muted);
-    let style_name = Style::default().fg(app.theme.info);
-    let style_dim = Style::default()
-        .fg(app.theme.muted)
-        .add_modifier(Modifier::DIM);
+    // Claude's fixed palette (Color is Copy) drives the transcript chrome.
+    let style_assistant = Style::default().fg(palette::TEXT);
+    let style_user = Style::default().fg(palette::CLAUDE);
+    let style_tool_marker = Style::default().fg(palette::SUCCESS);
+    let style_name = Style::default()
+        .fg(palette::TEXT)
+        .add_modifier(Modifier::BOLD);
+    let style_args = Style::default().fg(palette::INACTIVE);
+    let style_result = Style::default().fg(palette::INACTIVE);
+    let style_result_err = Style::default().fg(palette::ERROR);
     let style_thinking = Style::default()
-        .fg(app.theme.muted)
-        .add_modifier(Modifier::DIM | Modifier::ITALIC);
+        .fg(palette::INACTIVE)
+        .add_modifier(Modifier::ITALIC);
+
+    // A Claude-flavored theme so the Markdown body matches the chrome. Cloned
+    // once up front so the loop only borrows the (disjoint) cache/syntax fields.
+    let md_theme = claude_markdown_theme(&app.theme);
 
     // Content width after reserving the marker gutter.
     let body_width = width.saturating_sub(MARKER_COLS);
@@ -173,62 +231,93 @@ fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
             match block {
                 DisplayBlock::Text(text) => {
                     let key = format!("{ei}:{bi}");
-                    // app.reflow.cache and app.theme/syntax_set/syntect_theme are
-                    // disjoint fields — shared borrows of different struct members
-                    // are fine simultaneously in Rust 2021+ (NLL).
+                    // app.reflow.cache and the syntax fields are disjoint members
+                    // of `app`, so the simultaneous &mut / & borrows are fine
+                    // under NLL. `md_theme` is a local, independent of `app`.
                     let md_lines = app.reflow.cache.render(
                         &key,
                         text,
                         body_width,
-                        &app.theme,
+                        &md_theme,
                         &app.syntax_set,
                         &app.syntect_theme,
                     );
                     let (glyph, marker_style) = if is_user {
-                        (">", style_user)
+                        (USER_MARKER, style_user)
                     } else {
                         (ASSISTANT_MARKER, style_assistant)
                     };
                     all_lines.extend(with_marker(md_lines, glyph, marker_style));
                 }
                 DisplayBlock::ToolUse { name, summary } => {
-                    // ⏺ Name(summary) — single line, marker width + body truncated.
+                    // ⏺ Name(summary) — green bullet, bold name, dim args.
                     let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
                     let remaining = width.saturating_sub(MARKER_COLS);
                     let line = if summary.is_empty() {
-                        // ⏺ Name
                         let name_display = truncate_to_width(name, remaining);
                         Line::from(vec![
-                            Span::styled(marker_prefix, style_assistant),
+                            Span::styled(marker_prefix, style_tool_marker),
                             Span::styled(name_display, style_name),
                         ])
                     } else {
-                        // ⏺ Name(summary)
                         let name_cols = name.width();
                         // Budget for summary: remaining minus name cols and two parens.
                         let summary_budget = remaining.saturating_sub(name_cols + 2);
                         let summary_display = truncate_to_width(summary, summary_budget);
                         Line::from(vec![
-                            Span::styled(marker_prefix, style_assistant),
+                            Span::styled(marker_prefix, style_tool_marker),
                             Span::styled(name.clone(), style_name),
-                            Span::styled(format!("({summary_display})"), style_dim),
+                            Span::styled(format!("({summary_display})"), style_args),
                         ])
                     };
                     all_lines.push(line);
                 }
-                DisplayBlock::ToolResult { lines } => {
-                    // "  ⎿  {n} lines" — 2-space indent + corner glyph + 2 spaces + count.
-                    let result_str = format!("  {TOOL_RESULT_GLYPH}  {lines} lines");
-                    let result_display = truncate_to_width(&result_str, width);
-                    all_lines.push(Line::from(vec![Span::styled(result_display, style_dim)]));
+                DisplayBlock::ToolResult {
+                    preview,
+                    total_lines,
+                    is_error,
+                } => {
+                    all_lines.extend(render_tool_result(
+                        preview,
+                        *total_lines,
+                        *is_error,
+                        width,
+                        style_result,
+                        style_result_err,
+                    ));
                 }
-                DisplayBlock::Thinking => {
-                    // ⏺ Thinking… — italic dim body, assistant-colored marker.
-                    let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
+                DisplayBlock::Thinking { text } => {
+                    // ✻ Thinking… header, then the (dimmed, italic) reasoning body.
+                    let marker_prefix = pad_glyph_to(THINKING_GLYPH, MARKER_COLS);
                     all_lines.push(Line::from(vec![
-                        Span::styled(marker_prefix, style_assistant),
+                        Span::styled(marker_prefix, style_thinking),
                         Span::styled("Thinking\u{2026}", style_thinking),
                     ]));
+                    if !text.trim().is_empty() {
+                        let key = format!("{ei}:{bi}:think");
+                        let md_lines = app.reflow.cache.render(
+                            &key,
+                            text,
+                            body_width,
+                            &md_theme,
+                            &app.syntax_set,
+                            &app.syntect_theme,
+                        );
+                        // Recolor the Markdown output to dim italic and indent it
+                        // under the gutter (blank marker, so no glyph repeats).
+                        let dimmed = md_lines
+                            .into_iter()
+                            .map(|mut line| {
+                                for span in &mut line.spans {
+                                    span.style = Style::default()
+                                        .fg(palette::INACTIVE)
+                                        .add_modifier(Modifier::ITALIC);
+                                }
+                                line
+                            })
+                            .collect();
+                        all_lines.extend(with_marker(dimmed, " ", style_thinking));
+                    }
                 }
             }
         }
@@ -238,6 +327,52 @@ fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
     }
 
     all_lines
+}
+
+/// Render a tool result as Claude Code's collapsed `⎿` block: the first line
+/// hangs off the corner glyph, continuations align under it, and any overflow
+/// beyond the captured preview collapses into a `… +N lines` summary.
+fn render_tool_result(
+    preview: &[String],
+    total_lines: usize,
+    is_error: bool,
+    width: usize,
+    body_style: Style,
+    err_style: Style,
+) -> Vec<Line<'static>> {
+    // "  ⎿  " — 2-space indent + 1-col glyph + 2 spaces = 5 columns; continuation
+    // lines indent by the same amount so output text stays left-aligned.
+    let first_prefix = format!("  {TOOL_RESULT_GLYPH}  ");
+    let prefix_cols = UnicodeWidthStr::width(first_prefix.as_str());
+    let cont_indent = " ".repeat(prefix_cols);
+    let connector_style = if is_error { err_style } else { body_style };
+
+    if total_lines == 0 {
+        let s = truncate_to_width(&format!("{first_prefix}(no content)"), width);
+        return vec![Line::from(vec![Span::styled(s, connector_style)])];
+    }
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for (i, raw) in preview.iter().enumerate() {
+        let body = truncate_to_width(raw, width.saturating_sub(prefix_cols));
+        if i == 0 {
+            out.push(Line::from(vec![
+                Span::styled(first_prefix.clone(), connector_style),
+                Span::styled(body, body_style),
+            ]));
+        } else {
+            out.push(Line::from(vec![
+                Span::raw(cont_indent.clone()),
+                Span::styled(body, body_style),
+            ]));
+        }
+    }
+    if total_lines > preview.len() {
+        let more = total_lines - preview.len();
+        let s = truncate_to_width(&format!("{cont_indent}\u{2026} +{more} lines"), width);
+        out.push(Line::from(vec![Span::styled(s, body_style)]));
+    }
+    out
 }
 
 // ── Marker/indent helpers (pure, testable independently of App) ───────────────

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -171,7 +171,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         // border glides smoothly between the accent and that complement (a
         // single gentle gradient, no flicker); otherwise it's the normal
         // focus/unfocus color.
-        let effective_border = if app.reflow.active {
+        // Focus-gated to match the reflow render guard below: while the panel is
+        // unfocused it shows the live PTY (reflow is preserved but not rendered),
+        // so the read-mode complement would be a misleading border cue there.
+        let effective_border = if app.reflow.active && app.focus == Focus::TerminalClaude {
             let complement = crate::theme::Theme::complement(theme.accent);
             if let Some(sweep) = &app.reflow.sweep {
                 let p = crate::event::reflow::sweep_progress(


### PR DESCRIPTION
## Summary

Fixes scroll/scrollback isolation between multiple Claude panels and makes the reflow transcript view look much closer to the real Claude Code CLI.

### 1. Per-session reflow scrollback (the original bug)
When one worktree hosts multiple Claude sessions (CC:1, CC:2, …), scrolling up in CC:2 could open CC:1's transcript. `open_reflow` resolved the worktree's *most recently written* session by file mtime instead of the panel actually on screen.

- Each Claude PTY is now bound to a specific Claude session id: a fresh spawn forces one via `claude --session-id <uuid>`; a resumed spawn records the id it resumed (`PtySession::claude_session_id`).
- `open_reflow` resolves the transcript from the **active panel's** session id, falling back to the worktree's latest session only for untracked (pre-upgrade) sessions.

### 2. Scrollback position preserved across focus changes
Focusing another panel while reading scrollback snapped back to the live tail, because `set_focus` tore down the reflow view (which resets the scroll offset). Reflow is now kept across plain focus changes — both the key handler and renderer already gate on `focus == TerminalClaude`, so an unfocused Claude panel shows the live PTY without capturing keys, and refocusing returns to the same scroll position. Reflow is still closed on the transitions where the transcript becomes stale (session switch, worktree change, Esc/F4). The read-mode border cue is now focus-gated to match.

### 3. Transcript styling matched to Claude Code
The reflow view now mirrors Claude Code's dark theme (palette lifted from the CLI's hardcoded values):

- Tool results show the **actual output** (first few lines + `… +N lines`) instead of only a line count; errors use a red connector.
- Fixed Claude palette: green tool bullet `⏺`, white assistant text, dim-grey results, orange user `>` marker, periwinkle headings.
- Markdown body rendered with a Claude-flavored theme; thinking blocks render their reasoning text (dim italic).

Version bumped to 0.79.0 (backward-compatible feature addition).

## Test plan

- `cargo build`, `cargo clippy`, `cargo test` — all pass (469 tests, incl. new `claude_log` tests for tool-result preview capping, error flag, and thinking-text capture).
- Manual (TUI): open two Claude sessions in one worktree, scroll up in CC:2 → its own transcript opens; 3+ panels each scroll independently.
- Manual: while reading scrollback, focus another panel and return → scroll position preserved (no snap to bottom).
- Manual: confirm tool results, colors, and thinking render Claude-Code-like.
