### PR TITLE
feat: tmux-style pane resizing (Ctrl+Alt+Arrow) and zoom (Ctrl+Alt+Z)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@ Status bar
   count, ahead/behind, and Claude Code waiting/active state. Hidden while a panel
   is maximized.
 - The main area is a three-column accordion (`ui/layout.rs`): Explorer | Viewer |
-  Terminal, with focus-driven widths. Any panel can be maximized (`Alt+m`).
+  Terminal, with focus-driven widths. Any panel can be maximized (`Ctrl+Alt+Z`),
+  and resized tmux-style with `Ctrl+Alt+Arrow` (ratios persist to config.toml).
 - Explorer column is split 50/50 (file tree top, diff/comment list bottom).
 - Terminal column is split 80/20 vertically (Claude Code top, Shell bottom).
 - When the embedded editor is active (`Focus::Editor`), it merges the

--- a/README.md
+++ b/README.md
@@ -84,14 +84,16 @@ view.
 
 - **Explorer** column is split 50/50: file tree (top) and diff / comment list (bottom).
 - **Terminal** column is split 80/20: Claude Code (top) and Shell (bottom).
-- Any panel can be maximized (`Alt+m`) to take the full main area.
+- Any panel can be maximized (`Ctrl+Alt+Z`) to take the full main area, or resized
+  tmux-style with `Ctrl+Alt+Arrow` (the new ratios persist to `config.toml`).
 
 ### Keybindings
 
 - **Tab / Shift+Tab** — cycle panel focus (non-terminal panels)
 - **Alt+h / Alt+l** — cycle panel focus from anywhere, including terminals
 - **Alt+1…6** (or **⌘+1…6**) — focus a specific panel
-- **Alt+m** — maximize / restore the focused panel
+- **Ctrl+Alt+Z** — maximize / restore (zoom) the focused panel
+- **Ctrl+Alt+Arrow** — resize the focused panel tmux-style (ratios persist)
 - **Ctrl+Tab / Ctrl+Shift+Tab** (or **Alt+] / Alt+[**) — switch the selected worktree
 - **Ctrl+n** — new Claude Code session · **Ctrl+t** — new shell
 - **j/k** — navigate up/down · **h/l** — collapse/expand · **g/G** — top/bottom

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -133,6 +133,20 @@ impl Focus {
     }
 }
 
+/// Direction of a tmux-style pane resize, relative to the focused panel.
+///
+/// Semantics mirror tmux `resize-pane -L/-R/-U/-D`: the focused panel grows
+/// toward the given direction by moving the divider it shares with the neighbor
+/// on that side. When the panel has no neighbor on that side (it sits against
+/// the edge), the opposite divider moves instead, so the panel shrinks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeDir {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
 /// Input mode for worktree operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorktreeInputMode {
@@ -425,8 +439,9 @@ pub struct App {
 
     /// Runtime height percentage for the Claude Code area within the terminal
     /// column (the Shell gets the remainder). Seeded from
-    /// `config.layout.terminal_split_pct` at startup and adjusted live by the
-    /// grow/shrink-shell actions; not persisted back to the config file.
+    /// `config.layout.terminal_split_pct` at startup, adjusted live by a
+    /// tmux-style pane resize (Ctrl+Alt+Up/Down with a terminal focused), and
+    /// persisted back to the config file so the ratio survives a restart.
     pub terminal_split_pct: u16,
 
     /// Frame counter for UI animations (e.g. waiting-state pulse).
@@ -1322,7 +1337,7 @@ impl App {
                 self.terminal.needs_clear = true;
                 self.dirty.mark_all();
                 self.set_status(
-                    format!("Editing {fname} — Ctrl+Esc: Claude · :q: close · alt+m: zoom"),
+                    format!("Editing {fname} — Ctrl+Esc: Claude · :q: close · ctrl+alt+z: zoom"),
                     StatusLevel::Info,
                 );
             }
@@ -1708,6 +1723,16 @@ impl App {
         // and recomputes on the next frame; no explicit invalidation needed.
         self.config.adopt_appearance(new);
 
+        // The Claude/Shell split is a runtime field seeded from config; resync it
+        // so an external edit to layout.terminal_split_pct takes effect live. Our
+        // own resize-driven writes never reach here — they leave the appearance
+        // snapshot unchanged, so reload_appearance_config short-circuits first.
+        self.terminal_split_pct = self
+            .config
+            .layout
+            .terminal_split_pct
+            .clamp(Self::TERMINAL_SPLIT_MIN, Self::TERMINAL_SPLIT_MAX);
+
         // Refresh the viewer file tree + diff to pick up tab_width / word_diff.
         // refresh_viewer calls rehighlight_viewer unconditionally, so the new
         // syntect theme is applied to the open file as part of this call.
@@ -2019,8 +2044,10 @@ impl App {
             CommandId::NextWorktree => self.select_next_worktree(),
             CommandId::PrevWorktree => self.select_prev_worktree(),
             CommandId::TogglePanelExpand => self.cmd_toggle_panel_expand(),
-            CommandId::GrowShell => self.grow_shell(),
-            CommandId::ShrinkShell => self.shrink_shell(),
+            CommandId::ResizePaneLeft => self.resize_focused_pane(ResizeDir::Left),
+            CommandId::ResizePaneRight => self.resize_focused_pane(ResizeDir::Right),
+            CommandId::ResizePaneUp => self.resize_focused_pane(ResizeDir::Up),
+            CommandId::ResizePaneDown => self.resize_focused_pane(ResizeDir::Down),
             CommandId::CreateWorktree => self.cmd_create_worktree(),
             CommandId::DeleteWorktree => self.cmd_delete_worktree(),
             CommandId::SwitchBranch => self.cmd_switch_branch(),
@@ -2129,30 +2156,122 @@ impl App {
         }
     }
 
-    /// Grow the Shell area within the terminal column by one step (the Claude
-    /// area shrinks). Bound to the grow-shell action.
-    pub fn grow_shell(&mut self) {
-        self.adjust_terminal_split(-(Self::TERMINAL_SPLIT_STEP as i16));
-    }
-
-    /// Shrink the Shell area within the terminal column by one step (the Claude
-    /// area grows). Bound to the shrink-shell action.
-    pub fn shrink_shell(&mut self) {
-        self.adjust_terminal_split(Self::TERMINAL_SPLIT_STEP as i16);
-    }
-
-    /// Step (percentage points) each grow/shrink-shell action moves the
-    /// Claude/Shell divider.
+    /// Step (percentage points) each horizontal pane resize moves a column
+    /// divider.
+    const RESIZE_STEP_PCT: u16 = 5;
+    /// Minimum width percentage for each of the three columns (Explorer, Viewer,
+    /// Terminal), so a tmux-style resize can never collapse a column to nothing.
+    const MIN_COL_PCT: u16 = 10;
+    /// Step (percentage points) each vertical pane resize moves the Claude/Shell
+    /// divider.
     const TERMINAL_SPLIT_STEP: u16 = 5;
     /// Bounds for the runtime Claude-area percentage, leaving at least this much
     /// for each of the two terminal panes so neither can vanish.
     const TERMINAL_SPLIT_MIN: u16 = 20;
     const TERMINAL_SPLIT_MAX: u16 = 80;
 
+    /// Resize the focused panel tmux-style, growing it toward `dir`.
+    ///
+    /// Maps the focused panel and direction onto one of the three adjustable
+    /// dividers (Explorer|Viewer, Viewer|Terminal, Claude|Shell). The focused
+    /// panel grows toward `dir` by moving the divider it shares with its
+    /// neighbor on that side; against an edge it moves the only divider it has,
+    /// shrinking instead — mirroring `resize-pane -L/-R/-U/-D`. The middle
+    /// (Viewer) column can therefore push both of its borders, so it never
+    /// becomes the cramped pane that can only shrink.
+    pub fn resize_focused_pane(&mut self, dir: ResizeDir) {
+        let step = Self::RESIZE_STEP_PCT as i16;
+        match dir {
+            ResizeDir::Left | ResizeDir::Right => {
+                let grow_right = matches!(dir, ResizeDir::Right);
+                match self.focus {
+                    // The worktree strip is full-width, not one of the three
+                    // resizable columns — nothing to resize from there.
+                    Focus::Worktree => {}
+                    // Leftmost column: left/right ride the Explorer|Viewer divider.
+                    Focus::Explorer => {
+                        self.move_explorer_viewer_divider(if grow_right { step } else { -step });
+                    }
+                    // Middle column pushes whichever border faces `dir`.
+                    Focus::Viewer => {
+                        if grow_right {
+                            self.move_viewer_terminal_divider(step);
+                        } else {
+                            self.move_explorer_viewer_divider(-step);
+                        }
+                    }
+                    // Rightmost column: left grows it (shrinks Viewer), right shrinks it.
+                    Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => {
+                        self.move_viewer_terminal_divider(if grow_right { step } else { -step });
+                    }
+                }
+            }
+            ResizeDir::Up | ResizeDir::Down => {
+                // Only the Claude/Shell split is vertically adjustable. Down moves
+                // the divider down (Claude grows); Up moves it up (Claude shrinks),
+                // regardless of which of the two terminal panes is focused.
+                if matches!(self.focus, Focus::TerminalClaude | Focus::TerminalShell) {
+                    let delta = if matches!(dir, ResizeDir::Down) {
+                        Self::TERMINAL_SPLIT_STEP as i16
+                    } else {
+                        -(Self::TERMINAL_SPLIT_STEP as i16)
+                    };
+                    self.adjust_terminal_split(delta);
+                }
+            }
+        }
+    }
+
+    /// Move the Explorer|Viewer divider by `delta` points (positive = rightward,
+    /// enlarging Explorer and shrinking Viewer). Terminal width is conserved.
+    /// Clamped so neither Explorer nor Viewer drops below [`Self::MIN_COL_PCT`].
+    fn move_explorer_viewer_divider(&mut self, delta: i16) {
+        let (new_e, new_v) = clamp_ev_divider(
+            self.config.layout.explorer_width_pct,
+            self.config.layout.viewer_width_pct,
+            delta,
+            Self::MIN_COL_PCT,
+        );
+        if new_e == self.config.layout.explorer_width_pct {
+            return;
+        }
+        self.config.layout.explorer_width_pct = new_e;
+        self.config.layout.viewer_width_pct = new_v;
+        self.after_horizontal_resize();
+    }
+
+    /// Move the Viewer|Terminal divider by `delta` points (positive = rightward,
+    /// enlarging Viewer and shrinking Terminal). Explorer width is unchanged.
+    /// Clamped so neither Viewer nor Terminal drops below [`Self::MIN_COL_PCT`].
+    fn move_viewer_terminal_divider(&mut self, delta: i16) {
+        let new_v = clamp_vt_divider(
+            self.config.layout.explorer_width_pct,
+            self.config.layout.viewer_width_pct,
+            delta,
+            Self::MIN_COL_PCT,
+        );
+        if new_v == self.config.layout.viewer_width_pct {
+            return;
+        }
+        self.config.layout.viewer_width_pct = new_v;
+        self.after_horizontal_resize();
+    }
+
+    /// Shared tail for a column resize: redraw, flash the new split, and persist
+    /// the ratios so they survive a restart.
+    fn after_horizontal_resize(&mut self) {
+        self.dirty.mark_all();
+        let e = self.config.layout.explorer_width_pct;
+        let v = self.config.layout.viewer_width_pct;
+        let t = 100u16.saturating_sub(e.saturating_add(v));
+        self.set_status_info(format!("Layout: Explorer {e}% / Viewer {v}% / Terminal {t}%"));
+        self.persist_layout();
+    }
+
     /// Adjust the runtime Claude-area height percentage by `delta` points,
     /// clamped so both the Claude and Shell panes keep a usable minimum. A
     /// positive `delta` enlarges the Claude pane (shrinks the Shell); negative
-    /// enlarges the Shell. Flashes the resulting split as a status message.
+    /// enlarges the Shell. Flashes the resulting split and persists the ratio.
     fn adjust_terminal_split(&mut self, delta: i16) {
         let next = (self.terminal_split_pct as i16 + delta)
             .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
@@ -2161,11 +2280,28 @@ impl App {
             return;
         }
         self.terminal_split_pct = next;
+        // Keep the in-memory config in sync so the appearance snapshot matches
+        // what we write below — that makes the config watcher's reload a no-op
+        // (it only reacts when the snapshot differs), avoiding a self-write loop.
+        self.config.layout.terminal_split_pct = next;
         self.dirty.mark_all();
         self.set_status_info(format!(
             "Terminal split: Claude {next}% / Shell {}%",
             100 - next
         ));
+        self.persist_layout();
+    }
+
+    /// Persist the current panel proportions to `config.toml`. Best-effort: a
+    /// write failure is logged, never fatal (the in-memory layout still applies).
+    fn persist_layout(&self) {
+        if let Err(e) = crate::config::persist_layout_proportions(
+            self.config.layout.explorer_width_pct,
+            self.config.layout.viewer_width_pct,
+            self.terminal_split_pct,
+        ) {
+            log::warn!("failed to persist layout proportions: {e}");
+        }
     }
 
     fn cmd_create_worktree(&mut self) {
@@ -3160,9 +3296,83 @@ pub fn extract_symbol_at_column(line: &str, col: usize) -> Option<(String, usize
     Some((word.to_string(), start_col, end_col))
 }
 
+/// Compute the new `(explorer, viewer)` width percentages after moving the
+/// Explorer|Viewer divider by `delta` points. Explorer+Viewer is conserved
+/// (Terminal width is untouched), and both columns are kept `>= min`. A `delta`
+/// that would push a column below the floor is clamped, so the divider stops at
+/// the boundary rather than overshooting.
+fn clamp_ev_divider(explorer: u16, viewer: u16, delta: i16, min: u16) -> (u16, u16) {
+    let e = explorer as i16;
+    let v = viewer as i16;
+    let min = min as i16;
+    let upper = (e + v - min).max(min);
+    let new_e = (e + delta).clamp(min, upper);
+    (new_e as u16, (e + v - new_e) as u16)
+}
+
+/// Compute the new Viewer width percentage after moving the Viewer|Terminal
+/// divider by `delta` points. Explorer is untouched; Viewer and the implicit
+/// Terminal column (`100 - explorer - viewer`) are each kept `>= min`.
+fn clamp_vt_divider(explorer: u16, viewer: u16, delta: i16, min: u16) -> u16 {
+    let e = explorer as i16;
+    let v = viewer as i16;
+    let min = min as i16;
+    // Terminal = 100 - E - V, so keep new V in [min, 100 - E - min].
+    let upper = (100 - e - min).max(min);
+    (v + delta).clamp(min, upper) as u16
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── tmux-style pane resize divider math ──────────────────────────
+
+    const MIN: u16 = 10;
+
+    #[test]
+    fn ev_divider_moves_space_between_explorer_and_viewer() {
+        // Growing Explorer (delta +5) takes 5 points from Viewer; Terminal
+        // (the conserved remainder) is untouched.
+        assert_eq!(clamp_ev_divider(24, 38, 5, MIN), (29, 33));
+        // Growing Viewer (delta -5) gives 5 points back to Viewer.
+        assert_eq!(clamp_ev_divider(24, 38, -5, MIN), (19, 43));
+        // Explorer + Viewer is always conserved.
+        let (e, v) = clamp_ev_divider(24, 38, 5, MIN);
+        assert_eq!(e + v, 62);
+    }
+
+    #[test]
+    fn ev_divider_clamps_at_min_floor() {
+        // Explorer can't drop below MIN even with a big shrink.
+        assert_eq!(clamp_ev_divider(12, 50, -5, MIN), (10, 52));
+        // Viewer can't drop below MIN even when Explorer wants to grow.
+        assert_eq!(clamp_ev_divider(50, 12, 5, MIN), (52, 10));
+    }
+
+    #[test]
+    fn vt_divider_protects_the_terminal_column() {
+        // Explorer 24, Viewer 38 → Terminal 38. Growing Viewer right eats into
+        // Terminal but never past its MIN floor: max Viewer = 100 - 24 - 10 = 66.
+        assert_eq!(clamp_vt_divider(24, 38, 5, MIN), 43);
+        assert_eq!(clamp_vt_divider(24, 64, 5, MIN), 66); // clamped, Terminal=10
+        // Shrinking Viewer (grow Terminal) is floored at Viewer = MIN.
+        assert_eq!(clamp_vt_divider(24, 12, -5, MIN), 10);
+    }
+
+    #[test]
+    fn dividers_never_let_a_column_vanish() {
+        // Sweep deltas across the full range; all three columns stay >= MIN.
+        for delta in [-50i16, -20, -5, 5, 20, 50] {
+            let (e, v) = clamp_ev_divider(24, 38, delta, MIN);
+            let t = 100u16.saturating_sub(e + v);
+            assert!(e >= MIN && v >= MIN && t >= MIN, "ev delta={delta}: {e}/{v}/{t}");
+
+            let v2 = clamp_vt_divider(24, 38, delta, MIN);
+            let t2 = 100u16.saturating_sub(24 + v2);
+            assert!(v2 >= MIN && t2 >= MIN, "vt delta={delta}: 24/{v2}/{t2}");
+        }
+    }
 
     #[test]
     fn focus_is_pty_only_for_pty_panels() {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -19,8 +19,10 @@ pub enum CommandId {
     NextWorktree,
     PrevWorktree,
     TogglePanelExpand,
-    GrowShell,
-    ShrinkShell,
+    ResizePaneLeft,
+    ResizePaneRight,
+    ResizePaneUp,
+    ResizePaneDown,
 
     // Worktree
     CreateWorktree,
@@ -206,18 +208,32 @@ pub const COMMANDS: &[PaletteCommand] = &[
         keywords: "resize maximize fullscreen",
     },
     PaletteCommand {
-        id: CommandId::GrowShell,
-        label: "Layout: Grow Shell Area",
+        id: CommandId::ResizePaneLeft,
+        label: "Layout: Resize Pane Left",
         category: CommandCategory::Navigation,
-        action: Some(Action::GrowShell),
-        keywords: "resize terminal shell split bigger taller",
+        action: Some(Action::ResizePaneLeft),
+        keywords: "resize pane panel width column shrink grow tmux left",
     },
     PaletteCommand {
-        id: CommandId::ShrinkShell,
-        label: "Layout: Shrink Shell Area",
+        id: CommandId::ResizePaneRight,
+        label: "Layout: Resize Pane Right",
         category: CommandCategory::Navigation,
-        action: Some(Action::ShrinkShell),
-        keywords: "resize terminal shell split smaller shorter claude",
+        action: Some(Action::ResizePaneRight),
+        keywords: "resize pane panel width column shrink grow tmux right",
+    },
+    PaletteCommand {
+        id: CommandId::ResizePaneUp,
+        label: "Layout: Resize Pane Up",
+        category: CommandCategory::Navigation,
+        action: Some(Action::ResizePaneUp),
+        keywords: "resize pane panel height shell claude split shorter taller tmux up",
+    },
+    PaletteCommand {
+        id: CommandId::ResizePaneDown,
+        label: "Layout: Resize Pane Down",
+        category: CommandCategory::Navigation,
+        action: Some(Action::ResizePaneDown),
+        keywords: "resize pane panel height shell claude split shorter taller tmux down",
     },
     // Worktree
     PaletteCommand {

--- a/src/config.rs
+++ b/src/config.rs
@@ -655,10 +655,12 @@ pub fn generate_default_config() -> String {
 # viewer_width_pct = 38                 # viewer column width % (default: 38)
 #                                       # terminal column gets the remaining width
 # terminal_split_pct = 80              # Claude Code area height % within terminal column (default: 80)
-#                                       # shell area receives the remainder; the initial split only —
-#                                       # adjust it live with Ctrl+Alt+Up / Ctrl+Alt+Down (grow/shrink shell)
+#                                       # shell area receives the remainder. These three values are the
+#                                       # initial proportions; resize panels live, tmux-style, with
+#                                       # Ctrl+Alt+Arrow (grows the focused panel toward the arrow) and
+#                                       # conductor writes the new ratios back here automatically.
 #                                       # These proportions apply in the default layout only;
-#                                       # maximizing a panel (Alt+m) overrides them temporarily.
+#                                       # maximizing a panel (Ctrl+Alt+Z) overrides them temporarily.
 "#,
     )
 }
@@ -684,60 +686,64 @@ pub fn persist_ui_theme(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Return `true` when `line` is a `[ui]` TOML section header, possibly followed
-/// by whitespace and/or an inline comment (e.g. `[ui]  # colors`).
+/// Return `true` when `line` is a bare `[section]` TOML header, possibly
+/// followed by whitespace and/or an inline comment (e.g. `[ui]  # colors`).
 /// Sub-sections like `[ui.fonts]` are deliberately excluded.
-fn is_ui_section_header(line: &str) -> bool {
+fn is_section_header(line: &str, section: &str) -> bool {
     let trimmed = line.trim();
-    // Must start with exactly `[ui]` (not `[ui.something]`).
-    if !trimmed.starts_with("[ui]") {
+    let bracket = format!("[{section}]");
+    if !trimmed.starts_with(&bracket) {
         return false;
     }
-    // After `[ui]` only whitespace and/or a `#` comment may follow.
-    let after = trimmed["[ui]".len()..].trim_start();
+    // After `[section]` only whitespace and/or a `#` comment may follow.
+    let after = trimmed[bracket.len()..].trim_start();
     after.is_empty() || after.starts_with('#')
 }
 
-/// Pure function: upsert `theme = "<name>"` in the `[ui]` section of a
-/// config file string, preserving all comments and surrounding content.
+/// Pure function: upsert `<key> = <value>` in the `[section]` table of a config
+/// file string, preserving all comments and surrounding content.
 ///
-/// Extracted as a testable helper so file I/O in `persist_ui_theme` can be
-/// tested independently. Called transitively via `set_theme`.
-fn upsert_ui_theme(contents: &str, name: &str) -> String {
-    let theme_line = format!("theme = \"{name}\"");
+/// - If the section has an uncommented `key = ...` line, it is replaced in place.
+/// - If the section exists but has no uncommented `key` line (e.g. only the
+///   commented default), the line is inserted right after the section header.
+/// - If the section does not exist, `\n[section]\n<key> = <value>\n` is appended.
+///
+/// `value` must already be formatted as valid TOML (quote strings yourself).
+/// Extracted as a testable helper so file I/O stays separable from the edit.
+fn upsert_section_kv(contents: &str, section: &str, key: &str, value: &str) -> String {
+    let kv_line = format!("{key} = {value}");
     let lines: Vec<&str> = contents.lines().collect();
 
-    // Locate the [ui] section header.
-    // Match `[ui]` with optional trailing whitespace/comment, e.g. `[ui]  # colors`,
-    // but NOT sub-sections like `[ui.colors]`.
-    let ui_start = lines.iter().position(|l| is_ui_section_header(l));
+    let sec_start = lines.iter().position(|l| is_section_header(l, section));
 
-    if let Some(ui_idx) = ui_start {
+    if let Some(sec_idx) = sec_start {
         // End of section = next bare `[...]` header (not a comment).
-        let ui_end = lines[ui_idx + 1..]
+        let sec_end = lines[sec_idx + 1..]
             .iter()
             .position(|l| {
                 let t = l.trim();
                 t.starts_with('[') && !t.starts_with('#')
             })
-            .map(|i| ui_idx + 1 + i)
+            .map(|i| sec_idx + 1 + i)
             .unwrap_or(lines.len());
 
-        // Look for an existing uncommented `theme = ...` key within the section.
-        let existing_theme_idx = lines[ui_idx + 1..ui_end]
+        // Look for an existing uncommented `key = ...` line within the section.
+        let key_eq = format!("{key} =");
+        let key_eq_tight = format!("{key}=");
+        let existing_idx = lines[sec_idx + 1..sec_end]
             .iter()
             .position(|l| {
                 let t = l.trim();
-                !t.starts_with('#') && (t.starts_with("theme =") || t.starts_with("theme="))
+                !t.starts_with('#') && (t.starts_with(&key_eq) || t.starts_with(&key_eq_tight))
             })
-            .map(|i| ui_idx + 1 + i);
+            .map(|i| sec_idx + 1 + i);
 
         let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
-        if let Some(idx) = existing_theme_idx {
-            result_lines[idx] = theme_line;
+        if let Some(idx) = existing_idx {
+            result_lines[idx] = kv_line;
         } else {
-            // No uncommented theme line in the section — insert right after [ui].
-            result_lines.insert(ui_idx + 1, theme_line);
+            // No uncommented key line in the section — insert right after the header.
+            result_lines.insert(sec_idx + 1, kv_line);
         }
 
         let mut result = result_lines.join("\n");
@@ -746,14 +752,56 @@ fn upsert_ui_theme(contents: &str, name: &str) -> String {
         }
         result
     } else {
-        // No [ui] section at all — append one.
+        // No such section at all — append one.
         let mut result = contents.to_string();
         if !result.ends_with('\n') && !result.is_empty() {
             result.push('\n');
         }
-        result.push_str(&format!("\n[ui]\n{theme_line}\n"));
+        result.push_str(&format!("\n[{section}]\n{kv_line}\n"));
         result
     }
+}
+
+/// Pure function: upsert `theme = "<name>"` in the `[ui]` section. Thin wrapper
+/// over [`upsert_section_kv`] kept for call-site clarity and its dedicated tests.
+fn upsert_ui_theme(contents: &str, name: &str) -> String {
+    upsert_section_kv(contents, "ui", "theme", &format!("\"{name}\""))
+}
+
+/// Persist the runtime panel proportions to the `[layout]` section of
+/// `~/.config/conductor/config.toml`, preserving comments and structure.
+///
+/// Called after a tmux-style pane resize so the chosen ratios survive restarts.
+/// The three values are the explorer/viewer column width percentages and the
+/// Claude-area height percentage within the terminal column. Writing this file
+/// trips the config watcher, but `reload_appearance_config` no-ops because the
+/// running config already holds these values (the appearance snapshot matches).
+pub fn persist_layout_proportions(
+    explorer_width_pct: u16,
+    viewer_width_pct: u16,
+    terminal_split_pct: u16,
+) -> Result<()> {
+    let path = config_file_path();
+    let contents = if path.exists() {
+        std::fs::read_to_string(&path)?
+    } else {
+        generate_default_config()
+    };
+    let updated = upsert_section_kv(
+        &contents,
+        "layout",
+        "explorer_width_pct",
+        &explorer_width_pct.to_string(),
+    );
+    let updated = upsert_section_kv(&updated, "layout", "viewer_width_pct", &viewer_width_pct.to_string());
+    let updated = upsert_section_kv(
+        &updated,
+        "layout",
+        "terminal_split_pct",
+        &terminal_split_pct.to_string(),
+    );
+    std::fs::write(&path, updated)?;
+    Ok(())
 }
 
 /// Default review prompt template (Japanese).
@@ -916,6 +964,44 @@ theme = "catppuccin-latte"
     }
 
     #[test]
+    fn upsert_section_kv_inserts_layout_value_over_commented_default() {
+        // The generated config ships layout keys commented out; a resize must
+        // insert a live value after the header while keeping the comment.
+        let contents = "[layout]\n# explorer_width_pct = 24    # default\n";
+        let result = upsert_section_kv(contents, "layout", "explorer_width_pct", "30");
+        assert!(result.contains("explorer_width_pct = 30"));
+        assert!(result.contains("# explorer_width_pct = 24"));
+    }
+
+    #[test]
+    fn upsert_section_kv_replaces_existing_layout_value() {
+        let contents = "[layout]\nexplorer_width_pct = 24\nviewer_width_pct = 38\n";
+        let result = upsert_section_kv(contents, "layout", "viewer_width_pct", "42");
+        assert_eq!(result, "[layout]\nexplorer_width_pct = 24\nviewer_width_pct = 42\n");
+    }
+
+    #[test]
+    fn upsert_section_kv_chains_for_all_three_layout_keys() {
+        // Mirrors persist_layout_proportions: three sequential upserts land in
+        // the same [layout] table without clobbering each other.
+        let contents = "[layout]\n# explorer_width_pct = 24\n# viewer_width_pct = 38\n# terminal_split_pct = 80\n\n[ui]\ntheme = \"nord\"\n";
+        let r = upsert_section_kv(contents, "layout", "explorer_width_pct", "30");
+        let r = upsert_section_kv(&r, "layout", "viewer_width_pct", "40");
+        let r = upsert_section_kv(&r, "layout", "terminal_split_pct", "65");
+        assert!(r.contains("explorer_width_pct = 30"));
+        assert!(r.contains("viewer_width_pct = 40"));
+        assert!(r.contains("terminal_split_pct = 65"));
+        // Adjacent section is untouched.
+        assert!(r.contains("[ui]"));
+        assert!(r.contains("theme = \"nord\""));
+        // Round-trips as valid TOML reflecting the new values.
+        let cfg: Config = toml::from_str(&r).expect("layout edits stay valid TOML");
+        assert_eq!(cfg.layout.explorer_width_pct, 30);
+        assert_eq!(cfg.layout.viewer_width_pct, 40);
+        assert_eq!(cfg.layout.terminal_split_pct, 65);
+    }
+
+    #[test]
     fn upsert_ui_theme_replaces_existing_theme_line() {
         let contents = "[ui]\ntheme = \"dracula\"\n";
         let result = upsert_ui_theme(contents, "github-light");
@@ -982,14 +1068,17 @@ theme = "catppuccin-latte"
     }
 
     #[test]
-    fn is_ui_section_header_cases() {
-        assert!(super::is_ui_section_header("[ui]"));
-        assert!(super::is_ui_section_header("[ui]  "));
-        assert!(super::is_ui_section_header("[ui]  # comment"));
-        assert!(super::is_ui_section_header("  [ui]"));
-        assert!(!super::is_ui_section_header("[ui.sub]"));
-        assert!(!super::is_ui_section_header("[ui.colors]"));
-        assert!(!super::is_ui_section_header("[viewer]"));
+    fn is_section_header_cases() {
+        assert!(super::is_section_header("[ui]", "ui"));
+        assert!(super::is_section_header("[ui]  ", "ui"));
+        assert!(super::is_section_header("[ui]  # comment", "ui"));
+        assert!(super::is_section_header("  [ui]", "ui"));
+        assert!(!super::is_section_header("[ui.sub]", "ui"));
+        assert!(!super::is_section_header("[ui.colors]", "ui"));
+        assert!(!super::is_section_header("[viewer]", "ui"));
+        // Generic over the section name.
+        assert!(super::is_section_header("[layout]", "layout"));
+        assert!(!super::is_section_header("[layout]", "ui"));
     }
 
     #[test]

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -60,7 +60,7 @@
 "alt+4" = "focus_viewer"
 "alt+5" = "focus_terminal_claude"
 "alt+6" = "focus_terminal_shell"
-# Focus a panel with alt/super+digit, then maximize it with alt+m (below) —
+# Focus a panel with alt/super+digit, then maximize it with ctrl+alt+z (below) —
 # this replaces the old hard-to-press alt+shift+digit "focus+expand" combo.
 # macOS Option-produces-Unicode fallback (US layout): Option+1='¡' … Option+6='§'.
 "¡" = "focus_worktree"
@@ -70,15 +70,20 @@
 "∞" = "focus_terminal_claude"
 "§" = "focus_terminal_shell"
 "ctrl+g" = "search_full_text"
-"super+space" = "toggle_panel_expand"
-# alt+m — maximize/zoom the focused panel. Reliable everywhere (super+space's
-# Cmd is eaten by macOS/terminals); the easy half of "focus then zoom".
-"alt+m" = "toggle_panel_expand"
-# Resize the Claude/Shell vertical split at runtime (the Shell starts small).
-# Ctrl+Alt+Up grows the Shell (divider up); Ctrl+Alt+Down shrinks it. These fire
-# even with the Shell (a terminal) focused, so you can resize while typing in it.
-"ctrl+alt+up" = "grow_shell"
-"ctrl+alt+down" = "shrink_shell"
+# ── Layout: tmux-style pane sizing (the ctrl+alt family) ───────────────────────
+# Resize the focused panel: Ctrl+Alt+Arrow grows the focused panel toward the
+# arrow (against an edge it shrinks instead), moving the shared divider and
+# re-distributing space to the neighbor. Left/Right move the column dividers
+# (Explorer|Viewer|Terminal); Up/Down move the Claude|Shell split while a
+# terminal is focused. These fire even with a terminal focused, so you can resize
+# while typing in it, and the new ratios are persisted to config.toml.
+"ctrl+alt+left" = "resize_pane_left"
+"ctrl+alt+right" = "resize_pane_right"
+"ctrl+alt+up" = "resize_pane_up"
+"ctrl+alt+down" = "resize_pane_down"
+# Ctrl+Alt+Z — maximize/restore (zoom) the focused panel, tmux's `prefix z`.
+# Same ctrl+alt family as the resize chords; works over a PTY too.
+"ctrl+alt+z" = "toggle_panel_expand"
 "alt+/" = "toggle_panel_overlay"
 # macOS Unicode fallback (Option+/ = '÷', US layout).
 "÷" = "toggle_panel_overlay"

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -147,12 +147,20 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.toggle_panel_overlay();
             true
         }
-        Action::GrowShell => {
-            app.grow_shell();
+        Action::ResizePaneLeft => {
+            app.resize_focused_pane(crate::app::ResizeDir::Left);
             true
         }
-        Action::ShrinkShell => {
-            app.shrink_shell();
+        Action::ResizePaneRight => {
+            app.resize_focused_pane(crate::app::ResizeDir::Right);
+            true
+        }
+        Action::ResizePaneUp => {
+            app.resize_focused_pane(crate::app::ResizeDir::Up);
+            true
+        }
+        Action::ResizePaneDown => {
+            app.resize_focused_pane(crate::app::ResizeDir::Down);
             true
         }
         Action::OpenThemePicker => {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -145,10 +145,14 @@ pub enum Action {
     // ── Panel layout ────────────────────────────────────────────
     TogglePanelExpand,
     TogglePanelOverlay,
-    /// Grow the Shell area (move the Claude/Shell divider up).
-    GrowShell,
-    /// Shrink the Shell area (move the Claude/Shell divider down).
-    ShrinkShell,
+    /// Grow the focused panel toward the left (tmux `resize-pane -L`).
+    ResizePaneLeft,
+    /// Grow the focused panel toward the right (tmux `resize-pane -R`).
+    ResizePaneRight,
+    /// Grow the focused panel upward (tmux `resize-pane -U`).
+    ResizePaneUp,
+    /// Grow the focused panel downward (tmux `resize-pane -D`).
+    ResizePaneDown,
 
     // ── UI ──────────────────────────────────────────────────────
     /// Open the theme picker overlay to switch the UI color theme at runtime.
@@ -239,8 +243,10 @@ impl Action {
             "inline_reply" => Some(Action::InlineReply),
             "toggle_panel_expand" => Some(Action::TogglePanelExpand),
             "toggle_panel_overlay" => Some(Action::TogglePanelOverlay),
-            "grow_shell" => Some(Action::GrowShell),
-            "shrink_shell" => Some(Action::ShrinkShell),
+            "resize_pane_left" => Some(Action::ResizePaneLeft),
+            "resize_pane_right" => Some(Action::ResizePaneRight),
+            "resize_pane_up" => Some(Action::ResizePaneUp),
+            "resize_pane_down" => Some(Action::ResizePaneDown),
             "open_theme_picker" => Some(Action::OpenThemePicker),
             _ => None,
         }
@@ -330,8 +336,10 @@ impl Action {
             Action::InlineReply => "inline_reply",
             Action::TogglePanelExpand => "toggle_panel_expand",
             Action::TogglePanelOverlay => "toggle_panel_overlay",
-            Action::GrowShell => "grow_shell",
-            Action::ShrinkShell => "shrink_shell",
+            Action::ResizePaneLeft => "resize_pane_left",
+            Action::ResizePaneRight => "resize_pane_right",
+            Action::ResizePaneUp => "resize_pane_up",
+            Action::ResizePaneDown => "resize_pane_down",
             Action::OpenThemePicker => "open_theme_picker",
         }
     }
@@ -368,10 +376,13 @@ impl Action {
                 | Action::PrevWorktree
                 | Action::TogglePanelExpand
                 | Action::TogglePanelOverlay
-                // Resizing the Claude/Shell split is most useful with the Shell
-                // (a terminal) focused, so these must fire over a PTY too.
-                | Action::GrowShell
-                | Action::ShrinkShell
+                // Pane resizing is most useful with a terminal focused (resize
+                // the Claude/Shell split or the terminal column while typing in
+                // it), so these must fire over a PTY too.
+                | Action::ResizePaneLeft
+                | Action::ResizePaneRight
+                | Action::ResizePaneUp
+                | Action::ResizePaneDown
         )
     }
 }
@@ -766,12 +777,16 @@ mod tests {
     #[test]
     fn worktree_switch_and_zoom_aliases_resolve() {
         // alt+]/alt+[ are the kitty-protocol-free aliases for ctrl+tab worktree
-        // switching; alt+m zooms the focused panel (replacing alt+shift+digit).
+        // switching; ctrl+alt+z zooms the focused panel (tmux `prefix z`), joining
+        // the ctrl+alt pane-sizing family.
         let km = default_keymap();
         let cases = [
             (KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT), Action::NextWorktree),
             (KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT), Action::PrevWorktree),
-            (KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT), Action::TogglePanelExpand),
+            (
+                KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL | KeyModifiers::ALT),
+                Action::TogglePanelExpand,
+            ),
         ];
         for (key, action) in cases {
             assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "{key:?}");
@@ -887,9 +902,10 @@ mod tests {
             km.resolve(&alt_l, KeyContext::Editor),
             Some(Action::CycleFocusForward)
         );
-        let alt_m = KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT);
+        let ctrl_alt_z =
+            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL | KeyModifiers::ALT);
         assert_eq!(
-            km.resolve(&alt_m, KeyContext::Editor),
+            km.resolve(&ctrl_alt_z, KeyContext::Editor),
             Some(Action::TogglePanelExpand)
         );
     }

--- a/src/ui/editor_panel.rs
+++ b/src/ui/editor_panel.rs
@@ -59,7 +59,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let title_line = ratatui::text::Line::from(vec![
         Span::styled(format!(" EDIT — {title} "), title_style),
         Span::styled(
-            ":q close · Ctrl+Esc Claude · alt+m zoom",
+            ":q close · Ctrl+Esc Claude · ctrl+alt+z zoom",
             Style::default().fg(muted),
         ),
     ]);


### PR DESCRIPTION
## Summary

Adds tmux-style resizing for the three-column accordion (Explorer | Viewer | Terminal) and the Claude | Shell vertical split.

- **`Ctrl+Alt+Arrow`** — resize the focused panel tmux-style. Left/Right move the column dividers; Up/Down move the Claude|Shell split while a terminal is focused. Growing toward an edge shrinks instead, redistributing space to the neighbor. The chords fire even with a terminal (PTY) focused, so you can resize while typing in it.
- **`Ctrl+Alt+Z`** — maximize / restore (zoom) the focused panel, mirroring tmux's `prefix z`. Replaces the old `Alt+m` / `super+space` maximize bindings.
- New keymap actions: `resize_pane_left/right/up/down` (replacing `grow_shell` / `shrink_shell`).
- Panel ratios are **persisted to `config.toml`**, so a customized layout survives restarts.
- Docs (`README.md`, `CLAUDE.md`) and `default_keybinds.toml` updated to describe the new `ctrl+alt` layout family.
- Version bumped `0.78.0` → `0.79.0` (MINOR: backward-compatible feature addition).

## Test plan

- [ ] `cargo build` / `cargo clippy` pass
- [ ] `Ctrl+Alt+Left/Right` resizes the Explorer/Viewer/Terminal columns and the divider moves toward the focused panel
- [ ] `Ctrl+Alt+Up/Down` resizes the Claude|Shell split while a terminal is focused (works while typing in the PTY)
- [ ] Resizing against an edge shrinks the panel instead of overflowing
- [ ] `Ctrl+Alt+Z` maximizes and restores the focused panel
- [ ] Adjusted ratios persist across a restart (written to `config.toml`)
