### PR TITLE
fix: reflow scrollback session selection after resume, instant exit, queued-input display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.79.0"
+version = "0.79.1"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -566,22 +566,14 @@ pub struct App {
     pub reflow: ReflowView,
 }
 
-/// Direction of the reflow view entry/exit sweep animation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SweepDir {
-    /// Sweep front moves top-to-bottom (entering the transcript view).
-    In,
-    /// Sweep front moves bottom-to-top (returning to the live PTY).
-    Out,
-}
-
-/// Active sweep animation for the reflow transcript view.
+/// Active entry animation for the reflow transcript view.
 ///
-/// Holds the direction and the `Instant` the animation started so that
-/// `reflow_view::render` can compute progress via elapsed time without any
-/// frame-counter dependency.
+/// Holds the `Instant` the animation started so that `reflow_view::render` can
+/// compute progress via elapsed time without any frame-counter dependency.
+/// Only the *entry* transition is animated — it masks the initial
+/// `build_lines` latency. Leaving the view swaps back to the live PTY
+/// immediately (no exit animation) so returning to the prompt feels instant.
 pub struct Sweep {
-    pub dir: SweepDir,
     pub start: std::time::Instant,
 }
 
@@ -704,58 +696,41 @@ impl App {
             .active_claude_session
             .and_then(|idx| self.terminal.pty_manager.claude_session_ref(idx));
 
-        let (working_dir, session_id) = match resolved {
-            Some(pair) => pair,
+        // Working dir of the selected worktree, used for the mtime fallback.
+        let working_dir = match self.worktrees.get(self.selected_worktree) {
+            Some(wt) => wt.path.clone(),
             None => {
-                // Fallback for panels without a tracked id (e.g. sessions that
-                // predate id pinning): use the selected worktree's latest log.
-                let working_dir = match self.worktrees.get(self.selected_worktree) {
-                    Some(wt) => wt.path.clone(),
-                    None => {
-                        self.set_status(
-                            "No worktree selected for transcript view".to_string(),
-                            StatusLevel::Warning,
-                        );
-                        return;
-                    }
-                };
-                let canonical =
-                    std::fs::canonicalize(&working_dir).unwrap_or_else(|_| working_dir.clone());
-                let session = match crate::claude_sessions::find_latest_sessions_for_paths(
-                    std::slice::from_ref(&working_dir),
-                ) {
-                    Ok(mut map) => map.remove(&canonical),
-                    Err(e) => {
-                        log::warn!("reflow: cannot look up session: {e}");
-                        None
-                    }
-                };
-                match session {
-                    Some(s) => (working_dir, s.session_id),
-                    None => {
-                        self.set_status(
-                            "No Claude session found for this worktree".to_string(),
-                            StatusLevel::Info,
-                        );
-                        return;
-                    }
-                }
+                self.set_status(
+                    "No worktree selected for transcript view".to_string(),
+                    StatusLevel::Warning,
+                );
+                return;
             }
         };
 
-        let jsonl_path =
-            match crate::claude_sessions::session_jsonl_path(&working_dir, &session_id) {
-                Some(p) => p,
-                None => {
-                    self.set_status(
-                        "Cannot resolve session file path".to_string(),
-                        StatusLevel::Warning,
-                    );
-                    return;
-                }
-            };
+        // 1. Prefer the active panel's pinned session id. When a worktree hosts
+        //    several Claude panels (CC:1, CC:2, …) this ties the transcript to
+        //    the panel actually on screen, avoiding cross-panel scroll bleed.
+        let mut entries = resolved
+            .and_then(|(wd, sid)| crate::claude_sessions::session_jsonl_path(&wd, &sid))
+            .map(|path| crate::claude_log::load_session(&path))
+            .unwrap_or_default();
 
-        let entries = crate::claude_log::load_session(&jsonl_path);
+        // 2. Fall back to the most-recently-written log in this worktree's
+        //    project dir when the pinned session is missing or empty. This is
+        //    what catches a manual in-app `/resume`: it switches the live
+        //    session id away from the conductor-launched (pinned) one, so the
+        //    pinned file is stale/empty while the real transcript is whatever
+        //    Claude is now appending to (= freshest mtime). Empty/aux logs
+        //    (e.g. one-shot security-review runs sharing the dir) are skipped.
+        if entries.is_empty() {
+            entries = crate::claude_sessions::session_logs_by_mtime(&working_dir)
+                .iter()
+                .map(|path| crate::claude_log::load_session(path))
+                .find(|e| !e.is_empty())
+                .unwrap_or_default();
+        }
+
         if entries.is_empty() {
             self.set_status(
                 "Session log is empty or unreadable".to_string(),
@@ -782,7 +757,6 @@ impl App {
             // its complement over TRANSITION_DURATION_MS, masking the initial
             // build_lines latency.
             sweep: Some(Sweep {
-                dir: SweepDir::In,
                 start: std::time::Instant::now(),
             }),
         };
@@ -794,19 +768,23 @@ impl App {
         self.reflow.sweep = None;
         // Reset Claude scrollback so the live tail is shown immediately.
         self.terminal.scroll_claude = 0;
+        // Force a fresh PTY snapshot on the next frame. While the reflow view
+        // was up the PTY panel rendered nothing, so `cache_claude` holds the
+        // pre-scrollback frame. If no new output happens to arrive right after
+        // closing (e.g. Claude is idle at its prompt), the stale cache would
+        // otherwise persist and the input box would not reappear. Clearing the
+        // cache and marking it dirty rebuilds the live tail immediately.
+        self.terminal.cache_claude = Default::default();
+        self.terminal.dirty_claude = true;
     }
 
-    /// Begin the exit sweep animation rather than closing immediately.
+    /// Leave the reflow transcript view, returning to the live PTY immediately.
     ///
-    /// Sets `sweep` to a `SweepDir::Out` animation so `reflow_view::render`
-    /// plays the bottom-to-top wipe before calling `close_reflow()` once the
-    /// animation completes. Focus-loss closes the view immediately via
-    /// `set_focus` without a sweep (the panel disappears anyway).
+    /// Kept as a distinct entry point from `close_reflow` for the keybind/scroll
+    /// call sites, but there is no exit animation: the content swaps back to the
+    /// live tail on the same frame so returning to the prompt feels instant.
     pub fn request_close_reflow(&mut self) {
-        self.reflow.sweep = Some(Sweep {
-            dir: SweepDir::Out,
-            start: std::time::Instant::now(),
-        });
+        self.close_reflow();
     }
 
     /// Returns `true` when any overlay popup is visible on top of the main panels.

--- a/src/claude_log.rs
+++ b/src/claude_log.rs
@@ -23,6 +23,15 @@ pub struct LogRecord {
     pub is_sidechain: bool,
     #[serde(default)]
     pub message: Option<Message>,
+    /// `queue-operation` records carry the queued text at the top level (not in
+    /// `message`) and an `operation` discriminator. A user prompt typed while
+    /// Claude is still working is recorded as `operation: "enqueue"` here and
+    /// never re-emitted as a `user` record, so the transcript must read it from
+    /// these fields or the input is lost from the scrollback.
+    #[serde(default)]
+    pub operation: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
 }
 
 /// The `message` field present on `user` and `assistant` records.
@@ -233,6 +242,23 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
                 continue;
             }
         };
+
+        // A prompt queued while Claude is working is stored as a
+        // `queue-operation` enqueue, with the text at the top level. Surface it
+        // as a user turn so the user's own input appears in the transcript; the
+        // matching `remove` (dequeue) carries no text and is ignored.
+        if record.kind == "queue-operation" {
+            if record.operation.as_deref() == Some("enqueue")
+                && let Some(text) = record.content.filter(|s| !s.is_empty())
+            {
+                entries.push(LogEntry {
+                    role: Role::User,
+                    model: None,
+                    blocks: vec![DisplayBlock::Text(text)],
+                });
+            }
+            continue;
+        }
 
         // Only process `user` and `assistant` turns; skip sidechain records.
         if record.kind != "user" && record.kind != "assistant" {
@@ -509,6 +535,27 @@ mod tests {
         assert_eq!(entries[0].role, Role::User);
         assert_eq!(entries[1].role, Role::Assistant);
         assert_eq!(entries[2].role, Role::User);
+    }
+
+    #[test]
+    fn load_session_includes_enqueued_prompts_skips_removes() {
+        // A prompt typed while Claude is busy is an `enqueue` queue-operation
+        // (top-level content); the dequeue is a contentless `remove`.
+        let f = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":"first"}}"#,
+            r#"{"type":"queue-operation","operation":"enqueue","content":"typed while busy"}"#,
+            r#"{"type":"queue-operation","operation":"remove","content":""}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"reply"}}"#,
+        ]);
+        let entries = load_session(f.path());
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].role, Role::User);
+        assert_eq!(entries[1].role, Role::User);
+        assert!(
+            matches!(&entries[1].blocks[0], DisplayBlock::Text(t) if t == "typed while busy"),
+            "enqueued prompt text should be surfaced as a user turn"
+        );
+        assert_eq!(entries[2].role, Role::Assistant);
     }
 
     #[test]

--- a/src/claude_sessions.rs
+++ b/src/claude_sessions.rs
@@ -263,6 +263,53 @@ fn projects_dir_for(working_dir: &Path) -> Option<PathBuf> {
     Some(home.join(".claude").join("projects").join(encoded))
 }
 
+/// List the session `.jsonl` files in a worktree's Claude project directory,
+/// most recently modified first.
+///
+/// This is the basis for the reflow transcript view's session selection: the
+/// file Claude is *currently appending to* always has the freshest mtime, so
+/// picking by mtime tracks whatever session the live pane shows — including a
+/// session the user switched to with a manual `/resume` (which can mint a new
+/// session ID). That is more reliable than re-deriving the session from
+/// `history.jsonl`, whose newest entry can point at an unrelated auxiliary
+/// session (e.g. a one-shot security review run in the same directory) or at a
+/// freshly-spawned-but-empty session.
+///
+/// The working dir is canonicalized first because Claude Code encodes its
+/// *resolved* cwd; symlinked worktree paths would otherwise miss the directory.
+/// Symlinked session files (created by `migrate_session` for grabbed branches)
+/// are followed via `metadata()`; dangling or unreadable entries are skipped.
+pub fn session_logs_by_mtime(working_dir: &Path) -> Vec<PathBuf> {
+    let canonical = std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
+    let dir = match projects_dir_for(&canonical) {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+
+    let read_dir = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        // metadata() follows symlinks, so a migrated session resolves to its
+        // real file's mtime; a dangling symlink errors out and is skipped.
+        if let Ok(meta) = std::fs::metadata(&path)
+            && let Ok(mtime) = meta.modified()
+        {
+            files.push((mtime, path));
+        }
+    }
+
+    files.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+    files.into_iter().map(|(_, p)| p).collect()
+}
+
 /// Migrate a Claude Code session from one project directory to another by
 /// creating symlinks. This allows `claude --resume <id>` to find the session
 /// when run from a different working directory (e.g. main worktree after grab).

--- a/src/pty_manager.rs
+++ b/src/pty_manager.rs
@@ -21,10 +21,17 @@ use uuid::Uuid;
 /// Maximum number of raw PTY output bytes retained per session for
 /// reflow-on-resize. When the terminal width changes, vt100 cannot reflow
 /// existing content, so the parser is rebuilt by replaying this byte history
-/// at the new width. The cap is sized to comfortably exceed the vt100
-/// scrollback (a few thousand lines), so eviction only ever drops content
-/// already scrolled out of reach. Old bytes are trimmed at line boundaries.
-const MAX_RAW_HISTORY_BYTES: usize = 2 * 1024 * 1024;
+/// at the new width.
+///
+/// This replay runs synchronously on the main thread inside `resize_session`,
+/// so its cost is paid as a UI stall on *every* width change — panel maximize,
+/// focus shifts that resize the shared right column, Tab, tmux-style resize.
+/// The cap is therefore kept modest: 512 KiB still covers well over the
+/// default active scrollback (10 000 lines at typical shell line lengths) while
+/// keeping a worst-case replay to a single-frame stall instead of tens of ms.
+/// Bytes beyond the cap are trimmed at line boundaries — the only content lost
+/// to reflow is history already far out of view.
+const MAX_RAW_HISTORY_BYTES: usize = 512 * 1024;
 
 // ---------------------------------------------------------------------------
 // SessionKind

--- a/src/ui/reflow_view.rs
+++ b/src/ui/reflow_view.rs
@@ -31,7 +31,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, SweepDir};
+use crate::app::App;
 use crate::claude_log::{DisplayBlock, Role};
 use crate::theme::Theme;
 
@@ -152,33 +152,15 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         .collect();
 
     // ── Transition completion ─────────────────────────────────────────────────
-    // Drive the entry/exit transition timer. `SweepDir` is Copy so we snapshot
-    // direction and progress before dropping the borrow on `app.reflow`, then
-    // apply any completion side-effects. The border color transition is painted
-    // in `terminal_claude::render`, not here.
-    let transition_state = app.reflow.sweep.as_ref().map(|s| {
-        (
-            s.dir,
-            crate::event::reflow::sweep_progress(
-                &s.start,
-                crate::event::reflow::TRANSITION_DURATION_MS,
-            ),
-        )
+    // Drive the entry transition timer: once the entry sweep elapses, clear it
+    // so the border rests on the steady read-mode color. The border color
+    // transition itself is painted in `terminal_claude::render`, not here.
+    let entry_done = app.reflow.sweep.as_ref().is_some_and(|s| {
+        crate::event::reflow::sweep_progress(&s.start, crate::event::reflow::TRANSITION_DURATION_MS)
+            >= 1.0
     });
-
-    if let Some((dir, p)) = transition_state
-        && p >= 1.0
-    {
-        match dir {
-            SweepDir::In => {
-                app.reflow.sweep = None;
-            }
-            SweepDir::Out => {
-                // close_reflow sets active=false; the next frame renders
-                // the live PTY instead of this view.
-                app.close_reflow();
-            }
-        }
+    if entry_done {
+        app.reflow.sweep = None;
     }
 
     // No .wrap(): `markdown_cache.render` already produces lines ≤ `body_width`

--- a/src/ui/terminal_claude.rs
+++ b/src/ui/terminal_claude.rs
@@ -167,10 +167,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         Block::default()
     } else {
         // Border color while reflow is active: the complement of the accent is
-        // the persistent read-mode cue. During the entry/exit transition the
-        // border glides smoothly between the accent and that complement (a
-        // single gentle gradient, no flicker); otherwise it's the normal
-        // focus/unfocus color.
+        // the persistent read-mode cue. During the entry transition the border
+        // glides smoothly from the accent to that complement (a single gentle
+        // gradient, no flicker); leaving the view is instant, so there is no
+        // exit gradient; otherwise it's the normal focus/unfocus color.
         // Focus-gated to match the reflow render guard below: while the panel is
         // unfocused it shows the live PTY (reflow is preserved but not rendered),
         // so the read-mode complement would be a misleading border cue there.
@@ -182,12 +182,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                     crate::event::reflow::TRANSITION_DURATION_MS,
                 );
                 let t = crate::event::reflow::transition_eased(p);
-                match sweep.dir {
-                    // Entering read mode: accent → complement.
-                    crate::app::SweepDir::In => crate::theme::Theme::lerp(theme.accent, complement, t),
-                    // Leaving read mode: complement → accent, then close_reflow.
-                    crate::app::SweepDir::Out => crate::theme::Theme::lerp(complement, theme.accent, t),
-                }
+                // Entering read mode: accent → complement.
+                crate::theme::Theme::lerp(theme.accent, complement, t)
             } else {
                 // Steady read mode: rest on the complement.
                 complement


### PR DESCRIPTION
## Summary

Fixes several issues in the Claude reflow transcript (infinite-scrollback) view, found while dogfooding after a manual `/resume`.

- **Scrollback empty after manual `/resume`** — `open_reflow` now falls back to the most-recently-written `.jsonl` in the worktree's Claude project dir (`session_logs_by_mtime`) when the panel's pinned session id is missing or its log is empty. A manual in-app `/resume` switches the live session id away from the conductor-launched (pinned) one, so the pinned file was stale/empty while the real transcript lived in whatever Claude is now appending to. The pinned session id is still preferred first (keeps the multi-panel CC:1/CC:2 fix), with the mtime scan as fallback. Empty/auxiliary logs (e.g. one-shot security-review runs sharing the dir) are skipped.
- **Lag returning to the live prompt** — leaving the view was playing a 500 ms `SweepDir::Out` animation before closing. Exit is now instant (content swaps back to the live tail on the same frame); the entry transition that masks load latency is kept. `SweepDir` is simplified to entry-only.
- **Input box not reappearing after scrollback** — while the reflow view was up the PTY panel rendered nothing, so `cache_claude` held the pre-scrollback frame; if Claude was idle on exit, the stale cache persisted and the prompt did not redraw. `close_reflow` now clears the cache and marks it dirty to force a fresh live snapshot.
- **Own queued input missing from the transcript** — prompts typed while Claude is working are recorded as `queue-operation` (`enqueue`, text at top level) and never re-emitted as `user` records, so they were dropped. `load_session` now surfaces enqueues as user turns (ignoring the contentless `remove` dequeue).
- **Claude panel sluggishness** — the shell reflow-on-resize replay (`MAX_RAW_HISTORY_BYTES`) ran synchronously on the main thread on every shared right-column width change (maximize, focus, Tab, tmux-style resize), stalling the UI. Cap lowered 2 MiB -> 512 KiB, keeping the worst-case replay to ~one frame while still covering the default scrollback.

## Test plan

- `cargo test` — 470 passed (incl. new `load_session_includes_enqueued_prompts_skips_removes`).
- `cargo clippy` — clean.
- Manual: close conductor -> reopen -> manual `/resume` -> scrollback shows both pre- and post-resume turns; scroll to bottom returns to a live prompt instantly with the input box visible; queued inputs appear in the transcript; panel maximize/resize no longer stalls.
