### PR TITLE
feat: audit-driven improvements — data-loss guards, secret-exposure fixes, async reflow loading, render/scan perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.81.1"
+version = "0.82.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -346,6 +346,8 @@ pub struct BackgroundOps {
     pub branch_details: BackgroundOp<git_engine::BranchDetails>,
     /// Background symbol index build.
     pub symbol_index: BackgroundOp<Result<usize, String>>,
+    /// Background session-log parse for the reflow transcript view.
+    pub reflow_load: BackgroundOp<Vec<crate::claude_log::LogEntry>>,
 }
 
 /// State for an active embedded editor panel (vim/emacs in a PTY).
@@ -616,6 +618,10 @@ pub struct Sweep {
 pub struct ReflowView {
     /// Whether the reflow view is currently overlaying the Claude PTY panel.
     pub active: bool,
+    /// Whether the session log is still being parsed on a background thread.
+    /// While `true`, the view renders a "Loading…" placeholder instead of
+    /// transcript lines; cleared when `poll_reflow_load` receives the entries.
+    pub loading: bool,
     /// Parsed and normalised log entries from the session file.
     ///
     /// Wrapped in `Rc` so that `build_lines` can cheaply clone the handle
@@ -749,44 +755,44 @@ impl App {
             }
         };
 
-        // 1. Prefer the active panel's pinned session id. When a worktree hosts
-        //    several Claude panels (CC:1, CC:2, …) this ties the transcript to
-        //    the panel actually on screen, avoiding cross-panel scroll bleed.
-        let mut entries = resolved
-            .and_then(|(wd, sid)| crate::claude_sessions::session_jsonl_path(&wd, &sid))
-            .map(|path| crate::claude_log::load_session(&path))
-            .unwrap_or_default();
-
-        // 2. Fall back to the most-recently-written log in this worktree's
-        //    project dir when the pinned session is missing or empty. This is
-        //    what catches a manual in-app `/resume`: it switches the live
-        //    session id away from the conductor-launched (pinned) one, so the
-        //    pinned file is stale/empty while the real transcript is whatever
-        //    Claude is now appending to (= freshest mtime). Empty/aux logs
-        //    (e.g. one-shot security-review runs sharing the dir) are skipped.
-        if entries.is_empty() {
-            entries = crate::claude_sessions::session_logs_by_mtime(&working_dir)
-                .iter()
-                .map(|path| crate::claude_log::load_session(path))
-                .find(|e| !e.is_empty())
+        // Parse the log on a background thread: `load_session` reads and
+        // JSON-parses the whole `.jsonl`, which for large sessions (5MB+)
+        // would otherwise block the 60fps loop for several frames. The view
+        // activates immediately with a "Loading…" placeholder and
+        // `poll_reflow_load` swaps the entries in when they arrive.
+        self.bg.reflow_load.start(move |tx| {
+            // 1. Prefer the active panel's pinned session id. When a worktree
+            //    hosts several Claude panels (CC:1, CC:2, …) this ties the
+            //    transcript to the panel actually on screen, avoiding
+            //    cross-panel scroll bleed.
+            let mut entries = resolved
+                .and_then(|(wd, sid)| crate::claude_sessions::session_jsonl_path(&wd, &sid))
+                .map(|path| crate::claude_log::load_session(&path))
                 .unwrap_or_default();
-        }
 
-        if entries.is_empty() {
-            self.set_status(
-                "Session log is empty or unreadable".to_string(),
-                StatusLevel::Info,
-            );
-            return;
-        }
+            // 2. Fall back to the most-recently-written log in this worktree's
+            //    project dir when the pinned session is missing or empty. This
+            //    is what catches a manual in-app `/resume`: it switches the
+            //    live session id away from the conductor-launched (pinned)
+            //    one, so the pinned file is stale/empty while the real
+            //    transcript is whatever Claude is now appending to (= freshest
+            //    mtime). Empty/aux logs (e.g. one-shot security-review runs
+            //    sharing the dir) are skipped.
+            if entries.is_empty() {
+                entries = crate::claude_sessions::session_logs_by_mtime(&working_dir)
+                    .iter()
+                    .map(|path| crate::claude_log::load_session(path))
+                    .find(|e| !e.is_empty())
+                    .unwrap_or_default();
+            }
 
-        // TODO(background): load_session is currently synchronous; for very
-        // large files (5MB+) this may block the UI for a frame or two.
-        // A future version should spawn the parse on a background thread and
-        // show a "Loading…" placeholder while the entries arrive.
+            let _ = tx.send(entries);
+        });
+
         self.reflow = ReflowView {
             active: true,
-            entries: std::rc::Rc::new(entries),
+            loading: true,
+            entries: std::rc::Rc::new(Vec::new()),
             scroll: 0,
             total_lines: 0,
             last_width: 0, // Forces a full line rebuild on first render.
@@ -796,17 +802,49 @@ impl App {
             cache: crate::ui::markdown::MarkdownCache::new(),
             // Start the entry transition: the border glides from the accent to
             // its complement over TRANSITION_DURATION_MS, masking the initial
-            // build_lines latency.
+            // load + build_lines latency.
             sweep: Some(Sweep {
                 start: std::time::Instant::now(),
             }),
         };
     }
 
+    /// Apply a finished background session-log parse to the reflow view.
+    ///
+    /// Discards the result when the view was closed while loading (stale). An
+    /// empty log closes the view with a status flash — the same outcome the
+    /// old synchronous path produced before activating the view.
+    pub fn poll_reflow_load(&mut self) {
+        let Some(entries) = self.bg.reflow_load.poll() else {
+            return;
+        };
+        if !self.reflow.active {
+            return; // View closed while loading; drop the stale result.
+        }
+        if entries.is_empty() {
+            self.close_reflow();
+            self.set_status(
+                "Session log is empty or unreadable".to_string(),
+                StatusLevel::Info,
+            );
+            return;
+        }
+        self.reflow.entries = std::rc::Rc::new(entries);
+        self.reflow.loading = false;
+        self.reflow.last_width = 0; // Force a full line rebuild on next render.
+        self.reflow.pending_bottom = true;
+        // The entry sweep may already have finished on a slow load; redraw so
+        // the transcript replaces the "Loading…" placeholder immediately.
+        self.dirty.mark(DirtyPanels::TERMINAL);
+    }
+
     /// Leave the reflow transcript view and return to the live PTY display.
     pub fn close_reflow(&mut self) {
         self.reflow.active = false;
         self.reflow.sweep = None;
+        // Cancel any in-flight background log parse so a stale result can't
+        // arrive after the view is gone (or leak into the next open).
+        self.bg.reflow_load.clear();
         // Reset Claude scrollback so the live tail is shown immediately.
         self.terminal.scroll_claude = 0;
         // Force a fresh PTY snapshot on the next frame. While the reflow view
@@ -1216,19 +1254,26 @@ impl App {
                         ) {
                             self.selected_worktree = idx;
                         }
-                        // Detect commits by HEAD oid changes.
-                        for wt in &self.worktrees {
-                            if let Ok(wt_engine) = git_engine::GitEngine::open(&wt.path)
-                                && let Ok(head_oid) = wt_engine.head_oid_string()
+                        // Detect commits by HEAD oid changes. The oid was
+                        // captured while `list_worktrees` had each repo open,
+                        // so no second `Repository::open` per worktree here.
+                        let head_updates: Vec<(String, String)> = self
+                            .worktrees
+                            .iter()
+                            .filter_map(|wt| {
+                                wt.head_oid
+                                    .clone()
+                                    .map(|oid| (wt.branch.clone(), oid))
+                            })
+                            .collect();
+                        for (branch, head_oid) in head_updates {
+                            if let Some(old) = self.worktree_heads.get(&branch)
+                                && old != &head_oid
                             {
-                                if let Some(old) = self.worktree_heads.get(&wt.branch)
-                                    && old != &head_oid
-                                {
-                                    self.record_stat("commits_made");
-                                    changed = true;
-                                }
-                                self.worktree_heads.insert(wt.branch.clone(), head_oid);
+                                self.record_stat("commits_made");
+                                changed = true;
                             }
+                            self.worktree_heads.insert(branch, head_oid);
                         }
                     }
                     Err(e) => {
@@ -2832,6 +2877,7 @@ impl App {
         self.poll_bg_pull();
         self.poll_grep_search();
         self.poll_update_progress();
+        self.poll_reflow_load();
         self.poll_pr_url();
         self.poll_worktree_switch_ops();
         self.poll_worktree_ops();
@@ -3150,18 +3196,40 @@ fn try_binary_update(
         archive.to_string_lossy().to_string(),
     ];
 
-    // Use GITHUB_TOKEN if available.
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        curl_args.push("-H".to_string());
-        curl_args.push(format!("Authorization: token {token}"));
+    // Use GITHUB_TOKEN if available. The token is fed to curl via a config
+    // read from stdin (`--config -`), never as an argv header: command-line
+    // arguments are world-readable (`ps`/`/proc/<pid>/cmdline`), so an argv
+    // `-H "Authorization: token …"` would expose the credential to every
+    // local process for the duration of the download.
+    let token = std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty());
+    if token.is_some() {
+        curl_args.push("--config".to_string());
+        curl_args.push("-".to_string());
     }
 
     curl_args.push(asset.download_url.clone());
 
-    let dl = Command::new("curl")
-        .args(&curl_args)
-        .stdin(std::process::Stdio::null())
-        .output();
+    let dl = match token {
+        Some(token) => Command::new("curl")
+            .args(&curl_args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                if let Some(stdin) = child.stdin.take() {
+                    use std::io::Write;
+                    let mut stdin = stdin;
+                    // curl config syntax; a GitHub token never contains `"`.
+                    let _ = writeln!(stdin, "header = \"Authorization: token {token}\"");
+                }
+                child.wait_with_output()
+            }),
+        None => Command::new("curl")
+            .args(&curl_args)
+            .stdin(std::process::Stdio::null())
+            .output(),
+    };
     match dl {
         Err(e) => {
             log::warn!("binary download failed (curl): {e}");
@@ -3679,6 +3747,7 @@ mod tests {
             is_clean: true,
             ahead: None,
             behind: None,
+            head_oid: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ impl Config {
                 log::warn!("failed to create config directory: {e}");
             }
             let default_content = generate_default_config();
-            if let Err(e) = std::fs::write(&config_path, &default_content) {
+            if let Err(e) = write_atomic(&config_path, &default_content) {
                 log::warn!("failed to write default config: {e}");
             } else {
                 log::info!("generated default config at {}", config_path.display());
@@ -699,7 +699,24 @@ pub fn persist_ui_theme(name: &str) -> Result<()> {
         generate_default_config()
     };
     let updated = upsert_ui_theme(&contents, name);
-    std::fs::write(&path, updated)?;
+    write_atomic(&path, &updated)?;
+    Ok(())
+}
+
+/// Write `contents` to `path` atomically: write to a sibling temp file, fsync,
+/// then rename over the target. A crash, kill, or full disk mid-write can no
+/// longer leave the user's hand-edited config truncated or half-written —
+/// `std::fs::write` truncates in place, so the old direct writes could destroy
+/// the whole file on a mistimed failure.
+fn write_atomic(path: &std::path::Path, contents: &str) -> Result<()> {
+    let tmp = path.with_extension("toml.tmp");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
     Ok(())
 }
 
@@ -796,7 +813,7 @@ pub fn persist_ui_high_contrast(enabled: bool) -> Result<()> {
         generate_default_config()
     };
     let updated = upsert_section_kv(&contents, "ui", "high_contrast", &enabled.to_string());
-    std::fs::write(&path, updated)?;
+    write_atomic(&path, &updated)?;
     Ok(())
 }
 
@@ -839,7 +856,7 @@ pub fn persist_layout_proportions(
         "explorer_split_pct",
         &explorer_split_pct.to_string(),
     );
-    std::fs::write(&path, updated)?;
+    write_atomic(&path, &updated)?;
     Ok(())
 }
 

--- a/src/event/worktree.rs
+++ b/src/event/worktree.rs
@@ -81,11 +81,54 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
                         StatusLevel::Warning,
                     );
                 } else {
+                    // Confirming deletes both the worktree AND its branch
+                    // (force). Spell out exactly what will be lost so a
+                    // reflexive `y` can't silently destroy work: uncommitted
+                    // changes vanish with the directory, and commits not
+                    // merged into main become unreachable with the branch.
+                    let branch = wt.branch.clone();
+                    let dirty_count = wt.added + wt.modified + wt.deleted;
+                    let is_clean = wt.is_clean;
+                    let main_branch = app
+                        .worktrees
+                        .iter()
+                        .find(|w| w.is_main)
+                        .map(|w| w.branch.clone());
+
+                    let mut warnings: Vec<String> = Vec::new();
+                    if !is_clean {
+                        warnings.push(format!(
+                            "{dirty_count} uncommitted change(s) will be LOST"
+                        ));
+                    }
+                    if let Some(main_branch) =
+                        main_branch.filter(|m| *m != branch)
+                    {
+                        match git_engine::GitEngine::open(&app.repo_path)
+                            .and_then(|e| e.is_branch_merged_into(&branch, &main_branch))
+                        {
+                            Ok(false) => warnings.push(format!(
+                                "commits not merged into '{main_branch}' will be lost with the branch"
+                            )),
+                            Ok(true) => {}
+                            // Can't verify (e.g. branch renamed); don't block the
+                            // delete, but don't claim it's safe either.
+                            Err(e) => {
+                                log::warn!("merged-into-main check failed for '{branch}': {e}");
+                            }
+                        }
+                    }
+
                     app.worktree_mgr.input_mode = crate::app::WorktreeInputMode::ConfirmingDelete;
-                    app.set_status(
-                        format!("Delete worktree '{}'? (y/n)", wt.branch),
-                        StatusLevel::Warning,
-                    );
+                    let prompt = if warnings.is_empty() {
+                        format!("Delete worktree '{branch}' and its branch? (y/n)")
+                    } else {
+                        format!(
+                            "Delete worktree '{branch}'? WARNING: {} (y/n)",
+                            warnings.join("; ")
+                        )
+                    };
+                    app.set_status(prompt, StatusLevel::Warning);
                 }
             }
         }

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -32,18 +32,25 @@ impl FileWatcher {
             move |result: Result<Event, notify::Error>| {
                 if let Ok(event) = result {
                     // Only notify on modifications (not access-only events).
-                    if (event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove())
-                        && let Some(path) = event.paths.first()
+                    if !(event.kind.is_modify()
+                        || event.kind.is_create()
+                        || event.kind.is_remove())
                     {
-                        // Skip changes inside .git/ directories — git
-                        // operations (e.g. `git status`) touch index files
-                        // and would otherwise trigger expensive refreshes.
-                        if path
+                        return;
+                    }
+                    // Skip changes inside .git/ / .conductor directories — git
+                    // operations (e.g. `git status`) touch index files and
+                    // would otherwise trigger expensive refreshes. Check every
+                    // path in the event, not just the first: rename events
+                    // carry (from, to), and a move out of `.git` into the
+                    // working tree is a real change even when `paths[0]` is
+                    // the `.git` side.
+                    let any_real_path = event.paths.iter().any(|path| {
+                        !path
                             .components()
                             .any(|c| c.as_os_str() == ".git" || c.as_os_str() == ".conductor")
-                        {
-                            return;
-                        }
+                    });
+                    if any_real_path {
                         let _ = sender.send(FsEvent::Changed);
                     }
                 }

--- a/src/gemini_api.rs
+++ b/src/gemini_api.rs
@@ -101,7 +101,10 @@ pub fn call_messages_api(
         std::env::var("GEMINI_API_KEY").context("GEMINI_API_KEY environment variable not set")?;
 
     let model = model.unwrap_or(DEFAULT_MODEL);
-    let url = format!("{API_BASE_URL}/{model}:generateContent?key={api_key}");
+    // The key travels in the `x-goog-api-key` header (Google's recommended
+    // method), never in the URL: query strings leak into proxy/access logs
+    // and any request tracing.
+    let url = format!("{API_BASE_URL}/{model}:generateContent");
 
     let request_body = GenerateContentRequest {
         system_instruction: SystemInstruction {
@@ -127,6 +130,7 @@ pub fn call_messages_api(
         .context("Failed to build HTTP client")?;
     let response = client
         .post(&url)
+        .header("x-goog-api-key", &api_key)
         .header("content-type", "application/json")
         .json(&request_body)
         .send()

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -30,6 +30,10 @@ pub struct WorktreeInfo {
     pub ahead: Option<usize>,
     /// Commits behind upstream (remote commits not yet pulled). `None` if no upstream.
     pub behind: Option<usize>,
+    /// HEAD commit OID (hex). `None` on an unborn branch. Captured while the
+    /// repo is already open so callers don't need a second `Repository::open`
+    /// per worktree just to detect new commits.
+    pub head_oid: Option<String>,
 }
 
 /// Summary info for a single commit.
@@ -77,12 +81,6 @@ impl GitEngine {
             format!("failed to discover git repository from {}", path.display())
         })?;
         Ok(Self { repo })
-    }
-
-    /// Return the HEAD commit OID as a hex string.
-    pub fn head_oid_string(&self) -> Result<String> {
-        let head = self.repo.head()?.peel_to_commit()?.id();
-        Ok(head.to_string())
     }
 
     // ── Worktree enumeration ─────────────────────────────────────────
@@ -373,6 +371,33 @@ impl GitEngine {
                 .with_context(|| format!("failed to delete branch '{name}' (not fully merged?)"))?;
         }
         Ok(())
+    }
+
+    /// Return `true` when every commit on `branch` is already contained in
+    /// `into` (tip equal or an ancestor of `into`'s tip). Used to warn before
+    /// a worktree delete force-removes a branch whose commits would become
+    /// unreachable — libgit2's non-force `Branch::delete` does *not* perform
+    /// the "not fully merged" refusal that the git CLI does, so this check is
+    /// the only guard.
+    pub fn is_branch_merged_into(&self, branch: &str, into: &str) -> Result<bool> {
+        let branch_oid = self
+            .repo
+            .find_branch(branch, git2::BranchType::Local)
+            .with_context(|| format!("branch '{branch}' not found"))?
+            .get()
+            .peel_to_commit()?
+            .id();
+        let into_oid = self
+            .repo
+            .find_branch(into, git2::BranchType::Local)
+            .with_context(|| format!("branch '{into}' not found"))?
+            .get()
+            .peel_to_commit()?
+            .id();
+        if branch_oid == into_oid {
+            return Ok(true);
+        }
+        Ok(self.repo.graph_descendant_of(into_oid, branch_oid)?)
     }
 
     /// Forcefully remove a worktree even if dirty.
@@ -1453,6 +1478,11 @@ impl GitEngine {
         let (added, modified, deleted) = Self::status_counts(&repo).unwrap_or((0, 0, 0));
         let is_clean = added == 0 && modified == 0 && deleted == 0;
         let (ahead, behind) = Self::ahead_behind_upstream(&repo);
+        let head_oid = repo
+            .head()
+            .ok()
+            .and_then(|h| h.target())
+            .map(|oid| oid.to_string());
 
         Ok(WorktreeInfo {
             path: path.to_path_buf(),
@@ -1464,6 +1494,7 @@ impl GitEngine {
             is_clean,
             ahead,
             behind,
+            head_oid,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,17 @@ fn run_loop(
     // `git init` in a plain folder, or adds/removes a worktree — so newly
     // created files keep showing up instead of going unnoticed.
     let mut current_watch_paths = watch_paths_for(app);
-    let mut file_watcher = crate::file_watcher::FileWatcher::new(&current_watch_paths).ok();
+    let mut file_watcher = match crate::file_watcher::FileWatcher::new(&current_watch_paths) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            log::warn!("file watcher setup failed: {e}");
+            app.set_status(
+                format!("File watcher unavailable — auto-refresh degraded ({e})"),
+                crate::app::StatusLevel::Warning,
+            );
+            None
+        }
+    };
 
     // Set up a dedicated watcher for the conductor config file. Separate from
     // the worktree file watcher: the worktree watcher is rebuilt each time the
@@ -734,9 +744,22 @@ fn run_loop(
                     // keep monitoring a stale set and miss new files.
                     let desired = watch_paths_for(app);
                     if desired != current_watch_paths {
-                        current_watch_paths = desired;
-                        file_watcher =
-                            crate::file_watcher::FileWatcher::new(&current_watch_paths).ok();
+                        match crate::file_watcher::FileWatcher::new(&desired) {
+                            Ok(w) => {
+                                current_watch_paths = desired;
+                                file_watcher = Some(w);
+                            }
+                            Err(e) => {
+                                // Keep the previous watcher (still valid for the
+                                // old path set) instead of silently downgrading
+                                // to no watcher at all; retry on the next poll.
+                                log::warn!("file watcher rebuild failed: {e}");
+                                app.set_status(
+                                    format!("File watcher rebuild failed ({e})"),
+                                    crate::app::StatusLevel::Warning,
+                                );
+                            }
+                        }
                     }
                     // Periodic fallback: re-walk the file tree so newly created
                     // files appear even if a watcher event was missed. Cheap

--- a/src/media_state.rs
+++ b/src/media_state.rs
@@ -133,7 +133,9 @@ impl MediaState {
         self.rendered_path = Some(rel_path.to_string());
         self.rendered_size = size;
         self.rendered_pixel = picker.is_some();
-        *self.content.lock().unwrap() = MediaContent::Loading;
+        // Poison recovery: if a decode thread panicked while holding the lock,
+        // keep the viewer alive and overwrite the poisoned value.
+        *self.content.lock().unwrap_or_else(|e| e.into_inner()) = MediaContent::Loading;
 
         let path = full_path.to_path_buf();
         let content = Arc::clone(&self.content);
@@ -143,7 +145,7 @@ impl MediaState {
                 Some(mut picker) => render_image_to_pixels(&path, &mut picker, cols, rows),
                 None => render_image_to_lines(&path, cols, rows),
             };
-            *content.lock().unwrap() = result;
+            *content.lock().unwrap_or_else(|e| e.into_inner()) = result;
         });
     }
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -164,15 +164,20 @@ pub fn build_pty_lines(
 
 /// Render previously built PTY lines from a [`PtyRenderCache`].
 ///
-/// This is cheap: it just clones the cached `Line` data into a `Paragraph`.
+/// This is cheap: the cached `Line`s are blitted straight into the frame
+/// buffer by reference. (It used to `clone()` the whole line vector into a
+/// `Paragraph` — a full deep copy of every span string, twice per frame at
+/// the terminal-focus tick rate, for zero benefit.)
 pub fn render_pty_cached(frame: &mut Frame, area: Rect, cache: &PtyRenderCache, theme: &Theme) {
     // Clear first: when scrolled back the snapshot can have fewer/shorter lines
-    // than the live view, and a bare Paragraph leaves the uncovered cells
+    // than the live view, and bare line blitting leaves the uncovered cells
     // showing the previous frame's text (the "scrollback bleed"). Mirrors the
     // viewer panel, which clears for the same reason.
     frame.render_widget(ratatui::widgets::Clear, area);
-    let paragraph = Paragraph::new(cache.lines.clone());
-    frame.render_widget(paragraph, area);
+    let buf = frame.buffer_mut();
+    for (i, line) in cache.lines.iter().enumerate().take(area.height as usize) {
+        buf.set_line(area.x, area.y + i as u16, line, area.width);
+    }
 
     if cache.effective_offset > 0 {
         let indicator = Line::from(Span::styled(

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -177,140 +177,6 @@ pub(crate) fn accordion_widths(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use ratatui::layout::Rect;
-
-    use super::{LayoutCache, accordion_widths};
-    use crate::app::Focus;
-    use crate::config::LayoutConfig;
-
-    /// Build a minimal LayoutConfig with the given proportions.
-    fn layout(explorer: u16, viewer: u16, terminal: u16) -> LayoutConfig {
-        LayoutConfig {
-            explorer_width_pct: explorer,
-            viewer_width_pct: viewer,
-            terminal_split_pct: terminal,
-            explorer_split_pct: 50,
-        }
-    }
-
-    /// A non-zero Rect large enough to produce non-trivial layout splits.
-    fn rect(w: u16, h: u16) -> Rect {
-        Rect::new(0, 0, w, h)
-    }
-
-    // ── LayoutCache::update ──────────────────────────────────────────
-
-    #[test]
-    fn layout_cache_update_returns_true_first_call() {
-        let mut cache = LayoutCache::default();
-        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
-        assert!(changed, "first update must recompute");
-    }
-
-    #[test]
-    fn layout_cache_update_returns_false_on_identical_second_call() {
-        let mut cache = LayoutCache::default();
-        let cfg = layout(24, 38, 80);
-        cache.update(rect(200, 50), None, false, &cfg, 80);
-        let changed = cache.update(rect(200, 50), None, false, &cfg, 80);
-        assert!(!changed, "identical inputs must not recompute");
-    }
-
-    #[test]
-    fn layout_cache_invalidates_on_frame_area_change() {
-        let mut cache = LayoutCache::default();
-        let cfg = layout(24, 38, 80);
-        cache.update(rect(200, 50), None, false, &cfg, 80);
-        let changed = cache.update(rect(201, 50), None, false, &cfg, 80);
-        assert!(changed, "frame_area change must invalidate");
-    }
-
-    #[test]
-    fn layout_cache_invalidates_on_explorer_pct_change() {
-        let mut cache = LayoutCache::default();
-        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
-        let changed = cache.update(rect(200, 50), None, false, &layout(30, 38, 80), 80);
-        assert!(changed, "explorer_width_pct change must invalidate");
-    }
-
-    #[test]
-    fn layout_cache_invalidates_on_viewer_pct_change() {
-        let mut cache = LayoutCache::default();
-        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
-        let changed = cache.update(rect(200, 50), None, false, &layout(24, 42, 80), 80);
-        assert!(changed, "viewer_width_pct change must invalidate");
-    }
-
-    #[test]
-    fn layout_cache_invalidates_on_terminal_split_change() {
-        // The terminal split now arrives as a runtime parameter (grow/shrink
-        // shell), so vary that argument rather than the config field.
-        let mut cache = LayoutCache::default();
-        let cfg = layout(24, 38, 80);
-        cache.update(rect(200, 50), None, false, &cfg, 80);
-        let changed = cache.update(rect(200, 50), None, false, &cfg, 70);
-        assert!(changed, "terminal_split_pct change must invalidate");
-    }
-
-    #[test]
-    fn layout_cache_invalidates_on_explorer_split_change() {
-        let mut cache = LayoutCache::default();
-        let mut cfg = layout(24, 38, 80);
-        cfg.explorer_split_pct = 50;
-        cache.update(rect(200, 50), None, false, &cfg, 80);
-        cfg.explorer_split_pct = 30;
-        let changed = cache.update(rect(200, 50), None, false, &cfg, 80);
-        assert!(changed, "explorer_split_pct change must invalidate");
-        // The mid-point moves up when the file tree shrinks.
-        assert!(cache.explorer_mid_y > 0);
-    }
-
-    // ── accordion_widths: abnormal percentages ───────────────────────
-
-    #[test]
-    fn accordion_widths_does_not_panic_on_large_percentages() {
-        // Percentages exceeding 100 must not panic (Percentage constraint clamps).
-        let _ = accordion_widths(None, 200, 240, 0);
-        let _ = accordion_widths(None, 100, 60, 60);
-    }
-
-    #[test]
-    fn terminal_split_pct_over_100_does_not_panic() {
-        // terminal_split_pct > 100 makes shell_pct saturate to 0; must not panic.
-        let mut cache = LayoutCache::default();
-        let _ = cache.update(rect(200, 50), None, false, &layout(24, 38, 200), 200);
-    }
-
-    #[test]
-    fn maximized_editor_takes_full_width_via_explorer_slot() {
-        // render_ui unions the explorer+viewer columns into the editor area, so
-        // the maximized editor puts all width on the explorer slot (viewer 0),
-        // collapsing the terminal column to zero remaining.
-        let (left, explorer, viewer) = accordion_widths(Some(Focus::Editor), 120, 24, 38);
-        assert_eq!((left, explorer, viewer), (0, 120, 0));
-    }
-
-    #[test]
-    fn default_layout_uses_configured_percentages() {
-        // With default percentages (24/38) and 200-column terminal.
-        let (left, explorer, viewer) = accordion_widths(None, 200, 24, 38);
-        assert_eq!(left, 0, "worktree column is always hidden");
-        assert_eq!(explorer, 48, "200 * 24 / 100 = 48");
-        assert_eq!(viewer, 76, "200 * 38 / 100 = 76");
-    }
-
-    #[test]
-    fn custom_percentages_are_respected() {
-        // Wider explorer (30%) and narrower viewer (30%).
-        let (left, explorer, viewer) = accordion_widths(None, 100, 30, 30);
-        assert_eq!(left, 0);
-        assert_eq!(explorer, 30);
-        assert_eq!(viewer, 30);
-    }
-}
-
 /// Top-level UI renderer — 3-column accordion layout + status bar.
 pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
@@ -643,4 +509,138 @@ fn render_skip_reason_overlay(
     let paragraph =
         ratatui::widgets::Paragraph::new(text).wrap(ratatui::widgets::Wrap { trim: true });
     frame.render_widget(paragraph, inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::layout::Rect;
+
+    use super::{LayoutCache, accordion_widths};
+    use crate::app::Focus;
+    use crate::config::LayoutConfig;
+
+    /// Build a minimal LayoutConfig with the given proportions.
+    fn layout(explorer: u16, viewer: u16, terminal: u16) -> LayoutConfig {
+        LayoutConfig {
+            explorer_width_pct: explorer,
+            viewer_width_pct: viewer,
+            terminal_split_pct: terminal,
+            explorer_split_pct: 50,
+        }
+    }
+
+    /// A non-zero Rect large enough to produce non-trivial layout splits.
+    fn rect(w: u16, h: u16) -> Rect {
+        Rect::new(0, 0, w, h)
+    }
+
+    // ── LayoutCache::update ──────────────────────────────────────────
+
+    #[test]
+    fn layout_cache_update_returns_true_first_call() {
+        let mut cache = LayoutCache::default();
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+        assert!(changed, "first update must recompute");
+    }
+
+    #[test]
+    fn layout_cache_update_returns_false_on_identical_second_call() {
+        let mut cache = LayoutCache::default();
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(200, 50), None, false, &cfg, 80);
+        assert!(!changed, "identical inputs must not recompute");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_frame_area_change() {
+        let mut cache = LayoutCache::default();
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(201, 50), None, false, &cfg, 80);
+        assert!(changed, "frame_area change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_explorer_pct_change() {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+        let changed = cache.update(rect(200, 50), None, false, &layout(30, 38, 80), 80);
+        assert!(changed, "explorer_width_pct change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_viewer_pct_change() {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+        let changed = cache.update(rect(200, 50), None, false, &layout(24, 42, 80), 80);
+        assert!(changed, "viewer_width_pct change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_terminal_split_change() {
+        // The terminal split now arrives as a runtime parameter (grow/shrink
+        // shell), so vary that argument rather than the config field.
+        let mut cache = LayoutCache::default();
+        let cfg = layout(24, 38, 80);
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        let changed = cache.update(rect(200, 50), None, false, &cfg, 70);
+        assert!(changed, "terminal_split_pct change must invalidate");
+    }
+
+    #[test]
+    fn layout_cache_invalidates_on_explorer_split_change() {
+        let mut cache = LayoutCache::default();
+        let mut cfg = layout(24, 38, 80);
+        cfg.explorer_split_pct = 50;
+        cache.update(rect(200, 50), None, false, &cfg, 80);
+        cfg.explorer_split_pct = 30;
+        let changed = cache.update(rect(200, 50), None, false, &cfg, 80);
+        assert!(changed, "explorer_split_pct change must invalidate");
+        // The mid-point moves up when the file tree shrinks.
+        assert!(cache.explorer_mid_y > 0);
+    }
+
+    // ── accordion_widths: abnormal percentages ───────────────────────
+
+    #[test]
+    fn accordion_widths_does_not_panic_on_large_percentages() {
+        // Percentages exceeding 100 must not panic (Percentage constraint clamps).
+        let _ = accordion_widths(None, 200, 240, 0);
+        let _ = accordion_widths(None, 100, 60, 60);
+    }
+
+    #[test]
+    fn terminal_split_pct_over_100_does_not_panic() {
+        // terminal_split_pct > 100 makes shell_pct saturate to 0; must not panic.
+        let mut cache = LayoutCache::default();
+        let _ = cache.update(rect(200, 50), None, false, &layout(24, 38, 200), 200);
+    }
+
+    #[test]
+    fn maximized_editor_takes_full_width_via_explorer_slot() {
+        // render_ui unions the explorer+viewer columns into the editor area, so
+        // the maximized editor puts all width on the explorer slot (viewer 0),
+        // collapsing the terminal column to zero remaining.
+        let (left, explorer, viewer) = accordion_widths(Some(Focus::Editor), 120, 24, 38);
+        assert_eq!((left, explorer, viewer), (0, 120, 0));
+    }
+
+    #[test]
+    fn default_layout_uses_configured_percentages() {
+        // With default percentages (24/38) and 200-column terminal.
+        let (left, explorer, viewer) = accordion_widths(None, 200, 24, 38);
+        assert_eq!(left, 0, "worktree column is always hidden");
+        assert_eq!(explorer, 48, "200 * 24 / 100 = 48");
+        assert_eq!(viewer, 76, "200 * 38 / 100 = 76");
+    }
+
+    #[test]
+    fn custom_percentages_are_respected() {
+        // Wider explorer (30%) and narrower viewer (30%).
+        let (left, explorer, viewer) = accordion_widths(None, 100, 30, 30);
+        assert_eq!(left, 0);
+        assert_eq!(explorer, 30);
+        assert_eq!(viewer, 30);
+    }
 }

--- a/src/ui/reflow_view.rs
+++ b/src/ui/reflow_view.rs
@@ -137,6 +137,24 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let inner_width = render_area.width as usize;
     let inner_height = render_area.height as usize;
 
+    // ── Loading placeholder ───────────────────────────────────────────────────
+    // The session log is parsed on a background thread (see `open_reflow`);
+    // until the entries arrive, show a centered placeholder instead of an
+    // empty transcript. The entry sweep keeps animating over it, so the
+    // border transition doubles as the loading indicator.
+    if app.reflow.loading {
+        let msg = "Loading transcript\u{2026}";
+        let y = area.y + area.height / 2;
+        let msg_cols = UnicodeWidthStr::width(msg).min(inner_width) as u16;
+        let x = render_area.x + (render_area.width.saturating_sub(msg_cols)) / 2;
+        let line = Line::from(Span::styled(
+            truncate_to_width(msg, inner_width),
+            Style::default().fg(palette::INACTIVE),
+        ));
+        frame.render_widget(Paragraph::new(line), Rect::new(x, y, msg_cols, 1));
+        return;
+    }
+
     // ── (Re)build cached lines when the panel width changed ──────────────────
     if app.reflow.last_width != render_area.width {
         let new_lines = build_lines(app, inner_width);
@@ -166,16 +184,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     app.reflow.scroll =
         crate::event::reflow::clamp_scroll(app.reflow.scroll, app.reflow.total_lines, inner_height);
 
-    // ── Slice visible lines ───────────────────────────────────────────────────
     let scroll = app.reflow.scroll;
-    let visible: Vec<Line<'static>> = app
-        .reflow
-        .cached_lines
-        .iter()
-        .skip(scroll)
-        .take(inner_height)
-        .cloned()
-        .collect();
 
     // ── Transition completion ─────────────────────────────────────────────────
     // Drive the entry transition timer: once the entry sweep elapses, clear it
@@ -189,13 +198,30 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         app.reflow.sweep = None;
     }
 
-    // No .wrap(): `markdown_cache.render` already produces lines ≤ `body_width`
-    // columns, and each line then receives a `MARKER_COLS`-wide prefix, keeping
-    // total width ≤ `render_area.width`.  1 logical line == 1 visual row means
-    // scroll arithmetic is exact with no invisible over-height rows. Rendered
-    // into `render_area` (one column narrower than `area`) so the reserved
-    // safety gutter stays blank.
-    frame.render_widget(Paragraph::new(visible), render_area);
+    // Blit the visible window straight from the cache by reference — no
+    // per-frame clone of the line vector. No wrapping: `markdown_cache.render`
+    // already produces lines ≤ `body_width` columns, and each line then
+    // receives a `MARKER_COLS`-wide prefix, keeping total width ≤
+    // `render_area.width`.  1 logical line == 1 visual row means scroll
+    // arithmetic is exact with no invisible over-height rows. Rendered into
+    // `render_area` (one column narrower than `area`) so the reserved safety
+    // gutter stays blank.
+    let buf = frame.buffer_mut();
+    for (i, line) in app
+        .reflow
+        .cached_lines
+        .iter()
+        .skip(scroll)
+        .take(inner_height)
+        .enumerate()
+    {
+        buf.set_line(
+            render_area.x,
+            render_area.y + i as u16,
+            line,
+            render_area.width,
+        );
+    }
 }
 
 // ── Line builder ─────────────────────────────────────────────────────────────

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -1120,7 +1120,15 @@ fn render_media_view(frame: &mut Frame, area: Rect, app: &App, block: Block<'_>)
     let theme = &app.theme;
     let vs = &app.viewer_state;
 
-    let content = vs.media_state.content.lock().unwrap().clone();
+    // Recover from a poisoned lock instead of panicking: the decode thread
+    // holds this mutex while rendering, so a panic there (malformed media)
+    // must not take down the whole TUI on the next frame.
+    let content = vs
+        .media_state
+        .content
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
 
     match content {
         MediaContent::Loading => {

--- a/src/ui/worktree_bar.rs
+++ b/src/ui/worktree_bar.rs
@@ -346,6 +346,21 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
+/// Render the worktree switcher modal: a centered popup that reuses the full
+/// worktree panel (list + detail + sessions) so selection/creation/etc. keep
+/// their existing UI and key handling.
+pub fn render_switcher_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
+    // Clamp lower bounds to `area` so a tiny terminal can't make min > max
+    // (which would panic in `u16::clamp`).
+    let w = ((area.width as u32 * 60 / 100) as u16).clamp(24.min(area.width), area.width);
+    let h = ((area.height as u32 * 70 / 100) as u16).clamp(6.min(area.height), area.height);
+    let x = area.x + area.width.saturating_sub(w) / 2;
+    let y = area.y + area.height.saturating_sub(h) / 2;
+    let popup = Rect::new(x, y, w, h);
+    frame.render_widget(ratatui::widgets::Clear, popup);
+    crate::ui::worktree_panel::render(frame, popup, app);
+}
+
 #[cfg(test)]
 mod tests {
     use super::visible_window;
@@ -412,19 +427,4 @@ mod tests {
     fn empty_list_is_handled() {
         assert_eq!(visible_window(&[], 1, 100, 0, 0, true), (0, 0));
     }
-}
-
-/// Render the worktree switcher modal: a centered popup that reuses the full
-/// worktree panel (list + detail + sessions) so selection/creation/etc. keep
-/// their existing UI and key handling.
-pub fn render_switcher_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
-    // Clamp lower bounds to `area` so a tiny terminal can't make min > max
-    // (which would panic in `u16::clamp`).
-    let w = ((area.width as u32 * 60 / 100) as u16).clamp(24.min(area.width), area.width);
-    let h = ((area.height as u32 * 70 / 100) as u16).clamp(6.min(area.height), area.height);
-    let x = area.x + area.width.saturating_sub(w) / 2;
-    let y = area.y + area.height.saturating_sub(h) / 2;
-    let popup = Rect::new(x, y, w, h);
-    frame.render_widget(ratatui::widgets::Clear, popup);
-    crate::ui::worktree_panel::render(frame, popup, app);
 }


### PR DESCRIPTION
## Summary

Batch of improvements from a three-way audit (correctness / security / performance) plus one UX feature.

### Data-loss prevention
- **Worktree delete now warns about work that will be lost**: the confirm prompt spells out uncommitted changes ("N uncommitted change(s) will be LOST") and commits not merged into main ("commits not merged into 'main' will be lost with the branch"). libgit2's non-force `branch.delete()` does not perform the git-CLI "not fully merged" refusal, so a new `GitEngine::is_branch_merged_into` (graph_descendant_of) provides the check.
- **Atomic config writes**: theme / high-contrast / layout persistence and default-config generation now write via temp file + fsync + rename instead of truncate-in-place `fs::write`, so a crash or full disk can no longer destroy the user's hand-edited config.toml.

### Robustness
- **Media view no longer panics on a poisoned mutex**: a decode-thread panic (malformed image) used to poison the content lock and crash the whole TUI on the next frame; all lock sites now recover via `unwrap_or_else(into_inner)`.
- **File watcher failures are surfaced**: watcher construction/rebuild errors (e.g. inotify limits) now flash a status warning instead of silently disabling auto-refresh; a failed rebuild keeps the previous watcher and retries on the next poll.
- **File watcher checks every event path**: rename events carry (from, to); previously only `paths[0]` was inspected, misclassifying moves in/out of `.git`.

### Security
- **GITHUB_TOKEN no longer exposed in curl argv** during self-update downloads (argv is world-readable via `ps`); the auth header is fed through `curl --config -` on stdin.
- **GEMINI_API_KEY moved from URL query string to the `x-goog-api-key` header** (query strings leak into proxy/access logs).

### Performance
- **Reflow transcript log loading is now asynchronous**: `load_session` parses the whole session .jsonl and could block the 60fps loop for several frames on 5MB+ logs. The view opens instantly with a "Loading transcript…" placeholder and swaps the entries in via the existing `BackgroundOp` channel pattern (closing mid-load cancels cleanly).
- **Eliminated the second `Repository::open` per worktree** in the 3s refresh poll: `WorktreeInfo` now carries `head_oid` captured while the repo is already open.
- **Removed per-frame deep clones in PTY and reflow rendering**: cached `Line`s are blitted by reference with `Buffer::set_line` instead of `Paragraph::new(lines.clone())` (previously a full span-string copy per panel per frame at the terminal-focus tick rate).

### Cleanup
- Fixed both `items_after_test_module` clippy warnings (`ui/worktree_bar.rs`, `ui/layout.rs`).

Version bump: 0.81.1 → 0.82.0 (MINOR: backward-compatible features + fixes).

## Test plan

- `cargo clippy --all-targets` — zero warnings
- `cargo test` — 504 passed / 0 failed
- `cargo install --path .` — binary builds and installs in release mode
- Manual: reflow view opens with placeholder and pins to bottom once entries load; worktree delete prompt shows the dirty/unmerged warnings; theme/layout persistence still round-trips config.toml
