### PR TITLE
feat: PR review workflow — PR intake, AI walkthrough view, viewed marks, GitHub publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Status bar
 
 | Module | Role |
 |--------|------|
-| `app/` | All application state and business logic methods (`mod.rs` + `review.rs`, `terminal.rs`, `worktree.rs`) |
+| `app/` | All application state and business logic methods (`mod.rs` + `review.rs`, `terminal.rs`, `worktree.rs`, `review_publish.rs`, `walkthrough_view.rs`) |
 | `event/` | Keyboard/mouse event dispatch based on Focus and overlay state (per-context submodules) |
 | `git_engine.rs` | All git operations via `git2` (no shell-out) — worktrees, diffs, branches, cherry-pick, merge |
 | `diff_state.rs` | Diff data model (file diffs, hunks, lines) using `similar` crate |
@@ -70,6 +70,10 @@ Status bar
 | `config.rs` | Config loading from `~/.config/conductor/config.toml` |
 | `theme.rs` | Color themes (catppuccin-mocha default, dracula, nord, solarized-dark) |
 | `term_caps.rs` | Rich-mode terminal capability detection (truecolor / graphics protocol tiers) |
+| `pr_intake.rs` | Fetches a PR via `gh` and prepares its worktree for review (re-entrant: reuses an existing valid worktree) |
+| `walkthrough.rs` | AI walkthrough data model and generation trigger — spawns a headless `claude -p` session that saves its result via the MCP server |
+| `app/walkthrough_view.rs` | Explorer walkthrough-view methods for `App` — step selection, jumping to a step's diff location, and the "viewed" file/step toggle |
+| `app/review_publish.rs` | Publishes review comments to GitHub via `gh`, tracking which comments are already posted |
 
 ### UI Modules (`src/ui/`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.82.1"
+version = "0.83.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.82.1"
+version = "0.83.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Terminal-based Git workspace and code review TUI written in Rust. Manages multip
 | Dependency | Purpose | How to enable |
 |---|---|---|
 | **ccusage** (via npx) | Token usage / cost display in title bar | Set `ccusage.enabled = true` in config |
+| **GitHub CLI** (`gh`) | Pulling in a PR for review, and publishing review comments to GitHub | [Install](https://cli.github.com/) and run `gh auth login` |
 
 ## Installation
 
@@ -103,6 +104,38 @@ view.
 ### Command Palette
 
 **Ctrl+p** (any panel, including terminals) or **:** (non-terminal panels) opens the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
+
+## Reviewing a Pull Request
+
+PR review is built into the normal Explorer/Viewer/Terminal accordion — there's
+no separate full-screen mode to enter or exit, so all the usual navigation and
+terminal keybindings keep working while you review:
+
+1. **Pull Request → local worktree** — palette: *Review: Review Pull Request…*,
+   enter a PR number or URL. Conductor fetches it (via `gh`) into a worktree and
+   focuses the Explorer's changed-files list.
+2. **Changed files, comments, and walkthrough** — the Explorer's bottom pane
+   cycles between three views: the changed-files diff list, the review comment
+   list, and (once generated) the AI walkthrough — palette: *Review: Show
+   Walkthrough* to switch to it directly.
+3. **Jump into the code** — the diff pane supports the Viewer's `gd`/`gi`/`gr`
+   symbol-jump hints (go to definition / implementation / references). **Symbol
+   jumps only work for Rust, Go, and TypeScript** — other languages show no
+   hints.
+4. **AI walkthrough** — palette: *Review: Generate Walkthrough* asks Claude
+   Code to produce an ordered tour of the change (intent → core change →
+   ripple effects → tests). In the walkthrough view, `j`/`k` move the
+   selection, `n`/`N` jump to the next/previous step's location in the diff,
+   `Enter` jumps to the selected step, and `space` opens the full step text in
+   an overlay. A viewed step, or a changed file you've marked with `v`, is
+   greyed out with a ✓ once you've looked at it.
+5. **Publish comments** — palette: *Review: Publish Comments to GitHub* posts
+   your inline review comments (and replies) back to the PR via `gh`.
+
+Requires the `gh` CLI (see Prerequisites) to be installed and authenticated.
+
+> **Breaking change:** diff mode's "jump to top" moved from `g` to `gg` (vim-style),
+> since `g` is now a prefix for symbol-jump hints (`gd`/`gi`/`gr`/`gg`).
 
 ## MCP Server
 

--- a/plugins/conductor/commands/conductor-walkthrough.md
+++ b/plugins/conductor/commands/conductor-walkthrough.md
@@ -1,0 +1,36 @@
+---
+description: Generate a PR walkthrough (intent -> core -> ripple -> test) and save it via the conductor MCP server.
+---
+
+# Conductor Walkthrough
+
+現在のブランチの merge-base diff を読み、レビュアーがコードジャンプしながら追える「ウォークスルー」（ステップの列）を組み立てて、`mcp__conductor__save_walkthrough` で一度だけ保存する。
+
+## 1. 差分と関係コードを探索する
+
+- 現在のブランチの merge-base diff（base ブランチとの差分）を確認する。
+- 差分に出てくるファイルだけでなく、呼び出し元・呼び出し先など関係するコードも必要に応じて読み、変更の全体像を把握する。
+
+## 2. ステップを組み立てる
+
+ステップは **intent → core → ripple → test** のストーリー順で構成する。各ステップは `file_path`（リポジトリ相対）・任意で `line_start`/`line_end`・`kind`・`title`・`body` を持つ。
+
+- **intent**: この変更で何をしたかったか（背景・動機）。
+- **core**: 何をしたくてこう変えたか、既存コードへの影響。**代替案の比較は書かない** — 深掘りが必要ならレビュアーが手動で聞く。
+- **ripple**: core の変更に伴う波及的な変更（呼び出し元の更新、設定/スキーマの追随など）。
+- **test**: 何の振る舞いを検証しているかの要約。これを読めば元のテスト差分を全部読まなくてよいレベルの粒度にする。
+
+ステップ数や各種別の個数に固定の制約はない。変更の実態に合わせて過不足なく構成する。
+
+タイトル・summary・各ステップの title / body は、ユーザーの指定があればその言語で、なければこのコマンド文書と同じ言語（日本語）で書く。
+
+## 3. 保存する
+
+すべてのステップが揃ったら、`mcp__conductor__save_walkthrough` を **一度だけ** 呼び出す。
+
+- `branch`: 現在の worktree のブランチ名（`git rev-parse --abbrev-ref HEAD` で取得できるもの）
+- `title`: ウォークスルー全体の一行タイトル
+- `summary`: 変更全体の短い概要（intent の要約でよい）
+- `steps`: 上記で組み立てたステップ列（`seq` は 0 始まりの通し番号）
+
+保存が終わったら、ステップ数と各 kind の内訳を簡潔に報告して終了する。

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -725,6 +725,166 @@ server.tool(
 );
 
 // ---------------------------------------------------------------------------
+// Tool: save_walkthrough
+//
+// This is the production write path — the headless `claude -p` session
+// spawned by `walkthrough.rs` calls this tool directly over stdio. Rust's
+// `ReviewStore::save_walkthrough` (src/review_store.rs) is a second,
+// intentionally-unused-in-production implementation of the same insert that
+// exists only so the round-trip can be tested without spawning a Node
+// process. Keep the two in sync by hand: a schema or invariant change here
+// needs the matching change made there, and vice versa.
+// ---------------------------------------------------------------------------
+
+const WALKTHROUGH_STEP_KINDS = ["intent", "core", "ripple", "test"] as const;
+
+const walkthroughStepSchema = z.object({
+  seq: z.number().int().describe("Step order within the walkthrough, 0-based"),
+  file_path: z
+    .string()
+    .min(1)
+    .describe("Repo-relative file path the step points at (e.g. src/foo.rs)"),
+  line_start: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("1-based line number the step points at, if file-anchored"),
+  line_end: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("1-based end line for a multi-line range; omit for a single line"),
+  kind: z
+    .enum(WALKTHROUGH_STEP_KINDS)
+    .describe(
+      "'intent' (why this change), 'core' (the main implementation), 'ripple' (knock-on changes elsewhere), or 'test' (what the tests cover)"
+    ),
+  title: z.string().min(1).describe("Short step heading"),
+  body: z.string().min(1).describe("Step explanation, following the kind's content contract"),
+});
+
+server.tool(
+  "save_walkthrough",
+  "Save a completed PR walkthrough for a branch: an ordered set of steps (intent -> core -> ripple -> test) that narrate the change, each anchored to a file/line range. " +
+    "Called once, at the end, from the /conductor-walkthrough command after the exploration is done — replaces any prior walkthrough for the branch and marks it ready for the Conductor Viewer to render.",
+  {
+    branch: z.string().min(1).describe("Branch the walkthrough belongs to"),
+    title: z.string().min(1).describe("One-line walkthrough title"),
+    summary: z.string().min(1).describe("Short overview of the change, shown above the steps"),
+    steps: z
+      .array(walkthroughStepSchema)
+      .min(1)
+      .describe("Ordered walkthrough steps (see save_walkthrough's step fields)"),
+  },
+  async ({ branch, title, summary, steps }) => {
+    const d = getDb();
+
+    for (const step of steps) {
+      if (path.isAbsolute(step.file_path)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `step file_path must be repo-relative (e.g. src/foo.rs), got absolute path: ${step.file_path}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      if (
+        step.line_end !== undefined &&
+        step.line_start !== undefined &&
+        step.line_end < step.line_start
+      ) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Invalid range on step ${step.seq} (${step.file_path}): line_end (${step.line_end}) is before line_start (${step.line_start}).`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // walkthroughs.branch is UNIQUE with no generation history (see the Rust
+    // v6 migration): re-saving replaces the row and CASCADE-deletes its old
+    // steps rather than keeping past generations around.
+    const save = d.transaction(() => {
+      const walkthroughId = crypto.randomUUID();
+      d.prepare(
+        `INSERT INTO walkthroughs (id, branch, title, summary, status, error, created_at, updated_at)
+         VALUES (@id, @branch, @title, @summary, 'ready', NULL,
+                 COALESCE((SELECT created_at FROM walkthroughs WHERE branch = @branch), datetime('now')),
+                 datetime('now'))
+         ON CONFLICT(branch) DO UPDATE SET
+           title = excluded.title,
+           summary = excluded.summary,
+           status = 'ready',
+           error = NULL,
+           updated_at = datetime('now')`
+      ).run({ id: walkthroughId, branch, title, summary });
+
+      const { id: resolvedId } = d
+        .prepare("SELECT id FROM walkthroughs WHERE branch = ?")
+        .get(branch) as { id: string };
+
+      d.prepare("DELETE FROM walkthrough_steps WHERE walkthrough_id = ?").run(resolvedId);
+
+      const insertStep = d.prepare(
+        `INSERT INTO walkthrough_steps
+           (id, walkthrough_id, seq, file_path, line_start, line_end, kind, title, body)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const step of steps) {
+        insertStep.run(
+          crypto.randomUUID(),
+          resolvedId,
+          step.seq,
+          step.file_path,
+          step.line_start ?? null,
+          step.line_end ?? null,
+          step.kind,
+          step.title,
+          step.body
+        );
+      }
+
+      return resolvedId;
+    });
+
+    let walkthroughId: string;
+    try {
+      walkthroughId = save();
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to save walkthrough: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    signalUiRefresh();
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Walkthrough saved for branch "${branch}" (id: ${walkthroughId.slice(0, 8)}, ${steps.length} step(s)), status=ready.`,
+        },
+      ],
+    };
+  }
+);
+
+// ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,7 +4,9 @@
 //! layout focus model, and transitions between panels.
 
 mod review;
+mod review_publish;
 mod terminal;
+mod walkthrough_view;
 mod worktree;
 
 use std::collections::{HashMap, HashSet};
@@ -394,6 +396,23 @@ pub struct App {
     /// [`App::exit_editor`] (the only two methods that pair this field with
     /// `Focus::Editor`, keeping the invariant local).
     pub editor: Option<EditorPanel>,
+    /// In-flight headless walkthrough generation, if any. Polled by
+    /// [`App::poll_walkthrough_generation`]; the DB row is the source of
+    /// truth for completion, this handle only catches process failures.
+    pub walkthrough_gen: Option<crate::walkthrough::WalkthroughGeneration>,
+    /// The selected worktree's walkthrough (header + steps), reloaded by
+    /// [`App::refresh_reviews`] alongside the comment list.
+    pub current_walkthrough: Option<(
+        crate::walkthrough::Walkthrough,
+        Vec<crate::walkthrough::WalkthroughStep>,
+    )>,
+    /// Pending y/n confirmation for `Action::PublishReview`: `Some` while the
+    /// confirm overlay is showing (holding the already-filtered comments and
+    /// skip count to display), cleared on either answer.
+    pub publish_confirm: Option<crate::review_publish::PublishConfirm>,
+    /// In-flight GitHub-publish operation, polled by
+    /// [`App::poll_publish_review`].
+    pub publish_op: BackgroundOp<crate::review_publish::PublishOutcome>,
     /// Index of the currently selected worktree in the worktree list.
     pub selected_worktree: usize,
     /// Cached list of worktrees discovered in the repository.
@@ -957,6 +976,10 @@ impl App {
             main_repo_name,
             should_quit: false,
             editor: None,
+            walkthrough_gen: None,
+            current_walkthrough: None,
+            publish_confirm: None,
+            publish_op: BackgroundOp::default(),
             selected_worktree: 0,
             worktrees: Vec::new(),
             config,
@@ -1608,10 +1631,19 @@ impl App {
     /// Load (or reload) the diff for the currently selected worktree
     /// against the configured main branch.
     pub fn refresh_diff(&mut self) {
-        let base_branch = self.config.general.main_branch.clone();
         let word_diff = self.config.diff.word_diff;
         if let Some(wt) = self.worktrees.get(self.selected_worktree) {
             let path = wt.path.clone();
+            // A PR-review worktree may target a base other than the configured
+            // main branch (e.g. a release/develop branch); prefer the base ref
+            // recorded at intake time and only fall back to main_branch when
+            // none was saved (regular worktrees, or DB unavailable).
+            let saved_base = self
+                .review_store
+                .as_ref()
+                .and_then(|store| store.get_worktree_base_branch(&wt.branch).ok().flatten());
+            let base_branch =
+                resolve_diff_base_branch(saved_base, &self.config.general.main_branch);
             let tab_width = self.config.viewer.tab_width;
             self.diff_state
                 .load_diff(&path, &base_branch, word_diff, tab_width);
@@ -2177,11 +2209,15 @@ impl App {
                 self.review_state.template_picker_active = true;
             }
             CommandId::SessionHistory => self.cmd_session_history(),
+            CommandId::ReviewPullRequest => self.cmd_review_pull_request(),
+            CommandId::GenerateWalkthrough => self.cmd_generate_walkthrough(),
+            CommandId::PublishReview => self.cmd_publish_review(),
             CommandId::OpenRepo => self.cmd_open_repo(),
             CommandId::SwitchRepo => self.cmd_switch_repo(),
             CommandId::UngrabBranch => self.cmd_ungrab_branch(),
             CommandId::ShowDiffList => self.cmd_show_diff_list(),
             CommandId::ShowCommentList => self.cmd_show_comment_list(),
+            CommandId::ShowWalkthrough => self.cmd_show_walkthrough(),
             CommandId::AddReviewComment => self.cmd_add_review_comment(),
             CommandId::ViewCommentDetail => self.cmd_view_comment_detail(),
             CommandId::DeleteComment => self.cmd_delete_comment(),
@@ -2603,7 +2639,8 @@ impl App {
     }
 
     fn cmd_show_review_comments(&mut self) {
-        self.viewer_state.explorer.explorer_show_comments = true;
+        self.viewer_state.explorer.explorer_bottom_view =
+            crate::viewer::ExplorerBottomView::Comments;
         self.viewer_state.explorer.explorer_focus_on_diff_list = true;
         self.set_focus(Focus::Explorer);
     }
@@ -2619,6 +2656,13 @@ impl App {
             .open_repo
             .buffer
             .set_text(&self.repo_path.display().to_string());
+    }
+
+    fn cmd_review_pull_request(&mut self) {
+        self.overlays.active = ActiveOverlay::PrInput;
+        self.overlays.pr_input.buffer.clear();
+        self.overlays.pr_input.loading = false;
+        self.overlays.pr_input.error = None;
     }
 
     fn cmd_switch_repo(&mut self) {
@@ -2644,13 +2688,26 @@ impl App {
     }
 
     fn cmd_show_diff_list(&mut self) {
-        self.viewer_state.explorer.explorer_show_comments = false;
+        self.viewer_state.explorer.explorer_bottom_view = crate::viewer::ExplorerBottomView::DiffList;
         self.viewer_state.explorer.explorer_focus_on_diff_list = true;
         self.set_focus(Focus::Explorer);
     }
 
     fn cmd_show_comment_list(&mut self) {
-        self.viewer_state.explorer.explorer_show_comments = true;
+        self.viewer_state.explorer.explorer_bottom_view =
+            crate::viewer::ExplorerBottomView::Comments;
+        self.viewer_state.explorer.explorer_focus_on_diff_list = true;
+        self.set_focus(Focus::Explorer);
+    }
+
+    /// Palette/keybinding entry point: switch the Explorer's bottom pane to
+    /// the AI walkthrough view and focus the Explorer, mirroring
+    /// `cmd_show_diff_list`/`cmd_show_comment_list`. `cmd_generate_walkthrough`
+    /// uses a display-only variant instead (see its doc comment) so kicking
+    /// off a generation never steals focus from an active terminal input.
+    fn cmd_show_walkthrough(&mut self) {
+        self.viewer_state.explorer.explorer_bottom_view =
+            crate::viewer::ExplorerBottomView::Walkthrough;
         self.viewer_state.explorer.explorer_focus_on_diff_list = true;
         self.set_focus(Focus::Explorer);
     }
@@ -2717,7 +2774,7 @@ impl App {
     }
 
     fn cmd_delete_comment(&mut self) {
-        if self.viewer_state.explorer.explorer_show_comments
+        if self.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
             && self.viewer_state.explorer.explorer_focus_on_diff_list
             && !self.review_state.comment_list_rows.is_empty()
         {
@@ -2728,7 +2785,7 @@ impl App {
     }
 
     fn cmd_toggle_comment_resolve(&mut self) {
-        if self.viewer_state.explorer.explorer_show_comments
+        if self.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
             && self.viewer_state.explorer.explorer_focus_on_diff_list
             && !self.review_state.comment_list_rows.is_empty()
         {
@@ -2881,6 +2938,9 @@ impl App {
         self.poll_pr_url();
         self.poll_worktree_switch_ops();
         self.poll_worktree_ops();
+        self.poll_pr_intake();
+        self.poll_walkthrough_generation();
+        self.poll_publish_review();
 
         // ccusage
         if let Some(info) = self.bg.ccusage.poll() {
@@ -3571,6 +3631,16 @@ fn clamp_vt_divider(explorer: u16, viewer: u16, delta: i16, min: u16) -> u16 {
     (v + delta).clamp(min, upper) as u16
 }
 
+/// Resolve the base branch a diff should be computed against: a worktree's
+/// saved base ref (recorded at PR-intake time — see `save_worktree_base_branch`)
+/// takes priority, since a PR may target something other than the configured
+/// main branch (e.g. release/develop); `main_branch` is only used as a
+/// fallback for worktrees with no saved base (regular worktrees, or when the
+/// review DB is unavailable).
+fn resolve_diff_base_branch(saved_base: Option<String>, main_branch: &str) -> String {
+    saved_base.unwrap_or_else(|| main_branch.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3621,6 +3691,21 @@ mod tests {
             let t2 = 100u16.saturating_sub(24 + v2);
             assert!(v2 >= MIN && t2 >= MIN, "vt delta={delta}: 24/{v2}/{t2}");
         }
+    }
+
+    // ── diff base branch resolution (FIX-1: PR base ref must reach the diff) ──
+
+    #[test]
+    fn resolve_diff_base_branch_prefers_saved_base_over_main() {
+        assert_eq!(
+            resolve_diff_base_branch(Some("release/1.0".to_string()), "main"),
+            "release/1.0"
+        );
+    }
+
+    #[test]
+    fn resolve_diff_base_branch_falls_back_to_main_when_unsaved() {
+        assert_eq!(resolve_diff_base_branch(None, "main"), "main");
     }
 
     #[test]

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -1,7 +1,11 @@
 //! Review / Comment / History methods for [`App`].
 //!
 //! This module contains methods for managing review comments, templates,
-//! and session history.
+//! and session history. It also orchestrates AI walkthrough generation for
+//! review mode: starting a headless `claude -p` session via
+//! [`crate::walkthrough`], polling it to completion, and reflecting
+//! success/failure back into the review database via
+//! [`crate::review_store::ReviewStore`].
 
 use super::*;
 
@@ -11,6 +15,8 @@ impl App {
         if let Some(store) = &self.review_store {
             let wt = self.selected_worktree_branch();
             self.review_state.load_comments(store, &wt);
+            // Walkthrough (if any) rides along with the same branch scope.
+            self.current_walkthrough = store.get_walkthrough(&wt).ok().flatten();
             // Rebuild per-file cache for the currently viewed file.
             if let Some(file_path) = self.viewer_state.content.current_file.clone() {
                 self.review_state.build_file_comment_cache(&file_path);
@@ -630,5 +636,173 @@ impl App {
                 }
             }
         }
+    }
+
+    /// Kick off walkthrough generation for the selected worktree's branch:
+    /// insert the `generating` row, then spawn the headless Claude session.
+    /// Re-running while `failed` (or `ready`) regenerates from scratch; while
+    /// a generation is already in flight it's a no-op with a status hint.
+    pub fn cmd_generate_walkthrough(&mut self) {
+        if self.review_store.is_none() {
+            self.set_status(
+                "Review database unavailable — cannot generate a walkthrough.".to_string(),
+                StatusLevel::Error,
+            );
+            return;
+        }
+        let branch = self.selected_worktree_branch();
+        if branch.is_empty() {
+            self.set_status(
+                "No worktree selected — open one to generate a walkthrough.".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+        // Only one generation may be in flight per app instance: replacing
+        // the handle would silently drop (and orphan) the running `claude`
+        // child and strand its branch's row in `generating` forever.
+        if let Some(g) = &self.walkthrough_gen {
+            let msg = if g.branch == branch {
+                "A walkthrough is already being generated for this branch.".to_string()
+            } else {
+                format!(
+                    "A walkthrough is already being generated for '{}' — wait for it to finish.",
+                    g.branch
+                )
+            };
+            self.set_status(msg, StatusLevel::Warning);
+            return;
+        }
+        let Some(wt_path) = self
+            .worktrees
+            .get(self.selected_worktree)
+            .map(|w| w.path.clone())
+        else {
+            return;
+        };
+
+        // Insert the `generating` row first so the UI (and a timeout) always
+        // have a row to reflect, then spawn. Base ref comes from the PR meta
+        // when this branch was taken in via PR intake.
+        let store = self.review_store.as_ref().expect("checked above");
+        if let Err(e) = store.begin_walkthrough(&branch) {
+            let msg = format!("Failed to start walkthrough: {e}");
+            self.set_status(msg, StatusLevel::Error);
+            return;
+        }
+        let base_ref = store
+            .get_pr_review_meta(&branch)
+            .ok()
+            .flatten()
+            .and_then(|m| m.base_ref);
+        let db = crate::review_store::db_path(&self.repo_path);
+        let model = self.config.review.walkthrough_model.clone();
+        let language = self.config.review.walkthrough_language.clone();
+        match crate::walkthrough::spawn_generation(
+            &self.repo_path,
+            &wt_path,
+            &db,
+            &branch,
+            base_ref.as_deref(),
+            model.as_deref(),
+            language.as_deref(),
+        ) {
+            Ok(generation) => {
+                self.walkthrough_gen = Some(generation);
+                // Display-only switch — no `set_focus`, so kicking off a
+                // generation from the palette never steals focus from an
+                // active terminal input; it just makes the in-progress state
+                // visible once the reviewer does look at the Explorer.
+                self.viewer_state.explorer.explorer_bottom_view =
+                    crate::viewer::ExplorerBottomView::Walkthrough;
+                self.set_status(
+                    "Generating walkthrough in the background — this takes a few minutes."
+                        .to_string(),
+                    StatusLevel::Info,
+                );
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if let Some(store) = &self.review_store {
+                    let _ = store.fail_walkthrough(&branch, &msg);
+                }
+                self.set_status(
+                    format!("Failed to launch walkthrough generation: {msg}"),
+                    StatusLevel::Error,
+                );
+            }
+        }
+        self.refresh_reviews();
+    }
+
+    /// Kill an in-flight walkthrough generation, if any, so it doesn't
+    /// outlive the app as an orphaned headless `claude` process. Called once
+    /// on shutdown (see `main.rs`'s main loop, right before it returns on
+    /// `should_quit`) — a generation still running at that point would
+    /// otherwise keep making API calls with no one polling its outcome.
+    pub fn shutdown_walkthrough_generation(&mut self) {
+        if let Some(mut generation) = self.walkthrough_gen.take() {
+            generation.abort();
+        }
+    }
+
+    /// Poll the in-flight walkthrough generation (if any) and reconcile the
+    /// database row with what the process actually did. Called from
+    /// [`App::poll_all_background_ops`](Self::poll_all_background_ops).
+    pub fn poll_walkthrough_generation(&mut self) {
+        let Some(generation) = &mut self.walkthrough_gen else {
+            return;
+        };
+        use crate::walkthrough::{GenerationPoll, WalkthroughStatus};
+        let outcome = generation.poll();
+        if matches!(outcome, GenerationPoll::Running) {
+            return;
+        }
+        let branch = generation.branch.clone();
+        let log_path = generation.log_path.clone();
+        self.walkthrough_gen = None;
+
+        let (message, level) = match outcome {
+            GenerationPoll::Running => unreachable!("handled above"),
+            GenerationPoll::Exited => {
+                // Success is decided by the row the MCP tool wrote, not the
+                // exit code: a session that ended without saving is a failure.
+                let saved = self
+                    .review_store
+                    .as_ref()
+                    .and_then(|s| s.get_walkthrough(&branch).ok().flatten())
+                    .is_some_and(|(w, _)| w.status == WalkthroughStatus::Ready);
+                if saved {
+                    ("Walkthrough ready.".to_string(), StatusLevel::Success)
+                } else {
+                    let msg = format!(
+                        "Claude session ended without saving a walkthrough (log: {})",
+                        log_path.display()
+                    );
+                    if let Some(store) = &self.review_store {
+                        let _ = store.fail_walkthrough(&branch, &msg);
+                    }
+                    (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
+                }
+            }
+            GenerationPoll::Failed(msg) => {
+                if let Some(store) = &self.review_store {
+                    let _ = store.fail_walkthrough(&branch, &msg);
+                }
+                (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
+            }
+            GenerationPoll::TimedOut => {
+                let msg = format!(
+                    "Timed out after {} minutes.",
+                    crate::walkthrough::GENERATION_TIMEOUT.as_secs() / 60
+                );
+                if let Some(store) = &self.review_store {
+                    let _ = store.fail_walkthrough(&branch, &msg);
+                }
+                (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
+            }
+        };
+        self.set_status(message, level);
+        self.refresh_reviews();
     }
 }

--- a/src/app/review_publish.rs
+++ b/src/app/review_publish.rs
@@ -1,0 +1,243 @@
+//! Publish-to-GitHub orchestration for [`App`]: computing what's publishable,
+//! driving the y/n confirm overlay (`App::publish_confirm`), and running the
+//! background `gh api` call. The actual `gh` CLI/JSON spelling lives in
+//! `crate::review_publish`, mirroring how `pr_intake.rs` is kept separate
+//! from its `app/worktree.rs` orchestration.
+
+use chrono::Utc;
+
+use crate::review_publish::{PublishComment, PublishConfirm, PublishOutcome, PublishRequest};
+
+use super::*;
+
+impl App {
+    /// `Action::PublishReview`: compute the current branch's unpublished,
+    /// in-diff comments and open the y/n confirm overlay (`Enter`/`y`/`n`
+    /// handled in `event/mod.rs`'s `handle_publish_confirm_key`). A no-op
+    /// with a status message instead of an overlay when there's nothing to
+    /// confirm (no PR, no `gh`-publishable comments).
+    pub fn cmd_publish_review(&mut self) {
+        let Some(store) = self.review_store.as_ref() else {
+            self.set_status(
+                "Review database unavailable — cannot publish comments.".to_string(),
+                StatusLevel::Error,
+            );
+            return;
+        };
+        let branch = self.selected_worktree_branch();
+        if branch.is_empty() {
+            self.set_status(
+                "No worktree selected — open one to publish comments.".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+
+        let meta = store.get_pr_review_meta(&branch).ok().flatten();
+        let (Some(pr_number), Some(pr_url)) = (
+            meta.as_ref().and_then(|m| m.pr_number),
+            meta.as_ref().and_then(|m| m.pr_url.clone()),
+        ) else {
+            self.set_status(
+                "Comments can only be published on a branch opened via PR intake.".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        };
+        let Some((owner, repo)) = crate::review_publish::owner_repo_from_pr_url(&pr_url) else {
+            self.set_status(
+                format!("Could not parse owner/repo from PR URL: {pr_url}"),
+                StatusLevel::Error,
+            );
+            return;
+        };
+
+        let unpublished = match store.unpublished_reviews(&branch) {
+            Ok(comments) => comments,
+            Err(e) => {
+                self.set_status(
+                    format!("Failed to load unpublished comments: {e}"),
+                    StatusLevel::Error,
+                );
+                return;
+            }
+        };
+        if unpublished.is_empty() {
+            self.set_status(
+                "No unpublished comments on this branch.".to_string(),
+                StatusLevel::Info,
+            );
+            return;
+        }
+
+        let comments: Vec<PublishComment> = unpublished
+            .into_iter()
+            .map(|c| {
+                let body = self.comment_body_with_replies(store, &c.id, &c.body);
+                PublishComment {
+                    id: c.id,
+                    file_path: c.file_path,
+                    line_start: c.line_start,
+                    line_end: c.line_end,
+                    body,
+                }
+            })
+            .collect();
+        let (comments, skipped) =
+            crate::review_publish::filter_publishable(comments, &self.diff_state);
+        if comments.is_empty() {
+            self.set_status(
+                format!("All {skipped} unpublished comment(s) are outside the current diff — nothing to publish."),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+
+        self.publish_confirm = Some(PublishConfirm {
+            owner,
+            repo,
+            pr_number: pr_number as u64,
+            comments,
+            skipped,
+        });
+    }
+
+    /// A comment's body with its replies appended (v1 has no GitHub-side
+    /// reply thread — a comment with replies is flattened into one comment
+    /// body, per ADR-6).
+    fn comment_body_with_replies(
+        &self,
+        store: &ReviewStore,
+        comment_id: &str,
+        body: &str,
+    ) -> String {
+        let replies = store.get_replies(comment_id).unwrap_or_default();
+        if replies.is_empty() {
+            return body.to_string();
+        }
+        let mut out = body.to_string();
+        out.push_str("\n\n---\n");
+        for reply in replies {
+            out.push_str(&format!("\n**{}:** {}\n", reply.author, reply.body));
+        }
+        out
+    }
+
+    /// Confirm the pending publish (`y`): hand the confirmed request off to a
+    /// background thread. A no-op if there's nothing pending or a publish is
+    /// already running.
+    pub fn confirm_publish_review(&mut self) {
+        let Some(confirm) = self.publish_confirm.take() else {
+            return;
+        };
+        if !should_start_publish(self.publish_op.is_running()) {
+            self.set_status(
+                "A publish is already in progress.".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+        let count = confirm.comments.len();
+        let request = PublishRequest {
+            owner: confirm.owner,
+            repo: confirm.repo,
+            pr_number: confirm.pr_number,
+            comments: confirm.comments,
+        };
+        self.publish_op.start(move |tx| {
+            let outcome = crate::review_publish::publish(request);
+            let _ = tx.send(outcome);
+        });
+        self.set_status(
+            format!("Publishing {count} comment(s) to GitHub…"),
+            StatusLevel::Info,
+        );
+    }
+
+    /// Cancel the pending publish confirm (`n`/`Esc`).
+    pub fn cancel_publish_review(&mut self) {
+        self.publish_confirm = None;
+        self.set_status("Publish cancelled.".to_string(), StatusLevel::Warning);
+    }
+
+    /// Poll the background publish operation (if any) and apply its result:
+    /// mark whichever comments actually posted as published, then report
+    /// what happened. Called from
+    /// [`App::poll_all_background_ops`](Self::poll_all_background_ops).
+    pub fn poll_publish_review(&mut self) {
+        let Some(outcome) = self.publish_op.poll() else {
+            return;
+        };
+        let now = Utc::now().to_rfc3339();
+        match outcome {
+            PublishOutcome::Succeeded { published_ids } => {
+                let count = published_ids.len();
+                self.mark_published(&published_ids, &now);
+                self.set_status(
+                    format!("Published {count} comment(s) to GitHub."),
+                    StatusLevel::Success,
+                );
+            }
+            PublishOutcome::PartialFailure {
+                published_ids,
+                failed,
+            } => {
+                let published_count = published_ids.len();
+                self.mark_published(&published_ids, &now);
+                for (id, error) in &failed {
+                    log::warn!("failed to publish comment {id}: {error}");
+                }
+                self.set_status(
+                    format!(
+                        "Published {published_count} comment(s); {} failed — see logs.",
+                        failed.len()
+                    ),
+                    StatusLevel::Warning,
+                );
+            }
+            PublishOutcome::Failed { error } => {
+                self.set_status(
+                    format!("Failed to publish comments: {error}"),
+                    StatusLevel::Error,
+                );
+            }
+        }
+    }
+
+    /// Mark the given comment ids published and reload the comment list so
+    /// their new `published_at` is reflected immediately.
+    fn mark_published(&mut self, ids: &[String], timestamp: &str) {
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(store) = &self.review_store
+            && let Err(e) = store.mark_published(ids, timestamp)
+        {
+            log::warn!("failed to mark comments published: {e}");
+        }
+        self.refresh_reviews();
+    }
+}
+
+/// Whether a confirmed publish should actually start a new background
+/// request: never while one is already running, since a stray double
+/// confirm (e.g. `Enter` pressed twice) before the first request completes
+/// would otherwise submit two `gh api` calls for the same comments.
+fn should_start_publish(is_running: bool) -> bool {
+    !is_running
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_start_publish;
+
+    #[test]
+    fn confirming_again_while_a_publish_is_running_does_not_start_a_new_one() {
+        assert!(!should_start_publish(true));
+    }
+
+    #[test]
+    fn confirming_starts_when_nothing_is_running() {
+        assert!(should_start_publish(false));
+    }
+}

--- a/src/app/walkthrough_view.rs
+++ b/src/app/walkthrough_view.rs
@@ -1,0 +1,202 @@
+//! Explorer walkthrough-view methods for [`App`]: step selection, jumping to
+//! a step's location in the diff pane, and the "viewed" file toggle. These
+//! back the Explorer's `Walkthrough` bottom-pane view (see
+//! `viewer::ExplorerBottomView`) and the diff list's per-file viewed mark.
+
+use super::*;
+
+impl App {
+    /// Move the walkthrough step cursor by `delta` rows (`j`/`k`), clamped to
+    /// the step list's bounds. Selection only — no jump, unlike `n`/`N`.
+    pub fn walkthrough_move(&mut self, delta: isize) {
+        let Some(len) = self
+            .current_walkthrough
+            .as_ref()
+            .map(|(_, steps)| steps.len())
+        else {
+            return;
+        };
+        if len == 0 {
+            return;
+        }
+        let cur = self.viewer_state.explorer.walkthrough_selected as isize;
+        self.viewer_state.explorer.walkthrough_selected =
+            (cur + delta).clamp(0, len as isize - 1) as usize;
+    }
+
+    /// Jump to the currently selected walkthrough step (`Enter`): open its
+    /// file in the diff pane and move focus to the Viewer, mirroring the diff
+    /// list's own Enter handling so the two views feel consistent.
+    pub fn walkthrough_jump_selected(&mut self) {
+        let idx = self.viewer_state.explorer.walkthrough_selected;
+        if !self.jump_to_walkthrough_step(idx) {
+            return;
+        }
+        self.set_focus(Focus::Viewer);
+    }
+
+    /// Move the walkthrough selection by `delta` and jump immediately
+    /// (`n`/`N` while the Walkthrough view is focused). Stays on the
+    /// Walkthrough view, unlike `walkthrough_jump_selected`, so repeated
+    /// presses keep paging through steps without the diff pane taking
+    /// keyboard focus away from the step list.
+    pub fn walkthrough_step(&mut self, delta: isize) {
+        let Some(len) = self
+            .current_walkthrough
+            .as_ref()
+            .map(|(_, steps)| steps.len())
+        else {
+            return;
+        };
+        if len == 0 {
+            return;
+        }
+        let cur = self.viewer_state.explorer.walkthrough_selected as isize;
+        let next = (cur + delta).clamp(0, len as isize - 1) as usize;
+        self.jump_to_walkthrough_step(next);
+    }
+
+    /// Shared implementation for jumping to walkthrough step `idx`: opens its
+    /// file in the diff pane, scrolls to its starting line, and marks it
+    /// viewed. Returns `false` (a no-op otherwise) if there's no walkthrough,
+    /// the index is out of range, or the step's file isn't part of the
+    /// current diff.
+    fn jump_to_walkthrough_step(&mut self, idx: usize) -> bool {
+        let Some((_, steps)) = &self.current_walkthrough else {
+            return false;
+        };
+        let Some(step) = steps.get(idx) else {
+            return false;
+        };
+        let file_path = step.file_path.clone();
+        let line_start = step.line_start;
+        let step_id = step.id.clone();
+
+        let Some((file_diff, _)) = self
+            .diff_state
+            .display_index_for_path(&file_path)
+            .and_then(|i| self.diff_state.resolve_file(i))
+        else {
+            self.set_status(
+                format!("Walkthrough step references a file not in this diff: {file_path}"),
+                StatusLevel::Warning,
+            );
+            return false;
+        };
+        let file_diff_clone = file_diff.clone();
+        let Some(wt) = self.worktrees.get(self.selected_worktree) else {
+            return false;
+        };
+        let wt_path = wt.path.clone();
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.open_file(&wt_path, &file_path, tab_width);
+        self.viewer_state.reveal_file_in_tree(&file_path, &wt_path);
+        self.rehighlight_viewer();
+        self.review_state.build_file_comment_cache(&file_path);
+        self.expand_threads_for_file(&file_path);
+        self.viewer_state.build_unified_diff_view(&file_diff_clone);
+        if let Some(list_idx) = self.diff_state.display_index_for_path(&file_path) {
+            self.viewer_state.explorer.diff_list_selected = list_idx;
+        }
+
+        let target = line_start
+            .and_then(|line| {
+                self.viewer_state.diff_view.diff_view_lines.iter().position(|e| {
+                    matches!(e, crate::viewer::UnifiedDiffEntry::Line { new_line_no: Some(n), .. } if *n as i64 == line)
+                })
+            })
+            .or_else(|| {
+                self.viewer_state.diff_view.diff_view_lines.iter().position(|e| {
+                    matches!(e, crate::viewer::UnifiedDiffEntry::Line { tag, .. } if *tag != crate::diff_state::DiffLineTag::Equal)
+                })
+            });
+        if let Some(pos) = target {
+            self.viewer_state.diff_view.diff_view_scroll = pos.saturating_sub(3);
+        }
+
+        self.viewer_state.explorer.walkthrough_selected = idx;
+        self.viewer_state.explorer.viewed_steps.insert(step_id);
+        true
+    }
+
+    /// Toggle the "viewed" mark for a file path — used by the diff list's `v`
+    /// key and the Viewer's diff-mode `v` key (Section C).
+    pub fn toggle_path_viewed(&mut self, path: &str) {
+        let viewed = &mut self.viewer_state.explorer.viewed;
+        if !viewed.remove(path) {
+            viewed.insert(path.to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// A manually-saved walkthrough (mirroring what the headless generator
+    /// writes) round-trips through the store with the shape the walkthrough
+    /// UI and jump logic depend on: `WalkthroughStep::kind` parses back to
+    /// the same variant, line ranges survive as `Some`, and the file path
+    /// resolves through `DiffState::display_index_for_path` — the lookup
+    /// `jump_to_walkthrough_step` uses to find the step's file in the diff.
+    #[test]
+    fn saved_walkthrough_round_trips_for_ui_consumption() {
+        use crate::diff_state::{DiffListEntry, DiffSection, DiffState, DiffViewMode, FileDiff};
+        use crate::review_store::ReviewStore;
+        use crate::walkthrough::{NewWalkthroughStep, WalkthroughStatus, WalkthroughStepKind};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReviewStore::open(&dir.path().join("conductor.db")).unwrap();
+        store.begin_walkthrough("feature-x").unwrap();
+        store
+            .save_walkthrough(
+                "feature-x",
+                "Add feature X",
+                "Wires up feature X end to end.",
+                &[
+                    NewWalkthroughStep {
+                        file_path: "src/a.rs".to_string(),
+                        line_start: None,
+                        line_end: None,
+                        kind: WalkthroughStepKind::Intent,
+                        title: "Why".to_string(),
+                        body: "Motivation.".to_string(),
+                    },
+                    NewWalkthroughStep {
+                        file_path: "src/a.rs".to_string(),
+                        line_start: Some(10),
+                        line_end: Some(12),
+                        kind: WalkthroughStepKind::Core,
+                        title: "Core change".to_string(),
+                        body: "What changed.".to_string(),
+                    },
+                ],
+            )
+            .unwrap();
+
+        let (walkthrough, steps) = store.get_walkthrough("feature-x").unwrap().unwrap();
+        assert_eq!(walkthrough.status, WalkthroughStatus::Ready);
+        assert_eq!(steps.len(), 2);
+        let core = &steps[1];
+        assert_eq!(core.kind, WalkthroughStepKind::Core);
+        assert_eq!(core.line_start, Some(10));
+        assert_eq!(core.line_end, Some(12));
+        assert!(!core.id.is_empty());
+
+        // The jump path's file lookup: the step's file must resolve through
+        // the diff list exactly like `jump_to_walkthrough_step` requires.
+        let mut ds = DiffState::new("main", DiffViewMode::Unified);
+        ds.committed_files = vec![FileDiff {
+            path: core.file_path.clone(),
+            added_lines: 3,
+            deleted_lines: 0,
+            is_new: false,
+            is_deleted: false,
+            hunks: Vec::new(),
+        }];
+        ds.display_list = vec![DiffListEntry::File {
+            section: DiffSection::Committed,
+            file_index: 0,
+            depth: 0,
+        }];
+        assert_eq!(ds.display_index_for_path(&core.file_path), Some(0));
+    }
+}

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -1763,6 +1763,78 @@ impl App {
         }
     }
 
+    // ── PR intake (Review Pull Request) ───────────────────────────
+
+    /// Kick off a background PR intake (gh metadata + git fetch + worktree
+    /// creation) for the "Review Pull Request" overlay. Safe to call again
+    /// for a retry after a failed attempt — the previous `bg_op` is just
+    /// replaced.
+    pub fn start_pr_intake(&mut self, input: &str) {
+        self.overlays.pr_input.loading = true;
+        self.overlays.pr_input.error = None;
+
+        let repo_path = self.repo_path.clone();
+        let worktree_dir = self.config.general.worktree_dir.clone();
+        let input = input.to_string();
+
+        self.overlays.pr_input.bg_op.start(move |tx| {
+            let outcome = crate::pr_intake::intake_pr(&repo_path, worktree_dir.as_deref(), &input);
+            let _ = tx.send(outcome);
+        });
+    }
+
+    /// Poll the background PR intake for a result and apply it: persist any
+    /// freshly-fetched PR metadata, switch to the worktree, and auto-launch
+    /// review mode.
+    ///
+    /// Applies even if the overlay was dismissed (Esc) while the intake was
+    /// still running — the fetch/worktree-creation already succeeded by
+    /// then, so it shouldn't be discarded.
+    pub fn poll_pr_intake(&mut self) {
+        let Some(outcome) = self.overlays.pr_input.bg_op.poll() else {
+            return;
+        };
+        self.overlays.pr_input.loading = false;
+
+        match outcome {
+            crate::pr_intake::PrIntakeOutcome::Ready {
+                pr_number,
+                worktree_path,
+                meta,
+            } => {
+                if let Some(meta) = &meta
+                    && let Some(store) = &self.review_store
+                {
+                    let _ = store.save_worktree_base_branch(&meta.branch, &meta.base_ref);
+                    let _ = store.save_pr_review_meta(
+                        &meta.branch,
+                        Some(pr_number as i64),
+                        Some(&meta.url),
+                        Some(&meta.title),
+                        Some(&meta.base_ref),
+                        Some(&meta.head_ref),
+                        meta.head_owner_login.as_deref(),
+                    );
+                }
+                self.refresh_worktrees();
+                self.select_worktree_by_path(&worktree_path);
+                self.overlays.active = crate::overlay::ActiveOverlay::None;
+                self.overlays.pr_input.buffer.clear();
+                self.viewer_state.explorer.explorer_focus_on_diff_list = true;
+                self.set_focus(Focus::Explorer);
+                self.set_status(
+                    format!(
+                        "PR #{pr_number} ready for review — walkthrough: palette › Generate Walkthrough"
+                    ),
+                    StatusLevel::Success,
+                );
+            }
+            crate::pr_intake::PrIntakeOutcome::Failed { error } => {
+                self.overlays.pr_input.error = Some(error.to_string());
+            }
+        }
+    }
+
     // ── Open PR in browser ───────────────────────────────────────
 
     /// Open the pull-request page for the selected worktree's branch in the

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -52,6 +52,9 @@ pub enum CommandId {
     ShowReviewComments,
     ShowReviewTemplates,
     SessionHistory,
+    ReviewPullRequest,
+    GenerateWalkthrough,
+    PublishReview,
 
     // Repository
     OpenRepo,
@@ -63,6 +66,7 @@ pub enum CommandId {
     // Explorer
     ShowDiffList,
     ShowCommentList,
+    ShowWalkthrough,
 
     // Viewer / Review
     AddReviewComment,
@@ -382,6 +386,13 @@ pub const COMMANDS: &[PaletteCommand] = &[
         action: Some(Action::ShowCommentList),
         keywords: "comment review list",
     },
+    PaletteCommand {
+        id: CommandId::ShowWalkthrough,
+        label: "Review: Show Walkthrough",
+        category: CommandCategory::View,
+        action: Some(Action::ShowWalkthrough),
+        keywords: "walkthrough steps ai tour",
+    },
     // Review
     PaletteCommand {
         id: CommandId::ShowReviewComments,
@@ -403,6 +414,27 @@ pub const COMMANDS: &[PaletteCommand] = &[
         category: CommandCategory::Review,
         action: Some(Action::SessionHistory),
         keywords: "history log",
+    },
+    PaletteCommand {
+        id: CommandId::ReviewPullRequest,
+        label: "Review: Review Pull Request…",
+        category: CommandCategory::Review,
+        action: Some(Action::ReviewPullRequest),
+        keywords: "pr pull request github fetch worktree walkthrough number url",
+    },
+    PaletteCommand {
+        id: CommandId::GenerateWalkthrough,
+        label: "Review: Generate Walkthrough",
+        category: CommandCategory::Review,
+        action: Some(Action::GenerateWalkthrough),
+        keywords: "walkthrough tour generate ai claude steps regenerate retry",
+    },
+    PaletteCommand {
+        id: CommandId::PublishReview,
+        label: "Review: Publish Comments to GitHub",
+        category: CommandCategory::Review,
+        action: Some(Action::PublishReview),
+        keywords: "publish post github pr comments review upload",
     },
     PaletteCommand {
         id: CommandId::AddReviewComment,
@@ -666,6 +698,24 @@ mod tests {
             Action::PullWorktree,
             Action::CherryPick,
             Action::OpenPullRequest,
+        ];
+        for action in must_have {
+            assert!(
+                COMMANDS.iter().any(|c| c.action == Some(action)),
+                "missing palette command for {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn comprehensive_review_commands_present() {
+        // Guards the PR-intake and AI-walkthrough entry points — each needs a
+        // palette command so a user without a keybinding memorized can still
+        // reach them.
+        let must_have = [
+            Action::ReviewPullRequest,
+            Action::GenerateWalkthrough,
+            Action::PublishReview,
         ];
         for action in must_have {
             assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,13 @@ pub struct ReviewConfig {
     pub prompt_template: String,
     /// What to do with the rendered prompt.
     pub prompt_action: PromptAction,
+    /// Model for the headless walkthrough-generation session, passed to
+    /// `claude --model` (alias like "opus"/"sonnet" or a full model id).
+    /// `None` uses the Claude CLI's session default.
+    pub walkthrough_model: Option<String>,
+    /// Natural language the walkthrough should be written in (e.g. "日本語",
+    /// "English"). `None` leaves the choice to the model.
+    pub walkthrough_language: Option<String>,
 }
 
 impl Default for ReviewConfig {
@@ -233,6 +240,8 @@ impl Default for ReviewConfig {
         Self {
             prompt_template: default_prompt_template(),
             prompt_action: PromptAction::Clipboard,
+            walkthrough_model: None,
+            walkthrough_language: None,
         }
     }
 }
@@ -606,6 +615,10 @@ pub fn generate_default_config() -> String {
 # prompt_template = "以下のレビューコメントに対応してください。\n\n{comments}"
 #                                       # template for review prompts ({comments} is replaced)
 # prompt_action = "clipboard"           # clipboard | send_to_session
+# walkthrough_model = "opus"            # model for AI walkthrough generation
+#                                       # (claude --model alias or full id; unset = CLI default)
+# walkthrough_language = "日本語"        # language the walkthrough is written in
+#                                       # (unset = model's choice)
 
 [keybinds]
 # Key-bind overrides, in key→action form. Each entry maps a key chord to an

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -140,6 +140,7 @@
 "d" = "show_diff_list"
 "c" = "show_comment_list"
 "C" = "open_comment_list"
+"w" = "show_walkthrough"
 "/" = "search_filename"
 ":" = "command_palette"
 
@@ -158,6 +159,7 @@
 "enter" = "select"
 "g" = "go_to_top"
 "G" = "go_to_bottom"
+"v" = "toggle_viewed"
 "esc" = "exit_sub_panel"
 "ctrl+esc" = "exit_sub_panel"
 ":" = "command_palette"
@@ -183,6 +185,27 @@
 "e" = "edit_comment"
 "R" = "reply_to_comment"
 "space" = "view_comment_detail"
+"esc" = "exit_sub_panel"
+"ctrl+esc" = "exit_sub_panel"
+":" = "command_palette"
+
+# ── Explorer: walkthrough ───────────────────────────────────────────────────────
+[layers.explorer_walkthrough]
+"tab" = "cycle_focus_forward"
+"shift+tab" = "cycle_focus_backward"
+"j" = "navigate_down"
+"down" = "navigate_down"
+"k" = "navigate_up"
+"up" = "navigate_up"
+"enter" = "select"
+"g" = "go_to_top"
+"G" = "go_to_bottom"
+"space" = "view_comment_detail"
+# Jump to the next/previous step immediately and stay on this view, unlike
+# `enter` (which jumps and moves focus to the Viewer) — lets a reviewer page
+# through the whole walkthrough with the diff following along.
+"n" = "walkthrough_next_step"
+"N" = "walkthrough_prev_step"
 "esc" = "exit_sub_panel"
 "ctrl+esc" = "exit_sub_panel"
 ":" = "command_palette"
@@ -242,6 +265,9 @@
 "l" = "scroll_right"
 "right" = "scroll_right"
 "0" = "scroll_home"
+"/" = "search_in_file"
+"n" = "next_search_match"
+"N" = "prev_search_match"
 "ctrl+f" = "search_filename"
 # Jump between changes (hunks) and between review comments.
 "]" = "next_hunk"
@@ -252,6 +278,7 @@
 "J" = "next_changed_file"
 "K" = "prev_changed_file"
 "c" = "add_comment"
+"v" = "toggle_viewed"
 # 'e' for "edit": open the file under review in $VISUAL/$EDITOR for a quick
 # manual fix without leaving the diff workflow (reloads on return).
 "e" = "open_in_editor"

--- a/src/diff_state.rs
+++ b/src/diff_state.rs
@@ -444,6 +444,14 @@ impl DiffState {
         }
     }
 
+    /// Find the display list index for a file by its repo-relative path
+    /// (the reverse of [`Self::resolve_file`]). Used to keep the diff list's
+    /// cursor in sync when a file is opened by path rather than by list
+    /// index (e.g. jumping to a walkthrough step's file).
+    pub fn display_index_for_path(&self, path: &str) -> Option<usize> {
+        (0..self.display_list.len()).find(|&idx| self.resolve_file(idx).is_some_and(|(f, _)| f.path == path))
+    }
+
     /// Toggle the collapsed state of the directory at the given display index.
     /// Returns `true` if a directory was toggled (so the caller knows the list
     /// changed). Non-directory rows (files, the summary) are a no-op.
@@ -1088,5 +1096,40 @@ mod tests {
             collapsed: false,
         }];
         ds.expand_section(0); // must not panic
+    }
+
+    /// `display_index_for_path` is the reverse of `resolve_file` — used to
+    /// re-sync the diff list's cursor when a file is opened by path (e.g.
+    /// jumping to a walkthrough step) rather than by list index.
+    #[test]
+    fn display_index_for_path_finds_committed_and_uncommitted_files() {
+        use super::*;
+        let file = |path: &str| FileDiff {
+            path: path.to_string(),
+            added_lines: 0,
+            deleted_lines: 0,
+            is_new: false,
+            is_deleted: false,
+            hunks: Vec::new(),
+        };
+        let mut ds = DiffState::new("main", DiffViewMode::Unified);
+        ds.committed_files = vec![file("src/a.rs")];
+        ds.uncommitted_files = vec![file("src/b.rs")];
+        ds.display_list = vec![
+            DiffListEntry::File {
+                section: DiffSection::Committed,
+                file_index: 0,
+                depth: 0,
+            },
+            DiffListEntry::File {
+                section: DiffSection::Uncommitted,
+                file_index: 0,
+                depth: 0,
+            },
+        ];
+
+        assert_eq!(ds.display_index_for_path("src/a.rs"), Some(0));
+        assert_eq!(ds.display_index_for_path("src/b.rs"), Some(1));
+        assert_eq!(ds.display_index_for_path("src/missing.rs"), None);
     }
 }

--- a/src/event/explorer.rs
+++ b/src/event/explorer.rs
@@ -7,6 +7,7 @@ use crate::keymap::{Action, KeyContext};
 use crate::overlay::ActiveOverlay;
 use crate::review_state::{CommentListRow, ReviewInputMode};
 use crate::review_store::{Author, CommentKind};
+use crate::viewer::ExplorerBottomView;
 
 use super::{adjust_diff_list_scroll, adjust_tree_scroll};
 
@@ -16,16 +17,22 @@ pub(super) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
         app.refresh_viewer();
     }
 
-    // Check for show-diff / show-comments before delegating to sub-panels.
+    // Check for show-diff / show-comments / show-walkthrough before delegating
+    // to sub-panels.
     let action = app.keymap.resolve(&key, KeyContext::Explorer);
     match action {
         Some(Action::ShowDiffList) => {
-            app.viewer_state.explorer.explorer_show_comments = false;
+            app.viewer_state.explorer.explorer_bottom_view = ExplorerBottomView::DiffList;
             app.viewer_state.explorer.explorer_focus_on_diff_list = true;
             return;
         }
         Some(Action::ShowCommentList) => {
-            app.viewer_state.explorer.explorer_show_comments = true;
+            app.viewer_state.explorer.explorer_bottom_view = ExplorerBottomView::Comments;
+            app.viewer_state.explorer.explorer_focus_on_diff_list = true;
+            return;
+        }
+        Some(Action::ShowWalkthrough) => {
+            app.viewer_state.explorer.explorer_bottom_view = ExplorerBottomView::Walkthrough;
             app.viewer_state.explorer.explorer_focus_on_diff_list = true;
             return;
         }
@@ -33,10 +40,12 @@ pub(super) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
     }
 
     if app.viewer_state.explorer.explorer_focus_on_diff_list {
-        if app.viewer_state.explorer.explorer_show_comments {
-            handle_explorer_comment_list_key(app, key);
-        } else {
-            handle_explorer_diff_list_key(app, key);
+        match app.viewer_state.explorer.explorer_bottom_view {
+            ExplorerBottomView::Comments => handle_explorer_comment_list_key(app, key),
+            ExplorerBottomView::Walkthrough => {
+                super::explorer_walkthrough::handle_explorer_walkthrough_key(app, key)
+            }
+            ExplorerBottomView::DiffList => handle_explorer_diff_list_key(app, key),
         }
         return;
     }
@@ -169,6 +178,13 @@ pub(super) fn handle_explorer_diff_list_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::GoToBottom) if count > 0 => {
             app.viewer_state.explorer.diff_list_selected = count - 1;
+        }
+        Some(Action::ToggleViewed) => {
+            let selected = app.viewer_state.explorer.diff_list_selected;
+            if let Some((file_diff, _)) = app.diff_state.resolve_file(selected) {
+                let path = file_diff.path.clone();
+                app.toggle_path_viewed(&path);
+            }
         }
         _ => {}
     }

--- a/src/event/explorer_walkthrough.rs
+++ b/src/event/explorer_walkthrough.rs
@@ -1,0 +1,43 @@
+//! Explorer walkthrough-view key handling (the AI walkthrough shown in the
+//! Explorer's bottom pane, see `viewer::ExplorerBottomView::Walkthrough`).
+
+use crossterm::event::KeyEvent;
+
+use crate::app::App;
+use crate::keymap::{Action, KeyContext};
+
+use super::adjust_walkthrough_scroll;
+
+/// Handle keys while the Explorer's Walkthrough view is focused.
+pub(super) fn handle_explorer_walkthrough_key(app: &mut App, key: KeyEvent) {
+    let len = app
+        .current_walkthrough
+        .as_ref()
+        .map(|(_, steps)| steps.len())
+        .unwrap_or(0);
+    let action = app.keymap.resolve(&key, KeyContext::ExplorerWalkthrough);
+
+    match action {
+        Some(Action::ExitSubPanel) => {
+            app.viewer_state.explorer.explorer_focus_on_diff_list = false;
+        }
+        Some(Action::NavigateDown) => app.walkthrough_move(1),
+        Some(Action::NavigateUp) => app.walkthrough_move(-1),
+        Some(Action::GoToTop) => app.viewer_state.explorer.walkthrough_selected = 0,
+        Some(Action::GoToBottom) if len > 0 => {
+            app.viewer_state.explorer.walkthrough_selected = len - 1;
+        }
+        Some(Action::Select) => app.walkthrough_jump_selected(),
+        Some(Action::WalkthroughNextStep) => app.walkthrough_step(1),
+        Some(Action::WalkthroughPrevStep) => app.walkthrough_step(-1),
+        // Reuses the comment list's detail-overlay action name (see
+        // default_keybinds.toml's `[layers.explorer_walkthrough]`) — the
+        // walkthrough view's own detail overlay, not the comment one.
+        Some(Action::ViewCommentDetail) if len > 0 => {
+            app.viewer_state.explorer.walkthrough_detail_active = true;
+        }
+        _ => {}
+    }
+
+    adjust_walkthrough_scroll(app);
+}

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -114,6 +114,13 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             }
             true
         }
+        Action::ReviewPullRequest => {
+            app.overlays.active = ActiveOverlay::PrInput;
+            app.overlays.pr_input.buffer.clear();
+            app.overlays.pr_input.loading = false;
+            app.overlays.pr_input.error = None;
+            true
+        }
         Action::UpdateAndRestart => {
             if app.update_info.is_some() {
                 app.start_update_confirm();
@@ -165,6 +172,14 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
         }
         Action::OpenThemePicker => {
             app.cmd_open_theme_picker();
+            true
+        }
+        Action::GenerateWalkthrough => {
+            app.cmd_generate_walkthrough();
+            true
+        }
+        Action::PublishReview => {
+            app.cmd_publish_review();
             true
         }
         _ => false, // Not a global action — let panel-specific handler try.

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -6,6 +6,7 @@
 //! Terminal-focused panels forward keys to the active PTY session.
 
 mod explorer;
+mod explorer_walkthrough;
 mod global;
 mod mouse;
 mod overlay;
@@ -38,8 +39,12 @@ enum EffectiveOverlay {
     SkipReason,
     /// Update confirmation/progress/failure dialog.
     UpdateState,
+    /// Publish-to-GitHub confirmation dialog.
+    PublishConfirm,
     /// Comment detail popup.
     CommentDetail,
+    /// Walkthrough step detail popup (Explorer walkthrough view's `space`).
+    WalkthroughDetail,
     /// Review text input (add/edit/reply).
     ReviewInput,
     /// Worktree text input (create/confirm/smart).
@@ -66,8 +71,14 @@ fn effective_overlay(app: &App) -> EffectiveOverlay {
     if app.update_state != UpdateState::Idle {
         return EffectiveOverlay::UpdateState;
     }
+    if app.publish_confirm.is_some() {
+        return EffectiveOverlay::PublishConfirm;
+    }
     if app.review_state.comment_detail_active {
         return EffectiveOverlay::CommentDetail;
+    }
+    if app.viewer_state.explorer.walkthrough_detail_active {
+        return EffectiveOverlay::WalkthroughDetail;
     }
     if app.review_state.input_mode != ReviewInputMode::Normal {
         return EffectiveOverlay::ReviewInput;
@@ -122,6 +133,7 @@ fn is_text_input_active(app: &App) -> bool {
             | ActiveOverlay::SwitchBranch
             | ActiveOverlay::CommandPalette
             | ActiveOverlay::OpenRepo
+            | ActiveOverlay::PrInput
             | ActiveOverlay::History
             | ActiveOverlay::ResumeSession
     )
@@ -175,8 +187,21 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             handle_update_key(app, key);
             return;
         }
+        EffectiveOverlay::PublishConfirm => {
+            handle_publish_confirm_key(app, key);
+            return;
+        }
         EffectiveOverlay::CommentDetail => {
             handle_comment_detail_key(app, key);
+            return;
+        }
+        EffectiveOverlay::WalkthroughDetail => {
+            if matches!(
+                key.code,
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char(' ')
+            ) {
+                app.viewer_state.explorer.walkthrough_detail_active = false;
+            }
             return;
         }
         EffectiveOverlay::ReviewInput => {
@@ -197,6 +222,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
                 ActiveOverlay::ResumeSession => handle_resume_session_key(app, key),
                 ActiveOverlay::RepoSelector => handle_repo_selector_key(app, key),
                 ActiveOverlay::OpenRepo => handle_open_repo_key(app, key),
+                ActiveOverlay::PrInput => handle_pr_input_key(app, key),
                 ActiveOverlay::GrepSearch => handle_grep_search_key(app, key),
                 ActiveOverlay::Help => handle_help_key(app, key),
                 ActiveOverlay::CommandPalette => handle_command_palette_key(app, key),
@@ -244,85 +270,12 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // ── 1b4. Reflow transcript view — consume all keys while active ──────────
-    // Must sit before the PTY-forward path so keys are not forwarded to Claude.
-    if app.reflow.active && app.focus == Focus::TerminalClaude {
-        // Pane resize / zoom / panel-overlay still work while scrolled back —
-        // they don't conflict with reflow's plain-key navigation (j/k/arrows),
-        // so let those chords (Ctrl+Alt+Arrow, etc.) through instead of letting
-        // reflow silently swallow them.
-        if let Some(action) = app.keymap.resolve(&key, KeyContext::Terminal)
-            && matches!(
-                action,
-                Action::ResizePaneLeft
-                    | Action::ResizePaneRight
-                    | Action::ResizePaneUp
-                    | Action::ResizePaneDown
-                    | Action::TogglePanelExpand
-                    | Action::TogglePanelOverlay
-            )
-            && dispatch_global_action(app, action)
-        {
-            return;
-        }
-        handle_reflow_key(app, key);
-        return;
-    }
-
-    // ── 1c. PTY focus — intercept configurable keys, forward rest to PTY ─
-    // Covers the Claude/Shell terminals and the embedded editor: each forwards
-    // unstolen keys to its inner program, using its own keymap context.
-
-    if app.focus.is_pty() {
-        let pty_context = app.focus.key_context();
-
-        // If the selected worktree is grabbed, block all terminal input
-        // except navigation keys (focus switching is handled above in §0).
-        // (The editor never opens on a grabbed worktree, so this only guards
-        // the Claude/Shell terminals in practice.)
-        if app.is_selected_worktree_grabbed() {
-            // Allow Esc to leave terminal, but block everything else.
-            if let Some(Action::LeaveTerminal) = app.keymap.resolve(&key, pty_context) {
-                app.set_focus(Focus::Explorer);
-            }
-            return;
-        }
-
-        // Resolve via the keymap (panel layer + global fallback, already
-        // filtered to actions that fire in the terminal). Terminal-only actions
-        // need terminal state; everything else reuses the shared global
-        // dispatch. A miss falls through to the PTY below — the keymap is the
-        // single source of truth for what the panel steals from the inner
-        // program (no hand-maintained allowlist).
-        if let Some(action) = app.keymap.resolve(&key, pty_context)
-            && (handle_terminal_only_action(app, action) || dispatch_global_action(app, action))
-        {
-            return;
-        }
-
-        // Courtesy hint: Ctrl+Q is Conductor's quit chord, but in a terminal it's
-        // forwarded to the inner program (XON / flow-control), so a user pressing
-        // it here gets no quit. Flash how to actually quit, then forward as usual.
-        if key.code == KeyCode::Char('q')
-            && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-        {
-            app.set_status_info(
-                "Ctrl+Q is sent to the terminal here. To quit Conductor: Ctrl+Esc to leave, then Ctrl+Q.".to_string(),
-            );
-        }
-
-        // Forward all remaining keys to the active PTY session.
-        let session_idx = match app.focus {
-            Focus::TerminalClaude => app.terminal.active_claude_session,
-            Focus::TerminalShell => app.terminal.active_shell_session,
-            Focus::Editor => app.editor.as_ref().map(|e| e.session_idx),
-            _ => unreachable!(),
-        };
-        if let Some(idx) = session_idx {
-            forward_key_to_pty(app, idx, key);
-        } else if key.code == KeyCode::Enter && app.focus != Focus::Editor {
-            spawn_terminal_session(app);
-        }
+    // ── 1b4/1c. Reflow transcript view and PTY focus ──────────────────────
+    // Must sit before the Focus dispatch below so keys are not forwarded to
+    // Claude. Factored into `dispatch_pty_key` so both the reflow-over-Claude
+    // case and the plain PTY-focus case share one code path.
+    if (app.reflow.active && app.focus == Focus::TerminalClaude) || app.focus.is_pty() {
+        dispatch_pty_key(app, key);
         return;
     }
 
@@ -348,6 +301,89 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         Focus::Explorer => handle_explorer_key(app, key),
         Focus::Viewer => handle_viewer_key(app, key),
         Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => unreachable!(),
+    }
+}
+
+/// Dispatch a key event for a PTY-focused panel (Claude/Shell/Editor), or for
+/// the reflow transcript view layered over the Claude terminal. Callers must
+/// only invoke this when `app.focus.is_pty()` or the reflow-over-Claude
+/// condition holds — `handle_key_event`'s panel dispatch guarantees this.
+fn dispatch_pty_key(app: &mut App, key: KeyEvent) {
+    // Reflow transcript view — consume all keys while active. Pane
+    // resize/zoom/panel-overlay still work while scrolled back — they don't
+    // conflict with reflow's plain-key navigation (j/k/arrows), so let those
+    // chords (Ctrl+Alt+Arrow, etc.) through instead of letting reflow
+    // silently swallow them.
+    if app.reflow.active && app.focus == Focus::TerminalClaude {
+        if let Some(action) = app.keymap.resolve(&key, KeyContext::Terminal)
+            && matches!(
+                action,
+                Action::ResizePaneLeft
+                    | Action::ResizePaneRight
+                    | Action::ResizePaneUp
+                    | Action::ResizePaneDown
+                    | Action::TogglePanelExpand
+                    | Action::TogglePanelOverlay
+            )
+            && dispatch_global_action(app, action)
+        {
+            return;
+        }
+        handle_reflow_key(app, key);
+        return;
+    }
+
+    if !app.focus.is_pty() {
+        return;
+    }
+    let pty_context = app.focus.key_context();
+
+    // If the selected worktree is grabbed, block all terminal input
+    // except navigation keys (focus switching is handled above in §0).
+    // (The editor never opens on a grabbed worktree, so this only guards
+    // the Claude/Shell terminals in practice.)
+    if app.is_selected_worktree_grabbed() {
+        // Allow Esc to leave terminal, but block everything else.
+        if let Some(Action::LeaveTerminal) = app.keymap.resolve(&key, pty_context) {
+            app.set_focus(Focus::Explorer);
+        }
+        return;
+    }
+
+    // Resolve via the keymap (panel layer + global fallback, already
+    // filtered to actions that fire in the terminal). Terminal-only actions
+    // need terminal state; everything else reuses the shared global
+    // dispatch. A miss falls through to the PTY below — the keymap is the
+    // single source of truth for what the panel steals from the inner
+    // program (no hand-maintained allowlist).
+    if let Some(action) = app.keymap.resolve(&key, pty_context)
+        && (handle_terminal_only_action(app, action) || dispatch_global_action(app, action))
+    {
+        return;
+    }
+
+    // Courtesy hint: Ctrl+Q is Conductor's quit chord, but in a terminal it's
+    // forwarded to the inner program (XON / flow-control), so a user pressing
+    // it here gets no quit. Flash how to actually quit, then forward as usual.
+    if key.code == KeyCode::Char('q')
+        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+    {
+        app.set_status_info(
+            "Ctrl+Q is sent to the terminal here. To quit Conductor: Ctrl+Esc to leave, then Ctrl+Q.".to_string(),
+        );
+    }
+
+    // Forward all remaining keys to the active PTY session.
+    let session_idx = match app.focus {
+        Focus::TerminalClaude => app.terminal.active_claude_session,
+        Focus::TerminalShell => app.terminal.active_shell_session,
+        Focus::Editor => app.editor.as_ref().map(|e| e.session_idx),
+        _ => unreachable!(),
+    };
+    if let Some(idx) = session_idx {
+        forward_key_to_pty(app, idx, key);
+    } else if key.code == KeyCode::Enter && app.focus != Focus::Editor {
+        spawn_terminal_session(app);
     }
 }
 
@@ -598,6 +634,10 @@ pub fn handle_paste_event(app: &mut App, data: String) {
                 ActiveOverlay::OpenRepo => {
                     app.overlays.open_repo.buffer.insert_str(&single_line);
                 }
+                ActiveOverlay::PrInput => {
+                    app.overlays.pr_input.buffer.insert_str(&single_line);
+                    app.overlays.pr_input.error = None;
+                }
                 ActiveOverlay::History => {
                     app.overlays.history.search_query.insert_str(&single_line);
                 }
@@ -661,6 +701,20 @@ fn handle_update_key(app: &mut App, key: KeyEvent) {
             app.update_state = UpdateState::Idle;
         }
         UpdateState::Restarting | UpdateState::Idle => {}
+    }
+}
+
+// ── Publish-to-GitHub overlay ───────────────────────────────────────────
+
+fn handle_publish_confirm_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+            app.confirm_publish_review();
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            app.cancel_publish_review();
+        }
+        _ => {}
     }
 }
 
@@ -749,6 +803,21 @@ fn adjust_diff_list_scroll(app: &mut App) {
         app.viewer_state.explorer.diff_list_scroll = selected;
     } else if selected >= app.viewer_state.explorer.diff_list_scroll + page_size {
         app.viewer_state.explorer.diff_list_scroll = selected.saturating_sub(page_size - 1);
+    }
+}
+
+/// Adjust `walkthrough_scroll` so that `walkthrough_selected` stays visible.
+/// Shares `explorer_diff_list_height` with the diff list since both views
+/// occupy the same Explorer bottom-pane rect (mutually exclusive, so the
+/// height is always current for whichever one is showing).
+fn adjust_walkthrough_scroll(app: &mut App) {
+    let selected = app.viewer_state.explorer.walkthrough_selected;
+    let page_size = app.viewer_state.explorer.explorer_diff_list_height.max(1);
+
+    if selected < app.viewer_state.explorer.walkthrough_scroll {
+        app.viewer_state.explorer.walkthrough_scroll = selected;
+    } else if selected >= app.viewer_state.explorer.walkthrough_scroll + page_size {
+        app.viewer_state.explorer.walkthrough_scroll = selected.saturating_sub(page_size - 1);
     }
 }
 

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -614,7 +614,10 @@ fn handle_explorer_column_click(app: &mut App, col: u16, row: u16, geom: &ClickG
 
         // Check for click on bottom border "✨ Ask Claude All" button.
         let bottom_border_y = main_area.y + main_area.height.saturating_sub(1);
-        if row == bottom_border_y && app.viewer_state.explorer.explorer_show_comments {
+        if row == bottom_border_y
+            && app.viewer_state.explorer.explorer_bottom_view
+                == crate::viewer::ExplorerBottomView::Comments
+        {
             // " ✨ Ask Claude All " is right-aligned, ~19 chars from right edge.
             let ask_label_w = 19_u16;
             let ask_start_col = explorer_end.saturating_sub(ask_label_w + 1);
@@ -628,7 +631,9 @@ fn handle_explorer_column_click(app: &mut App, col: u16, row: u16, geom: &ClickG
         if row >= inner_y {
             let click_offset = (row - inner_y) as usize;
 
-            if app.viewer_state.explorer.explorer_show_comments {
+            if app.viewer_state.explorer.explorer_bottom_view
+                == crate::viewer::ExplorerBottomView::Comments
+            {
                 // Comment list is displayed — handle comment selection.
                 let idx = app.viewer_state.explorer.comment_list_scroll + click_offset;
                 let row_count = app.review_state.comment_list_rows.len();
@@ -650,7 +655,9 @@ fn handle_explorer_column_click(app: &mut App, col: u16, row: u16, geom: &ClickG
                         navigate_to_comment_with_focus(app, comment_idx, is_double);
                     }
                 }
-            } else {
+            } else if app.viewer_state.explorer.explorer_bottom_view
+                == crate::viewer::ExplorerBottomView::DiffList
+            {
                 // Diff list is displayed — handle diff selection.
                 let idx = app.viewer_state.explorer.diff_list_scroll + click_offset;
                 if idx < app.diff_state.display_list.len() {

--- a/src/event/overlay.rs
+++ b/src/event/overlay.rs
@@ -523,6 +523,45 @@ pub(super) fn handle_open_repo_key(app: &mut App, key: KeyEvent) {
     }
 }
 
+// ── Overlay: PR intake (Review Pull Request) ────────────────────────────
+
+pub(super) fn handle_pr_input_key(app: &mut App, key: KeyEvent) {
+    // While a gh/git intake is running, only Esc is honored — the input
+    // itself is frozen so a stray keystroke can't race the background thread.
+    if app.overlays.pr_input.loading {
+        if key.code == KeyCode::Esc {
+            app.overlays.active = ActiveOverlay::None;
+        }
+        return;
+    }
+    match key.code {
+        KeyCode::Esc => {
+            app.overlays.active = ActiveOverlay::None;
+            app.overlays.pr_input.buffer.clear();
+            app.overlays.pr_input.error = None;
+        }
+        KeyCode::Enter => {
+            let input = app.overlays.pr_input.buffer.text().to_string();
+            if !input.trim().is_empty() {
+                app.overlays.pr_input.error = None;
+                app.start_pr_intake(&input);
+            }
+        }
+        KeyCode::Backspace if key.modifiers.contains(KeyModifiers::SUPER) => {
+            app.overlays.pr_input.buffer.delete_to_line_start();
+        }
+        KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            clipboard_paste(app, |a| &mut a.overlays.pr_input.buffer, false);
+        }
+        _ => {
+            // Any edit after a failed attempt clears the stale error so it
+            // doesn't linger next to input the user has already changed.
+            app.overlays.pr_input.error = None;
+            app.overlays.pr_input.buffer.handle_key(key);
+        }
+    }
+}
+
 // ── Overlay: comment detail ─────────────────────────────────────────────
 
 pub(super) fn handle_comment_detail_key(app: &mut App, key: KeyEvent) {

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -11,6 +11,20 @@ use crate::viewer::UnifiedDiffEntry;
 
 use super::explorer::open_viewer_comment_detail;
 
+/// 'g' — show symbol hints and wait for a second key (gd, gi, gr, gg, or a
+/// hint label). Shared by the plain-file view and unified-diff view so `g`
+/// means the same thing in both; the caller is responsible for syncing
+/// `content.file_scroll` to the diff cursor first when in diff mode; hints
+/// are built from that same synced position.
+fn enter_g_prefix_mode(app: &mut App) {
+    app.viewer_state.pending_g_key = true;
+    // Build hints using an estimated viewer height (will be clipped by actual content).
+    let hints = app.build_symbol_hints(50);
+    app.symbol_hint_overlay.active = !hints.is_empty();
+    app.symbol_hint_overlay.hints = hints;
+    app.symbol_hint_overlay.input.clear();
+}
+
 /// Handle keys when the Viewer panel is focused.
 pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
     // ── Inline reply input mode ──────────────────────────────────
@@ -28,13 +42,9 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // Unified diff mode has its own navigation.
-    if app.viewer_state.diff_view.diff_mode {
-        handle_viewer_diff_mode_key(app, key);
-        return;
-    }
-
     // ── pending 'g' key — symbol hints are shown, waiting for second key ──
+    // Checked before the diff-mode dispatch below since gd/gi/gr/gg apply the
+    // same way whether the viewer is showing a plain file or a unified diff.
     if app.viewer_state.pending_g_key {
         app.viewer_state.pending_g_key = false;
         match key.code {
@@ -56,7 +66,11 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
             KeyCode::Char('g') => {
                 // gg = go to top
                 app.symbol_hint_overlay = Default::default();
-                app.viewer_state.content.file_scroll = 0;
+                if app.viewer_state.diff_view.diff_mode {
+                    app.viewer_state.diff_view.diff_view_scroll = 0;
+                } else {
+                    app.viewer_state.content.file_scroll = 0;
+                }
                 return;
             }
             KeyCode::Esc => {
@@ -73,6 +87,12 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
                 app.symbol_hint_overlay = Default::default();
             }
         }
+    }
+
+    // Unified diff mode has its own navigation.
+    if app.viewer_state.diff_view.diff_mode {
+        handle_viewer_diff_mode_key(app, key);
+        return;
     }
 
     let total = app.viewer_state.content.file_content.len();
@@ -121,15 +141,7 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
             app.viewer_state.content.file_scroll =
                 app.viewer_state.content.file_scroll.saturating_sub(15);
         }
-        Some(Action::GoToTop) => {
-            // 'g' — show symbol hints and wait for second key (gd, gi, gr, gg, or hint label).
-            app.viewer_state.pending_g_key = true;
-            // Build hints using an estimated viewer height (will be clipped by actual content).
-            let hints = app.build_symbol_hints(50);
-            app.symbol_hint_overlay.active = !hints.is_empty();
-            app.symbol_hint_overlay.hints = hints;
-            app.symbol_hint_overlay.input.clear();
-        }
+        Some(Action::GoToTop) => enter_g_prefix_mode(app),
         Some(Action::GoToBottom) => {
             app.viewer_state.content.file_scroll = total.saturating_sub(1);
         }
@@ -273,10 +285,28 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
                 .saturating_sub(15);
         }
         Some(Action::GoToTop) => {
-            app.viewer_state.diff_view.diff_view_scroll = 0;
+            // 'g' now matches the plain-file view's symbol-hint prefix (gd,
+            // gi, gr, gg, or a hint label) instead of jumping to the top
+            // directly — the previous single-`g`-jumps-to-top behavior moved
+            // to `gg` so `g` means the same thing in both views. Sync
+            // `content.file_scroll` to the line under the diff cursor first,
+            // since symbol lookup and hint-building read that field.
+            app.viewer_state.sync_file_scroll_to_diff_scroll();
+            enter_g_prefix_mode(app);
         }
         Some(Action::GoToBottom) => {
             app.viewer_state.diff_view.diff_view_scroll = total.saturating_sub(1);
+        }
+        Some(Action::SearchInFile) => {
+            app.viewer_state.sync_file_scroll_to_diff_scroll();
+            app.viewer_state.search.search_active = true;
+            app.viewer_state.search.search_query.clear();
+        }
+        Some(Action::NextSearchMatch) => {
+            app.viewer_state.next_search_match();
+        }
+        Some(Action::PrevSearchMatch) => {
+            app.viewer_state.prev_search_match();
         }
         Some(Action::NextHunk) => {
             let lines = &app.viewer_state.diff_view.diff_view_lines;
@@ -343,6 +373,11 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
             // Expand all lines at the first visible ExpandableContext.
             if let Some(idx) = app.viewer_state.find_visible_expandable(50) {
                 app.viewer_state.expand_context_at(idx, true);
+            }
+        }
+        Some(Action::ToggleViewed) => {
+            if let Some(path) = app.viewer_state.content.current_file.clone() {
+                app.toggle_path_viewed(&path);
             }
         }
         _ => {}

--- a/src/git_engine.rs
+++ b/src/git_engine.rs
@@ -250,6 +250,109 @@ impl GitEngine {
         Ok(wt_path)
     }
 
+    /// Create a worktree checking out a branch that already exists locally
+    /// (PR intake equivalent — the branch was created by a prior
+    /// `fetch_refspec`, so this is a plain `git worktree add <path> <branch>`
+    /// with no `-b`, unlike `create_worktree_from_base`/`create_worktree_from_remote`).
+    ///
+    /// `wt_dir` is the full worktree directory to create (the caller decides
+    /// its name/location, e.g. via `worktrees_base_dir`).
+    pub fn create_worktree_for_existing_branch(
+        &self,
+        branch: &str,
+        wt_dir: &Path,
+    ) -> Result<PathBuf> {
+        if wt_dir.exists() {
+            anyhow::bail!("directory already exists: {}", wt_dir.display());
+        }
+
+        let name = wt_dir.file_name().ok_or_else(|| {
+            anyhow!(
+                "cannot determine worktree name from path {}",
+                wt_dir.display()
+            )
+        })?;
+        self.force_prune_worktree_entry(&name.to_string_lossy());
+
+        // See create_worktree_from_base() for why we use spawn()+wait() over output().
+        let main_dir = self.main_worktree_path()?;
+        let mut child = std::process::Command::new("git")
+            .args(["worktree", "add", &wt_dir.display().to_string(), branch])
+            .current_dir(&main_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .context("failed to run `git worktree add`")?;
+        let status = child
+            .wait()
+            .context("failed to wait for `git worktree add`")?;
+        if !status.success() {
+            let mut stderr_buf = String::new();
+            if let Some(mut stderr) = child.stderr.take() {
+                use std::io::Read;
+                let _ = stderr.read_to_string(&mut stderr_buf);
+            }
+            anyhow::bail!("git worktree add failed: {}", stderr_buf.trim());
+        }
+
+        Ok(wt_dir.to_path_buf())
+    }
+
+    /// Ensure a local branch for `base_branch` exists and is reasonably
+    /// up to date, without ever force-updating or checking it out.
+    ///
+    /// - If no local branch exists yet, fetch it straight into
+    ///   `refs/heads/<base_branch>`.
+    /// - If it exists, fetch the remote tip into a scratch ref first (fetching
+    ///   directly into `refs/heads/<base_branch>` would be rejected by git if
+    ///   that branch happens to be checked out in another worktree) and only
+    ///   fast-forward the local branch if the fetched tip is a strict
+    ///   descendant of it. A non-fast-forward (diverged, or already caught
+    ///   up) is left untouched — this is metadata for a diff base, not a
+    ///   branch the user is actively working on, so silently discarding local
+    ///   history would be the wrong failure mode.
+    pub fn ensure_base_ref_available(&self, base_branch: &str) -> Result<()> {
+        if self
+            .repo
+            .find_branch(base_branch, git2::BranchType::Local)
+            .is_err()
+        {
+            self.fetch_refspec(&format!("{base_branch}:refs/heads/{base_branch}"))?;
+            return Ok(());
+        }
+
+        const SCRATCH_REF: &str = "refs/conductor/pr-intake-base-update";
+        self.fetch_refspec(&format!("{base_branch}:{SCRATCH_REF}"))?;
+
+        let local_oid = self
+            .repo
+            .find_branch(base_branch, git2::BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+        let fetched_oid = self
+            .repo
+            .find_reference(SCRATCH_REF)?
+            .peel_to_commit()?
+            .id();
+
+        if fetched_oid != local_oid && self.repo.graph_descendant_of(fetched_oid, local_oid)? {
+            let mut branch_ref = self
+                .repo
+                .find_reference(&format!("refs/heads/{base_branch}"))?;
+            branch_ref.set_target(
+                fetched_oid,
+                "conductor: fast-forward base branch for PR intake",
+            )?;
+        }
+
+        if let Ok(mut scratch) = self.repo.find_reference(SCRATCH_REF) {
+            let _ = scratch.delete();
+        }
+
+        Ok(())
+    }
+
     // ── Remote branch operations (wt switch) ─────────────────────
 
     /// List remote branches (refs/remotes/origin/*), excluding HEAD.
@@ -947,16 +1050,31 @@ impl GitEngine {
     /// NOTE: This performs network I/O and may block for several seconds.
     /// Do NOT call from the UI thread — use a background thread instead.
     pub fn fetch_origin(&self) -> Result<()> {
+        self.run_git_fetch(&["--prune", "origin"])
+    }
+
+    /// Run `git fetch origin <refspec>` by shelling out to the `git` CLI —
+    /// the refspec-taking sibling of `fetch_origin`, for pulling down a
+    /// specific ref (e.g. a PR head: `pull/123/head:pr-123`) rather than
+    /// syncing every remote-tracking branch.
+    ///
+    /// NOTE: This performs network I/O and may block for several seconds.
+    /// Do NOT call from the UI thread — use a background thread instead.
+    pub fn fetch_refspec(&self, refspec: &str) -> Result<()> {
+        self.run_git_fetch(&["origin", refspec])
+    }
+
+    /// Shell out to `git fetch <args>`, with the timeout/output handling
+    /// shared by `fetch_origin` and `fetch_refspec`.
+    fn run_git_fetch(&self, args: &[&str]) -> Result<()> {
         use std::process::{Command, Stdio};
         use std::time::Duration;
 
         let cwd = self.repo.workdir().unwrap_or(self.repo.path());
-        log::debug!(
-            "fetch_origin: running `git fetch --prune origin` in {}",
-            cwd.display()
-        );
+        log::debug!("run_git_fetch: running `git fetch {}` in {}", args.join(" "), cwd.display());
         let mut child = Command::new("git")
-            .args(["fetch", "--prune", "origin"])
+            .arg("fetch")
+            .args(args)
             .current_dir(cwd)
             .env("GIT_TERMINAL_PROMPT", "0")
             .stdin(Stdio::null())
@@ -982,22 +1100,27 @@ impl GitEngine {
                                 buf
                             })
                             .unwrap_or_default();
-                        log::warn!("fetch_origin stderr: {stderr}");
-                        anyhow::bail!("git fetch failed (exit {}): {}", status, stderr.trim());
+                        log::warn!("git fetch {} stderr: {stderr}", args.join(" "));
+                        anyhow::bail!(
+                            "git fetch {} failed (exit {}): {}",
+                            args.join(" "),
+                            status,
+                            stderr.trim()
+                        );
                     }
-                    log::debug!("fetch_origin: success");
+                    log::debug!("run_git_fetch: success ({})", args.join(" "));
                     return Ok(());
                 }
                 Ok(None) => {
                     // Still running.
                     if start.elapsed() > timeout {
                         let _ = child.kill();
-                        anyhow::bail!("git fetch timed out after {timeout:?}");
+                        anyhow::bail!("git fetch {} timed out after {timeout:?}", args.join(" "));
                     }
                     std::thread::sleep(Duration::from_millis(100));
                 }
                 Err(e) => {
-                    anyhow::bail!("failed to wait for git fetch: {e}");
+                    anyhow::bail!("failed to wait for git fetch {}: {e}", args.join(" "));
                 }
             }
         }
@@ -1898,5 +2021,247 @@ mod tests {
         assert_eq!(loaded.3, None);
 
         engine.remove_grab_state().unwrap();
+    }
+
+    /// Create a bare "origin" repo with a `main` branch, plus a local repo
+    /// that has it configured as `origin` and has fetched `main`. Returns
+    /// `(origin_tmp, local_tmp, origin_repo, local_engine)` — `origin_repo`
+    /// lets a test add more commits/branches to push into the "remote".
+    fn temp_repo_with_origin() -> (tempfile::TempDir, tempfile::TempDir, Repository, GitEngine) {
+        let origin_tmp = tempfile::tempdir().expect("create origin temp dir");
+        let origin_repo = Repository::init_bare(origin_tmp.path()).expect("init bare origin");
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        {
+            // A bare repo has no index/workdir, so build the (empty) tree
+            // directly rather than going through Repository::index().
+            let tree_oid = origin_repo.treebuilder(None).unwrap().write().unwrap();
+            let tree = origin_repo.find_tree(tree_oid).unwrap();
+            origin_repo
+                .commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+                .unwrap();
+        }
+
+        let local_tmp = tempfile::tempdir().expect("create local temp dir");
+        let local_repo = Repository::init(local_tmp.path()).expect("init local repo");
+        // A fresh repo's HEAD points at (an unborn) refs/heads/main, which
+        // git fetch treats as "checked out" and refuses to fetch into.
+        // Point HEAD elsewhere first so fetching `main` directly is allowed.
+        local_repo.set_head("refs/heads/scratch").unwrap();
+        local_repo
+            .remote("origin", &origin_tmp.path().display().to_string())
+            .unwrap();
+        let engine = GitEngine::open(local_tmp.path()).expect("open local repo");
+        engine.fetch_refspec("main:refs/heads/main").unwrap();
+
+        (origin_tmp, local_tmp, origin_repo, engine)
+    }
+
+    /// Add a commit to `refs/heads/<branch_name>` in `repo`, parented on
+    /// `main`'s current tip. Used to simulate a PR head landing on "origin".
+    fn commit_on_branch(repo: &Repository, branch_name: &str, message: &str) {
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let parent = repo
+            .find_reference("refs/heads/main")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+        let tree = parent.tree().unwrap();
+        repo.commit(
+            Some(&format!("refs/heads/{branch_name}")),
+            &sig,
+            &sig,
+            message,
+            &tree,
+            &[&parent],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn fetch_refspec_creates_local_branch() {
+        let (_origin_tmp, _local_tmp, origin_repo, engine) = temp_repo_with_origin();
+        commit_on_branch(&origin_repo, "feature", "a PR head");
+
+        engine
+            .fetch_refspec("refs/heads/feature:refs/heads/pr-99")
+            .unwrap();
+
+        let branch = engine
+            .repo
+            .find_branch("pr-99", git2::BranchType::Local)
+            .expect("pr-99 branch should exist after fetch_refspec");
+        assert_eq!(
+            branch.get().peel_to_commit().unwrap().message(),
+            Some("a PR head")
+        );
+    }
+
+    #[test]
+    fn fetch_refspec_reports_failure_for_unknown_ref() {
+        let (_origin_tmp, _local_tmp, _origin_repo, engine) = temp_repo_with_origin();
+        let err = engine
+            .fetch_refspec("refs/heads/does-not-exist:refs/heads/pr-1")
+            .unwrap_err();
+        assert!(err.to_string().contains("git fetch"));
+    }
+
+    #[test]
+    fn create_worktree_for_existing_branch_checks_out_branch() {
+        let (_origin_tmp, _local_tmp, origin_repo, engine) = temp_repo_with_origin();
+        commit_on_branch(&origin_repo, "feature", "a PR head");
+        engine
+            .fetch_refspec("refs/heads/feature:refs/heads/pr-99")
+            .unwrap();
+
+        let base_dir = engine.worktrees_base_dir(None).unwrap();
+        let wt_dir = base_dir.join("pr-99");
+        let created = engine
+            .create_worktree_for_existing_branch("pr-99", &wt_dir)
+            .unwrap();
+
+        assert_eq!(created, wt_dir);
+        assert!(wt_dir.join(".git").exists());
+        let checked_out = GitEngine::open(&wt_dir).unwrap();
+        assert_eq!(
+            checked_out
+                .repo
+                .head()
+                .unwrap()
+                .shorthand()
+                .unwrap_or_default(),
+            "pr-99"
+        );
+    }
+
+    #[test]
+    fn create_worktree_for_existing_branch_rejects_existing_dir() {
+        let (_origin_tmp, _local_tmp, origin_repo, engine) = temp_repo_with_origin();
+        commit_on_branch(&origin_repo, "feature", "a PR head");
+        engine
+            .fetch_refspec("refs/heads/feature:refs/heads/pr-99")
+            .unwrap();
+
+        let base_dir = engine.worktrees_base_dir(None).unwrap();
+        let wt_dir = base_dir.join("pr-99");
+        std::fs::create_dir_all(&wt_dir).unwrap();
+
+        assert!(
+            engine
+                .create_worktree_for_existing_branch("pr-99", &wt_dir)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ensure_base_ref_available_creates_missing_local_branch() {
+        // A local repo with `origin` configured but that hasn't fetched
+        // `main` yet, to exercise the "no local branch" path.
+        let origin_tmp = tempfile::tempdir().unwrap();
+        let origin_repo = Repository::init_bare(origin_tmp.path()).unwrap();
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_oid = origin_repo.treebuilder(None).unwrap().write().unwrap();
+            let tree = origin_repo.find_tree(tree_oid).unwrap();
+            origin_repo
+                .commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+                .unwrap();
+        }
+
+        let local_tmp = tempfile::tempdir().unwrap();
+        let local_repo = Repository::init(local_tmp.path()).unwrap();
+        // See temp_repo_with_origin() for why HEAD must move off main first.
+        local_repo.set_head("refs/heads/scratch").unwrap();
+        local_repo
+            .remote("origin", &origin_tmp.path().display().to_string())
+            .unwrap();
+        let engine = GitEngine::open(local_tmp.path()).unwrap();
+
+        assert!(
+            engine
+                .repo
+                .find_branch("main", git2::BranchType::Local)
+                .is_err()
+        );
+        engine.ensure_base_ref_available("main").unwrap();
+        assert!(
+            engine
+                .repo
+                .find_branch("main", git2::BranchType::Local)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn ensure_base_ref_available_fast_forwards_existing_local_branch() {
+        let (origin_tmp, _local_tmp, origin_repo, engine) = temp_repo_with_origin();
+        let before = engine
+            .repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+
+        // Origin's main moves forward after the local clone already has it.
+        commit_on_branch(&origin_repo, "main", "a later commit on main");
+        let _ = origin_tmp;
+
+        engine.ensure_base_ref_available("main").unwrap();
+
+        let after = engine
+            .repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        assert_ne!(before, after, "local main should fast-forward");
+        assert_eq!(after.to_string().len(), 40);
+    }
+
+    #[test]
+    fn ensure_base_ref_available_leaves_diverged_branch_untouched() {
+        let (_origin_tmp, _local_tmp, origin_repo, engine) = temp_repo_with_origin();
+
+        // Diverge local main from origin's main with a local-only commit.
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let parent = engine
+            .repo
+            .find_reference("refs/heads/main")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+        let tree = parent.tree().unwrap();
+        let local_only_oid = engine
+            .repo
+            .commit(
+                Some("refs/heads/main"),
+                &sig,
+                &sig,
+                "local-only commit",
+                &tree,
+                &[&parent],
+            )
+            .unwrap();
+
+        // Origin also moves forward independently — a true divergence.
+        commit_on_branch(&origin_repo, "main", "origin-only commit");
+
+        engine.ensure_base_ref_available("main").unwrap();
+
+        let after = engine
+            .repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        assert_eq!(
+            after, local_only_oid,
+            "diverged local branch must not be force-updated"
+        );
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -176,6 +176,29 @@ keymap_suite::actions! {
         // ── UI ──────────────────────────────────────────────────────
         /// Open the theme picker overlay to switch the UI color theme at runtime.
         OpenThemePicker => "open_theme_picker",
+
+        // ── PR review ───────────────────────────────────────────────
+        /// Show the AI walkthrough as the Explorer's bottom-pane view.
+        ShowWalkthrough => "show_walkthrough",
+        /// Toggle the "viewed" mark on a file (diff list row, or the file
+        /// currently open in the Viewer's diff mode).
+        ToggleViewed => "toggle_viewed",
+        /// Move the walkthrough step selection to the next/previous step and jump
+        /// to it immediately (only in the Explorer's Walkthrough view).
+        WalkthroughNextStep => "walkthrough_next_step",
+        WalkthroughPrevStep => "walkthrough_prev_step",
+        /// Open the PR-number/URL input overlay to fetch (or reuse) a worktree
+        /// for a pull request.
+        ReviewPullRequest => "review_pull_request",
+        /// Generate (or regenerate) the AI walkthrough for the selected
+        /// worktree's branch via a background headless Claude session.
+        /// Palette-only by default: `g` is the go-to-top idiom everywhere, and a
+        /// minutes-long generation is too expensive to fire from a slipped key.
+        GenerateWalkthrough => "generate_walkthrough",
+        /// Publish this branch's unpublished review comments to the GitHub PR
+        /// they were opened from. Palette-only: it's an irreversible external
+        /// action and always goes through a y/n confirm overlay first.
+        PublishReview => "publish_review",
     }
 }
 
@@ -220,6 +243,13 @@ impl Action {
             Action::PullWorktree => "Pull worktree",
             Action::SessionHistory => "Session history",
             Action::OpenPullRequest => "Open pull request",
+            Action::ShowWalkthrough => "Show AI walkthrough",
+            Action::ToggleViewed => "Toggle file viewed",
+            Action::WalkthroughNextStep => "Jump to next walkthrough step",
+            Action::WalkthroughPrevStep => "Jump to previous walkthrough step",
+            Action::ReviewPullRequest => "Review a pull request by number or URL",
+            Action::GenerateWalkthrough => "Generate an AI walkthrough of this branch's diff",
+            Action::PublishReview => "Publish unpublished review comments to the GitHub PR",
             Action::ShowDiffList => "Show changed-files list",
             Action::ShowCommentList => "Show comment list",
             Action::OpenCommentList => "Open comment-list modal",
@@ -330,6 +360,8 @@ pub enum KeyContext {
     Explorer,
     ExplorerDiffList,
     ExplorerCommentList,
+    /// The Explorer bottom pane showing the AI walkthrough step list.
+    ExplorerWalkthrough,
     Viewer,
     ViewerDiffMode,
     Terminal,
@@ -344,11 +376,12 @@ pub enum KeyContext {
 }
 
 /// The non-global contexts, each backed by a named `[layers.<name>]` table.
-const PANEL_CONTEXTS: [KeyContext; 9] = [
+const PANEL_CONTEXTS: [KeyContext; 10] = [
     KeyContext::Worktree,
     KeyContext::Explorer,
     KeyContext::ExplorerDiffList,
     KeyContext::ExplorerCommentList,
+    KeyContext::ExplorerWalkthrough,
     KeyContext::Viewer,
     KeyContext::ViewerDiffMode,
     KeyContext::Terminal,
@@ -366,6 +399,7 @@ impl KeyContext {
             KeyContext::Explorer => "explorer",
             KeyContext::ExplorerDiffList => "explorer_diff_list",
             KeyContext::ExplorerCommentList => "explorer_comment_list",
+            KeyContext::ExplorerWalkthrough => "explorer_walkthrough",
             KeyContext::Viewer => "viewer",
             KeyContext::ViewerDiffMode => "viewer_diff_mode",
             KeyContext::Terminal => "terminal",
@@ -722,6 +756,26 @@ mod tests {
         ];
         for (key, action) in cases {
             assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "{key:?}");
+        }
+    }
+
+    #[test]
+    fn explorer_walkthrough_layer_resolves() {
+        let km = default_keymap();
+        let cases = [
+            (KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()), Action::NavigateDown),
+            (KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty()), Action::NavigateUp),
+            (KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()), Action::Select),
+            (KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()), Action::WalkthroughNextStep),
+            (KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT), Action::WalkthroughPrevStep),
+            (KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()), Action::ExitSubPanel),
+        ];
+        for (key, action) in cases {
+            assert_eq!(
+                km.resolve(&key, KeyContext::ExplorerWalkthrough),
+                Some(action),
+                "{key:?}"
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,10 @@ mod jump_history;
 mod keymap;
 mod media_state;
 mod overlay;
+mod pr_intake;
 mod pty_manager;
 mod refresh_pipe;
+mod review_publish;
 mod review_state;
 mod review_store;
 mod search_result_tree;
@@ -36,6 +38,7 @@ mod timer;
 mod ui;
 mod update_checker;
 mod viewer;
+mod walkthrough;
 mod worktree_ops;
 
 use std::io;
@@ -892,6 +895,11 @@ fn run_loop(
         app.terminal.pty_manager.nudge_alt_screen_sessions();
 
         if app.should_quit {
+            // An in-flight walkthrough generation is a headless `claude`
+            // child process; without this it would keep running (and
+            // billing API calls) as an orphan after Conductor exits, since
+            // nothing polls it once the main loop stops.
+            app.shutdown_walkthrough_generation();
             return Ok(());
         }
     }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -28,6 +28,10 @@ pub enum ActiveOverlay {
     ResumeSession,
     RepoSelector,
     OpenRepo,
+    /// PR-number/URL input for "Review: Review Pull Request…" — stays open
+    /// (with the typed input preserved) if the intake attempt fails, so the
+    /// user can correct and retry without retyping.
+    PrInput,
     GrepSearch,
     Help,
     CommandPalette,
@@ -144,6 +148,19 @@ pub struct OpenRepoOverlay {
     pub buffer: TextInput,
 }
 
+/// PR-number/URL input overlay state ("Review: Review Pull Request…").
+#[derive(Default)]
+pub struct PrInputOverlay {
+    pub buffer: TextInput,
+    /// Set while a background PR intake (gh/git) is running for this overlay.
+    pub loading: bool,
+    /// Set on a failed intake attempt; cleared on the next Enter/edit. The
+    /// overlay stays open and `buffer` is left untouched so the user can
+    /// correct and retry.
+    pub error: Option<String>,
+    pub bg_op: BackgroundOp<crate::pr_intake::PrIntakeOutcome>,
+}
+
 /// Code navigation: references overlay state (for `gr` — Find References).
 #[derive(Default)]
 pub struct ReferencesOverlay {
@@ -231,6 +248,7 @@ pub struct OverlayManager {
     pub resume_session: ResumeSessionOverlay,
     pub repo_selector: RepoSelectorOverlay,
     pub open_repo: OpenRepoOverlay,
+    pub pr_input: PrInputOverlay,
     pub grep_search: GrepSearchOverlay,
     pub help: HelpOverlay,
     pub command_palette: CommandPaletteOverlay,

--- a/src/pr_intake.rs
+++ b/src/pr_intake.rs
@@ -1,0 +1,478 @@
+//! PR intake orchestration: turn a PR number or GitHub PR URL into a local
+//! worktree ready for review mode.
+//!
+//! Shells out to `gh` for PR metadata (relies on the user's existing `gh
+//! auth` session) and to [`crate::git_engine::GitEngine`] for the fetch and
+//! worktree creation. Kept separate from `app/worktree.rs` so the exact
+//! `gh`/`git` command spelling (JSON fields, refspec format, branch naming)
+//! lives in one place.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::git_engine::GitEngine;
+
+/// Local branch name for a fetched PR head: `pr-<N>` (hyphen, not `pr/<N>` —
+/// the latter would collide with any existing `pr/`-namespaced branches a
+/// repo already uses for its own work).
+pub fn local_branch_name(pr_number: u64) -> String {
+    format!("pr-{pr_number}")
+}
+
+/// PR metadata as reported by `gh pr view --json ...`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PrMeta {
+    /// Echo of the requested PR number; deserialized for completeness but
+    /// callers thread the number they asked for instead.
+    #[allow(dead_code)]
+    pub number: u64,
+    pub title: String,
+    #[serde(rename = "headRefName")]
+    pub head_ref: String,
+    #[serde(rename = "baseRefName")]
+    pub base_ref: String,
+    #[serde(rename = "headRepositoryOwner")]
+    pub head_owner: Option<GhOwner>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GhOwner {
+    pub login: String,
+}
+
+/// Cause of a PR-intake failure, classified from `gh`/`git` output — each
+/// variant maps to a distinct, actionable message so the input overlay can
+/// tell the user what to do next instead of showing a raw error string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrIntakeError {
+    GhNotInstalled,
+    GhNotAuthenticated,
+    PrNotFound(u64),
+    NetworkError,
+    InvalidInput(String),
+    Other(String),
+}
+
+impl std::fmt::Display for PrIntakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrIntakeError::GhNotInstalled => write!(
+                f,
+                "`gh` (GitHub CLI) is not installed. Install it from https://cli.github.com/ and retry."
+            ),
+            PrIntakeError::GhNotAuthenticated => {
+                write!(f, "Not logged in to GitHub CLI. Run `gh auth login` and retry.")
+            }
+            PrIntakeError::PrNotFound(n) => write!(f, "Pull request #{n} not found."),
+            PrIntakeError::NetworkError => write!(
+                f,
+                "Network error while contacting GitHub. Check your connection and retry."
+            ),
+            PrIntakeError::InvalidInput(s) => {
+                write!(f, "Not a valid PR number or GitHub PR URL: {s}")
+            }
+            PrIntakeError::Other(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Classify `gh`/`git` failure text into an actionable [`PrIntakeError`].
+/// `pr_number` is threaded through so a "not found" match can name the PR.
+fn classify_failure_text(pr_number: u64, text: &str) -> PrIntakeError {
+    let lower = text.to_lowercase();
+    if lower.contains("gh auth login") || lower.contains("not logged in") || lower.contains("authentication") {
+        PrIntakeError::GhNotAuthenticated
+    } else if lower.contains("could not resolve host")
+        || lower.contains("connection timed out")
+        || lower.contains("could not read from remote repository")
+        || lower.contains("network")
+        || lower.contains("dial tcp")
+        || lower.contains("timeout")
+    {
+        PrIntakeError::NetworkError
+    } else if lower.contains("no pull requests found")
+        || lower.contains("could not find")
+        || lower.contains("couldn't find remote ref")
+        || lower.contains("not found")
+    {
+        PrIntakeError::PrNotFound(pr_number)
+    } else {
+        PrIntakeError::Other(text.trim().to_string())
+    }
+}
+
+/// Parse a PR number or a GitHub PR URL (e.g.
+/// `https://github.com/owner/repo/pull/123`, with or without a trailing
+/// path/query) into a bare PR number.
+pub fn parse_pr_input(input: &str) -> Result<u64, PrIntakeError> {
+    let trimmed = input.trim();
+    if let Ok(n) = trimmed.parse::<u64>() {
+        return Ok(n);
+    }
+    if let Some(idx) = trimmed.find("/pull/") {
+        let rest = &trimmed[idx + "/pull/".len()..];
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if !digits.is_empty()
+            && let Ok(n) = digits.parse::<u64>()
+        {
+            return Ok(n);
+        }
+    }
+    Err(PrIntakeError::InvalidInput(trimmed.to_string()))
+}
+
+/// Whether a ref name (as reported by `gh`'s JSON output) is unsafe to hand
+/// to git as a bare argument — a leading `-` would let it be parsed as an
+/// option rather than a ref name.
+fn is_suspicious_ref(ref_name: &str) -> bool {
+    ref_name.starts_with('-')
+}
+
+/// Whether `dir` looks like a real git worktree rather than a stray/broken
+/// directory (e.g. left over from an interrupted intake, or an empty dir a
+/// user created by hand). In a worktree, `.git` is a file (a gitdir pointer),
+/// not a directory, but either is accepted here — the check only needs to
+/// rule out "definitely not a worktree", not fully validate git's internals.
+fn is_valid_worktree_dir(dir: &Path) -> bool {
+    dir.join(".git").exists()
+}
+
+/// Fetch PR metadata via `gh pr view <N> --json ...`.
+fn fetch_pr_meta(pr_number: u64) -> Result<PrMeta, PrIntakeError> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "number,title,headRefName,baseRefName,headRepositoryOwner,url",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(PrIntakeError::GhNotInstalled);
+        }
+        Err(e) => return Err(PrIntakeError::Other(e.to_string())),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(classify_failure_text(pr_number, &stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<PrMeta>(&stdout)
+        .map_err(|e| PrIntakeError::Other(format!("failed to parse `gh pr view` output: {e}")))
+}
+
+/// PR metadata to persist once a fresh fetch/create succeeds. `None` on a
+/// worktree re-entry hit, since the prior intake already persisted it and no
+/// `gh` call was made this time.
+pub struct FetchedPr {
+    pub branch: String,
+    pub title: String,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub url: String,
+    pub head_owner_login: Option<String>,
+}
+
+/// Outcome of a completed PR intake attempt.
+pub enum PrIntakeOutcome {
+    /// A worktree is ready — either freshly fetched/created, or reused from
+    /// a prior intake of the same PR number. The caller should switch to
+    /// `worktree_path`, persist `meta` (if present) to the review store, and
+    /// enter review mode.
+    ///
+    /// DB writes are deliberately left to the caller (main thread) rather
+    /// than done here, since [`crate::review_store::ReviewStore`] lives on
+    /// `App` and isn't meant to be shared across threads mid-flight.
+    Ready {
+        pr_number: u64,
+        worktree_path: PathBuf,
+        meta: Option<FetchedPr>,
+    },
+    Failed { error: PrIntakeError },
+}
+
+/// Run the full PR intake flow synchronously: resolve `input` to a PR
+/// number, and fetch (or reuse) its worktree.
+///
+/// Intended to run on a background thread (network + git I/O); the caller
+/// polls for the returned outcome and applies it (including any DB writes)
+/// on the main thread.
+///
+/// Re-entry: if a worktree for this PR number already exists on disk, it is
+/// reused as-is — no `gh`/`git fetch` round-trip, and no auto-fast-forward
+/// of the existing checkout (matches the "open pull request" precedent of
+/// never surprising the user with a silent branch update).
+pub fn intake_pr(
+    repo_path: &Path,
+    worktree_dir_override: Option<&Path>,
+    input: &str,
+) -> PrIntakeOutcome {
+    let pr_number = match parse_pr_input(input) {
+        Ok(n) => n,
+        Err(error) => return PrIntakeOutcome::Failed { error },
+    };
+
+    let engine = match GitEngine::open(repo_path) {
+        Ok(e) => e,
+        Err(e) => {
+            return PrIntakeOutcome::Failed {
+                error: PrIntakeError::Other(e.to_string()),
+            };
+        }
+    };
+
+    let branch = local_branch_name(pr_number);
+    let wt_dir = match engine.worktrees_base_dir(worktree_dir_override) {
+        Ok(base) => base.join(&branch),
+        Err(e) => {
+            return PrIntakeOutcome::Failed {
+                error: PrIntakeError::Other(e.to_string()),
+            };
+        }
+    };
+
+    if wt_dir.exists() {
+        if !is_valid_worktree_dir(&wt_dir) {
+            return PrIntakeOutcome::Failed {
+                error: PrIntakeError::Other(format!(
+                    "Existing directory is not a valid worktree: {}. Delete it and re-run intake.",
+                    wt_dir.display()
+                )),
+            };
+        }
+        return PrIntakeOutcome::Ready {
+            pr_number,
+            worktree_path: wt_dir,
+            meta: None,
+        };
+    }
+
+    let pr_meta = match fetch_pr_meta(pr_number) {
+        Ok(m) => m,
+        Err(error) => return PrIntakeOutcome::Failed { error },
+    };
+
+    let refspec = format!("pull/{pr_number}/head:{branch}");
+    if let Err(e) = engine.fetch_refspec(&refspec) {
+        return PrIntakeOutcome::Failed {
+            error: classify_failure_text(pr_number, &e.to_string()),
+        };
+    }
+
+    if let Err(e) = engine.create_worktree_for_existing_branch(&branch, &wt_dir) {
+        return PrIntakeOutcome::Failed {
+            error: PrIntakeError::Other(e.to_string()),
+        };
+    }
+
+    // Best-effort: review mode's diff still works off whatever local base
+    // ref already exists if this fails, so don't fail the whole intake over it.
+    // Guard against a base_ref starting with '-' before it reaches git: it
+    // comes from `gh`'s JSON output, and a leading dash would let it be
+    // misread as a git option rather than a ref name.
+    if is_suspicious_ref(&pr_meta.base_ref) {
+        log::warn!(
+            "pr_intake: refusing to fetch suspicious base ref '{}' (starts with '-')",
+            pr_meta.base_ref
+        );
+    } else if let Err(e) = engine.ensure_base_ref_available(&pr_meta.base_ref) {
+        log::warn!(
+            "pr_intake: failed to ensure base ref '{}' is available: {e}",
+            pr_meta.base_ref
+        );
+    }
+
+    PrIntakeOutcome::Ready {
+        pr_number,
+        worktree_path: wt_dir,
+        meta: Some(FetchedPr {
+            branch,
+            title: pr_meta.title,
+            base_ref: pr_meta.base_ref,
+            head_ref: pr_meta.head_ref,
+            url: pr_meta.url,
+            head_owner_login: pr_meta.head_owner.map(|o| o.login),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_suspicious_ref_rejects_leading_dash() {
+        assert!(is_suspicious_ref("--upload-pack=evil"));
+        assert!(!is_suspicious_ref("main"));
+        assert!(!is_suspicious_ref("release/1.0"));
+    }
+
+    #[test]
+    fn parse_pr_input_accepts_bare_number() {
+        assert_eq!(parse_pr_input("279"), Ok(279));
+        assert_eq!(parse_pr_input("  42  "), Ok(42));
+    }
+
+    #[test]
+    fn parse_pr_input_accepts_github_url() {
+        assert_eq!(
+            parse_pr_input("https://github.com/S-Nakamur-a/conductor/pull/279"),
+            Ok(279)
+        );
+        assert_eq!(
+            parse_pr_input("https://github.com/o/r/pull/12/files"),
+            Ok(12)
+        );
+    }
+
+    #[test]
+    fn parse_pr_input_rejects_garbage() {
+        assert_eq!(
+            parse_pr_input("not-a-pr"),
+            Err(PrIntakeError::InvalidInput("not-a-pr".to_string()))
+        );
+    }
+
+    #[test]
+    fn classify_failure_text_detects_auth() {
+        assert_eq!(
+            classify_failure_text(1, "To get started with GitHub CLI, please run:  gh auth login"),
+            PrIntakeError::GhNotAuthenticated
+        );
+    }
+
+    #[test]
+    fn classify_failure_text_detects_not_found() {
+        assert_eq!(
+            classify_failure_text(404, "no pull requests found for branch \"x\""),
+            PrIntakeError::PrNotFound(404)
+        );
+        assert_eq!(
+            classify_failure_text(5, "fatal: couldn't find remote ref pull/5/head"),
+            PrIntakeError::PrNotFound(5)
+        );
+    }
+
+    #[test]
+    fn classify_failure_text_detects_network_error() {
+        assert_eq!(
+            classify_failure_text(1, "fatal: unable to access: Could not resolve host: github.com"),
+            PrIntakeError::NetworkError
+        );
+    }
+
+    #[test]
+    fn classify_failure_text_falls_back_to_other() {
+        assert_eq!(
+            classify_failure_text(1, "something unexpected happened"),
+            PrIntakeError::Other("something unexpected happened".to_string())
+        );
+    }
+
+    #[test]
+    fn display_messages_are_actionable() {
+        assert!(
+            PrIntakeError::GhNotAuthenticated
+                .to_string()
+                .contains("gh auth login")
+        );
+        assert!(PrIntakeError::PrNotFound(9).to_string().contains('9'));
+    }
+
+    /// Re-entry: intake_pr must reuse an existing worktree directory without
+    /// touching gh/git at all (so it works even without `gh` installed).
+    #[test]
+    fn intake_pr_reenters_existing_worktree_without_gh_or_network() {
+        let parent = tempfile::tempdir().unwrap();
+        // Canonicalize so this compares equal on platforms (e.g. macOS) where
+        // the OS temp dir is itself a symlink (`/tmp` -> `/private/tmp`).
+        let parent_path = parent.path().canonicalize().unwrap();
+        let repo_path = parent_path.join("repo");
+        git2::Repository::init(&repo_path).unwrap();
+
+        // Simulate a worktree that a prior intake already created for PR 42
+        // (a real worktree's `.git` is a gitdir-pointer file, not a directory).
+        let base_dir = parent_path.join("repo-worktrees");
+        std::fs::create_dir_all(base_dir.join("pr-42")).unwrap();
+        std::fs::write(base_dir.join("pr-42").join(".git"), "gitdir: /tmp/fake").unwrap();
+
+        let outcome = intake_pr(&repo_path, None, "42");
+        match outcome {
+            PrIntakeOutcome::Ready {
+                pr_number,
+                worktree_path,
+                ..
+            } => {
+                assert_eq!(pr_number, 42);
+                assert_eq!(worktree_path, base_dir.join("pr-42"));
+            }
+            PrIntakeOutcome::Failed { error } => panic!("expected Ready, got Failed: {error}"),
+        }
+    }
+
+    /// A stale/broken directory left at the worktree path (no `.git`) must
+    /// fail with an actionable message rather than silently returning `Ready`
+    /// and showing a blank review screen.
+    #[test]
+    fn intake_pr_reenters_broken_directory_fails_with_actionable_message() {
+        let parent = tempfile::tempdir().unwrap();
+        let parent_path = parent.path().canonicalize().unwrap();
+        let repo_path = parent_path.join("repo");
+        git2::Repository::init(&repo_path).unwrap();
+
+        let base_dir = parent_path.join("repo-worktrees");
+        let broken_dir = base_dir.join("pr-42");
+        std::fs::create_dir_all(&broken_dir).unwrap();
+
+        let outcome = intake_pr(&repo_path, None, "42");
+        match outcome {
+            PrIntakeOutcome::Failed { error } => {
+                assert!(error.to_string().contains(&broken_dir.display().to_string()));
+            }
+            PrIntakeOutcome::Ready { .. } => panic!("expected Failed, got Ready"),
+        }
+    }
+
+    /// End-to-end check against this repository's real GitHub remote and a
+    /// merged PR (`refs/pull/<N>/head` stays resolvable after merge). Needs
+    /// network + an authenticated `gh`, so it's `#[ignore]`d by default; run
+    /// explicitly with `cargo test --  --ignored intake_pr_against_real_pr`.
+    /// Clones into a tempdir so it never touches this repo's own worktrees.
+    #[test]
+    #[ignore]
+    fn intake_pr_against_real_pr() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo_path = parent.path().join("repo");
+        let mut fetch_opts = git2::FetchOptions::new();
+        fetch_opts.depth(50);
+        git2::build::RepoBuilder::new()
+            .fetch_options(fetch_opts)
+            .clone("https://github.com/S-Nakamur-a/conductor.git", &repo_path)
+            .expect("clone should succeed");
+
+        let outcome = intake_pr(&repo_path, None, "279");
+        match outcome {
+            PrIntakeOutcome::Ready {
+                pr_number,
+                worktree_path,
+                meta,
+            } => {
+                assert_eq!(pr_number, 279);
+                assert!(worktree_path.exists());
+                let meta = meta.expect("fresh intake should carry fetched metadata");
+                assert_eq!(meta.base_ref, "main");
+                assert_eq!(meta.branch, "pr-279");
+            }
+            PrIntakeOutcome::Failed { error } => panic!("expected Ready, got Failed: {error}"),
+        }
+    }
+}

--- a/src/review_publish.rs
+++ b/src/review_publish.rs
@@ -1,0 +1,473 @@
+//! Publishing review comments back to GitHub via `gh api`.
+//!
+//! Kept separate from `app/review_publish.rs` (the `App`-side orchestration:
+//! confirm-overlay state, background-thread spawn, DB writes) the same way
+//! `pr_intake.rs` is kept separate from `app/worktree.rs` — the exact `gh`
+//! CLI/JSON spelling lives in one place, and everything here is plain data +
+//! `gh` subprocess calls with no `App` dependency, so it can be unit tested
+//! without a running application.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use serde::Serialize;
+
+use crate::diff_state::DiffState;
+
+/// One review comment ready to publish: the parent comment's body with its
+/// replies appended. GitHub review comments don't have a v1 concept of
+/// threaded replies here, so a comment with replies is flattened into one
+/// GitHub comment body (see ADR-6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishComment {
+    pub id: String,
+    pub file_path: String,
+    pub line_start: u32,
+    pub line_end: Option<u32>,
+    pub body: String,
+}
+
+/// A confirmed, ready-to-run publish request: everything [`publish`] needs,
+/// already resolved by the caller (owner/repo from `pr_review_meta.pr_url`,
+/// comments already filtered to lines that are actually in the diff).
+pub struct PublishRequest {
+    pub owner: String,
+    pub repo: String,
+    pub pr_number: u64,
+    pub comments: Vec<PublishComment>,
+}
+
+/// State backing `App::publish_confirm`'s y/n overlay: the already-filtered
+/// comments a confirmed publish will send, plus how many were skipped for
+/// not being on a line the current diff covers. Doubles as the source for
+/// building the [`PublishRequest`] once the user confirms.
+pub struct PublishConfirm {
+    pub owner: String,
+    pub repo: String,
+    pub pr_number: u64,
+    pub comments: Vec<PublishComment>,
+    pub skipped: usize,
+}
+
+/// Result of a publish attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// Every comment in the request was posted (or there was nothing to post).
+    Succeeded { published_ids: Vec<String> },
+    /// The batch review call failed and the per-comment fallback posted some
+    /// but not all of the comments.
+    PartialFailure {
+        published_ids: Vec<String>,
+        failed: Vec<(String, String)>,
+    },
+    /// Nothing was posted (couldn't resolve the commit id, or every attempt
+    /// — batch and fallback — failed).
+    Failed { error: String },
+}
+
+/// Split `comments` into what's safe to publish and how many were skipped.
+///
+/// A GitHub review comment must anchor to a line that's part of the current
+/// diff's hunks; posting even one comment on a line outside the diff fails
+/// the *entire* batch with a 422, so out-of-diff comments must be filtered
+/// out before ever reaching [`publish`], not just discarded on failure.
+pub fn filter_publishable(
+    comments: Vec<PublishComment>,
+    diff: &DiffState,
+) -> (Vec<PublishComment>, usize) {
+    let mut publishable = Vec::new();
+    let mut skipped = 0;
+    for c in comments {
+        let end = c.line_end.unwrap_or(c.line_start);
+        if line_range_in_diff(&c.file_path, c.line_start, end, diff) {
+            publishable.push(c);
+        } else {
+            skipped += 1;
+        }
+    }
+    (publishable, skipped)
+}
+
+/// Whether `[start, end]` (new-side line numbers) both fall within the same
+/// diff hunk for `file_path`, across either diff section (committed or
+/// uncommitted — a review comment doesn't record which section it was made
+/// against, so both are checked).
+fn line_range_in_diff(file_path: &str, start: u32, end: u32, diff: &DiffState) -> bool {
+    diff.committed_files
+        .iter()
+        .chain(diff.uncommitted_files.iter())
+        .filter(|fd| fd.path == file_path)
+        .any(|fd| {
+            fd.hunks.iter().any(|hunk| {
+                let mut has_start = false;
+                let mut has_end = false;
+                for line in &hunk.lines {
+                    if let Some(n) = line.new_line_no {
+                        has_start |= n as u32 == start;
+                        has_end |= n as u32 == end;
+                    }
+                }
+                has_start && has_end
+            })
+        })
+}
+
+/// Parse `owner`/`repo` out of a GitHub PR URL
+/// (`https://github.com/{owner}/{repo}/pull/{n}`).
+pub fn owner_repo_from_pr_url(url: &str) -> Option<(String, String)> {
+    let rest = url.strip_prefix("https://github.com/")?;
+    let mut parts = rest.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Payload shapes (see ADR-6's greta-grounded field spelling)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ReviewCommentPayload<'a> {
+    path: &'a str,
+    body: &'a str,
+    line: u32,
+    side: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_side: Option<&'static str>,
+}
+
+impl<'a> ReviewCommentPayload<'a> {
+    fn from_comment(c: &'a PublishComment) -> Self {
+        let end = c.line_end.unwrap_or(c.line_start);
+        if end == c.line_start {
+            ReviewCommentPayload {
+                path: &c.file_path,
+                body: &c.body,
+                line: c.line_start,
+                side: "RIGHT",
+                start_line: None,
+                start_side: None,
+            }
+        } else {
+            ReviewCommentPayload {
+                path: &c.file_path,
+                body: &c.body,
+                line: end,
+                side: "RIGHT",
+                start_line: Some(c.line_start),
+                start_side: Some("RIGHT"),
+            }
+        }
+    }
+}
+
+/// `POST /repos/{owner}/{repo}/pulls/{N}/reviews` body.
+#[derive(Serialize)]
+struct BatchReviewPayload<'a> {
+    commit_id: &'a str,
+    event: &'static str,
+    body: &'static str,
+    comments: Vec<ReviewCommentPayload<'a>>,
+}
+
+/// `POST /repos/{owner}/{repo}/pulls/{N}/comments` body (single-comment
+/// fallback — always accepts `line`/`side`, unlike the batch endpoint's
+/// unverified acceptance of them per ADR-6).
+#[derive(Serialize)]
+struct SingleCommentPayload<'a> {
+    commit_id: &'a str,
+    #[serde(flatten)]
+    comment: ReviewCommentPayload<'a>,
+}
+
+// ---------------------------------------------------------------------------
+// gh CLI plumbing
+// ---------------------------------------------------------------------------
+
+/// Fetch the PR's head commit sha via `gh pr view <N> --json headRefOid`,
+/// explicitly rather than letting the review API default to whatever HEAD
+/// happens to be at post time — the default is a race with a concurrent push.
+fn fetch_head_commit_id(pr_number: u64) -> Result<String, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "headRefOid",
+            "-q",
+            ".headRefOid",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if oid.is_empty() {
+        return Err("`gh pr view` returned an empty headRefOid".to_string());
+    }
+    Ok(oid)
+}
+
+/// `gh api <path> --input -` — the JSON body is piped over stdin rather than
+/// passed as a CLI argument, since a comment body can be long/multiline.
+fn gh_api_post(path: &str, body: &str) -> Result<(), GhApiError> {
+    let mut child = Command::new("gh")
+        .args(["api", path, "--input", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| GhApiError {
+            is_422: false,
+            message: e.to_string(),
+        })?;
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(body.as_bytes());
+    }
+    let output = child.wait_with_output().map_err(|e| GhApiError {
+        is_422: false,
+        message: e.to_string(),
+    })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Err(GhApiError {
+        is_422: stderr.contains("422"),
+        message: stderr,
+    })
+}
+
+struct GhApiError {
+    /// Whether the failure looks like GitHub's 422 Unprocessable Entity —
+    /// the signal to fall back to single-comment posting (ADR-6). `gh api`
+    /// reports this as e.g. `gh: Validation Failed (HTTP 422): ...` on
+    /// stderr; matching the substring is the least brittle check available
+    /// without parsing `gh`'s own error formatting.
+    is_422: bool,
+    message: String,
+}
+
+/// Run a publish request: resolve the commit id, POST the batch review, and
+/// fall back to posting comments one at a time if the batch is rejected as a
+/// 422 (per ADR-6, the batch endpoint's acceptance of `line`/`side` was the
+/// one thing left unverified by the pre-implementation `gh api` grounding).
+pub fn publish(req: PublishRequest) -> PublishOutcome {
+    if req.comments.is_empty() {
+        return PublishOutcome::Succeeded {
+            published_ids: Vec::new(),
+        };
+    }
+
+    let commit_id = match fetch_head_commit_id(req.pr_number) {
+        Ok(id) => id,
+        Err(error) => return PublishOutcome::Failed { error },
+    };
+
+    let payload = BatchReviewPayload {
+        commit_id: &commit_id,
+        event: "COMMENT",
+        body: "",
+        comments: req
+            .comments
+            .iter()
+            .map(ReviewCommentPayload::from_comment)
+            .collect(),
+    };
+    let body = match serde_json::to_string(&payload) {
+        Ok(b) => b,
+        Err(e) => {
+            return PublishOutcome::Failed {
+                error: format!("failed to build request body: {e}"),
+            };
+        }
+    };
+    let reviews_path = format!(
+        "repos/{}/{}/pulls/{}/reviews",
+        req.owner, req.repo, req.pr_number
+    );
+
+    match gh_api_post(&reviews_path, &body) {
+        Ok(()) => PublishOutcome::Succeeded {
+            published_ids: req.comments.iter().map(|c| c.id.clone()).collect(),
+        },
+        Err(e) if e.is_422 => publish_fallback(&req, &commit_id),
+        Err(e) => PublishOutcome::Failed { error: e.message },
+    }
+}
+
+/// Post each comment individually to `/pulls/{N}/comments`, which accepts
+/// `line`/`side` unconditionally — the fallback for a batch review the
+/// GitHub API rejected.
+fn publish_fallback(req: &PublishRequest, commit_id: &str) -> PublishOutcome {
+    let comments_path = format!(
+        "repos/{}/{}/pulls/{}/comments",
+        req.owner, req.repo, req.pr_number
+    );
+    let mut published_ids = Vec::new();
+    let mut failed = Vec::new();
+    for c in &req.comments {
+        let payload = SingleCommentPayload {
+            commit_id,
+            comment: ReviewCommentPayload::from_comment(c),
+        };
+        let body = match serde_json::to_string(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                failed.push((c.id.clone(), e.to_string()));
+                continue;
+            }
+        };
+        match gh_api_post(&comments_path, &body) {
+            Ok(()) => published_ids.push(c.id.clone()),
+            Err(e) => failed.push((c.id.clone(), e.message)),
+        }
+    }
+    if failed.is_empty() {
+        PublishOutcome::Succeeded { published_ids }
+    } else {
+        PublishOutcome::PartialFailure {
+            published_ids,
+            failed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff_state::{DiffHunk, DiffLine, DiffLineTag, DiffViewMode, FileDiff};
+
+    fn diff_with_hunk(path: &str, new_lines: &[usize]) -> DiffState {
+        let mut ds = DiffState::new("main", DiffViewMode::Unified);
+        let lines = new_lines
+            .iter()
+            .map(|&n| DiffLine {
+                tag: DiffLineTag::Insert,
+                old_line_no: None,
+                new_line_no: Some(n),
+                inline_segments: Vec::new(),
+                content: String::new(),
+            })
+            .collect();
+        ds.committed_files = vec![FileDiff {
+            path: path.to_string(),
+            added_lines: new_lines.len(),
+            deleted_lines: 0,
+            is_new: false,
+            is_deleted: false,
+            hunks: vec![DiffHunk {
+                lines,
+                func_header: None,
+            }],
+        }];
+        ds
+    }
+
+    fn comment(file_path: &str, line_start: u32, line_end: Option<u32>) -> PublishComment {
+        PublishComment {
+            id: format!("{file_path}:{line_start}"),
+            file_path: file_path.to_string(),
+            line_start,
+            line_end,
+            body: "looks good".to_string(),
+        }
+    }
+
+    #[test]
+    fn filter_publishable_keeps_single_line_on_diff() {
+        let diff = diff_with_hunk("src/a.rs", &[10, 11, 12]);
+        let (kept, skipped) = filter_publishable(vec![comment("src/a.rs", 11, None)], &diff);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(skipped, 0);
+    }
+
+    #[test]
+    fn filter_publishable_keeps_range_with_both_endpoints_in_hunk() {
+        let diff = diff_with_hunk("src/a.rs", &[10, 11, 12]);
+        let (kept, skipped) = filter_publishable(vec![comment("src/a.rs", 10, Some(12))], &diff);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(skipped, 0);
+    }
+
+    #[test]
+    fn filter_publishable_skips_line_outside_diff() {
+        let diff = diff_with_hunk("src/a.rs", &[10, 11, 12]);
+        let (kept, skipped) = filter_publishable(vec![comment("src/a.rs", 99, None)], &diff);
+        assert!(kept.is_empty());
+        assert_eq!(skipped, 1);
+    }
+
+    #[test]
+    fn filter_publishable_skips_file_not_in_diff() {
+        let diff = diff_with_hunk("src/a.rs", &[10]);
+        let (kept, skipped) = filter_publishable(vec![comment("src/missing.rs", 10, None)], &diff);
+        assert!(kept.is_empty());
+        assert_eq!(skipped, 1);
+    }
+
+    #[test]
+    fn owner_repo_from_pr_url_parses_standard_url() {
+        assert_eq!(
+            owner_repo_from_pr_url("https://github.com/S-Nakamur-a/conductor/pull/279"),
+            Some(("S-Nakamur-a".to_string(), "conductor".to_string()))
+        );
+    }
+
+    #[test]
+    fn owner_repo_from_pr_url_rejects_non_github_url() {
+        assert_eq!(
+            owner_repo_from_pr_url("https://example.com/o/r/pull/1"),
+            None
+        );
+    }
+
+    #[test]
+    fn single_line_comment_payload_omits_start_line() {
+        let c = comment("src/a.rs", 10, None);
+        let payload = ReviewCommentPayload::from_comment(&c);
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["line"], 10);
+        assert_eq!(json["side"], "RIGHT");
+        assert!(json.get("start_line").is_none());
+        assert!(json.get("start_side").is_none());
+    }
+
+    #[test]
+    fn range_comment_payload_sets_start_line_and_end_line() {
+        let c = comment("src/a.rs", 10, Some(15));
+        let payload = ReviewCommentPayload::from_comment(&c);
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["line"], 15);
+        assert_eq!(json["start_line"], 10);
+        assert_eq!(json["start_side"], "RIGHT");
+    }
+
+    #[test]
+    fn publish_with_no_comments_succeeds_without_calling_gh() {
+        // No commit-id lookup should happen for an empty comment list — this
+        // would hang/fail in a sandboxed test environment without a real
+        // `gh`/network, so it's the one `publish()` path exercised here.
+        let outcome = publish(PublishRequest {
+            owner: "o".to_string(),
+            repo: "r".to_string(),
+            pr_number: 1,
+            comments: Vec::new(),
+        });
+        assert_eq!(
+            outcome,
+            PublishOutcome::Succeeded {
+                published_ids: Vec::new()
+            }
+        );
+    }
+}

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -12,6 +12,10 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, params};
 use uuid::Uuid;
 
+use crate::walkthrough::{
+    NewWalkthroughStep, Walkthrough, WalkthroughStatus, WalkthroughStep, WalkthroughStepKind,
+};
+
 // ---------------------------------------------------------------------------
 // Enums
 // ---------------------------------------------------------------------------
@@ -147,6 +151,23 @@ pub struct SessionStatsSnapshot {
 #[derive(Debug, Clone)]
 pub struct StreakInfo {
     pub consecutive_days: u32,
+}
+
+/// PR metadata for a review-mode branch (`pr_review_meta` table) — the facts
+/// needed to render the review header and, later, to publish comments back
+/// to the right PR. Unlike `worktree_metadata`, every field but `branch` is
+/// optional since a review can start from a bare branch name without a PR.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct PrReviewMeta {
+    pub branch: String,
+    pub pr_number: Option<i64>,
+    pub pr_url: Option<String>,
+    pub pr_title: Option<String>,
+    pub base_ref: Option<String>,
+    pub head_ref: Option<String>,
+    pub author: Option<String>,
+    pub created_at: String,
 }
 
 /// A saved session history record.
@@ -434,6 +455,59 @@ impl ReviewStore {
             .context("failed to migrate to v5 (change_summary)")?;
         }
 
+        if version < 6 {
+            // Review mode's PR walkthrough + GitHub-publish support.
+            // `walkthroughs.branch` is UNIQUE with no generation history —
+            // re-generating deletes and recreates the row (pamela's ruling:
+            // a versioned/generational scheme wasn't worth the complexity
+            // for a single-branch, single-current-walkthrough feature).
+            conn.execute_batch(
+                "
+                CREATE TABLE IF NOT EXISTS walkthroughs (
+                    id          TEXT PRIMARY KEY,
+                    branch      TEXT NOT NULL UNIQUE,
+                    title       TEXT,
+                    summary     TEXT,
+                    status      TEXT NOT NULL DEFAULT 'generating'
+                                  CHECK (status IN ('generating', 'ready', 'failed')),
+                    error       TEXT,
+                    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE TABLE IF NOT EXISTS walkthrough_steps (
+                    id             TEXT PRIMARY KEY,
+                    walkthrough_id TEXT NOT NULL REFERENCES walkthroughs(id) ON DELETE CASCADE,
+                    seq            INTEGER NOT NULL,
+                    file_path      TEXT NOT NULL,
+                    line_start     INTEGER,
+                    line_end       INTEGER,
+                    kind           TEXT NOT NULL CHECK (kind IN ('intent', 'core', 'ripple', 'test')),
+                    title          TEXT NOT NULL,
+                    body           TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS pr_review_meta (
+                    branch      TEXT PRIMARY KEY,
+                    pr_number   INTEGER,
+                    pr_url      TEXT,
+                    pr_title    TEXT,
+                    base_ref    TEXT,
+                    head_ref    TEXT,
+                    author      TEXT,
+                    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                ALTER TABLE reviews ADD COLUMN published_at TEXT;
+
+                PRAGMA user_version = 6;
+                ",
+            )
+            .context(
+                "failed to migrate to v6 (walkthroughs, walkthrough_steps, pr_review_meta, reviews.published_at)",
+            )?;
+        }
+
         Ok(Self { conn })
     }
 
@@ -547,6 +621,46 @@ impl ReviewStore {
              ORDER BY line_start",
         )?;
         collect_reviews(&mut stmt, params![worktree, file_path])
+    }
+
+    /// Mark the given review comments as published to GitHub, stamping them
+    /// all with the same `timestamp` (one publish batch = one moment in
+    /// time). Once set, `unpublished_reviews` no longer returns them, so a
+    /// retried publish doesn't repost the same comment.
+    pub fn mark_published(&self, comment_ids: &[String], timestamp: &str) -> Result<()> {
+        self.conn.execute_batch("BEGIN;")?;
+        let result = (|| -> Result<()> {
+            for id in comment_ids {
+                self.conn.execute(
+                    "UPDATE reviews SET published_at = ?1 WHERE id = ?2",
+                    params![timestamp, id],
+                )?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT;")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
+    }
+
+    /// Return a branch's review comments that have not yet been posted to
+    /// GitHub (`published_at IS NULL`).
+    pub fn unpublished_reviews(&self, branch: &str) -> Result<Vec<ReviewComment>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, worktree, file_path, line_start, line_end, kind, body, status,
+                    commit_ref, author, branch, created_at, updated_at
+             FROM reviews
+             WHERE branch = ?1 AND published_at IS NULL
+             ORDER BY file_path, line_start",
+        )?;
+        collect_reviews(&mut stmt, params![branch])
     }
 
     // -- Replies ------------------------------------------------------------
@@ -815,6 +929,211 @@ impl ReviewStore {
             out.push(row?);
         }
         Ok(out)
+    }
+
+    // -- PR review metadata ---------------------------------------------------
+
+    /// Insert or replace the PR metadata for a branch.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)]
+    pub fn save_pr_review_meta(
+        &self,
+        branch: &str,
+        pr_number: Option<i64>,
+        pr_url: Option<&str>,
+        pr_title: Option<&str>,
+        base_ref: Option<&str>,
+        head_ref: Option<&str>,
+        author: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO pr_review_meta
+                (branch, pr_number, pr_url, pr_title, base_ref, head_ref, author)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(branch) DO UPDATE SET
+                 pr_number = excluded.pr_number,
+                 pr_url    = excluded.pr_url,
+                 pr_title  = excluded.pr_title,
+                 base_ref  = excluded.base_ref,
+                 head_ref  = excluded.head_ref,
+                 author    = excluded.author",
+            params![branch, pr_number, pr_url, pr_title, base_ref, head_ref, author],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve the PR metadata for a branch, if any has been saved.
+    pub fn get_pr_review_meta(&self, branch: &str) -> Result<Option<PrReviewMeta>> {
+        match self.conn.query_row(
+            "SELECT branch, pr_number, pr_url, pr_title, base_ref, head_ref, author, created_at
+             FROM pr_review_meta WHERE branch = ?1",
+            params![branch],
+            row_to_pr_review_meta,
+        ) {
+            Ok(meta) => Ok(Some(meta)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // -- Walkthroughs ---------------------------------------------------------
+
+    /// Start (or restart) walkthrough generation for a branch: delete any
+    /// existing walkthrough for it (no generation history is kept — see the
+    /// v6 migration note) and insert a fresh `generating` row, so the caller
+    /// has an id to poll for completion / detect a stuck generation.
+    pub fn begin_walkthrough(&self, branch: &str) -> Result<Walkthrough> {
+        self.conn.execute(
+            "DELETE FROM walkthroughs WHERE branch = ?1",
+            params![branch],
+        )?;
+        let id = Uuid::new_v4().to_string();
+        self.conn.execute(
+            "INSERT INTO walkthroughs (id, branch, status) VALUES (?1, ?2, 'generating')",
+            params![id, branch],
+        )?;
+        self.walkthrough_row_by_id(&id)
+    }
+
+    /// Save a completed walkthrough: replaces the branch's steps and marks it
+    /// `ready`, in one transaction. `begin_walkthrough` must have already
+    /// created the row — this only updates/populates it, so a generation
+    /// that skipped the "generating" placeholder is treated as an error
+    /// rather than silently creating one (the placeholder is what a stuck- or
+    /// failed-generation UI depends on existing).
+    ///
+    /// Not called in production: the actual write path is the conductor MCP
+    /// server's `save_walkthrough` tool (`plugins/conductor/mcp/conductor-comment/src/index.ts`),
+    /// which the headless `claude -p` session invokes directly over stdio —
+    /// this Rust method exists only so the save round-trip can be tested
+    /// without spawning a Node process. The two implementations must be kept
+    /// in sync by hand: a schema or invariant change here needs the same
+    /// change made in `index.ts`, and vice versa.
+    #[allow(dead_code)]
+    pub fn save_walkthrough(
+        &self,
+        branch: &str,
+        title: &str,
+        summary: &str,
+        steps: &[NewWalkthroughStep],
+    ) -> Result<()> {
+        let walkthrough_id: String = self
+            .conn
+            .query_row(
+                "SELECT id FROM walkthroughs WHERE branch = ?1",
+                params![branch],
+                |row| row.get(0),
+            )
+            .with_context(|| {
+                format!("no walkthrough row for branch {branch} — call begin_walkthrough first")
+            })?;
+
+        self.conn.execute_batch("BEGIN;")?;
+        let result = (|| -> Result<()> {
+            self.conn.execute(
+                "UPDATE walkthroughs
+                 SET title = ?1, summary = ?2, status = 'ready', error = NULL,
+                     updated_at = datetime('now')
+                 WHERE id = ?3",
+                params![title, summary, walkthrough_id],
+            )?;
+            self.conn.execute(
+                "DELETE FROM walkthrough_steps WHERE walkthrough_id = ?1",
+                params![walkthrough_id],
+            )?;
+            for (seq, step) in steps.iter().enumerate() {
+                let step_id = Uuid::new_v4().to_string();
+                self.conn.execute(
+                    "INSERT INTO walkthrough_steps
+                        (id, walkthrough_id, seq, file_path, line_start, line_end, kind, title, body)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    params![
+                        step_id,
+                        walkthrough_id,
+                        seq as i64,
+                        step.file_path,
+                        step.line_start,
+                        step.line_end,
+                        step.kind.as_str(),
+                        step.title,
+                        step.body,
+                    ],
+                )?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT;")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
+    }
+
+    /// Mark a branch's walkthrough as failed, recording why. Requires
+    /// `begin_walkthrough` to have created the row first.
+    pub fn fail_walkthrough(&self, branch: &str, error: &str) -> Result<()> {
+        let changed = self.conn.execute(
+            "UPDATE walkthroughs
+             SET status = 'failed', error = ?1, updated_at = datetime('now')
+             WHERE branch = ?2",
+            params![error, branch],
+        )?;
+        if changed == 0 {
+            anyhow::bail!(
+                "no walkthrough row for branch {branch} — call begin_walkthrough first"
+            );
+        }
+        Ok(())
+    }
+
+    /// Retrieve a branch's walkthrough header and its steps (ordered by
+    /// `seq`), or `None` if no walkthrough has been started for it.
+    pub fn get_walkthrough(
+        &self,
+        branch: &str,
+    ) -> Result<Option<(Walkthrough, Vec<WalkthroughStep>)>> {
+        let walkthrough = match self.conn.query_row(
+            "SELECT id, branch, title, summary, status, error, created_at, updated_at
+             FROM walkthroughs WHERE branch = ?1",
+            params![branch],
+            row_to_walkthrough,
+        ) {
+            Ok(w) => w,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let mut stmt = self.conn.prepare(
+            "SELECT id, walkthrough_id, seq, file_path, line_start, line_end, kind, title, body
+             FROM walkthrough_steps
+             WHERE walkthrough_id = ?1
+             ORDER BY seq",
+        )?;
+        let rows = stmt.query_map(params![walkthrough.id], row_to_walkthrough_step)?;
+        let mut steps = Vec::new();
+        for row in rows {
+            steps.push(row?);
+        }
+        Ok(Some((walkthrough, steps)))
+    }
+
+    /// Fetch a walkthrough row by id (used right after `begin_walkthrough`
+    /// inserts it, to read back server-side defaults like `created_at`).
+    fn walkthrough_row_by_id(&self, id: &str) -> Result<Walkthrough> {
+        self.conn
+            .query_row(
+                "SELECT id, branch, title, summary, status, error, created_at, updated_at
+                 FROM walkthroughs WHERE id = ?1",
+                params![id],
+                row_to_walkthrough,
+            )
+            .map_err(Into::into)
     }
 
     // -- View state (restore where the user was on restart) -----------------
@@ -1110,6 +1429,64 @@ fn collect_reviews(
         out.push(row?);
     }
     Ok(out)
+}
+
+fn row_to_walkthrough(row: &rusqlite::Row<'_>) -> rusqlite::Result<Walkthrough> {
+    let status_str: String = row.get(4)?;
+    let status = WalkthroughStatus::from_str(&status_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            format!("unknown WalkthroughStatus: {status_str}").into(),
+        )
+    })?;
+
+    Ok(Walkthrough {
+        id: row.get(0)?,
+        branch: row.get(1)?,
+        title: row.get(2)?,
+        summary: row.get(3)?,
+        status,
+        error: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+fn row_to_walkthrough_step(row: &rusqlite::Row<'_>) -> rusqlite::Result<WalkthroughStep> {
+    let kind_str: String = row.get(6)?;
+    let kind = WalkthroughStepKind::from_str(&kind_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            6,
+            rusqlite::types::Type::Text,
+            format!("unknown WalkthroughStepKind: {kind_str}").into(),
+        )
+    })?;
+
+    Ok(WalkthroughStep {
+        id: row.get(0)?,
+        walkthrough_id: row.get(1)?,
+        seq: row.get(2)?,
+        file_path: row.get(3)?,
+        line_start: row.get(4)?,
+        line_end: row.get(5)?,
+        kind,
+        title: row.get(7)?,
+        body: row.get(8)?,
+    })
+}
+
+fn row_to_pr_review_meta(row: &rusqlite::Row<'_>) -> rusqlite::Result<PrReviewMeta> {
+    Ok(PrReviewMeta {
+        branch: row.get(0)?,
+        pr_number: row.get(1)?,
+        pr_url: row.get(2)?,
+        pr_title: row.get(3)?,
+        base_ref: row.get(4)?,
+        head_ref: row.get(5)?,
+        author: row.get(6)?,
+        created_at: row.get(7)?,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1764,5 +2141,225 @@ mod tests {
         assert_eq!(snap1.commits_made, 0);
         assert_eq!(snap2.reviews_created, 0);
         assert_eq!(snap2.commits_made, 2);
+    }
+
+    #[test]
+    fn migrates_existing_v5_db_to_v6() {
+        // Simulate a pre-v6 database on disk: open a fresh store (which
+        // migrates straight to the latest version), then hand-roll it back
+        // down to what a v5 database looked like, and reopen it the same
+        // way ReviewStore::open would encounter it in the wild.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("conductor.db");
+
+        {
+            let store = ReviewStore::open(&db_path).unwrap();
+            store
+                .add_review(
+                    "feat/x",
+                    "src/main.rs",
+                    1,
+                    None,
+                    CommentKind::Suggest,
+                    "predates the v6 migration",
+                    "abc123",
+                    Author::User,
+                    Some("feat/x"),
+                )
+                .unwrap();
+
+            store
+                .conn
+                .execute_batch(
+                    "
+                    DROP TABLE walkthroughs;
+                    DROP TABLE walkthrough_steps;
+                    DROP TABLE pr_review_meta;
+                    ALTER TABLE reviews DROP COLUMN published_at;
+                    PRAGMA user_version = 5;
+                    ",
+                )
+                .unwrap();
+        }
+
+        let store = ReviewStore::open(&db_path).unwrap();
+        let version: i32 = store
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, 6);
+
+        // Pre-existing data survived the migration.
+        let reviews = store.reviews_for_worktree("feat/x").unwrap();
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].body, "predates the v6 migration");
+
+        // The new tables/columns are usable.
+        assert!(store.get_walkthrough("feat/x").unwrap().is_none());
+        assert!(store.get_pr_review_meta("feat/x").unwrap().is_none());
+        assert_eq!(store.unpublished_reviews("feat/x").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn walkthrough_lifecycle() {
+        let store = test_store();
+
+        // No walkthrough yet.
+        assert!(store.get_walkthrough("feat/x").unwrap().is_none());
+
+        let started = store.begin_walkthrough("feat/x").unwrap();
+        assert_eq!(started.branch, "feat/x");
+        assert_eq!(started.status, WalkthroughStatus::Generating);
+
+        let (walkthrough, steps) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(walkthrough.id, started.id);
+        assert_eq!(walkthrough.status, WalkthroughStatus::Generating);
+        assert!(steps.is_empty());
+
+        let new_steps = vec![
+            NewWalkthroughStep {
+                file_path: "src/main.rs".to_string(),
+                line_start: Some(10),
+                line_end: Some(20),
+                kind: WalkthroughStepKind::Intent,
+                title: "Why this change exists".to_string(),
+                body: "Fixes a startup crash.".to_string(),
+            },
+            NewWalkthroughStep {
+                file_path: "src/lib.rs".to_string(),
+                line_start: None,
+                line_end: None,
+                kind: WalkthroughStepKind::Core,
+                title: "Core fix".to_string(),
+                body: "Guards against the null case.".to_string(),
+            },
+        ];
+        store
+            .save_walkthrough("feat/x", "Fix startup crash", "A short summary.", &new_steps)
+            .unwrap();
+
+        let (walkthrough, steps) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(walkthrough.status, WalkthroughStatus::Ready);
+        assert_eq!(walkthrough.title.as_deref(), Some("Fix startup crash"));
+        assert_eq!(walkthrough.summary.as_deref(), Some("A short summary."));
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[0].seq, 0);
+        assert_eq!(steps[0].file_path, "src/main.rs");
+        assert_eq!(steps[0].kind, WalkthroughStepKind::Intent);
+        assert_eq!(steps[1].seq, 1);
+        assert_eq!(steps[1].kind, WalkthroughStepKind::Core);
+
+        // Re-generating replaces the row entirely (no history kept).
+        let restarted = store.begin_walkthrough("feat/x").unwrap();
+        assert_ne!(restarted.id, started.id);
+        let (walkthrough, steps) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(walkthrough.status, WalkthroughStatus::Generating);
+        assert!(steps.is_empty());
+
+        store.fail_walkthrough("feat/x", "Claude Code exited early").unwrap();
+        let (walkthrough, _) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(walkthrough.status, WalkthroughStatus::Failed);
+        assert_eq!(
+            walkthrough.error.as_deref(),
+            Some("Claude Code exited early")
+        );
+    }
+
+    #[test]
+    fn fail_walkthrough_without_begin_is_an_error() {
+        let store = test_store();
+        assert!(store.fail_walkthrough("feat/x", "boom").is_err());
+    }
+
+    #[test]
+    fn save_walkthrough_without_begin_is_an_error() {
+        let store = test_store();
+        assert!(
+            store
+                .save_walkthrough("feat/x", "title", "summary", &[])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pr_review_meta_upsert_and_get() {
+        let store = test_store();
+
+        assert!(store.get_pr_review_meta("feat/x").unwrap().is_none());
+
+        store
+            .save_pr_review_meta(
+                "feat/x",
+                Some(42),
+                Some("https://github.com/o/r/pull/42"),
+                Some("Add feature"),
+                Some("main"),
+                Some("feat/x"),
+                Some("octocat"),
+            )
+            .unwrap();
+
+        let meta = store.get_pr_review_meta("feat/x").unwrap().unwrap();
+        assert_eq!(meta.pr_number, Some(42));
+        assert_eq!(meta.pr_url.as_deref(), Some("https://github.com/o/r/pull/42"));
+        assert_eq!(meta.author.as_deref(), Some("octocat"));
+
+        // Upsert overwrites rather than duplicating.
+        store
+            .save_pr_review_meta(
+                "feat/x",
+                Some(42),
+                Some("https://github.com/o/r/pull/42"),
+                Some("Add feature (renamed)"),
+                Some("main"),
+                Some("feat/x"),
+                Some("octocat"),
+            )
+            .unwrap();
+        let meta = store.get_pr_review_meta("feat/x").unwrap().unwrap();
+        assert_eq!(meta.pr_title.as_deref(), Some("Add feature (renamed)"));
+    }
+
+    #[test]
+    fn mark_published_hides_reviews_from_unpublished_query() {
+        let store = test_store();
+
+        let r1 = store
+            .add_review(
+                "feat/x",
+                "src/main.rs",
+                1,
+                None,
+                CommentKind::Suggest,
+                "first",
+                "abc123",
+                Author::User,
+                Some("feat/x"),
+            )
+            .unwrap();
+        let r2 = store
+            .add_review(
+                "feat/x",
+                "src/lib.rs",
+                2,
+                None,
+                CommentKind::Question,
+                "second",
+                "abc123",
+                Author::User,
+                Some("feat/x"),
+            )
+            .unwrap();
+
+        let unpublished = store.unpublished_reviews("feat/x").unwrap();
+        assert_eq!(unpublished.len(), 2);
+
+        store
+            .mark_published(std::slice::from_ref(&r1.id), "2026-07-05T00:00:00Z")
+            .unwrap();
+
+        let unpublished = store.unpublished_reviews("feat/x").unwrap();
+        assert_eq!(unpublished.len(), 1);
+        assert_eq!(unpublished[0].id, r2.id);
     }
 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -356,6 +356,69 @@ pub fn render_open_repo_overlay(frame: &mut Frame, area: Rect, app: &App) {
     set_cursor_for_input(frame, inner, &app.overlays.open_repo.buffer);
 }
 
+/// Render the PR-number/URL input overlay ("Review: Review Pull Request…").
+///
+/// Below the input line, shows either a loading notice while the background
+/// gh/git intake runs, or the last failure's message — the overlay stays
+/// open on failure (input preserved) so the user can correct and retry.
+pub fn render_pr_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let overlay = &app.overlays.pr_input;
+    let popup_width = 70_u16.min(area.width.saturating_sub(4));
+    let popup_height = 6_u16.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let title = if overlay.loading {
+        " Review Pull Request (fetching...) "
+    } else {
+        " Review Pull Request (Enter: fetch & review, Esc: cancel) "
+    };
+    let border_color = if overlay.error.is_some() {
+        theme.error
+    } else {
+        theme.border_focused
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(inner);
+
+    let input_text = format_input_with_cursor(&overlay.buffer);
+    let input_style = if overlay.loading {
+        Style::default().fg(theme.muted)
+    } else {
+        Style::default().fg(theme.fg)
+    };
+    frame.render_widget(Paragraph::new(Span::styled(input_text, input_style)), chunks[0]);
+    if !overlay.loading {
+        set_cursor_for_input(frame, chunks[0], &overlay.buffer);
+    }
+
+    let message = if overlay.loading {
+        Some(("Fetching PR metadata via gh...".to_string(), theme.muted))
+    } else {
+        overlay
+            .error
+            .as_ref()
+            .map(|e| (e.clone(), theme.error))
+    };
+    if let Some((text, color)) = message {
+        let paragraph =
+            Paragraph::new(Span::styled(text, Style::default().fg(color)))
+                .wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(paragraph, chunks[1]);
+    }
+}
+
 /// Render the switch-branch (remote branch checkout) overlay.
 pub fn render_switch_branch_overlay(frame: &mut Frame, area: Rect, app: &App) {
     let theme = &app.theme;
@@ -1093,6 +1156,7 @@ fn help_lines_for(app: &App, focus: crate::app::Focus, theme: &Theme) -> Vec<Lin
             ("Explorer — file tree", KeyContext::Explorer),
             ("Explorer — changed files", KeyContext::ExplorerDiffList),
             ("Explorer — comment list", KeyContext::ExplorerCommentList),
+            ("Explorer — walkthrough", KeyContext::ExplorerWalkthrough),
         ],
         Focus::Viewer => &[
             ("Viewer", KeyContext::Viewer),
@@ -1104,9 +1168,37 @@ fn help_lines_for(app: &App, focus: crate::app::Focus, theme: &Theme) -> Vec<Lin
     for (title, ctx) in panel_ctxs {
         section(&mut lines, title, *ctx);
     }
+    help_review_commands_section(&mut lines, theme);
     section(&mut lines, "Global — works anywhere", KeyContext::Global);
 
     lines
+}
+
+/// The PR-intake, walkthrough-generation, and publish commands have no
+/// default keybinding (see `default_keybinds.toml`) — they're reached only
+/// through the command palette, so `section()` above (which walks
+/// `app.keymap`) never finds them. Listed here instead so the help screen
+/// still surfaces them.
+fn help_review_commands_section(lines: &mut Vec<Line<'static>>, theme: &Theme) {
+    help_section(lines, "Review (via command palette)", theme);
+    help_key_dyn(
+        lines,
+        "palette".to_string(),
+        "Review: Review Pull Request…",
+        theme,
+    );
+    help_key_dyn(
+        lines,
+        "palette".to_string(),
+        "Review: Generate Walkthrough",
+        theme,
+    );
+    help_key_dyn(
+        lines,
+        "palette".to_string(),
+        "Review: Publish Comments to GitHub",
+        theme,
+    );
 }
 
 // ── Smart Worktree overlays ──────────────────────────────────────────
@@ -1292,6 +1384,67 @@ pub fn render_update_confirm_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled(": いいえ", Style::default().fg(theme.muted)),
         ]),
     ];
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Render the confirm dialog for publishing review comments to GitHub —
+/// shown before the irreversible external POST, listing how many comments
+/// will be posted and how many were skipped for not being on a diff line.
+pub fn render_publish_confirm_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let Some(confirm) = app.publish_confirm.as_ref() else {
+        return;
+    };
+    let popup_width = 60_u16.min(area.width.saturating_sub(4));
+    let popup_height = if confirm.skipped > 0 { 6 } else { 5 };
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Publish Comments to GitHub ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.warning));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let mut lines = vec![Line::from(Span::styled(
+        format!(
+            " Publish {} comment(s) to PR #{}?",
+            confirm.comments.len(),
+            confirm.pr_number
+        ),
+        Style::default().fg(theme.fg),
+    ))];
+    if confirm.skipped > 0 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " {} comment(s) skipped — outside the current diff",
+                confirm.skipped
+            ),
+            Style::default().fg(theme.muted),
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            " y",
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": publish / ", Style::default().fg(theme.muted)),
+        Span::styled(
+            "n",
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": cancel", Style::default().fg(theme.muted)),
+    ]));
     frame.render_widget(Paragraph::new(lines), inner);
 }
 

--- a/src/ui/explorer_panel.rs
+++ b/src/ui/explorer_panel.rs
@@ -39,10 +39,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     app.viewer_state.explorer.explorer_diff_list_height = diff_inner_height.max(1);
 
     render_file_tree(frame, chunks[0], app, focused);
-    if app.viewer_state.explorer.explorer_show_comments {
-        render_comment_list(frame, chunks[1], app, focused);
-    } else {
-        render_diff_list(frame, chunks[1], app, focused);
+    match app.viewer_state.explorer.explorer_bottom_view {
+        crate::viewer::ExplorerBottomView::Comments => {
+            render_comment_list(frame, chunks[1], app, focused);
+        }
+        crate::viewer::ExplorerBottomView::Walkthrough => {
+            super::walkthrough_pane::render(frame, chunks[1], app, focused);
+        }
+        crate::viewer::ExplorerBottomView::DiffList => {
+            render_diff_list(frame, chunks[1], app, focused);
+        }
     }
 
     // Show search input overlay (skip cursor positioning when a global overlay covers us).
@@ -111,11 +117,23 @@ fn render_file_tree(frame: &mut Frame, area: Rect, app: &mut App, panel_focused:
         .position(|&i| i == tree_selected)
         .unwrap_or(0);
 
-    let title = if visible.len() > inner_height {
+    let mut title = if visible.len() > inner_height {
         format!(" Explorer ({}/{}) ", selected_vis_idx + 1, visible.len())
     } else {
         " Explorer ".to_string()
     };
+    // Walkthrough-ready signal, mirroring the comment badge's "there's
+    // something here you haven't opened" pattern — hidden once the
+    // walkthrough view is already showing since the badge would be redundant.
+    let walkthrough_ready = matches!(
+        app.current_walkthrough.as_ref().map(|(w, _)| w.status),
+        Some(crate::walkthrough::WalkthroughStatus::Ready)
+    );
+    if walkthrough_ready
+        && app.viewer_state.explorer.explorer_bottom_view != crate::viewer::ExplorerBottomView::Walkthrough
+    {
+        title.push_str("\u{1f9ed} ");
+    }
 
     let is_expanded = app.expanded_panel == Some(Focus::Explorer);
     let theme = &app.theme;
@@ -338,6 +356,12 @@ fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_focused: boo
                 if let Some(badge) = comment_badge(app, &file_diff.path, theme) {
                     spans.push(badge);
                 }
+                if vs_explorer.viewed.contains(&file_diff.path) {
+                    spans.push(Span::styled(
+                        "  \u{2713}",
+                        Style::default().fg(theme.success),
+                    ));
+                }
                 ListItem::new(Line::from(spans))
             }
             DiffListEntry::Summary {} => {
@@ -370,7 +394,11 @@ fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_focused: boo
 /// Build a GitHub-style comment-count badge (e.g. ` 💬3`) for a file path, or
 /// `None` when the file has no review comments. Unresolved comments colour the
 /// badge with the accent; an all-resolved file uses muted.
-fn comment_badge<'a>(app: &App, file_path: &str, theme: &crate::theme::Theme) -> Option<Span<'a>> {
+pub(crate) fn comment_badge<'a>(
+    app: &App,
+    file_path: &str,
+    theme: &crate::theme::Theme,
+) -> Option<Span<'a>> {
     use crate::review_store::CommentStatus;
     let mut total = 0usize;
     let mut unresolved = 0usize;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -248,7 +248,6 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
 
     // ── Column 3: Terminal split (Claude 80% / Shell 20%) ───────────
     let terminal_split = app.layout_cache.terminal_split;
-
     super::terminal_claude::render(frame, terminal_split[0], app);
     super::terminal_shell::render(frame, terminal_split[1], app);
 
@@ -265,141 +264,7 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
         super::panel_overlay::render_panel_overlay(frame, app);
     }
 
-    // ── Overlays ────────────────────────────────────────────────────
-    // These render on top of everything else when active.
-
-    // Worktree input mode overlays (not part of ActiveOverlay enum).
-    match app.worktree_mgr.input_mode {
-        crate::app::WorktreeInputMode::CreatingWorktree => {
-            super::dashboard::render_worktree_input_overlay(frame, main_area, app);
-        }
-        crate::app::WorktreeInputMode::CreatingWorktreeBase => {
-            super::dashboard::render_worktree_base_input_overlay(frame, main_area, app);
-        }
-        crate::app::WorktreeInputMode::ConfirmingDelete => {
-            render_confirming_delete_overlay(frame, main_area, app);
-        }
-        crate::app::WorktreeInputMode::ConfirmingDeleteBranch => {
-            super::dashboard::render_delete_branch_confirm_overlay(frame, main_area, app);
-        }
-        crate::app::WorktreeInputMode::ConfirmingUngrab => {
-            render_confirm_overlay(frame, main_area, app, " Confirm Ungrab ", app.theme.warning);
-        }
-        crate::app::WorktreeInputMode::ConfirmingReset => {
-            render_confirm_overlay(frame, main_area, app, " Confirm Reset ", app.theme.error);
-        }
-        crate::app::WorktreeInputMode::SmartDescription => {
-            super::dashboard::render_smart_description_overlay(frame, main_area, app);
-        }
-        crate::app::WorktreeInputMode::Normal => {}
-    }
-    // Review input overlays (not part of ActiveOverlay enum). A new comment with
-    // an anchor renders as an inline compose box in the viewer instead of this
-    // modal, so suppress the modal in that case.
-    if app.review_state.input_mode == crate::review_state::ReviewInputMode::ConfirmingDelete {
-        super::review::render_delete_confirm_overlay(frame, main_area, app);
-    } else if app.review_state.input_mode != crate::review_state::ReviewInputMode::Normal {
-        let inline_new_comment = app.review_state.input_mode
-            == crate::review_state::ReviewInputMode::AddingComment
-            && app
-                .review_state
-                .input_anchor
-                .as_ref()
-                .is_some_and(|(f, _, _)| {
-                    Some(f.as_str()) == app.viewer_state.content.current_file.as_deref()
-                });
-        if !inline_new_comment {
-            super::review::render_input_overlay(frame, main_area, app);
-        }
-    }
-    if app.review_state.template_picker_active {
-        super::review::render_template_picker_overlay(
-            frame,
-            main_area,
-            &app.review_state,
-            &app.theme,
-        );
-    }
-    if app.review_state.comment_detail_active {
-        super::review::render_comment_detail_overlay(frame, main_area, app);
-    }
-    // ActiveOverlay-based overlays.
-    match app.overlays.active {
-        crate::overlay::ActiveOverlay::None => {}
-        crate::overlay::ActiveOverlay::History => {
-            super::dashboard::render_history_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::CherryPick => {
-            super::dashboard::render_cherry_pick_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::SwitchBranch => {
-            super::dashboard::render_switch_branch_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::Grab => {
-            super::dashboard::render_grab_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::Prune => {
-            super::dashboard::render_prune_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::RepoSelector => {
-            super::dashboard::render_repo_selector_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::OpenRepo => {
-            super::dashboard::render_open_repo_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::ResumeSession => {
-            super::dashboard::render_resume_session_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::GrepSearch => {
-            super::grep_search::render_grep_search_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::CommandPalette => {
-            super::dashboard::render_command_palette_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::Help => {
-            super::dashboard::render_help_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::WorktreeSwitcher => {
-            super::worktree_bar::render_switcher_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::CommentList => {
-            super::explorer_panel::render_comment_list_overlay(frame, main_area, app);
-        }
-        crate::overlay::ActiveOverlay::ThemePicker => {
-            super::theme_picker::render_theme_picker_overlay(frame, main_area, app);
-        }
-    }
-    // Fuzzy filename-search ("jump to file") modal — rendered at the top level
-    // so it works even when the explorer column is collapsed (viewer maximized).
-    if app.viewer_state.filename_search.filename_search_active {
-        super::dashboard::render_filename_search_overlay(frame, main_area, app);
-    }
-    match app.update_state {
-        crate::app::UpdateState::Confirming => {
-            super::dashboard::render_update_confirm_overlay(frame, main_area, app);
-        }
-        crate::app::UpdateState::InProgress
-        | crate::app::UpdateState::Restarting
-        | crate::app::UpdateState::Failed => {
-            super::dashboard::render_update_progress_overlay(frame, main_area, app);
-        }
-        crate::app::UpdateState::Idle => {}
-    }
-
-    // ── References overlay (panel-level, not part of OverlayManager) ──
-    if app.references_overlay.active {
-        crate::ui::references::render_references_overlay(frame, main_area, app);
-    }
-
-    // ── Symbol action overlay (after hint selection) ──
-    if app.symbol_action_overlay.active {
-        crate::ui::symbol_action::render_symbol_action_overlay(frame, main_area, app);
-    }
-
-    // ── Skip reason modal ────────────────────────────────────────────
-    if let Some(ref reason) = app.worktree_mgr.skip_reason {
-        render_skip_reason_overlay(frame, main_area, reason, &app.theme);
-    }
+    render_overlays(frame, main_area, app);
 
     // ── Status bar ──────────────────────────────────────────────────
     // Show worktree branch + repo on the right of status bar.
@@ -431,6 +296,151 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // title bar, and confetti land on top of everything (including overlays).
     if app.party_mode {
         super::party::apply_party_effects(frame, app);
+    }
+}
+
+/// Render every overlay/modal that can appear on top of the panels: worktree
+/// and review text-input modals, the `ActiveOverlay` popups (switch-branch,
+/// cherry-pick, help, etc.), the filename-search modal, the update dialog, the
+/// references/symbol-action popups, and the skip-reason modal. Shared by the
+/// normal accordion layout and review mode, so overlays keep working
+/// (comments, help, the command palette, …) no matter which layout is showing.
+fn render_overlays(frame: &mut Frame, area: Rect, app: &mut App) {
+    // Worktree input mode overlays (not part of ActiveOverlay enum).
+    match app.worktree_mgr.input_mode {
+        crate::app::WorktreeInputMode::CreatingWorktree => {
+            super::dashboard::render_worktree_input_overlay(frame, area, app);
+        }
+        crate::app::WorktreeInputMode::CreatingWorktreeBase => {
+            super::dashboard::render_worktree_base_input_overlay(frame, area, app);
+        }
+        crate::app::WorktreeInputMode::ConfirmingDelete => {
+            render_confirming_delete_overlay(frame, area, app);
+        }
+        crate::app::WorktreeInputMode::ConfirmingDeleteBranch => {
+            super::dashboard::render_delete_branch_confirm_overlay(frame, area, app);
+        }
+        crate::app::WorktreeInputMode::ConfirmingUngrab => {
+            render_confirm_overlay(frame, area, app, " Confirm Ungrab ", app.theme.warning);
+        }
+        crate::app::WorktreeInputMode::ConfirmingReset => {
+            render_confirm_overlay(frame, area, app, " Confirm Reset ", app.theme.error);
+        }
+        crate::app::WorktreeInputMode::SmartDescription => {
+            super::dashboard::render_smart_description_overlay(frame, area, app);
+        }
+        crate::app::WorktreeInputMode::Normal => {}
+    }
+    // Review input overlays (not part of ActiveOverlay enum). A new comment with
+    // an anchor renders as an inline compose box in the viewer instead of this
+    // modal, so suppress the modal in that case.
+    if app.review_state.input_mode == crate::review_state::ReviewInputMode::ConfirmingDelete {
+        super::review::render_delete_confirm_overlay(frame, area, app);
+    } else if app.review_state.input_mode != crate::review_state::ReviewInputMode::Normal {
+        let inline_new_comment = app.review_state.input_mode
+            == crate::review_state::ReviewInputMode::AddingComment
+            && app
+                .review_state
+                .input_anchor
+                .as_ref()
+                .is_some_and(|(f, _, _)| {
+                    Some(f.as_str()) == app.viewer_state.content.current_file.as_deref()
+                });
+        if !inline_new_comment {
+            super::review::render_input_overlay(frame, area, app);
+        }
+    }
+    if app.review_state.template_picker_active {
+        super::review::render_template_picker_overlay(frame, area, &app.review_state, &app.theme);
+    }
+    if app.review_state.comment_detail_active {
+        super::review::render_comment_detail_overlay(frame, area, app);
+    }
+    if app.viewer_state.explorer.walkthrough_detail_active {
+        super::walkthrough_pane::render_detail_overlay(frame, area, app);
+    }
+    // ActiveOverlay-based overlays.
+    match app.overlays.active {
+        crate::overlay::ActiveOverlay::None => {}
+        crate::overlay::ActiveOverlay::History => {
+            super::dashboard::render_history_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::CherryPick => {
+            super::dashboard::render_cherry_pick_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::SwitchBranch => {
+            super::dashboard::render_switch_branch_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::Grab => {
+            super::dashboard::render_grab_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::Prune => {
+            super::dashboard::render_prune_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::RepoSelector => {
+            super::dashboard::render_repo_selector_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::OpenRepo => {
+            super::dashboard::render_open_repo_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::PrInput => {
+            super::dashboard::render_pr_input_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::ResumeSession => {
+            super::dashboard::render_resume_session_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::GrepSearch => {
+            super::grep_search::render_grep_search_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::CommandPalette => {
+            super::dashboard::render_command_palette_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::Help => {
+            super::dashboard::render_help_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::WorktreeSwitcher => {
+            super::worktree_bar::render_switcher_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::CommentList => {
+            super::explorer_panel::render_comment_list_overlay(frame, area, app);
+        }
+        crate::overlay::ActiveOverlay::ThemePicker => {
+            super::theme_picker::render_theme_picker_overlay(frame, area, app);
+        }
+    }
+    // Fuzzy filename-search ("jump to file") modal — rendered at the top level
+    // so it works even when the explorer column is collapsed (viewer maximized).
+    if app.viewer_state.filename_search.filename_search_active {
+        super::dashboard::render_filename_search_overlay(frame, area, app);
+    }
+    match app.update_state {
+        crate::app::UpdateState::Confirming => {
+            super::dashboard::render_update_confirm_overlay(frame, area, app);
+        }
+        crate::app::UpdateState::InProgress
+        | crate::app::UpdateState::Restarting
+        | crate::app::UpdateState::Failed => {
+            super::dashboard::render_update_progress_overlay(frame, area, app);
+        }
+        crate::app::UpdateState::Idle => {}
+    }
+    if app.publish_confirm.is_some() {
+        super::dashboard::render_publish_confirm_overlay(frame, area, app);
+    }
+
+    // ── References overlay (panel-level, not part of OverlayManager) ──
+    if app.references_overlay.active {
+        crate::ui::references::render_references_overlay(frame, area, app);
+    }
+
+    // ── Symbol action overlay (after hint selection) ──
+    if app.symbol_action_overlay.active {
+        crate::ui::symbol_action::render_symbol_action_overlay(frame, area, app);
+    }
+
+    // ── Skip reason modal ────────────────────────────────────────────
+    if let Some(ref reason) = app.worktree_mgr.skip_reason {
+        render_skip_reason_overlay(frame, area, reason, &app.theme);
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,6 +17,7 @@ pub mod tab_bar;
 pub mod terminal_claude;
 pub mod terminal_shell;
 pub mod viewer_panel;
+pub mod walkthrough_pane;
 pub mod worktree_bar;
 pub mod worktree_panel;
 

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -624,6 +624,10 @@ struct DiffLineRenderCtx<'a> {
     area_width: u16,
     comment_lines: &'a std::collections::HashSet<usize>,
     comment_end_lines: &'a std::collections::HashSet<usize>,
+    /// Inclusive new-side line range of the walkthrough step currently
+    /// selected in review mode, when it points at the file being rendered.
+    /// `None` outside review mode, with no walkthrough, or for other files.
+    walkthrough_highlight: Option<(usize, usize)>,
     /// Party-mode rainbow phase (`None` when party mode is off).
     party: Option<f64>,
 }
@@ -669,6 +673,10 @@ fn render_diff_content_line(
             };
             n >= lo && n <= hi
         };
+    let is_in_walkthrough_highlight = new_line_no.is_some_and(|n| {
+        ctx.walkthrough_highlight
+            .is_some_and(|(lo, hi)| n >= lo && n <= hi)
+    });
 
     // Gutter marker.
     let (gutter_prefix, diff_bg, emphasis_bg) = match tag {
@@ -846,6 +854,18 @@ fn render_diff_content_line(
     let content_max_w = (ctx.area_width as usize).saturating_sub(gutter_width + 8);
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
+    // Underline the current walkthrough step's line range — a highlight that
+    // doesn't fight the existing selection/diff background colors, since it
+    // only lasts while this step stays current.
+    let content_spans: Vec<Span> = if is_in_walkthrough_highlight {
+        content_spans
+            .into_iter()
+            .map(|s| Span::styled(s.content, s.style.add_modifier(Modifier::UNDERLINED)))
+            .collect()
+    } else {
+        content_spans
+    };
+
     let mut spans = vec![gutter_span, badge];
     spans.extend(content_spans);
 
@@ -973,6 +993,19 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'
         let inline_reply_line = vs.explorer.inline_reply_line;
         let compose_anchor_end = new_comment_anchor_end(app);
 
+        // The selected walkthrough step's line range, if it's anchored to
+        // the file currently open in this pane.
+        let walkthrough_highlight = (|| {
+            let (_, steps) = app.current_walkthrough.as_ref()?;
+            let step = steps.get(vs.explorer.walkthrough_selected)?;
+            if vs.content.current_file.as_deref() != Some(step.file_path.as_str()) {
+                return None;
+            }
+            let start = step.line_start?;
+            let end = step.line_end.unwrap_or(start);
+            Some((start as usize, end as usize))
+        })();
+
         let line_ctx = DiffLineRenderCtx {
             vs,
             theme,
@@ -981,6 +1014,7 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'
             area_width: area.width,
             comment_lines: &comment_lines,
             comment_end_lines: &comment_end_lines,
+            walkthrough_highlight,
             party,
         };
 
@@ -1112,6 +1146,17 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'
                 .bg(theme.gutter_selected_bg),
         ));
         frame.render_widget(hint_widget, hint_area);
+    }
+
+    // Show search input overlay (skip cursor positioning when a global overlay covers us).
+    if vs.search.search_active {
+        render_search_box(
+            frame,
+            area,
+            &vs.search.search_query,
+            theme,
+            app.is_any_overlay_active(),
+        );
     }
 }
 

--- a/src/ui/walkthrough_pane.rs
+++ b/src/ui/walkthrough_pane.rs
@@ -1,0 +1,266 @@
+//! The AI walkthrough view — one of the Explorer's three bottom-pane views
+//! (alongside the diff list and comment list; see
+//! `viewer::ExplorerBottomView`).
+//!
+//! Renders as a single flat list, one row per step, with only the selected
+//! step's body inlined (word-wrapped, clipped) directly below its row —
+//! there is no fixed-percentage split between "list" and "body" areas, so a
+//! narrow pane still shows as much of the selected step as fits. The full
+//! body is available via the `space` detail overlay for anything the clip
+//! cuts off.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap};
+
+use crate::app::{App, Focus};
+use crate::walkthrough::{WalkthroughStatus, WalkthroughStep, WalkthroughStepKind};
+
+/// Render the walkthrough view into the Explorer's bottom pane.
+pub fn render(frame: &mut Frame, area: Rect, app: &App, panel_focused: bool) {
+    let theme = &app.theme;
+    let vs_explorer = &app.viewer_state.explorer;
+    let list_focused = panel_focused && vs_explorer.explorer_focus_on_diff_list;
+    let border_color = if list_focused {
+        app.animated_border_color(Focus::Explorer)
+    } else if panel_focused {
+        theme.border_secondary
+    } else {
+        theme.border_unfocused
+    };
+    let border_type = if panel_focused {
+        BorderType::Thick
+    } else {
+        BorderType::Plain
+    };
+    let title_style = if list_focused {
+        Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
+
+    let title = match app.current_walkthrough.as_ref().and_then(|(w, _)| w.title.as_deref()) {
+        Some(t) => format!(" Walkthrough: {t} "),
+        None => " Walkthrough ".to_string(),
+    };
+    let block = Block::default()
+        .title(Span::styled(title, title_style))
+        .borders(Borders::ALL)
+        .border_type(border_type)
+        .border_style(Style::default().fg(border_color));
+
+    let Some((walkthrough, steps)) = &app.current_walkthrough else {
+        let paragraph = Paragraph::new("No walkthrough yet — palette: Generate Walkthrough")
+            .style(Style::default().fg(theme.muted))
+            .block(block);
+        frame.render_widget(Clear, area);
+        frame.render_widget(paragraph, area);
+        return;
+    };
+
+    match walkthrough.status {
+        WalkthroughStatus::Generating => {
+            let paragraph = Paragraph::new("Generating walkthrough… (this takes a few minutes)")
+                .style(Style::default().fg(theme.info))
+                .block(block);
+            frame.render_widget(Clear, area);
+            frame.render_widget(paragraph, area);
+        }
+        WalkthroughStatus::Failed => {
+            let error = walkthrough.error.as_deref().unwrap_or("unknown error");
+            let paragraph = Paragraph::new(vec![
+                Line::from(Span::styled(
+                    format!("Generation failed: {error}"),
+                    Style::default().fg(theme.error),
+                )),
+                Line::from(Span::styled(
+                    "palette: Generate Walkthrough to retry",
+                    Style::default().fg(theme.muted),
+                )),
+            ])
+            .block(block);
+            frame.render_widget(Clear, area);
+            frame.render_widget(paragraph, area);
+        }
+        WalkthroughStatus::Ready => {
+            render_steps(frame, area, app, block, steps, list_focused);
+        }
+    }
+}
+
+/// The icon shown next to a walkthrough step, matching this UI's existing
+/// emoji-badge convention (comment badges, file-tree icons, …).
+fn step_icon(kind: WalkthroughStepKind) -> &'static str {
+    match kind {
+        WalkthroughStepKind::Intent => "\u{1f3af}", // 🎯
+        WalkthroughStepKind::Core => "\u{1f527}",   // 🔧
+        WalkthroughStepKind::Ripple => "\u{1f30a}", // 🌊
+        WalkthroughStepKind::Test => "\u{1f9ea}",   // 🧪
+    }
+}
+
+/// Greedily word-wrap `text` to `width` columns, splitting on existing
+/// newlines first so intentional paragraph breaks in the step body survive.
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut out = Vec::new();
+    for para in text.lines() {
+        if para.is_empty() {
+            out.push(String::new());
+            continue;
+        }
+        let mut current = String::new();
+        for word in para.split_whitespace() {
+            let candidate_len = if current.is_empty() {
+                word.len()
+            } else {
+                current.len() + 1 + word.len()
+            };
+            if candidate_len > width && !current.is_empty() {
+                out.push(std::mem::take(&mut current));
+            }
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            current.push_str(word);
+        }
+        out.push(current);
+    }
+    out
+}
+
+/// The ready walkthrough's flat step list: one row per step, with the
+/// selected step's word-wrapped body inlined directly below its row (clipped
+/// to at most 6 lines and whatever fits the remaining pane height). Scrolling
+/// is in step units — `walkthrough_scroll`/`walkthrough_selected` share the
+/// same index space the diff list uses, and since only the selected step
+/// ever expands, every row before it is exactly one line, so the clamp in
+/// `event::adjust_walkthrough_scroll` keeps the selected step's header
+/// visible.
+fn render_steps(
+    frame: &mut Frame,
+    area: Rect,
+    app: &App,
+    block: Block,
+    steps: &[WalkthroughStep],
+    focused: bool,
+) {
+    let theme = &app.theme;
+    let selected = app.viewer_state.explorer.walkthrough_selected;
+    let scroll = app.viewer_state.explorer.walkthrough_scroll;
+    let viewed_steps = &app.viewer_state.explorer.viewed_steps;
+
+    let inner = block.inner(area);
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    if inner.height == 0 {
+        return;
+    }
+    let inner_height = inner.height as usize;
+    let body_indent = "    ";
+    let wrap_width = (inner.width as usize).saturating_sub(body_indent.len()).max(1);
+
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut consumed = 0usize;
+    const MAX_BODY_LINES: usize = 6;
+
+    for (idx, step) in steps.iter().enumerate().skip(scroll) {
+        if consumed >= inner_height {
+            break;
+        }
+        let is_current = idx == selected;
+        let is_viewed = viewed_steps.contains(&step.id);
+        let style = if is_current && focused {
+            Style::default()
+                .fg(theme.selected_fg)
+                .bg(theme.selected_bg)
+                .add_modifier(Modifier::BOLD)
+        } else if is_current {
+            Style::default()
+                .fg(theme.selected_fg_inactive)
+                .bg(theme.selected_bg_inactive)
+                .add_modifier(Modifier::BOLD)
+        } else if is_viewed {
+            Style::default().fg(theme.muted)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        let filename = step.file_path.rsplit('/').next().unwrap_or(&step.file_path);
+        items.push(ListItem::new(Span::styled(
+            format!(
+                "  {} {} — {} ({filename})",
+                step_icon(step.kind),
+                step.kind,
+                step.title
+            ),
+            style,
+        )));
+        consumed += 1;
+
+        if is_current {
+            let budget = (inner_height - consumed).min(MAX_BODY_LINES);
+            for wrapped_line in wrap_text(&step.body, wrap_width).into_iter().take(budget) {
+                items.push(ListItem::new(Span::styled(
+                    format!("{body_indent}{wrapped_line}"),
+                    Style::default().fg(theme.fg),
+                )));
+                consumed += 1;
+            }
+        }
+    }
+
+    frame.render_widget(List::new(items), inner);
+}
+
+/// Full-text detail overlay for the selected walkthrough step (`space` in the
+/// walkthrough view — the same detail-overlay pattern the comment list uses
+/// for `view_comment_detail`, applied to a step's untruncated body).
+pub fn render_detail_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
+    let theme = &app.theme;
+    let Some((_, steps)) = &app.current_walkthrough else {
+        app.viewer_state.explorer.walkthrough_detail_active = false;
+        return;
+    };
+    let selected = app.viewer_state.explorer.walkthrough_selected;
+    let Some(step) = steps.get(selected) else {
+        app.viewer_state.explorer.walkthrough_detail_active = false;
+        return;
+    };
+
+    let popup_width = 72_u16.min(area.width.saturating_sub(4));
+    let popup_height = area.height.saturating_sub(4).max(10);
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+
+    let filename = step.file_path.rsplit('/').next().unwrap_or(&step.file_path);
+    let title = format!(
+        " {} {} \u{2502} {filename} (Esc/q/space: close) ",
+        step_icon(step.kind),
+        step.kind
+    );
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_focused));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let mut lines = vec![
+        Line::from(Span::styled(
+            step.title.clone(),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+    lines.extend(step.body.lines().map(|l| Line::from(l.to_string())));
+
+    let paragraph = Paragraph::new(lines)
+        .style(Style::default().fg(theme.fg))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -119,6 +119,18 @@ pub struct DiffViewState {
     pub screen_entry_map: Vec<Option<usize>>,
 }
 
+/// Which view the Explorer's bottom pane is showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExplorerBottomView {
+    /// The changed-files diff list.
+    #[default]
+    DiffList,
+    /// The review comment list.
+    Comments,
+    /// The AI walkthrough (steps + selected step's body).
+    Walkthrough,
+}
+
 /// Explorer panel state (selections, scrolls).
 pub struct ExplorerState {
     /// Index of the selected diff file in the diff list.
@@ -131,8 +143,8 @@ pub struct ExplorerState {
     pub explorer_tree_height: usize,
     /// Last known inner height of the explorer diff-list pane (updated during render).
     pub explorer_diff_list_height: usize,
-    /// Whether the explorer bottom pane shows comments instead of the diff list.
-    pub explorer_show_comments: bool,
+    /// Which view the explorer's bottom pane is currently showing.
+    pub explorer_bottom_view: ExplorerBottomView,
     /// Index of the selected comment in the explorer comment list.
     pub comment_list_selected: usize,
     /// Vertical scroll offset for the explorer comment list.
@@ -147,6 +159,16 @@ pub struct ExplorerState {
     pub inline_reply_comment_id: Option<String>,
     /// Text buffer for inline reply input.
     pub inline_reply_buffer: TextInput,
+    /// Index of the selected step in the walkthrough view.
+    pub walkthrough_selected: usize,
+    /// Vertical scroll offset for the walkthrough step list.
+    pub walkthrough_scroll: usize,
+    /// IDs of walkthrough steps that have been jumped to at least once.
+    pub viewed_steps: HashSet<String>,
+    /// Whether the walkthrough step detail overlay (`space`) is open.
+    pub walkthrough_detail_active: bool,
+    /// Relative paths of files marked "viewed" by the reviewer.
+    pub viewed: HashSet<String>,
 }
 
 impl Default for ExplorerState {
@@ -157,7 +179,7 @@ impl Default for ExplorerState {
             explorer_focus_on_diff_list: false,
             explorer_tree_height: 20,
             explorer_diff_list_height: 20,
-            explorer_show_comments: false,
+            explorer_bottom_view: ExplorerBottomView::default(),
             comment_list_selected: 0,
             comment_list_scroll: 0,
             comment_preview_line: None,
@@ -165,6 +187,11 @@ impl Default for ExplorerState {
             inline_reply_line: None,
             inline_reply_comment_id: None,
             inline_reply_buffer: TextInput::new_multiline(),
+            walkthrough_selected: 0,
+            walkthrough_scroll: 0,
+            viewed_steps: HashSet::new(),
+            walkthrough_detail_active: false,
+            viewed: HashSet::new(),
         }
     }
 }
@@ -293,6 +320,18 @@ pub struct ViewerState {
     /// Total wrapped line count of the summary view, written during render and
     /// read by the key handler to clamp `summary_scroll`.
     pub summary_total_lines: usize,
+}
+
+/// The new-file line number a diff entry represents, for entries that map to
+/// one: a concrete `Line` (`None` for a deletion, which has no new-file
+/// line), or an `ExpandableContext`'s first hidden line. `HunkSeparator`
+/// carries no line number.
+fn diff_entry_new_line_no(entry: &UnifiedDiffEntry) -> Option<usize> {
+    match entry {
+        UnifiedDiffEntry::Line { new_line_no, .. } => *new_line_no,
+        UnifiedDiffEntry::ExpandableContext { new_line_start, .. } => Some(*new_line_start),
+        UnifiedDiffEntry::HunkSeparator { .. } => None,
+    }
 }
 
 impl ViewerState {
@@ -571,6 +610,7 @@ impl ViewerState {
                 .unwrap_or(0);
             self.content.file_scroll = self.search.search_matches[self.search.search_match_idx];
         }
+        self.sync_diff_scroll_to_file_scroll();
     }
 
     /// Jump to the next search match.
@@ -581,6 +621,7 @@ impl ViewerState {
         self.search.search_match_idx =
             (self.search.search_match_idx + 1) % self.search.search_matches.len();
         self.content.file_scroll = self.search.search_matches[self.search.search_match_idx];
+        self.sync_diff_scroll_to_file_scroll();
     }
 
     /// Jump to the previous search match.
@@ -594,6 +635,61 @@ impl ViewerState {
             self.search.search_match_idx - 1
         };
         self.content.file_scroll = self.search.search_matches[self.search.search_match_idx];
+        self.sync_diff_scroll_to_file_scroll();
+    }
+
+    /// Resolve the file line (0-indexed, matching `content.file_scroll`) that
+    /// the diff view's current scroll position corresponds to, from the
+    /// nearest concrete new-file line number at or after `diff_view_scroll`
+    /// (falling back to the nearest one before it — e.g. when the cursor
+    /// sits on a deleted line, which has no new-file line number).
+    fn diff_scroll_file_line(&self) -> Option<usize> {
+        let lines = &self.diff_view.diff_view_lines;
+        let scroll = self.diff_view.diff_view_scroll.min(lines.len());
+        lines[scroll..]
+            .iter()
+            .find_map(diff_entry_new_line_no)
+            .or_else(|| {
+                lines[..scroll]
+                    .iter()
+                    .rev()
+                    .find_map(diff_entry_new_line_no)
+            })
+            .map(|n| n.saturating_sub(1))
+    }
+
+    /// Keep `content.file_scroll` in sync with the diff view's scroll
+    /// position. Symbol lookup and search operate on `content.file_scroll`
+    /// unconditionally (they predate diff mode), so anything reached while
+    /// browsing a diff needs this synced first, or it would act on whatever
+    /// line plain-view browsing last left `file_scroll` at. A no-op outside
+    /// diff mode.
+    pub fn sync_file_scroll_to_diff_scroll(&mut self) {
+        if !self.diff_view.diff_mode {
+            return;
+        }
+        if let Some(line) = self.diff_scroll_file_line() {
+            self.content.file_scroll = line;
+        }
+    }
+
+    /// Keep the diff view's scroll position in sync with `content.file_scroll`
+    /// after it moves on its own (e.g. a search match) so the diff pane
+    /// visibly follows along instead of staying put while the underlying
+    /// cursor moves. A no-op outside diff mode.
+    fn sync_diff_scroll_to_file_scroll(&mut self) {
+        if !self.diff_view.diff_mode {
+            return;
+        }
+        let target_line = self.content.file_scroll + 1; // new_line_no is 1-indexed
+        if let Some(idx) = self
+            .diff_view
+            .diff_view_lines
+            .iter()
+            .position(|entry| diff_entry_new_line_no(entry).is_some_and(|n| n >= target_line))
+        {
+            self.diff_view.diff_view_scroll = idx;
+        }
     }
 
     // -- Filename fuzzy search ------------------------------------------------
@@ -1535,6 +1631,68 @@ fn digit_count(n: usize) -> usize {
 mod tests {
     use super::*;
     use std::fs;
+
+    /// Builds a `Line` entry with the given new-file line number (`None` for
+    /// a deletion, which has no new-file line).
+    fn diff_line(new_line_no: Option<usize>) -> UnifiedDiffEntry {
+        UnifiedDiffEntry::Line {
+            tag: DiffLineTag::Equal,
+            new_line_no,
+            content: String::new(),
+            inline_segments: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn sync_file_scroll_to_diff_scroll_resolves_deletion_lines_forward() {
+        let mut vs = ViewerState::default();
+        vs.diff_view.diff_mode = true;
+        vs.diff_view.diff_view_lines = vec![
+            UnifiedDiffEntry::HunkSeparator { func_header: None },
+            diff_line(Some(10)), // idx 1
+            diff_line(None),     // idx 2 — a deletion, no new-file line
+            diff_line(Some(11)), // idx 3
+        ];
+
+        // Scrolled onto the deletion: no new-file line at this exact index,
+        // so the cursor resolves forward to the next concrete line (11).
+        vs.diff_view.diff_view_scroll = 2;
+        vs.sync_file_scroll_to_diff_scroll();
+        assert_eq!(vs.content.file_scroll, 10); // line 11, 0-indexed
+
+        // Scrolled directly onto a concrete line: resolves to that line.
+        vs.diff_view.diff_view_scroll = 1;
+        vs.sync_file_scroll_to_diff_scroll();
+        assert_eq!(vs.content.file_scroll, 9); // line 10, 0-indexed
+    }
+
+    #[test]
+    fn sync_file_scroll_to_diff_scroll_is_noop_outside_diff_mode() {
+        let mut vs = ViewerState::default();
+        vs.diff_view.diff_mode = false;
+        vs.diff_view.diff_view_lines = vec![diff_line(Some(5))];
+        vs.diff_view.diff_view_scroll = 0;
+        vs.content.file_scroll = 42;
+        vs.sync_file_scroll_to_diff_scroll();
+        assert_eq!(vs.content.file_scroll, 42);
+    }
+
+    #[test]
+    fn sync_diff_scroll_to_file_scroll_follows_a_search_jump() {
+        let mut vs = ViewerState::default();
+        vs.diff_view.diff_mode = true;
+        vs.diff_view.diff_view_lines = vec![
+            diff_line(Some(1)), // idx 0
+            diff_line(Some(2)), // idx 1
+            diff_line(Some(3)), // idx 2
+        ];
+        vs.diff_view.diff_view_scroll = 0;
+
+        // A search match landed on file_scroll = 2 (line 3, 0-indexed).
+        vs.content.file_scroll = 2;
+        vs.sync_diff_scroll_to_file_scroll();
+        assert_eq!(vs.diff_view.diff_view_scroll, 2);
+    }
 
     #[test]
     fn gutter_click_selects_single_line() {

--- a/src/walkthrough.rs
+++ b/src/walkthrough.rs
@@ -1,0 +1,447 @@
+//! Data model and generation trigger for AI-generated PR walkthroughs.
+//!
+//! A walkthrough is a Claude-authored, ordered tour of a branch's diff
+//! (`walkthroughs` + `walkthrough_steps` in the review database, persisted
+//! and queried via [`crate::review_store::ReviewStore`]). This module holds
+//! the plain data types shared by the store, the UI pane, and the generator:
+//! a headless `claude -p` process spawned in the reviewed worktree that
+//! explores the diff and saves the result through the conductor MCP server's
+//! `save_walkthrough` tool. The database row's `status` column is the source
+//! of truth for completion; the process handle here only detects failures
+//! (spawn error, non-zero exit, exit without saving, timeout).
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+/// Generation status of a walkthrough.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalkthroughStatus {
+    /// A background Claude Code session is producing the steps.
+    Generating,
+    /// Steps are saved and ready to display.
+    Ready,
+    /// Generation failed; `Walkthrough::error` holds the reason.
+    Failed,
+}
+
+impl WalkthroughStatus {
+    /// Convert to the string representation stored in the database.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WalkthroughStatus::Generating => "generating",
+            WalkthroughStatus::Ready => "ready",
+            WalkthroughStatus::Failed => "failed",
+        }
+    }
+
+    /// Parse the string representation stored in the database.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "generating" => Some(WalkthroughStatus::Generating),
+            "ready" => Some(WalkthroughStatus::Ready),
+            "failed" => Some(WalkthroughStatus::Failed),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WalkthroughStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The kind of a walkthrough step, driving its icon/emphasis in the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalkthroughStepKind {
+    /// Why the change exists — the motivating problem or request.
+    Intent,
+    /// The main implementation of the change.
+    Core,
+    /// A knock-on effect of the core change (call-site updates, config, etc).
+    Ripple,
+    /// Test coverage added or updated for the change.
+    Test,
+}
+
+impl WalkthroughStepKind {
+    /// Convert to the string representation stored in the database.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WalkthroughStepKind::Intent => "intent",
+            WalkthroughStepKind::Core => "core",
+            WalkthroughStepKind::Ripple => "ripple",
+            WalkthroughStepKind::Test => "test",
+        }
+    }
+
+    /// Parse the string representation stored in the database.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "intent" => Some(WalkthroughStepKind::Intent),
+            "core" => Some(WalkthroughStepKind::Core),
+            "ripple" => Some(WalkthroughStepKind::Ripple),
+            "test" => Some(WalkthroughStepKind::Test),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WalkthroughStepKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A branch's walkthrough header row (`walkthroughs` table). One per branch —
+/// re-generating deletes and recreates this row rather than keeping history.
+#[derive(Debug, Clone)]
+pub struct Walkthrough {
+    pub id: String,
+    // Row-identifying/audit fields, kept for parity with the `walkthroughs`
+    // table and for `Debug` output when troubleshooting, but no caller reads
+    // them today: lookups key on the branch string they already have, and the
+    // UI doesn't surface timestamps.
+    #[allow(dead_code)]
+    pub branch: String,
+    pub title: Option<String>,
+    // The pane title carries `title` and the intent step carries the same
+    // narrative as `summary`, so the compact walkthrough pane doesn't render
+    // this separately; kept for round-trip fidelity with `save_walkthrough`.
+    #[allow(dead_code)]
+    pub summary: Option<String>,
+    pub status: WalkthroughStatus,
+    pub error: Option<String>,
+    #[allow(dead_code)]
+    pub created_at: String,
+    #[allow(dead_code)]
+    pub updated_at: String,
+}
+
+/// A single ordered step of a walkthrough (`walkthrough_steps` table),
+/// anchored to a file and optional line range.
+#[derive(Debug, Clone)]
+pub struct WalkthroughStep {
+    pub id: String,
+    /// Foreign key to the owning `Walkthrough`, kept for parity with the
+    /// `walkthrough_steps` table; steps are always accessed already scoped to
+    /// their walkthrough (via `get_walkthrough`), so nothing re-derives it.
+    #[allow(dead_code)]
+    pub walkthrough_id: String,
+    /// Display order, kept for parity with the table; the UI reads steps
+    /// from the already-ordered `Vec` `get_walkthrough` returns instead of
+    /// re-sorting by this field.
+    #[allow(dead_code)]
+    pub seq: i64,
+    pub file_path: String,
+    pub line_start: Option<i64>,
+    pub line_end: Option<i64>,
+    pub kind: WalkthroughStepKind,
+    pub title: String,
+    pub body: String,
+}
+
+/// A step as supplied when saving a completed walkthrough — no `id` or
+/// `walkthrough_id`, since the store assigns those (`seq` is likewise
+/// implied by the slice's order, not repeated here).
+#[derive(Debug, Clone)]
+pub struct NewWalkthroughStep {
+    pub file_path: String,
+    pub line_start: Option<i64>,
+    pub line_end: Option<i64>,
+    pub kind: WalkthroughStepKind,
+    pub title: String,
+    pub body: String,
+}
+
+/// Kill a generation that has been running longer than this. Claude writes
+/// its result through the MCP tool well before this on any reasonable PR;
+/// past it we assume the session is wedged.
+pub const GENERATION_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// Tools the headless generation session may use. Both `save_walkthrough`
+/// tool-name forms are listed so the session works whether the MCP server
+/// comes from the bundled `--mcp-config` below (dogfooding: `conductor`) or
+/// from the user's installed marketplace plugin
+/// (`plugin_conductor_conductor`).
+///
+/// This session reads a PR's diff, which may be adversarial (a malicious
+/// contributor's prompt-injection attempt), so the git subcommands are
+/// restricted to read-only ones — no `git push`, `git remote add`, etc. — to
+/// close off any exfiltration path that would otherwise be reachable purely
+/// through allowedTools.
+const GENERATION_ALLOWED_TOOLS: &str = "mcp__conductor__save_walkthrough,\
+mcp__plugin_conductor_conductor__save_walkthrough,\
+Read,Grep,Glob,\
+Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),\
+Bash(git rev-parse:*),Bash(git status:*),Bash(git branch:*)";
+
+/// What a [`WalkthroughGeneration::poll`] observed about the child process.
+pub enum GenerationPoll {
+    /// Still running (and within the timeout).
+    Running,
+    /// Exited with success. Whether a walkthrough was actually saved is up
+    /// to the database row — the caller must check `walkthroughs.status`.
+    Exited,
+    /// Exited with a non-zero status, or polling the process failed.
+    Failed(String),
+    /// Ran past [`GENERATION_TIMEOUT`]; the process has been killed.
+    TimedOut,
+}
+
+/// Handle to an in-flight walkthrough generation: the headless `claude`
+/// child plus enough context to report failures against the right branch.
+pub struct WalkthroughGeneration {
+    pub branch: String,
+    child: Child,
+    started: Instant,
+    /// Where the child's stdout/stderr go — named in error messages so the
+    /// user can inspect what the session actually did.
+    pub log_path: PathBuf,
+}
+
+impl WalkthroughGeneration {
+    /// Non-blocking check of the child process, enforcing the timeout.
+    pub fn poll(&mut self) -> GenerationPoll {
+        match self.child.try_wait() {
+            Ok(Some(status)) if status.success() => GenerationPoll::Exited,
+            Ok(Some(status)) => GenerationPoll::Failed(format!(
+                "claude exited with {status} (log: {})",
+                self.log_path.display()
+            )),
+            Ok(None) => {
+                if self.started.elapsed() > GENERATION_TIMEOUT {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    GenerationPoll::TimedOut
+                } else {
+                    GenerationPoll::Running
+                }
+            }
+            Err(e) => GenerationPoll::Failed(format!("failed to poll claude process: {e}")),
+        }
+    }
+
+    /// Kill the child (used when the app shuts down mid-generation).
+    pub fn abort(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Build the `--mcp-config` JSON registering the repo-bundled conductor MCP
+/// server, or `None` when this repository doesn't carry the server (e.g. a
+/// non-conductor repo reviewed by a marketplace-plugin install — there the
+/// headless session inherits the user's ambient plugin MCP instead).
+fn bundled_mcp_config(repo_root: &Path, db_path: &Path) -> Option<String> {
+    let server_dir = repo_root.join("plugins/conductor/mcp/conductor-comment");
+    let dist = server_dir.join("dist/index.js");
+    let src = server_dir.join("src/index.ts");
+    let (command, args) = if dist.is_file() {
+        ("node", vec![dist.to_string_lossy().into_owned()])
+    } else if src.is_file() {
+        (
+            "npx",
+            vec![
+                "--yes".to_string(),
+                "tsx".to_string(),
+                src.to_string_lossy().into_owned(),
+            ],
+        )
+    } else {
+        return None;
+    };
+    let config = serde_json::json!({
+        "mcpServers": {
+            "conductor": {
+                "command": command,
+                "args": args,
+                "env": { "CONDUCTOR_DB_PATH": db_path.to_string_lossy() },
+            }
+        }
+    });
+    Some(config.to_string())
+}
+
+/// The generation instructions handed to the headless session. Mirrors
+/// `plugins/conductor/commands/conductor-walkthrough.md` (kept for
+/// marketplace-plugin users) but is embedded here so generation works
+/// regardless of which slash commands the installed plugin cache has.
+fn generation_prompt(branch: &str, base_ref: Option<&str>, language: Option<&str>) -> String {
+    let base_hint = match base_ref {
+        Some(b) => format!("The base branch is `{b}`."),
+        None => "Determine the base branch (origin/HEAD, usually main).".to_string(),
+    };
+    let language_hint = match language {
+        Some(lang) => format!(
+            "\n\nWrite the walkthrough title, summary, and every step's title and body in {lang}."
+        ),
+        None => String::new(),
+    };
+    format!(
+        "Read this branch's merge-base diff against its base branch and build a reviewer \
+walkthrough (an ordered tour of the change), then save it with the conductor MCP server's \
+`save_walkthrough` tool.\n\
+\n\
+{base_hint} The branch under review is `{branch}`. Use `git diff <base>...HEAD` (three-dot, \
+merge-base) to see the change. Read not only the changed files but, where needed, their \
+callers/callees so you understand the whole picture.\n\
+\n\
+Order the steps as a story: intent -> core -> ripple -> test.\n\
+- intent: what this change wanted to achieve (background, motivation).\n\
+- core: what was changed to achieve it, and its effect on existing code. Do NOT compare \
+alternative designs — reviewers ask those questions themselves.\n\
+- ripple: knock-on changes (call-site updates, config/schema follow-ups).\n\
+- test: a summary of what behavior each test verifies, detailed enough that a reviewer can \
+skip reading the full test diff.\n\
+\n\
+Each step needs: file_path (repo-relative), optional line_start/line_end (new-side line \
+numbers), kind, title, body. There is no fixed step count — match the actual change.\n\
+\n\
+When all steps are assembled, call the `save_walkthrough` tool exactly once with: \
+branch = `{branch}`, a one-line title, a short summary, and the steps (seq starting at 0). \
+Then report the step count and kind breakdown briefly and stop.{language_hint}"
+    )
+}
+
+/// Spawn the headless generation session in `worktree_path`.
+///
+/// The caller must have inserted the `generating` row first
+/// ([`crate::review_store::ReviewStore::begin_walkthrough`]); on spawn
+/// failure it should flip that row to `failed`.
+pub fn spawn_generation(
+    repo_root: &Path,
+    worktree_path: &Path,
+    db_path: &Path,
+    branch: &str,
+    base_ref: Option<&str>,
+    model: Option<&str>,
+    language: Option<&str>,
+) -> Result<WalkthroughGeneration> {
+    let log_path = db_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join(format!("walkthrough-{}.log", branch.replace('/', "-")));
+    let log_file = std::fs::File::create(&log_path)
+        .with_context(|| format!("failed to create log file {}", log_path.display()))?;
+    let log_err = log_file
+        .try_clone()
+        .context("failed to clone log file handle")?;
+
+    let mut cmd = Command::new("claude");
+    cmd.arg("-p")
+        .arg(generation_prompt(branch, base_ref, language))
+        .arg("--allowedTools")
+        .arg(GENERATION_ALLOWED_TOOLS)
+        .current_dir(worktree_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log_file))
+        .stderr(Stdio::from(log_err));
+    if let Some(model) = model {
+        cmd.arg("--model").arg(model);
+    }
+    if let Some(config) = bundled_mcp_config(repo_root, db_path) {
+        cmd.arg("--mcp-config").arg(config);
+    }
+
+    let child = cmd.spawn().context(
+        "failed to launch `claude` — is Claude Code installed and on PATH?",
+    )?;
+    Ok(WalkthroughGeneration {
+        branch: branch.to_string(),
+        child,
+        started: Instant::now(),
+        log_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── bundled_mcp_config: dist takes priority over src, else None ──
+
+    #[test]
+    fn bundled_mcp_config_prefers_compiled_dist_over_ts_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let server_dir = dir.path().join("plugins/conductor/mcp/conductor-comment");
+        std::fs::create_dir_all(server_dir.join("dist")).unwrap();
+        std::fs::create_dir_all(server_dir.join("src")).unwrap();
+        std::fs::write(server_dir.join("dist/index.js"), "").unwrap();
+        std::fs::write(server_dir.join("src/index.ts"), "").unwrap();
+
+        let config = bundled_mcp_config(dir.path(), &dir.path().join("db.sqlite")).unwrap();
+        assert!(config.contains("\"node\""));
+        assert!(config.contains("dist/index.js"));
+    }
+
+    #[test]
+    fn bundled_mcp_config_falls_back_to_ts_source_via_npx_tsx() {
+        let dir = tempfile::tempdir().unwrap();
+        let server_dir = dir.path().join("plugins/conductor/mcp/conductor-comment");
+        std::fs::create_dir_all(server_dir.join("src")).unwrap();
+        std::fs::write(server_dir.join("src/index.ts"), "").unwrap();
+
+        let config = bundled_mcp_config(dir.path(), &dir.path().join("db.sqlite")).unwrap();
+        assert!(config.contains("\"npx\""));
+        assert!(config.contains("tsx"));
+        assert!(config.contains("src/index.ts"));
+    }
+
+    #[test]
+    fn bundled_mcp_config_is_none_when_neither_dist_nor_src_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(bundled_mcp_config(dir.path(), &dir.path().join("db.sqlite")).is_none());
+    }
+
+    // ── allowedTools: MCP tool names present, git restricted to read-only ──
+
+    #[test]
+    fn generation_allowed_tools_lists_both_save_walkthrough_tool_name_forms() {
+        assert!(GENERATION_ALLOWED_TOOLS.contains("mcp__conductor__save_walkthrough"));
+        assert!(GENERATION_ALLOWED_TOOLS.contains("mcp__plugin_conductor_conductor__save_walkthrough"));
+    }
+
+    #[test]
+    fn generation_allowed_tools_has_no_write_git_subcommands() {
+        // Matches the FIX-2 restriction: no bare `Bash(git:*)`, and none of
+        // the write-capable subcommands that would open an exfiltration path
+        // for an adversarial PR diff (push, remote, fetch with refspec-write
+        // side effects, config, etc).
+        assert!(!GENERATION_ALLOWED_TOOLS.contains("Bash(git:*)"));
+        for write_subcommand in ["push", "remote", "config", "commit", "checkout", "reset"] {
+            assert!(
+                !GENERATION_ALLOWED_TOOLS.contains(&format!("git {write_subcommand}")),
+                "allowedTools should not permit `git {write_subcommand}`"
+            );
+        }
+    }
+
+    // ── generation_prompt: branch name and no-alternatives instruction ──
+
+    #[test]
+    fn generation_prompt_includes_the_branch_name() {
+        let prompt = generation_prompt("pr-42", Some("main"), None);
+        assert!(prompt.contains("pr-42"));
+        assert!(prompt.contains("main"));
+    }
+
+    #[test]
+    fn generation_prompt_tells_the_model_not_to_compare_alternative_designs() {
+        let prompt = generation_prompt("pr-42", None, None);
+        assert!(prompt.to_lowercase().contains("do not compare"));
+        assert!(prompt.contains("Determine the base branch"));
+    }
+
+    #[test]
+    fn generation_prompt_requests_the_configured_language() {
+        let prompt = generation_prompt("pr-42", Some("main"), Some("日本語"));
+        assert!(prompt.contains("in 日本語"));
+        // No language configured → no language directive at all.
+        let unconstrained = generation_prompt("pr-42", Some("main"), None);
+        assert!(!unconstrained.contains("Write the walkthrough title"));
+    }
+}


### PR DESCRIPTION
## Summary

GitHub の PR を手元でレビューするためのワークフロー一式を、通常UIに統合する形で追加する（専用モードは試作の末に廃止し、既存のパネル/キー体系に溶かした）。

- **PR取り込み** (`src/pr_intake.rs`): palette「Review: Review Pull Request…」→ 番号/URL入力 → `refs/pull/N/head` を `pr-<N>` として fetch → worktree 化 → PR の実 base をローカル確保し merge-base diff を表示。再入時は既存 worktree を検証して再利用
- **AIウォークスルー** (`src/walkthrough.rs`, `src/ui/walkthrough_pane.rs`, `src/app/walkthrough_view.rs`): Explorer 下段の第3ビュー（diff list / comments / walkthrough）。headless `claude -p` が diff を探索し、intent→core→ripple→test のストーリー順ステップを MCP `save_walkthrough`（新規ツール）で DB 保存。`n`/`N` でステップ巡回（Viewer が追従＋範囲ハイライト）、`space` で全文 overlay。モデル/言語は `[review] walkthrough_model` / `walkthrough_language` で設定可。同時生成は1本に制限（孤児プロセス防止）
- **viewed マーク**: diff list の行と Viewer の diff mode 双方で `v`。✓ は diff list に表示
- **GitHub 投稿** (`src/review_publish.rs`): ローカルのインラインコメントを PR レビュー（event=COMMENT）として一括投稿。diff外行の事前フィルタ・commit_id 明示・422時の単一コメント fallback・published_at で重複防止・確認ダイアログ必須
- **diff mode のコードジャンプ**: `gd`/`gr`/`gi` と `/` 検索を diff 閲覧に追加（破壊的変更: diff mode の `g` 単体 top は `gg` に統一）
- DB migration v6（walkthroughs / walkthrough_steps / pr_review_meta / reviews.published_at）
- 敵対的 PR diff を読む headless セッションの allowedTools は read-only git に制限

version 0.82.1 → 0.83.0（minor）。

## Test plan

- [x] `cargo build` / `cargo clippy --all-targets`（warning 0）/ `cargo test`（568 tests, 0 failed）
- [x] 実PR (#279) での取り込み e2e（`cargo test -- --ignored intake_pr_against_real_pr`）
- [x] ウォークスルー実生成 e2e（headless claude → MCP → DB、16ステップの実ナラティブを確認）
- [x] 実機での操作確認（PR取り込み・walkthrough ビュー・Opus/日本語生成設定）
- [ ] GitHub 投稿の実 e2e はテストPRで別途（422 fallback の発火文言確認含む）
