### PR TITLE
feat: マウスドラッグでパネルをリサイズ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.83.0"
+version = "0.84.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -149,6 +149,23 @@ pub enum ResizeDir {
     Down,
 }
 
+/// A panel boundary that can be grabbed and dragged with the mouse to resize.
+///
+/// Each variant maps onto the same clamped state mutator the keyboard
+/// (Ctrl+Alt+Arrow) resize drives, so mouse and keyboard share one source of
+/// truth for the layout ratios ([`App::drag_divider_to`] resolves the mapping).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Divider {
+    /// Vertical boundary between the Explorer and Viewer columns.
+    ExplorerViewer,
+    /// Vertical boundary between the Viewer and Terminal columns.
+    ViewerTerminal,
+    /// Horizontal boundary between the Explorer's file tree and changed-files list.
+    ExplorerSplit,
+    /// Horizontal boundary between the Claude and Shell terminal panes.
+    TerminalSplit,
+}
+
 /// Input mode for worktree operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorktreeInputMode {
@@ -473,6 +490,17 @@ pub struct App {
     /// tmux-style pane resize (Ctrl+Alt+Up/Down with a terminal focused), and
     /// persisted back to the config file so the ratio survives a restart.
     pub terminal_split_pct: u16,
+
+    /// The panel divider currently being dragged with the mouse, if any. Set on
+    /// mouse-down over a boundary, moved on each drag event, and cleared (with a
+    /// single config persist) on mouse-up. While `Some`, drag events resize
+    /// instead of doing their normal per-panel work.
+    pub divider_drag: Option<Divider>,
+    /// The panel divider the mouse is hovering, if any. Drives the resize
+    /// affordance — the hovered boundary is highlighted, standing in for a
+    /// `col-resize`/`row-resize` cursor (a terminal can't switch the OS cursor
+    /// shape). A live drag takes precedence over hover when rendering.
+    pub divider_hover: Option<Divider>,
 
     /// Frame counter for UI animations (e.g. waiting-state pulse).
     pub ui_tick: u64,
@@ -1003,6 +1031,8 @@ impl App {
             markdown_cache: crate::ui::markdown::MarkdownCache::new(),
             expanded_panel: None,
             terminal_split_pct: config_terminal_split_pct,
+            divider_drag: None,
+            divider_hover: None,
             ui_tick: 0,
             decoration_tick: 0,
             notification_bar_badges: Vec::new(),
@@ -2325,28 +2355,28 @@ impl App {
     /// becomes the cramped pane that can only shrink.
     pub fn resize_focused_pane(&mut self, dir: ResizeDir) {
         let step = Self::RESIZE_STEP_PCT as i16;
-        match dir {
+        let changed = match dir {
             ResizeDir::Left | ResizeDir::Right => {
                 let grow_right = matches!(dir, ResizeDir::Right);
                 match self.focus {
                     // The worktree strip is full-width, not one of the three
                     // resizable columns — nothing to resize from there.
-                    Focus::Worktree => {}
+                    Focus::Worktree => false,
                     // Leftmost column: left/right ride the Explorer|Viewer divider.
                     Focus::Explorer => {
-                        self.move_explorer_viewer_divider(if grow_right { step } else { -step });
+                        self.move_explorer_viewer_divider(if grow_right { step } else { -step })
                     }
                     // Middle column pushes whichever border faces `dir`.
                     Focus::Viewer => {
                         if grow_right {
-                            self.move_viewer_terminal_divider(step);
+                            self.move_viewer_terminal_divider(step)
                         } else {
-                            self.move_explorer_viewer_divider(-step);
+                            self.move_explorer_viewer_divider(-step)
                         }
                     }
                     // Rightmost column: left grows it (shrinks Viewer), right shrinks it.
                     Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => {
-                        self.move_viewer_terminal_divider(if grow_right { step } else { -step });
+                        self.move_viewer_terminal_divider(if grow_right { step } else { -step })
                     }
                 }
             }
@@ -2358,14 +2388,77 @@ impl App {
                 match self.focus {
                     Focus::TerminalClaude | Focus::TerminalShell => {
                         let step = Self::TERMINAL_SPLIT_STEP as i16;
-                        self.adjust_terminal_split(if down { step } else { -step });
+                        self.adjust_terminal_split(if down { step } else { -step })
                     }
                     Focus::Explorer => {
                         let step = Self::TERMINAL_SPLIT_STEP as i16;
-                        self.adjust_explorer_split(if down { step } else { -step });
+                        self.adjust_explorer_split(if down { step } else { -step })
                     }
-                    _ => {}
+                    _ => false,
                 }
+            }
+        };
+        // Persist once per keypress (only when a ratio actually moved — a resize
+        // that hit the clamp floor writes nothing). The mouse-drag path persists
+        // once on release instead, so both share the same clamped mutators
+        // without writing the config on every intermediate step.
+        if changed {
+            self.persist_layout();
+        }
+    }
+
+    /// Drag `divider` so its boundary tracks the mouse at screen cell
+    /// (`col`, `row`), reusing the same clamped mutators as the keyboard resize.
+    /// Returns whether a ratio actually moved. Does **not** persist — the caller
+    /// writes the config once when the drag ends, avoiding a disk write per
+    /// mouse event.
+    pub fn drag_divider_to(&mut self, divider: Divider, col: u16, row: u16) -> bool {
+        // Snapshot the (Copy) geometry before taking `&mut self` for the mutator.
+        let main = self.layout_cache.main_area;
+        let explorer_col = self.layout_cache.columns[1];
+        let terminal_col = self.layout_cache.columns[3];
+        match divider {
+            // Vertical dividers: percentages are relative to the main area width.
+            Divider::ExplorerViewer => {
+                if main.width == 0 {
+                    return false;
+                }
+                let target_px = col.saturating_sub(main.x);
+                let target_pct = (target_px as u32 * 100 / main.width as u32) as i16;
+                let delta = target_pct - self.config.layout.explorer_width_pct as i16;
+                self.move_explorer_viewer_divider(delta)
+            }
+            Divider::ViewerTerminal => {
+                if main.width == 0 {
+                    return false;
+                }
+                // The divider sits at the right edge of (Explorer + Viewer); with
+                // Explorer fixed, the target Viewer % is that combined width minus
+                // Explorer.
+                let combined_px = col.saturating_sub(main.x);
+                let combined_pct = (combined_px as u32 * 100 / main.width as u32) as i16;
+                let target_v = combined_pct - self.config.layout.explorer_width_pct as i16;
+                let delta = target_v - self.config.layout.viewer_width_pct as i16;
+                self.move_viewer_terminal_divider(delta)
+            }
+            // Horizontal dividers: percentages are relative to their column height.
+            Divider::ExplorerSplit => {
+                if explorer_col.height == 0 {
+                    return false;
+                }
+                let target_px = row.saturating_sub(explorer_col.y);
+                let target_pct = (target_px as u32 * 100 / explorer_col.height as u32) as i16;
+                let delta = target_pct - self.config.layout.explorer_split_pct as i16;
+                self.adjust_explorer_split(delta)
+            }
+            Divider::TerminalSplit => {
+                if terminal_col.height == 0 {
+                    return false;
+                }
+                let target_px = row.saturating_sub(terminal_col.y);
+                let target_pct = (target_px as u32 * 100 / terminal_col.height as u32) as i16;
+                let delta = target_pct - self.terminal_split_pct as i16;
+                self.adjust_terminal_split(delta)
             }
         }
     }
@@ -2373,7 +2466,8 @@ impl App {
     /// Move the Explorer|Viewer divider by `delta` points (positive = rightward,
     /// enlarging Explorer and shrinking Viewer). Terminal width is conserved.
     /// Clamped so neither Explorer nor Viewer drops below [`Self::MIN_COL_PCT`].
-    fn move_explorer_viewer_divider(&mut self, delta: i16) {
+    /// Returns whether the ratio changed; the caller persists.
+    fn move_explorer_viewer_divider(&mut self, delta: i16) -> bool {
         let (new_e, new_v) = clamp_ev_divider(
             self.config.layout.explorer_width_pct,
             self.config.layout.viewer_width_pct,
@@ -2381,17 +2475,19 @@ impl App {
             Self::MIN_COL_PCT,
         );
         if new_e == self.config.layout.explorer_width_pct {
-            return;
+            return false;
         }
         self.config.layout.explorer_width_pct = new_e;
         self.config.layout.viewer_width_pct = new_v;
         self.after_horizontal_resize();
+        true
     }
 
     /// Move the Viewer|Terminal divider by `delta` points (positive = rightward,
     /// enlarging Viewer and shrinking Terminal). Explorer width is unchanged.
     /// Clamped so neither Viewer nor Terminal drops below [`Self::MIN_COL_PCT`].
-    fn move_viewer_terminal_divider(&mut self, delta: i16) {
+    /// Returns whether the ratio changed; the caller persists.
+    fn move_viewer_terminal_divider(&mut self, delta: i16) -> bool {
         let new_v = clamp_vt_divider(
             self.config.layout.explorer_width_pct,
             self.config.layout.viewer_width_pct,
@@ -2399,56 +2495,59 @@ impl App {
             Self::MIN_COL_PCT,
         );
         if new_v == self.config.layout.viewer_width_pct {
-            return;
+            return false;
         }
         self.config.layout.viewer_width_pct = new_v;
         self.after_horizontal_resize();
+        true
     }
 
-    /// Shared tail for a column resize: redraw, flash the new split, and persist
-    /// the ratios so they survive a restart.
+    /// Shared tail for a column resize: redraw and flash the new split. Persist
+    /// is left to the caller (keyboard: per keypress; mouse: on drag release).
     fn after_horizontal_resize(&mut self) {
         self.dirty.mark_all();
         let e = self.config.layout.explorer_width_pct;
         let v = self.config.layout.viewer_width_pct;
         let t = 100u16.saturating_sub(e.saturating_add(v));
         self.set_status_info(format!("Layout: Explorer {e}% / Viewer {v}% / Terminal {t}%"));
-        self.persist_layout();
     }
 
     /// Adjust the runtime Claude-area height percentage by `delta` points,
     /// clamped so both the Claude and Shell panes keep a usable minimum. A
     /// positive `delta` enlarges the Claude pane (shrinks the Shell); negative
-    /// enlarges the Shell. Flashes the resulting split and persists the ratio.
-    fn adjust_terminal_split(&mut self, delta: i16) {
+    /// enlarges the Shell. Flashes the resulting split. Returns whether the ratio
+    /// changed; the caller persists.
+    fn adjust_terminal_split(&mut self, delta: i16) -> bool {
         let next = (self.terminal_split_pct as i16 + delta)
             .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
             as u16;
         if next == self.terminal_split_pct {
-            return;
+            return false;
         }
         self.terminal_split_pct = next;
         // Keep the in-memory config in sync so the appearance snapshot matches
-        // what we write below — that makes the config watcher's reload a no-op
-        // (it only reacts when the snapshot differs), avoiding a self-write loop.
+        // what we write on persist — that makes the config watcher's reload a
+        // no-op (it only reacts when the snapshot differs), avoiding a self-write
+        // loop.
         self.config.layout.terminal_split_pct = next;
         self.dirty.mark_all();
         self.set_status_info(format!(
             "Terminal split: Claude {next}% / Shell {}%",
             100 - next
         ));
-        self.persist_layout();
+        true
     }
 
     /// Adjust the Explorer column's file-tree height percentage by `delta`
     /// points (positive grows the file tree, shrinking the changed-files list),
-    /// clamped so both panels keep a usable minimum. Flashes and persists.
-    fn adjust_explorer_split(&mut self, delta: i16) {
+    /// clamped so both panels keep a usable minimum. Flashes. Returns whether the
+    /// ratio changed; the caller persists.
+    fn adjust_explorer_split(&mut self, delta: i16) -> bool {
         let next = (self.config.layout.explorer_split_pct as i16 + delta)
             .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
             as u16;
         if next == self.config.layout.explorer_split_pct {
-            return;
+            return false;
         }
         self.config.layout.explorer_split_pct = next;
         self.dirty.mark_all();
@@ -2456,12 +2555,12 @@ impl App {
             "Explorer split: tree {next}% / changed files {}%",
             100 - next
         ));
-        self.persist_layout();
+        true
     }
 
     /// Persist the current panel proportions to `config.toml`. Best-effort: a
     /// write failure is logged, never fatal (the in-memory layout still applies).
-    fn persist_layout(&self) {
+    pub(crate) fn persist_layout(&self) {
         if let Err(e) = crate::config::persist_layout_proportions(
             self.config.layout.explorer_width_pct,
             self.config.layout.viewer_width_pct,

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -148,6 +148,21 @@ fn has_blocking_overlay(app: &App) -> bool {
         || app.symbol_action_overlay.active
 }
 
+/// Whether `divider` can currently be grabbed for a mouse resize. Never while a
+/// panel is maximized (the columns collapse to the edges, so the boundaries are
+/// meaningless), and not the Explorer-side boundaries while the editor has
+/// merged the Explorer+Viewer columns into a single PTY.
+fn divider_draggable(app: &App, divider: crate::app::Divider) -> bool {
+    use crate::app::Divider;
+    if app.expanded_panel.is_some() {
+        return false;
+    }
+    if app.editor.is_some() && matches!(divider, Divider::ExplorerViewer | Divider::ExplorerSplit) {
+        return false;
+    }
+    true
+}
+
 /// Which of the four main columns a screen column falls into.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Column {
@@ -186,6 +201,44 @@ impl ClickGeometry {
         } else {
             Column::Terminal
         }
+    }
+
+    /// Hit-test a draggable panel divider at screen cell (`col`, `row`).
+    ///
+    /// Adjacent columns each render their own border, so a vertical boundary is
+    /// a two-cell-thick line (the left panel's right border at `edge - 1` and
+    /// the right panel's left border at `edge`); both cells count as a grab
+    /// zone, and likewise for horizontal boundaries. Vertical dividers (column
+    /// boundaries) win over horizontal ones (interior column splits) where they
+    /// meet at a corner. Editor-merge and maximize gating is left to the caller.
+    fn divider_at(&self, col: u16, row: u16) -> Option<crate::app::Divider> {
+        use crate::app::Divider;
+
+        let top = self.main_area.y;
+        let bottom = self.main_area.y.saturating_add(self.main_area.height);
+        let right = self.main_area.x.saturating_add(self.main_area.width);
+        let on_boundary = |v: u16, edge: u16| edge > 0 && (v == edge - 1 || v == edge);
+
+        // Vertical dividers: the full-height column boundaries.
+        if row >= top && row < bottom {
+            if on_boundary(col, self.explorer_end) {
+                return Some(Divider::ExplorerViewer);
+            }
+            if on_boundary(col, self.viewer_end) {
+                return Some(Divider::ViewerTerminal);
+            }
+        }
+        // Horizontal dividers: splits interior to a single column.
+        if col >= self.left_end
+            && col < self.explorer_end
+            && on_boundary(row, self.explorer_mid_y)
+        {
+            return Some(Divider::ExplorerSplit);
+        }
+        if col >= self.viewer_end && col < right && on_boundary(row, self.terminal_split_y) {
+            return Some(Divider::TerminalSplit);
+        }
+        None
     }
 
     /// Hit-test the `[<=>]` expand button on the top border row, returning the
@@ -430,6 +483,18 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 return;
             }
 
+            // Grab a panel divider to begin a mouse resize. Checked before the
+            // editor-refocus and column routing below so a boundary always wins
+            // over the panel that sits on it (the [<=>] expand buttons live a few
+            // cells inward, so they don't overlap the grab zone).
+            if let Some(divider) = geom.divider_at(col, row)
+                && divider_draggable(app, divider)
+            {
+                app.divider_drag = Some(divider);
+                app.divider_hover = Some(divider);
+                return;
+            }
+
             // The embedded editor occupies the merged Explorer+Viewer region; a
             // click anywhere in it just (re)focuses the editor — the Explorer and
             // Viewer panels behind it are hidden, so their click handlers must
@@ -458,6 +523,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             }
         }
         MouseEventKind::Drag(MouseButton::Left) => {
+            // A divider drag takes priority: move the grabbed boundary to track
+            // the cursor. The clamped mutators reject out-of-bounds targets, so
+            // dragging past a panel's minimum simply pins the divider there.
+            if let Some(divider) = app.divider_drag {
+                app.drag_divider_to(divider, col, row);
+                return;
+            }
             // Extend an in-progress gutter range selection to the dragged line.
             if let Some(anchor) = app.viewer_state.click.gutter_drag_anchor {
                 let inner_y = main_area.y + 1;
@@ -476,6 +548,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             }
         }
         MouseEventKind::Up(MouseButton::Left) => {
+            // Finish a divider drag: persist the final ratios once (the drag
+            // itself intentionally skips the per-event config write).
+            if app.divider_drag.take().is_some() {
+                app.divider_hover = geom.divider_at(col, row);
+                app.persist_layout();
+                return;
+            }
             // Finish a gutter drag: commit the (single-line or range) selection
             // by opening the comment composer for it.
             let was_dragging = app.viewer_state.click.gutter_drag_anchor.take().is_some();
@@ -484,6 +563,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             }
         }
         MouseEventKind::Moved => {
+            // Light up the divider under the cursor as a resize affordance — the
+            // terminal stand-in for a col-/row-resize mouse cursor (a plain hover
+            // never mutates a ratio; only a drag does).
+            app.divider_hover = geom
+                .divider_at(col, row)
+                .filter(|&d| divider_draggable(app, d));
+
             // Track hover line for gutter highlight in the viewer panel.
             let inner_y = main_area.y + 1;
             if col >= explorer_end && col < viewer_end && row >= inner_y && row < main_area.y + main_area.height.saturating_sub(1) {
@@ -1381,6 +1467,53 @@ mod tests {
             terminal_claude_y: 1,
             terminal_split_y: 33,
         }
+    }
+
+    #[test]
+    fn divider_at_hits_both_cells_of_a_vertical_boundary() {
+        use crate::app::Divider;
+        // main_area spans y in [1, 41); a vertical boundary is a 2-cell zone at
+        // {edge-1, edge}.
+        let g = geom(0, 24, 62);
+        assert_eq!(g.divider_at(23, 10), Some(Divider::ExplorerViewer));
+        assert_eq!(g.divider_at(24, 10), Some(Divider::ExplorerViewer));
+        assert_eq!(g.divider_at(61, 10), Some(Divider::ViewerTerminal));
+        assert_eq!(g.divider_at(62, 10), Some(Divider::ViewerTerminal));
+        // One cell either side of the zone is not a hit.
+        assert_eq!(g.divider_at(22, 10), None);
+        assert_eq!(g.divider_at(25, 10), None);
+    }
+
+    #[test]
+    fn divider_at_hits_horizontal_splits_within_their_column() {
+        use crate::app::Divider;
+        let g = geom(0, 24, 62); // explorer_mid_y=20, terminal_split_y=33
+        // Explorer split: only inside the Explorer column [0, 24).
+        assert_eq!(g.divider_at(10, 19), Some(Divider::ExplorerSplit));
+        assert_eq!(g.divider_at(10, 20), Some(Divider::ExplorerSplit));
+        assert_eq!(g.divider_at(10, 18), None);
+        // The Explorer split does not extend into the Viewer/Terminal columns.
+        assert_eq!(g.divider_at(40, 20), None);
+        // Terminal split: only inside the Terminal column [62, right).
+        assert_eq!(g.divider_at(70, 32), Some(Divider::TerminalSplit));
+        assert_eq!(g.divider_at(70, 33), Some(Divider::TerminalSplit));
+        assert_eq!(g.divider_at(40, 33), None);
+    }
+
+    #[test]
+    fn divider_at_vertical_boundary_wins_at_a_corner() {
+        use crate::app::Divider;
+        // (explorer_end-1, explorer_mid_y) is both a vertical-boundary cell and
+        // on the Explorer split row — the vertical divider must take priority.
+        let g = geom(0, 24, 62);
+        assert_eq!(g.divider_at(23, 20), Some(Divider::ExplorerViewer));
+    }
+
+    #[test]
+    fn divider_at_misses_open_panel_area() {
+        let g = geom(0, 24, 62);
+        assert_eq!(g.divider_at(10, 10), None);
+        assert_eq!(g.divider_at(70, 10), None);
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -251,6 +251,9 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     super::terminal_claude::render(frame, terminal_split[0], app);
     super::terminal_shell::render(frame, terminal_split[1], app);
 
+    // ── Resize affordance: light up a hovered/dragged divider ────────
+    highlight_active_divider(frame, app);
+
     // ── Panel number overlay (Alt+/ toggle) ──────────────────────────
     // Only show when no other overlay/modal is active.
     if app.show_panel_overlay()
@@ -296,6 +299,66 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     // title bar, and confetti land on top of everything (including overlays).
     if app.party_mode {
         super::party::apply_party_effects(frame, app);
+    }
+}
+
+/// Paint the divider currently hovered or being dragged in the theme accent
+/// colour — the terminal stand-in for the `col-resize`/`row-resize` cursor a GUI
+/// would show, since crossterm can't switch the OS cursor shape. A live drag
+/// wins over hover and keeps the boundary lit even if the cursor slips a cell
+/// off it mid-drag. Only border glyphs are recoloured, so panel content is never
+/// touched. Runs before the rich/party post-processing, which only recolours
+/// cells matching the focused-border colour and so leaves the accent line alone.
+fn highlight_active_divider(frame: &mut Frame, app: &App) {
+    use crate::app::Divider;
+
+    let Some(divider) = app.divider_drag.or(app.divider_hover) else {
+        return;
+    };
+    let lc = &app.layout_cache;
+    let color = app.theme.accent;
+
+    // Resolve the divider to (is_vertical, fixed coordinate, span area). The
+    // fixed coordinate is the top/left panel's border cell (`edge - 1`), which
+    // is the visible divider line.
+    let (vertical, fixed, area) = match divider {
+        Divider::ExplorerViewer => {
+            let edge = lc.columns[1].x.saturating_add(lc.columns[1].width);
+            (true, edge.saturating_sub(1), lc.main_area)
+        }
+        Divider::ViewerTerminal => {
+            let edge = lc.columns[2].x.saturating_add(lc.columns[2].width);
+            (true, edge.saturating_sub(1), lc.main_area)
+        }
+        Divider::ExplorerSplit => (false, lc.explorer_mid_y.saturating_sub(1), lc.columns[1]),
+        Divider::TerminalSplit => {
+            (false, lc.terminal_split[1].y.saturating_sub(1), lc.columns[3])
+        }
+    };
+
+    let buf = frame.buffer_mut();
+    if vertical {
+        if fixed < area.x || fixed >= area.x.saturating_add(area.width) {
+            return;
+        }
+        for y in area.y..area.y.saturating_add(area.height) {
+            if let Some(cell) = buf.cell_mut((fixed, y))
+                && super::party::is_border_glyph(cell.symbol())
+            {
+                cell.set_fg(color);
+            }
+        }
+    } else {
+        if fixed < area.y || fixed >= area.y.saturating_add(area.height) {
+            return;
+        }
+        for x in area.x..area.x.saturating_add(area.width) {
+            if let Some(cell) = buf.cell_mut((x, fixed))
+                && super::party::is_border_glyph(cell.symbol())
+            {
+                cell.set_fg(color);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

パネル境界（ディバイダ）をマウスでドラッグしてレイアウトをリサイズできるようにしました。既存のキーボード操作（Ctrl+Alt+矢印）と同じ clamp 付きの状態ミューテータを共有し、マウス／キーボードでレイアウト比率の単一の真実の源を保ちます。

- **境界のドラッグ**: Explorer|Viewer・Viewer|Terminal の縦境界、Explorer 内（ファイルツリー/変更ファイル一覧）と Terminal 内（Claude/Shell）の横境界を、掴んでドラッグでリサイズ。
- **hover アフォーダンス**: カーソル下の境界をテーマの accent 色でハイライトし、`col-resize`/`row-resize` カーソルの代替に（端末は OS カーソル形状を変えられないため）。ドラッグ中は hover より優先。
- **ゲーティング**: パネル最大化中は境界が無意味なので掴めない。エディタが Explorer+Viewer を1つの PTY に統合している間は Explorer 側の境界を無効化。
- **境界の判定**: 隣接カラムがそれぞれ枠線を描くため境界は2セル幅。両セルをグラブゾーンとして扱い、角で交わる箇所は縦境界を優先。
- **永続化**: ドラッグ中は config 書き込みをスキップし、離した瞬間に一度だけ比率を `config.toml` に永続化（キーボードは従来どおりキー押下ごと）。既存のミューテータは「変更があったか」を返すよう変更し、永続化のタイミングを呼び出し側に委譲。

バージョンを 0.83.0 → 0.84.0 に更新（後方互換の機能追加のため MINOR）。

## Test plan

- `cargo check` が通ること（確認済み）
- `divider_at` のヒットテストに対するユニットテストを追加:
  - 縦境界の2セル両方でヒット、両脇はミス
  - 横 split は所属カラム内でのみヒット
  - 角では縦境界が優先
  - 開いたパネル領域ではミス
- 実機確認（要ユーザー）:
  - 各境界を掴んでドラッグしパネルがリサイズされること
  - hover で境界がハイライトされること
  - パネル最大化中／エディタ統合中は該当境界が掴めないこと
  - ドラッグ後に比率が config に永続化され再起動後も維持されること
