### PR TITLE
feat: show Explorer-style scrollbar in viewer file and diff views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.86.0"
+version = "0.87.0"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -10,10 +10,12 @@ use crate::media_state::MediaContent;
 use crate::theme::Theme;
 use crate::viewer::UnifiedDiffEntry;
 use ratatui::Frame;
-use ratatui::layout::{Alignment, Position, Rect};
+use ratatui::layout::{Alignment, Margin, Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 
 /// Shared definition of the inline-thread action row.
 ///
@@ -524,6 +526,25 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
     let paragraph = Paragraph::new(all_lines).block(block);
     frame.render_widget(paragraph, area);
+
+    // Render scrollbar when the file has more lines than fit in the panel —
+    // same trigger and look as the Explorer file tree.
+    if vs.content.file_content.len() > inner_height {
+        let mut scrollbar_area = area.inner(Margin {
+            horizontal: 0,
+            vertical: 1,
+        });
+        // Keep the track below the breadcrumb row so it spans only the code area.
+        scrollbar_area.y += breadcrumb_height;
+        scrollbar_area.height = scrollbar_area.height.saturating_sub(breadcrumb_height);
+        let mut scrollbar_state =
+            ScrollbarState::new(vs.content.file_content.len().saturating_sub(inner_height))
+                .position(vs.content.file_scroll);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None);
+        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
+    }
 
     // Show selection hint overlay.
     if let Some((start, end)) = vs.selected_range() {
@@ -1229,6 +1250,22 @@ fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'
     // Show selection hint overlay.
     let theme = &app.theme;
     let vs = &app.viewer_state;
+
+    // Render scrollbar when the diff has more rows than fit in the panel —
+    // same trigger and look as the Explorer file tree.
+    if vs.diff_view.diff_view_lines.len() > inner_height {
+        let scrollbar_area = area.inner(Margin {
+            horizontal: 0,
+            vertical: 1,
+        });
+        let mut scrollbar_state =
+            ScrollbarState::new(vs.diff_view.diff_view_lines.len().saturating_sub(inner_height))
+                .position(vs.diff_view.diff_view_scroll);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None);
+        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
+    }
     if let Some((start, end)) = vs.selected_range() {
         let hint = if start == end {
             format!(" L{start} selected \u{2502} c: comment  Esc: clear ")


### PR DESCRIPTION
## Summary
- Viewer パネルのファイル内容ビューと unified diff ビューに、Explorer と同じ ratatui `Scrollbar`（VerticalRight・begin/end シンボルなし・デフォルトスタイル）を追加
- 表示条件も Explorer と同一: 内容が表示域を超えているときのみ右枠線カラム上に描画
- ファイルビューでは breadcrumb バー表示中にその分トラック開始位置を下げ、コード領域だけにトラックが乗るよう調整
- バージョンを 0.87.0 に更新（後方互換の機能追加）

## Test plan
- [x] `cargo clippy --all-targets` / `cargo test` 通過
- [x] ratatui 0.29.0 のソースで境界挙動を確認（`position` は `content_length-1` にクランプ、track 長 0 は早期リターンで極小パネルでも panic しない）
- [ ] 長いファイル（例: `src/ui/viewer_panel.rs`）を Viewer で開き j/k・G でスクロールしてスクロールバー表示を目視確認
- [ ] diff ビューでも同様に目視確認
