### PR TITLE
feat: dedicated comment-marker column so overlapping comment ranges stay creatable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.88.0"
+version = "0.89.0"
 edition = "2024"
 
 [dependencies]

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -603,11 +603,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 let line_offset = (row - inner_y) as usize;
                 let inner_x = explorer_end + 1;
                 let gutter_w = app.viewer_state.gutter_total_width();
-                // Include the 2-cell comment-badge column so the "+" button stays
-                // lit (and clickable) while the cursor is over it — otherwise the
-                // button would vanish the moment you moved onto it.
+                // Include the comment-marker column (left) and the 2-cell "+"
+                // badge column (right) so the "+" button stays lit (and
+                // clickable) while the cursor is over the whole left margin.
                 let badge_w: u16 = 2;
-                let on_gutter = col >= inner_x && col < inner_x + gutter_w + badge_w;
+                let marker_w = crate::viewer::COMMENT_MARKER_W;
+                let on_gutter =
+                    col >= inner_x && col < inner_x + marker_w + gutter_w + badge_w;
 
                 // Both diff and file-content views now populate `screen_row_map`
                 // (the diff view injects inline comment threads), so a single
@@ -623,7 +625,8 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                     let gutter_w = app.viewer_state.gutter_total_width();
                     let inner_x = explorer_end + 1;
                     let badge_w: u16 = 2;
-                    let content_start_x = inner_x + gutter_w + badge_w;
+                    let content_start_x =
+                        inner_x + crate::viewer::COMMENT_MARKER_W + gutter_w + badge_w;
                     if col >= content_start_x {
                         if let Some(line_1) = resolve_screen_line(app, line_offset) {
                             let content_col = (col - content_start_x) as usize + app.viewer_state.content.h_scroll;
@@ -863,15 +866,16 @@ fn handle_viewer_column_click(
 
     let inner_x = explorer_end + 1; // inside left border
     let inner_y = main_area.y + 1; // inside top border
+    let marker_w = crate::viewer::COMMENT_MARKER_W;
     let gutter_w = app.viewer_state.gutter_total_width();
-    let on_gutter = col >= inner_x && col < inner_x + gutter_w;
+    let on_gutter = col >= inner_x && col < inner_x + marker_w + gutter_w;
 
     // Cmd+Click (macOS) / Ctrl+Click — go-to-definition on the clicked symbol.
     let has_jump_modifier = mouse.modifiers.contains(KeyModifiers::SUPER)
         || mouse.modifiers.contains(KeyModifiers::CONTROL);
     if has_jump_modifier && !on_gutter && !app.viewer_state.diff_view.diff_mode && row >= inner_y {
         let badge_w: u16 = 2;
-        let content_start_x = inner_x + gutter_w + badge_w;
+        let content_start_x = inner_x + marker_w + gutter_w + badge_w;
         if col >= content_start_x {
             let screen_offset = (row - inner_y) as usize;
             if let Some(line_1) = resolve_screen_line(app, screen_offset) {
@@ -897,9 +901,9 @@ fn handle_viewer_column_click(
             // Determine which action was clicked by column offset, using the
             // same layout constants the renderer draws the row with.
             // Offset equivalence with the renderer: gutter_total_width() is
-            // digits+4, and the renderer indents digits + 6 (left_pad) + 4
-            // ("  │ ") = digits + 10 = gutter_total_width() + 2 + 4.
-            let content_x = inner_x + gutter_w + 2 + 4;
+            // digits+4, and the renderer indents marker(2) + digits + 6
+            // (left_pad) + 4 ("  │ ") = marker + gutter_total_width() + 2 + 4.
+            let content_x = inner_x + marker_w + gutter_w + 2 + 4;
             let click_col = col.saturating_sub(content_x) as usize;
             if click_col < thread_actions::reply_end() {
                 // Reply: start inline reply for this comment.
@@ -969,76 +973,10 @@ fn handle_viewer_column_click(
         }
     }
 
-    // Run-test button: clicking the ▶ marker in the left margin of a runnable
-    // test line sends its `go test …` / `cargo test …` command to the Shell PTY.
-    // Only in file view — the diff renderer doesn't draw these markers, so don't
-    // hit-test them there.
-    if !app.viewer_state.diff_view.diff_mode && row >= inner_y {
-        let badge_end = inner_x + gutter_w + 2;
-        if col >= inner_x && col < badge_end {
-            let screen_offset = (row - inner_y) as usize;
-            if let Some(line_1) = resolve_screen_line(app, screen_offset)
-                // Comment badges take visual precedence over the ▶ marker, so a
-                // commented line falls through to the comment-toggle path below.
-                && !app.review_state.file_comments.contains_key(&line_1)
-                && let Some(run) = app.viewer_state.content.test_runs.get(&line_1).cloned()
-            {
-                run_test(app, &run);
-                return;
-            }
-        }
-    }
-
-    // Click anywhere in the left margin (line-number gutter + comment badge) of
-    // a *commented* line toggles its inline thread. A generous hit target so it
-    // works regardless of landing exactly on the 2-cell 💬 glyph, whose width
-    // and column can drift with the terminal/font. Non-commented lines fall
-    // through to the gutter selection path below.
-    let badge_w: u16 = 2;
-    let on_margin = col >= inner_x && col < inner_x + gutter_w + badge_w;
-    if on_margin && row >= inner_y {
-        let screen_offset = (row - inner_y) as usize;
-        if let Some(line_1) = resolve_screen_line(app, screen_offset) {
-            // Defensively refresh the per-file comment cache if it's stale (e.g.
-            // a comment was created via MCP while a different file was current),
-            // so the badge and the toggle gate agree.
-            if app.review_state.file_comments_path.as_deref()
-                != app.viewer_state.content.current_file.as_deref()
-                && let Some(f) = app.viewer_state.content.current_file.clone()
-            {
-                app.review_state.build_file_comment_cache(&f);
-            }
-            if app.review_state.file_comments.contains_key(&line_1) {
-                let threads = &mut app.viewer_state.explorer.expanded_inline_threads;
-                if threads.contains(&line_1) {
-                    threads.remove(&line_1);
-                    if app.viewer_state.explorer.inline_reply_line == Some(line_1) {
-                        app.viewer_state.explorer.inline_reply_line = None;
-                        app.viewer_state.explorer.inline_reply_comment_id = None;
-                        app.viewer_state.explorer.inline_reply_buffer.clear();
-                    }
-                } else {
-                    threads.insert(line_1);
-                    if let Some(comments) = app.review_state.file_comments.get(&line_1) {
-                        for comment in comments {
-                            if !app.review_state.cached_replies.contains_key(&comment.id)
-                                && let Some(store) = app.review_store.as_ref()
-                                && let Ok(replies) = store.get_replies(&comment.id)
-                            {
-                                app.review_state
-                                    .cached_replies
-                                    .insert(comment.id.clone(), replies);
-                            }
-                        }
-                    }
-                }
-                return;
-            }
-        }
-    }
-
     // Click on an ExpandableContext row expands it. Inline threads shift screen
-    // rows, so map the row back to its diff entry via the entry map.
+    // rows, so map the row back to its diff entry via the entry map. (These
+    // rows carry no line number, so they never collide with the margin
+    // dispatch below.)
     if app.viewer_state.diff_view.diff_mode && row >= inner_y {
         let screen_offset = (row - inner_y) as usize;
         if let Some(idx) = app
@@ -1057,32 +995,158 @@ fn handle_viewer_column_click(
         }
     }
 
-    // Trigger commenting when clicking the left margin — the line-number gutter
-    // OR the "+" badge column (matching the hover region above). Clicks on the
-    // code content area are treated as plain focus changes.
-    if on_margin && row >= inner_y {
+    // Left-margin dispatch. The margin is three zones with distinct jobs:
+    //   - comment-marker column (far left, 💬/│) → toggles the existing
+    //     inline thread; this is the only place thread focus lives;
+    //   - line-number gutter → always starts a NEW comment, even on lines
+    //     already covered by a comment range (overlapping/nested ranges);
+    //   - 2-cell badge column → ▶ runs the test, otherwise "+" starts a new
+    //     comment — identical on every line, commented or not.
+    // Clicks on the code content area are treated as plain focus changes.
+    let badge_w: u16 = 2;
+    let on_marker = col >= inner_x && col < inner_x + marker_w;
+    let gutter_start = inner_x + marker_w;
+    let on_number_gutter = col >= gutter_start && col < gutter_start + gutter_w;
+    let on_badge = col >= gutter_start + gutter_w && col < gutter_start + gutter_w + badge_w;
+    if (on_marker || on_number_gutter || on_badge) && row >= inner_y {
         let screen_offset = (row - inner_y) as usize;
         // Screen-row mapping handles inline thread rows and both view modes
         // (deletion lines have no new-line number, so they resolve to None).
         if let Some(line_1) = resolve_screen_line(app, screen_offset) {
-            if app.review_state.file_comments.contains_key(&line_1) {
-                // Existing comment on this line → reveal its thread instead of
-                // starting a new one.
-                app.viewer_state.explorer.comment_preview_line = Some(line_1);
-            } else if mouse.modifiers.contains(KeyModifiers::SHIFT) {
-                // Shift+click extends a range from the previously clicked line
-                // and opens the composer immediately.
-                app.viewer_state.explorer.comment_preview_line = None;
-                app.viewer_state.gutter_comment_click(line_1, true);
-                open_viewer_comment(app);
+            // Defensively refresh the per-file comment cache if it's stale (e.g.
+            // a comment was created via MCP while a different file was current),
+            // so the badge and the dispatch below agree.
+            if app.review_state.file_comments_path.as_deref()
+                != app.viewer_state.content.current_file.as_deref()
+                && let Some(f) = app.viewer_state.content.current_file.clone()
+            {
+                app.review_state.build_file_comment_cache(&f);
+            }
+            let zone = if on_marker {
+                MarginZone::Marker
+            } else if on_badge {
+                MarginZone::Badge
             } else {
-                // Plain press: begin a gutter drag. The selection starts as this
-                // single line and grows as the cursor is dragged over more lines;
-                // the composer opens on mouse-up (GitHub-style: click = one line,
-                // drag = a range).
-                app.viewer_state.explorer.comment_preview_line = None;
-                app.viewer_state.gutter_comment_click(line_1, false);
-                app.viewer_state.click.gutter_drag_anchor = Some(line_1);
+                MarginZone::NumberGutter
+            };
+            let has_comment = app.review_state.file_comments.contains_key(&line_1);
+            // The ▶ marker is only drawn in file view — don't hit-test it in
+            // diff view.
+            let has_test_run = !app.viewer_state.diff_view.diff_mode
+                && app.viewer_state.content.test_runs.contains_key(&line_1);
+            let shift = mouse.modifiers.contains(KeyModifiers::SHIFT);
+            match classify_margin_click(zone, has_comment, has_test_run, shift) {
+                MarginClickAction::ToggleThread => toggle_inline_thread_at(app, line_1),
+                MarginClickAction::RunTest => {
+                    if let Some(run) = app.viewer_state.content.test_runs.get(&line_1).cloned() {
+                        run_test(app, &run);
+                    }
+                }
+                MarginClickAction::StartComment { extend: true } => {
+                    // Shift+click extends a range from the previously clicked
+                    // line and opens the composer immediately.
+                    app.viewer_state.gutter_comment_click(line_1, true);
+                    open_viewer_comment(app);
+                }
+                MarginClickAction::StartComment { extend: false } => {
+                    // Plain press: begin a gutter drag. The selection starts as
+                    // this single line and grows as the cursor is dragged over
+                    // more lines; the composer opens on mouse-up (GitHub-style:
+                    // click = one line, drag = a range).
+                    app.viewer_state.gutter_comment_click(line_1, false);
+                    app.viewer_state.click.gutter_drag_anchor = Some(line_1);
+                }
+            }
+        }
+    }
+}
+
+/// Which zone of the viewer's left margin a click landed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarginZone {
+    /// The comment-marker column at the far left (💬 / │), before the numbers.
+    Marker,
+    /// The line-number gutter.
+    NumberGutter,
+    /// The 2-cell badge column right of the gutter (▶ / hover "+").
+    Badge,
+}
+
+/// What a left click in the viewer's left margin does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarginClickAction {
+    /// Toggle the inline comment thread injected below the clicked line.
+    ToggleThread,
+    /// Send the line's test command to the Shell PTY.
+    RunTest,
+    /// Start a new comment (`extend` = shift-click range extension).
+    StartComment { extend: bool },
+}
+
+/// Decide what a left click in the viewer's left margin does.
+///
+/// Thread focus lives ONLY in the marker column (its 💬/│ glyphs mark the
+/// thread); the number gutter and the "+" badge column always start a NEW
+/// comment — even on lines already covered by an existing comment range — so
+/// ranges that overlap or nest inside another comment's range stay creatable,
+/// and the "+" affordance behaves identically on every line. The ▶ run-test
+/// button keeps its spot in the badge column.
+fn classify_margin_click(
+    zone: MarginZone,
+    has_comment: bool,
+    has_test_run: bool,
+    shift: bool,
+) -> MarginClickAction {
+    match zone {
+        MarginZone::Marker if has_comment => MarginClickAction::ToggleThread,
+        MarginZone::Badge if has_test_run => MarginClickAction::RunTest,
+        _ => MarginClickAction::StartComment { extend: shift },
+    }
+}
+
+/// Where the inline thread for a badge click on `line_1` is anchored.
+///
+/// Threads are injected below a comment's END line (where its 💬 sits) — the
+/// diff renderer draws them nowhere else — so a click on a mid-range │ line
+/// redirects to the nearest covering end line instead of dead-toggling a line
+/// that never shows a thread. On an end line the minimum is the line itself.
+fn thread_anchor_line(comments: &[crate::review_store::ReviewComment], line_1: usize) -> usize {
+    comments
+        .iter()
+        .map(|c| c.line_end.unwrap_or(c.line_start) as usize)
+        .min()
+        .unwrap_or(line_1)
+}
+
+/// Toggle the inline comment thread for the comment(s) covering `line_1`,
+/// loading replies on first expansion and cancelling an in-progress reply on
+/// collapse. Shared by the mouse (marker-column click) and keyboard toggles.
+pub(super) fn toggle_inline_thread_at(app: &mut App, line_1: usize) {
+    let line_1 = app
+        .review_state
+        .file_comments
+        .get(&line_1)
+        .map_or(line_1, |comments| thread_anchor_line(comments, line_1));
+    let threads = &mut app.viewer_state.explorer.expanded_inline_threads;
+    if threads.contains(&line_1) {
+        threads.remove(&line_1);
+        if app.viewer_state.explorer.inline_reply_line == Some(line_1) {
+            app.viewer_state.explorer.inline_reply_line = None;
+            app.viewer_state.explorer.inline_reply_comment_id = None;
+            app.viewer_state.explorer.inline_reply_buffer.clear();
+        }
+    } else {
+        threads.insert(line_1);
+        if let Some(comments) = app.review_state.file_comments.get(&line_1) {
+            for comment in comments {
+                if !app.review_state.cached_replies.contains_key(&comment.id)
+                    && let Some(store) = app.review_store.as_ref()
+                    && let Ok(replies) = store.get_replies(&comment.id)
+                {
+                    app.review_state
+                        .cached_replies
+                        .insert(comment.id.clone(), replies);
+                }
             }
         }
     }
@@ -1514,6 +1578,95 @@ mod tests {
             terminal_claude_y: 1,
             terminal_split_y: 33,
         }
+    }
+
+    #[test]
+    fn gutter_and_badge_clicks_always_start_a_comment() {
+        // The core of the overlap fix: a line inside an existing comment's
+        // range (has_comment = true) must still start a NEW comment from the
+        // number gutter and the "+" badge column — never get swallowed by
+        // thread focus. The affordance is identical on every line.
+        for zone in [MarginZone::NumberGutter, MarginZone::Badge] {
+            for has_comment in [false, true] {
+                assert_eq!(
+                    classify_margin_click(zone, has_comment, false, false),
+                    MarginClickAction::StartComment { extend: false }
+                );
+                assert_eq!(
+                    classify_margin_click(zone, has_comment, false, true),
+                    MarginClickAction::StartComment { extend: true }
+                );
+            }
+        }
+        // Even on a runnable-test line, the number gutter comments.
+        assert_eq!(
+            classify_margin_click(MarginZone::NumberGutter, false, true, false),
+            MarginClickAction::StartComment { extend: false }
+        );
+    }
+
+    #[test]
+    fn marker_click_focuses_existing_thread() {
+        // The far-left 💬/│ marker column is the ONLY place thread focus lives.
+        assert_eq!(
+            classify_margin_click(MarginZone::Marker, true, false, false),
+            MarginClickAction::ToggleThread
+        );
+        // Comment wins even on a commented test line (▶ lives in the badge
+        // column, not here).
+        assert_eq!(
+            classify_margin_click(MarginZone::Marker, true, true, false),
+            MarginClickAction::ToggleThread
+        );
+        // An empty marker cell falls back to starting a comment.
+        assert_eq!(
+            classify_margin_click(MarginZone::Marker, false, false, false),
+            MarginClickAction::StartComment { extend: false }
+        );
+    }
+
+    #[test]
+    fn badge_click_on_test_line_runs_the_test() {
+        assert_eq!(
+            classify_margin_click(MarginZone::Badge, false, true, false),
+            MarginClickAction::RunTest
+        );
+        // A commented test line: ▶ still renders in the badge column, so the
+        // click there still runs the test (thread focus is the marker's job).
+        assert_eq!(
+            classify_margin_click(MarginZone::Badge, true, true, false),
+            MarginClickAction::RunTest
+        );
+    }
+
+    #[test]
+    fn thread_anchor_redirects_mid_range_lines_to_nearest_end_line() {
+        use crate::review_store::{Author, CommentKind, CommentStatus, ReviewComment};
+        let range = |id: &str, start: u32, end: u32| ReviewComment {
+            id: id.to_string(),
+            worktree: "wt".to_string(),
+            file_path: "src/main.rs".to_string(),
+            line_start: start,
+            line_end: Some(end),
+            kind: CommentKind::Suggest,
+            body: "body".to_string(),
+            status: CommentStatus::Pending,
+            commit_ref: "abc".to_string(),
+            author: Author::User,
+            branch: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        // Nested ranges L10-L20 and L11-L19: a mid-range │ click lands on the
+        // nearest end line (💬), where both views render the thread.
+        let both = [range("outer", 10, 20), range("inner", 11, 19)];
+        assert_eq!(thread_anchor_line(&both, 15), 19);
+        // A line covered only by the outer range anchors at its end.
+        let outer_only = [range("outer", 10, 20)];
+        assert_eq!(thread_anchor_line(&outer_only, 10), 20);
+        // An end line anchors at itself.
+        assert_eq!(thread_anchor_line(&both, 19), 19);
+        assert_eq!(thread_anchor_line(&outer_only, 20), 20);
     }
 
     #[test]

--- a/src/event/viewer.rs
+++ b/src/event/viewer.rs
@@ -33,9 +33,6 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // Clear comment preview on any key input.
-    app.viewer_state.explorer.comment_preview_line = None;
-
     // Summary pseudo-file view has its own (simple) scroll navigation.
     if app.viewer_state.is_summary() {
         handle_viewer_summary_mode_key(app, key);
@@ -461,36 +458,13 @@ fn toggle_inline_thread(app: &mut App) {
         app.viewer_state.content.file_scroll + 1
     };
 
-    // Only toggle if the line has comments.
+    // Only toggle if the line has comments. The shared helper redirects a
+    // mid-range line to its thread's end-line anchor, matching the mouse path
+    // (the diff view only renders threads at end lines).
     if !app.review_state.file_comments.contains_key(&cursor_line) {
         return;
     }
-
-    let threads = &mut app.viewer_state.explorer.expanded_inline_threads;
-    if threads.contains(&cursor_line) {
-        threads.remove(&cursor_line);
-        // Also cancel any active reply on this line.
-        if app.viewer_state.explorer.inline_reply_line == Some(cursor_line) {
-            app.viewer_state.explorer.inline_reply_line = None;
-            app.viewer_state.explorer.inline_reply_comment_id = None;
-            app.viewer_state.explorer.inline_reply_buffer.clear();
-        }
-    } else {
-        threads.insert(cursor_line);
-        // Load replies if not cached.
-        if let Some(comments) = app.review_state.file_comments.get(&cursor_line) {
-            for comment in comments {
-                if !app.review_state.cached_replies.contains_key(&comment.id)
-                    && let Some(store) = app.review_store.as_ref()
-                    && let Ok(replies) = store.get_replies(&comment.id)
-                {
-                    app.review_state
-                        .cached_replies
-                        .insert(comment.id.clone(), replies);
-                }
-            }
-        }
-    }
+    super::mouse::toggle_inline_thread_at(app, cursor_line);
 }
 
 /// Start inline reply mode for the current cursor line.

--- a/src/review_state.rs
+++ b/src/review_state.rs
@@ -340,12 +340,21 @@ mod tests {
     use crate::review_store::{Author, CommentKind, CommentStatus, ReviewComment};
 
     fn comment(id: &str, line: u32, status: CommentStatus) -> ReviewComment {
+        range_comment(id, line, None, status)
+    }
+
+    fn range_comment(
+        id: &str,
+        line_start: u32,
+        line_end: Option<u32>,
+        status: CommentStatus,
+    ) -> ReviewComment {
         ReviewComment {
             id: id.to_string(),
             worktree: "wt".to_string(),
             file_path: "src/main.rs".to_string(),
-            line_start: line,
-            line_end: None,
+            line_start,
+            line_end,
             kind: CommentKind::Suggest,
             body: "body".to_string(),
             status,
@@ -371,5 +380,33 @@ mod tests {
         // resolved comments are only hidden from the inline thread expansion.
         assert!(state.file_comments.contains_key(&10));
         assert!(state.file_comments.contains_key(&20));
+    }
+
+    #[test]
+    fn build_file_comment_cache_supports_overlapping_ranges() {
+        // Two comments whose ranges nest (L10-L20 and L11-L19) must coexist:
+        // shared lines carry both, and each keeps its own distinct end line
+        // (where its 💬 badge and inline thread live).
+        let mut state = ReviewState::new();
+        state.comments = vec![
+            range_comment("outer", 10, Some(20), CommentStatus::Pending),
+            range_comment("inner", 11, Some(19), CommentStatus::Pending),
+        ];
+
+        state.build_file_comment_cache("src/main.rs");
+
+        let on = |line: usize| -> Vec<&str> {
+            state.file_comments[&line]
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect()
+        };
+        // A line inside both ranges sees both comments.
+        assert_eq!(on(15), vec!["outer", "inner"]);
+        // Boundary lines covered only by the outer range see just it.
+        assert_eq!(on(10), vec!["outer"]);
+        assert_eq!(on(20), vec!["outer"]);
+        // Each comment's own end line is present with its comment.
+        assert!(on(19).contains(&"inner"));
     }
 }

--- a/src/ui/viewer_panel.rs
+++ b/src/ui/viewer_panel.rs
@@ -303,14 +303,22 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         };
         let gutter_span = Span::styled(num, gutter_style);
 
-        // Comment badge: 💬 on the last line of a comment range,
-        // │ on earlier lines in the range, and a GitHub-style "+" button on
-        // gutter hover (click it to start a comment).
-        let badge = if comment_end_lines.contains(&line_1) {
+        // Comment-marker column (far left, BEFORE the line numbers): 💬 on
+        // the last line of a comment range, │ on earlier lines in the range.
+        // Clicking it toggles the thread — kept out of the gutter/badge side
+        // so starting a new comment works identically on every line.
+        let marker = if comment_end_lines.contains(&line_1) {
             Span::styled("💬", Style::default().fg(theme.accent))
         } else if comment_lines.contains(&line_1) {
             Span::styled("│ ", Style::default().fg(theme.accent))
-        } else if vs.content.test_runs.contains_key(&line_1) {
+        } else {
+            Span::raw("  ")
+        };
+
+        // Badge column (right of the line numbers): ▶ on runnable test lines,
+        // otherwise a GitHub-style "+" button on gutter hover (click it to
+        // start a comment) — shown regardless of existing comments.
+        let badge = if vs.content.test_runs.contains_key(&line_1) {
             // Runnable test line: a ▶ button that sends the test command
             // (`go test …` / `cargo test …`) to the Shell PTY (handled in
             // event/mouse.rs).
@@ -414,8 +422,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             syntax_spans_for_line(vs, line_no, gutter_bg, theme.fg, party)
         };
 
-        // Apply horizontal scroll to content spans, clipping to panel width.
-        let content_max_w = (area.width as usize).saturating_sub(gutter_width + 8);
+        // Apply horizontal scroll to content spans, clipping to panel width
+        // (borders + marker column + gutter + badge).
+        let content_max_w = (area.width as usize)
+            .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 8);
         let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
         // Apply underline to hover symbol (Cmd+hover for jump targets).
@@ -458,7 +468,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             content_spans
         };
 
-        let mut spans = vec![gutter_span, badge];
+        let mut spans = vec![marker, gutter_span, badge];
         spans.extend(content_spans);
         lines.push(Line::from(spans));
         screen_row_map.push(crate::viewer::ScreenRow::Code(line_1));
@@ -773,13 +783,20 @@ fn render_diff_content_line(
     };
     let gutter_span = Span::styled(num, gutter_style);
 
-    // Comment badge: 💬 on end lines, │ on earlier range lines, and a
-    // GitHub-style "+" button on hovered gutter (click to start a comment).
-    let badge = if new_line_no.is_some_and(|n| ctx.comment_end_lines.contains(&n)) {
+    // Comment-marker column (far left, BEFORE the line numbers): 💬 on end
+    // lines, │ on earlier range lines. Clicking it toggles the thread.
+    let marker = if new_line_no.is_some_and(|n| ctx.comment_end_lines.contains(&n)) {
         Span::styled("💬", Style::default().fg(theme.accent))
     } else if new_line_no.is_some_and(|n| ctx.comment_lines.contains(&n)) {
         Span::styled("│ ", Style::default().fg(theme.accent))
-    } else if is_gutter_hovered {
+    } else {
+        Span::raw("  ")
+    };
+
+    // Badge column (right of the line numbers): a GitHub-style "+" button on
+    // hovered gutter (click to start a comment) — regardless of existing
+    // comments. (The diff view draws no ▶ test markers.)
+    let badge = if is_gutter_hovered {
         Span::styled(
             "+ ",
             Style::default()
@@ -899,8 +916,10 @@ fn render_diff_content_line(
         }
     };
 
-    // Apply horizontal scroll, clipping to panel width.
-    let content_max_w = (ctx.area_width as usize).saturating_sub(gutter_width + 8);
+    // Apply horizontal scroll, clipping to panel width
+    // (borders + marker column + gutter + badge).
+    let content_max_w = (ctx.area_width as usize)
+        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 8);
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
     // Underline the current walkthrough step's line range — a highlight that
@@ -915,7 +934,7 @@ fn render_diff_content_line(
         content_spans
     };
 
-    let mut spans = vec![gutter_span, badge];
+    let mut spans = vec![marker, gutter_span, badge];
     spans.extend(content_spans);
 
     // Extend background color to the end of the line for
@@ -1422,7 +1441,7 @@ fn build_inline_thread_lines<'a>(
 
     use crate::viewer::ScreenRow;
     let mut out: Vec<(Line, ScreenRow)> = Vec::new();
-    let left_pad = gutter_width + 4 + 2; // gutter + badge
+    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 4 + 2; // marker + gutter + badge
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     // Per-author surface tint so "who wrote this" reads at a glance: Claude's
@@ -1709,7 +1728,7 @@ fn build_inline_compose_lines<'a>(
 ) -> Vec<(Line<'a>, crate::viewer::ScreenRow)> {
     use crate::viewer::ScreenRow;
     let bg = theme.comment_user_bg;
-    let left_pad = gutter_width + 4 + 2;
+    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 4 + 2;
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     let bg_style = Style::default().bg(bg);

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -154,8 +154,6 @@ pub struct ExplorerState {
     pub comment_list_selected: usize,
     /// Vertical scroll offset for the explorer comment list.
     pub comment_list_scroll: usize,
-    /// Line number (1-indexed) for comment preview triggered by single-clicking a comment marker.
-    pub comment_preview_line: Option<usize>,
     /// Set of 1-indexed line numbers whose inline comment threads are expanded.
     pub expanded_inline_threads: HashSet<usize>,
     /// Line number where inline reply input is active (None = not replying).
@@ -195,7 +193,6 @@ impl Default for ExplorerState {
             explorer_bottom_view: ExplorerBottomView::default(),
             comment_list_selected: 0,
             comment_list_scroll: 0,
-            comment_preview_line: None,
             expanded_inline_threads: HashSet::new(),
             inline_reply_line: None,
             inline_reply_comment_id: None,
@@ -301,6 +298,13 @@ impl Default for ClickTracker {
 }
 
 // ── Main struct ──────────────────────────────────────────────────────
+
+/// Width (in columns) of the comment-marker column at the far left of the
+/// Viewer — where the 💬/│ thread markers live, LEFT of the line numbers.
+/// Kept separate from the "+" badge column (right of the numbers) so that
+/// toggling an existing thread and starting a new comment never share a
+/// click target: the whole gutter+badge side always starts a comment.
+pub const COMMENT_MARKER_W: u16 = 2;
 
 /// All state owned by the Viewer mode.
 #[derive(Default)]


### PR DESCRIPTION
## Summary

既存コメント範囲（例: L10-L20）の内側の行をクリックすると、新規コメント作成が既存スレッドのトグルに横取りされて重複・ネスト範囲のコメントを作れないバグの修正。あわせて、作成とスレッド開閉が同じクリック領域を取り合う構造自体を解消するため、Viewer の左マージンを3ゾーンに再構成した。

- **コメントマーク列（新設・最左・常時2セル）**: 💬（範囲終端）/│（範囲中間）を描画。クリックはスレッドの開閉専用。中間行クリックは最寄りの終端行（スレッドが描画される場所）へリダイレクト（`thread_anchor_line`）
- **行番号ガター**: クリックは常に新規コメント開始（クリック=1行、ドラッグ=範囲、Shift+クリック=拡張）— 既存コメントの有無に関わらず同じ挙動
- **バッジ列（行番号右の2セル）**: ▶（テスト実行）または hover "+"（新規コメント）。コメントの有無で表示・クリック領域が変わらなくなり、コメント付きテスト行でも ▶ が押せる
- マージンクリックの判定を純関数 `classify_margin_click` に抽出、キーボードのスレッドトグルもマウスと同じ `toggle_inline_thread_at` を共有
- set のみで読まれていなかった死にフィールド `comment_preview_line` を削除
- 描画とヒットテストの列演算（Cmd+クリック、スレッド操作ボタン、hover 領域、コンテンツ幅、スレッド/入力箱のインデント）を `COMMENT_MARKER_W` 分シフト

## Test plan

- `cargo test`: `classify_margin_click` のゾーン別分類（ガター/バッジは既存コメント行でも常に新規作成、マーク列はトグル、▶ はバッジ列のみ）、`thread_anchor_line` の中間行リダイレクト、`build_file_comment_cache` の重複・ネスト範囲共存を追加。全テスト green
- `cargo clippy` クリーン
- 実機確認: L10-20 / L11-19（ネスト）/ L15-25（部分重複）のテストコメントを投入し、範囲内側の行からの新規コメント作成・💬/│ クリックでのスレッド開閉・"+" の全行一貫表示を確認済み