### PR TITLE
fix: Changed files パネルが起動直後に表示されない不具合を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.89.1"
+version = "0.89.2"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.89.1"
+version = "0.89.2"
 edition = "2024"
 
 [dependencies]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -199,6 +199,14 @@ impl App {
         // restart (e.g. after an update) lands the user where they left off.
         app.restore_selected_worktree_and_view();
         app.refresh_reviews();
+        // Seed the Explorer's file tree and the "Changed files" diff for the
+        // restored worktree right away. Without this the diff list stays empty
+        // on the first frame and only fills in once the 3s `worktree_poll`
+        // staleness check (or a worktree-bar click) fires — the panel appeared
+        // to "not show up" until the user clicked the bar. Mirrors the
+        // refresh_viewer + refresh_diff pairing in `check_diff_viewer_staleness`.
+        app.refresh_viewer();
+        app.refresh_diff();
 
         // Restore grab state from $git_common_dir/wt-grab if it exists.
         if let Ok(engine) = git_engine::GitEngine::open(&app.repo_path) {


### PR DESCRIPTION
## Summary

「変更ファイル一覧（Changed files）」パネルが起動直後に表示されず、worktree bar をクリックして初めて表示される不具合を修正した。

- 原因: `App::new`（起動時）が初期 diff 計算を行っていなかった。パネルは `diff_state.committed_files` / `uncommitted_files` を参照するが、これらを埋めるのは (1) `on_worktree_changed()`（worktree bar クリック）と (2) `refresh_diff()`（file-watcher / 3秒ごとの `worktree_poll` staleness チェック）のみ。起動直後はどちらも走らないため、最初の 3秒 poll かバークリックまで空のままだった。
- 修正: `App::new` の起動シーケンス（`refresh_worktrees` → `restore_selected_worktree_and_view` → `refresh_reviews`）の後に `refresh_viewer()` + `refresh_diff()` を追加。`check_diff_viewer_staleness` の refresh_viewer + refresh_diff のペアリングと同じ形で、復元された worktree の diff を最初のフレームで seed する。
- focus ハンドラは追加していない。初期ロード欠落を直すことで3症状（表示が遅い / focus で出ない / クリックで初めて出る）すべて解消するため冗長。

## Test plan

- [x] `cargo build` が通ること
- [ ] 起動直後に Changed files パネルが即座に表示される（実機確認）
- [ ] worktree bar クリックの既存挙動が壊れていない（実機確認）