### PR TITLE
feat: symbol hover info popup with interactive references modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.89.2"
+version = "0.90.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.89.2"
+version = "0.90.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -14,6 +14,333 @@ impl App {
         extract_symbol_from_line(line)
     }
 
+    /// Explicitly show the hover-info popup for the symbol under the viewer
+    /// cursor (the first identifier on the top line — same lookup as `gd`).
+    ///
+    /// Bound to `K` as an instant, no-wait trigger. Because it's a deliberate
+    /// press it gives feedback when it can't produce a popup (status flash),
+    /// unlike the passive auto-hover which stays silent.
+    pub fn show_hover_info(&mut self) {
+        use crate::app::StatusLevel;
+
+        let symbol = match self.get_symbol_at_cursor() {
+            Some(s) => s,
+            None => {
+                self.set_status("No symbol under cursor".to_string(), StatusLevel::Warning);
+                return;
+            }
+        };
+        if !self.symbol_index.is_available() {
+            self.set_status(
+                "Symbol index not ready yet".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+        let current_file = self.viewer_state.content.current_file.clone();
+        match crate::hover_info::build_hover_info(
+            &self.symbol_index,
+            &symbol,
+            current_file.as_deref(),
+        ) {
+            Some(info) => {
+                self.hover_info_overlay.shown_file = current_file.clone();
+                self.hover_info_overlay.info = Some(info);
+            }
+            None => {
+                self.set_status(
+                    format!("No definition indexed for '{symbol}'"),
+                    StatusLevel::Info,
+                );
+            }
+        }
+    }
+
+    /// Whether the passive auto-hover popup is allowed to appear right now:
+    /// a file (plain or diff) open in the focused Viewer, with no blocking
+    /// overlay or the summary pseudo-view stealing the surface.
+    fn hover_auto_allowed(&self) -> bool {
+        self.focus == Focus::Viewer
+            && !self.viewer_state.is_summary()
+            && self.overlays.active == crate::overlay::ActiveOverlay::None
+            && !self.references_overlay.active
+            && !self.symbol_action_overlay.active
+            && !self.symbol_hint_overlay.active
+            && self.viewer_state.content.current_file.is_some()
+    }
+
+    /// Clear the whole hover modal stack (popup, pending candidate, refs list,
+    /// preview, pin). Returns whether anything was actually showing.
+    pub fn clear_hover(&mut self) -> bool {
+        let had = self.hover_info_overlay.info.is_some()
+            || self.hover_info_overlay.pending.is_some()
+            || self.hover_info_overlay.pinned;
+        self.hover_info_overlay.reset();
+        had
+    }
+
+    /// Record the symbol the mouse is currently resting on (from a mouse-move
+    /// event). `cand` is `(symbol, 1-indexed line, anchor_row, anchor_col)` in
+    /// absolute screen coords, or `None` when the mouse is over blank space / a
+    /// non-identifier. A *new* symbol restarts the idle countdown and drops any
+    /// popup shown for the previous one.
+    pub fn set_mouse_hover_candidate(&mut self, cand: Option<(String, usize, u16, u16)>) {
+        match cand {
+            Some((symbol, line, anchor_row, anchor_col)) => {
+                let same = self
+                    .hover_info_overlay
+                    .pending
+                    .as_ref()
+                    .is_some_and(|c| c.symbol == symbol && c.line == line);
+                if same {
+                    return;
+                }
+                let file = self.viewer_state.content.current_file.clone();
+                self.hover_info_overlay.pending = Some(crate::overlay::HoverCandidate {
+                    symbol,
+                    line,
+                    file,
+                    anchor_row,
+                    anchor_col,
+                    since: std::time::Instant::now(),
+                    resolved: false,
+                });
+                self.hover_info_overlay.leave_at = None;
+                if self.hover_info_overlay.info.take().is_some() {
+                    self.dirty.mark_all();
+                }
+            }
+            None => {
+                // Mouse moved off the symbol onto blank space. If a popup is
+                // showing, don't drop it instantly — start a short grace window
+                // (see `tick_hover`) so the cursor can travel onto the popup to
+                // click it. If nothing is shown yet, just drop the candidate.
+                if self.hover_info_overlay.info.is_some() {
+                    self.hover_info_overlay.pending = None;
+                    if self.hover_info_overlay.leave_at.is_none() {
+                        self.hover_info_overlay.leave_at = Some(std::time::Instant::now());
+                    }
+                } else if self.hover_info_overlay.pending.take().is_some() {
+                    self.dirty.mark_all();
+                }
+            }
+        }
+    }
+
+    /// True when the given absolute screen point lies within any part of the
+    /// hover modal stack (base popup, refs list, or preview) — used to keep the
+    /// popup alive while the mouse is over it and to route clicks.
+    pub fn hover_point_hit(&self, col: u16, row: u16) -> bool {
+        let hv = &self.hover_info_overlay;
+        let in_rect = |r: ratatui::layout::Rect| {
+            r.width > 0
+                && r.height > 0
+                && col >= r.x
+                && col < r.x + r.width
+                && row >= r.y
+                && row < r.y + r.height
+        };
+        if in_rect(hv.info_rect) {
+            return true;
+        }
+        if let Some(refs) = &hv.refs {
+            if in_rect(refs.rect) {
+                return true;
+            }
+            if let Some(p) = &refs.preview {
+                if in_rect(p.rect) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Per-frame auto-hover driver. When the mouse has rested on a symbol past
+    /// the debounce, resolves its hover popup; stays silent when nothing is
+    /// found. Also manages the grace window and stale-file/focus invalidation.
+    pub fn tick_hover(&mut self) {
+        /// How long the mouse must rest on a symbol before the popup appears.
+        const HOVER_IDLE: std::time::Duration = std::time::Duration::from_millis(350);
+        /// Grace window keeping a transient popup alive after the mouse leaves
+        /// the symbol, so the cursor can reach the popup to click it.
+        const HOVER_GRACE: std::time::Duration = std::time::Duration::from_millis(700);
+
+        // A pinned modal is user-driven: it survives focus/idle loss and is only
+        // dismissed by Esc or a click outside (handled in the event layer).
+        if self.hover_info_overlay.pinned {
+            return;
+        }
+
+        // Stale-file guard: if the viewer switched files (via a jump, the file
+        // tree, or an external reload) while a popup was up, the popup now
+        // describes a symbol from a file no longer on screen. Drop it — even
+        // within the grace window — so it can never linger over unrelated code.
+        if self.hover_info_overlay.info.is_some()
+            && self.hover_info_overlay.shown_file != self.viewer_state.content.current_file
+        {
+            if self.clear_hover() {
+                self.dirty.mark_all();
+            }
+            return;
+        }
+
+        // Grace window: a popup whose symbol the mouse left stays up briefly, but
+        // only while the mouse is actually over it or the timer hasn't expired.
+        if let Some(left) = self.hover_info_overlay.leave_at {
+            if left.elapsed() >= HOVER_GRACE {
+                if self.clear_hover() {
+                    self.dirty.mark_all();
+                }
+                return;
+            }
+        }
+
+        if !self.hover_auto_allowed() {
+            // Don't kill a popup that's within its grace window — the user may be
+            // moving the mouse toward it (which briefly leaves the content area).
+            if self.hover_info_overlay.leave_at.is_some() {
+                return;
+            }
+            if self.clear_hover() {
+                self.dirty.mark_all();
+            }
+            return;
+        }
+
+        // Auto-hover is driven purely by the mouse resting on a symbol (set by the
+        // mouse-move handler). A top-line/keyboard heuristic was tried and dropped:
+        // with no per-line text cursor, "the cursor line" is always the top visible
+        // line, so it fired for code the user wasn't pointing at. Mouse position is
+        // exact — on a symbol shows the popup, on whitespace shows nothing.
+
+        // Resolve a candidate that has rested long enough.
+        let ready = self
+            .hover_info_overlay
+            .pending
+            .as_ref()
+            .is_some_and(|c| !c.resolved && c.since.elapsed() >= HOVER_IDLE);
+        if ready {
+            let (symbol, file, anchor_row, anchor_col) = {
+                let c = self.hover_info_overlay.pending.as_ref().unwrap();
+                (c.symbol.clone(), c.file.clone(), c.anchor_row, c.anchor_col)
+            };
+            let info = crate::hover_info::build_hover_info(
+                &self.symbol_index,
+                &symbol,
+                file.as_deref(),
+            );
+            if let Some(c) = self.hover_info_overlay.pending.as_mut() {
+                c.resolved = true;
+            }
+            self.hover_info_overlay.anchor_row = anchor_row;
+            self.hover_info_overlay.anchor_col = anchor_col;
+            // Remember which viewed file this popup describes, so the stale-file
+            // guard can drop it the moment the viewer moves to another file.
+            self.hover_info_overlay.shown_file = if info.is_some() { file } else { None };
+            self.hover_info_overlay.info = info;
+            self.dirty.mark_all();
+        }
+    }
+
+    /// Cancel the grace window because the mouse is now over the popup itself.
+    pub fn hover_keep_alive(&mut self) {
+        self.hover_info_overlay.leave_at = None;
+    }
+
+    /// Open the references list (level 1) for the currently-shown symbol and pin
+    /// the popup. No-op when nothing is shown or the symbol has no references.
+    pub fn open_hover_refs(&mut self) {
+        let symbol = match self.hover_info_overlay.info.as_ref() {
+            Some(info) if info.ref_count > 0 => info.symbol_name.clone(),
+            _ => return,
+        };
+        let root = self.symbol_index.root();
+        let results = self.symbol_index.find_references(&symbol, &root);
+        if results.is_empty() {
+            return;
+        }
+        self.hover_info_overlay.pinned = true;
+        self.hover_info_overlay.leave_at = None;
+        self.hover_info_overlay.refs = Some(crate::overlay::HoverRefs {
+            symbol,
+            results,
+            selected: 0,
+            scroll: 0,
+            rect: ratatui::layout::Rect::default(),
+            row_hits: Vec::new(),
+            preview: None,
+        });
+        self.dirty.mark_all();
+    }
+
+    /// Open the code preview (level 2) for reference row `idx` in the list.
+    pub fn open_hover_preview(&mut self, idx: usize) {
+        let (file, line) = match self.hover_info_overlay.refs.as_mut() {
+            Some(refs) => match refs.results.get(idx) {
+                Some(r) => {
+                    refs.selected = idx;
+                    (r.file_path.clone(), r.line)
+                }
+                None => return,
+            },
+            None => return,
+        };
+        let root = self.symbol_index.root();
+        let preview = build_hover_preview(&root, &file, line);
+        if let Some(refs) = self.hover_info_overlay.refs.as_mut() {
+            refs.preview = preview;
+        }
+        self.dirty.mark_all();
+    }
+
+    /// Jump to the open preview's location and dismiss the whole hover stack.
+    pub fn hover_jump_to_preview(&mut self) {
+        let target = self
+            .hover_info_overlay
+            .refs
+            .as_ref()
+            .and_then(|r| r.preview.as_ref())
+            .map(|p| (p.file.clone(), p.center_line));
+        if let Some((file, line)) = target {
+            self.clear_hover();
+            self.jump_to_location(&file, line, 0);
+        }
+    }
+
+    /// Move the references-list selection by `delta` (keyboard nav), clamping.
+    pub fn hover_refs_move(&mut self, delta: isize) {
+        if let Some(refs) = self.hover_info_overlay.refs.as_mut() {
+            let n = refs.results.len();
+            if n == 0 {
+                return;
+            }
+            let cur = refs.selected as isize;
+            refs.selected = (cur + delta).clamp(0, n as isize - 1) as usize;
+            self.dirty.mark_all();
+        }
+    }
+
+    /// Esc from the hover stack: close the deepest open level (preview → list →
+    /// the whole popup). Returns whether a level was closed.
+    pub fn hover_pop_level(&mut self) -> bool {
+        if let Some(refs) = self.hover_info_overlay.refs.as_mut() {
+            if refs.preview.take().is_some() {
+                self.dirty.mark_all();
+                return true;
+            }
+            self.hover_info_overlay.refs = None;
+            self.hover_info_overlay.pinned = false;
+            self.dirty.mark_all();
+            return true;
+        }
+        if self.clear_hover() {
+            self.dirty.mark_all();
+            return true;
+        }
+        false
+    }
+
     /// Check if the cursor is currently at (or very near) a definition site
     /// for the given symbol. Returns `true` when the current file + line
     /// matches one of the symbol's definition locations.
@@ -203,11 +530,53 @@ impl App {
     }
 }
 
+/// Build a code preview window around `line_1` (1-indexed) in `rel_path`,
+/// reading a few lines of context on each side. Returns `None` if the file
+/// can't be read or the line is out of range.
+fn build_hover_preview(
+    root: &std::path::Path,
+    rel_path: &str,
+    line_1: usize,
+) -> Option<crate::overlay::HoverPreview> {
+    /// Lines of context shown on each side of the reference line.
+    const CONTEXT: usize = 3;
+
+    let source = std::fs::read_to_string(root.join(rel_path)).ok()?;
+    let all: Vec<&str> = source.lines().collect();
+    if line_1 == 0 || line_1 > all.len() {
+        return None;
+    }
+    let idx = line_1 - 1;
+    let start = idx.saturating_sub(CONTEXT);
+    let end = (idx + CONTEXT + 1).min(all.len());
+    let lines = (start..end)
+        .map(|i| (i + 1, all[i].to_string()))
+        .collect::<Vec<_>>();
+    Some(crate::overlay::HoverPreview {
+        file: rel_path.to_string(),
+        center_line: line_1,
+        lines,
+        rect: ratatui::layout::Rect::default(),
+    })
+}
+
 // ── Free functions for symbol extraction ──────────────────────────────
 
 /// Extract a symbol name from a source code line at the cursor position.
-/// Returns the first Rust-like identifier found on the line that is not a keyword.
+/// Returns the first Rust-like identifier found on the line that is not a
+/// keyword. Comment and attribute lines yield nothing — an English word in a
+/// doc comment (e.g. `//! Building …`) must not resolve to a same-named symbol.
 pub fn extract_symbol_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    // Skip lines that are comments (`//`, `///`, `//!`, `/* … */`, block-comment
+    // continuation `* …`) or attributes (`#[…]`) — none carry a code symbol.
+    if trimmed.starts_with("//")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with('#')
+    {
+        return None;
+    }
     let re = regex::Regex::new(r"\b([A-Za-z_][A-Za-z0-9_]*)\b").ok()?;
     for cap in re.captures_iter(line) {
         let word = cap.get(1)?.as_str();
@@ -353,5 +722,65 @@ mod tests {
         let line = "    _handler.call();";
         let result = extract_symbol_at_column(line, 5);
         assert_eq!(result, Some(("_handler".to_string(), 4, 12)));
+    }
+
+    #[test]
+    fn build_hover_preview_windows_around_line() {
+        let dir = std::env::temp_dir().join(format!("hover_prev_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = (1..=10)
+            .map(|n| format!("line{n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.join("f.rs"), src).unwrap();
+
+        // Center line 5 → 3 lines of context each side (2..=8).
+        let p = build_hover_preview(&dir, "f.rs", 5).expect("preview");
+        assert_eq!(p.center_line, 5);
+        assert_eq!(p.file, "f.rs");
+        assert_eq!(
+            p.lines,
+            vec![
+                (2, "line2".to_string()),
+                (3, "line3".to_string()),
+                (4, "line4".to_string()),
+                (5, "line5".to_string()),
+                (6, "line6".to_string()),
+                (7, "line7".to_string()),
+                (8, "line8".to_string()),
+            ]
+        );
+
+        // Near the top the window clamps to the file start.
+        let p = build_hover_preview(&dir, "f.rs", 1).expect("preview");
+        assert_eq!(p.lines.first().unwrap().0, 1);
+
+        // Out-of-range / missing file → None.
+        assert!(build_hover_preview(&dir, "f.rs", 999).is_none());
+        assert!(build_hover_preview(&dir, "nope.rs", 1).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extract_symbol_from_line_skips_comments_and_attributes() {
+        // Doc/line/block comments must not yield an English word that happens
+        // to collide with a real type name (the "Building" bug).
+        assert_eq!(extract_symbol_from_line("//! Building and navigating"), None);
+        assert_eq!(extract_symbol_from_line("/// Create a new state"), None);
+        assert_eq!(extract_symbol_from_line("    // Building the list"), None);
+        assert_eq!(extract_symbol_from_line("/* Building */"), None);
+        assert_eq!(extract_symbol_from_line("     * Building (block cont.)"), None);
+        assert_eq!(extract_symbol_from_line("#[derive(Debug)]"), None);
+        // Real code lines still resolve to their first identifier.
+        assert_eq!(
+            extract_symbol_from_line("    let state = DiffState::new();"),
+            Some("state".to_string())
+        );
+        assert_eq!(
+            extract_symbol_from_line("pub struct Building {"),
+            Some("Building".to_string())
+        );
     }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -12,7 +12,9 @@ use crate::diff_state::{DiffState, DiffViewMode};
 use crate::git_engine;
 use crate::jump_history::JumpHistory;
 use crate::keymap::KeyMap;
-use crate::overlay::{OverlayManager, ReferencesOverlay, SymbolActionOverlay, SymbolHintOverlay};
+use crate::overlay::{
+    HoverInfoOverlay, OverlayManager, ReferencesOverlay, SymbolActionOverlay, SymbolHintOverlay,
+};
 use crate::review_state::ReviewState;
 use crate::review_store::{self, ReviewStore};
 use crate::symbol_index::SymbolIndex;
@@ -164,6 +166,7 @@ impl App {
             references_overlay: ReferencesOverlay::default(),
             symbol_hint_overlay: SymbolHintOverlay::default(),
             symbol_action_overlay: SymbolActionOverlay::default(),
+            hover_info_overlay: HoverInfoOverlay::default(),
             bg: BackgroundOps::default(),
             new_worktree_paths: HashSet::new(),
             show_panel_number_overlay: false,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,7 +49,7 @@ use crate::git_engine;
 use crate::jump_history::JumpHistory;
 use crate::keymap::KeyMap;
 use crate::overlay::{ActiveOverlay, OverlayManager};
-use crate::overlay::{ReferencesOverlay, SymbolActionOverlay, SymbolHintOverlay};
+use crate::overlay::{HoverInfoOverlay, ReferencesOverlay, SymbolActionOverlay, SymbolHintOverlay};
 use crate::pty_manager;
 use crate::review_state::ReviewState;
 use crate::review_store::{self, ReviewStore};
@@ -281,6 +281,7 @@ pub struct App {
     pub references_overlay: ReferencesOverlay,
     pub symbol_hint_overlay: SymbolHintOverlay,
     pub symbol_action_overlay: SymbolActionOverlay,
+    pub hover_info_overlay: HoverInfoOverlay,
 
     // ── Background operations (polled by the event loop) ─────────
     pub bg: BackgroundOps,

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -254,6 +254,9 @@
 ":" = "command_palette"
 "ctrl+o" = "jump_back"
 "ctrl+i" = "jump_forward"
+# Hover info also appears automatically when the mouse rests on a symbol or the
+# cursor sits idle. `K` (à la Vim/LSP hover) forces it instantly without waiting.
+"K" = "show_hover_info"
 
 # ── Viewer: diff mode ────────────────────────────────────────────────────────────
 [layers.viewer_diff_mode]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -277,6 +277,22 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // ── 1b1. Hover modal. When pinned (the user clicked into it), keys drive
+    // the modal stack — Esc pops a level, arrows navigate the refs list, Enter
+    // drills in / jumps — and are consumed. Otherwise it's a transient auto
+    // popup: any key dismisses it (Esc consumed; other keys fall through to do
+    // their normal job as the popup vanishes). ──
+    if app.hover_info_overlay.pinned {
+        handle_hover_modal_key(app, key);
+        return;
+    }
+    if app.hover_info_overlay.info.is_some() || app.hover_info_overlay.pending.is_some() {
+        app.clear_hover();
+        if key.code == KeyCode::Esc {
+            return;
+        }
+    }
+
     // ── 1b2. Symbol action overlay (after hint selection) ──
     if app.symbol_action_overlay.active {
         handle_symbol_action_key(app, key);
@@ -320,6 +336,35 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
         Focus::Explorer => handle_explorer_key(app, key),
         Focus::Viewer => handle_viewer_key(app, key),
         Focus::TerminalClaude | Focus::TerminalShell | Focus::Editor => unreachable!(),
+    }
+}
+
+/// Keyboard driver for the pinned interactive hover modal stack. Esc pops the
+/// deepest open level (preview → refs list → the whole popup); Up/Down (or k/j)
+/// move the references selection; Enter opens the selected reference's preview,
+/// or — when a preview is already showing — jumps to that location.
+fn handle_hover_modal_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc => {
+            app.hover_pop_level();
+        }
+        KeyCode::Up | KeyCode::Char('k') => app.hover_refs_move(-1),
+        KeyCode::Down | KeyCode::Char('j') => app.hover_refs_move(1),
+        KeyCode::Enter => {
+            let has_preview = app
+                .hover_info_overlay
+                .refs
+                .as_ref()
+                .is_some_and(|r| r.preview.is_some());
+            if has_preview {
+                app.hover_jump_to_preview();
+            } else if let Some(sel) =
+                app.hover_info_overlay.refs.as_ref().map(|r| r.selected)
+            {
+                app.open_hover_preview(sel);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -83,6 +83,106 @@ fn resolve_screen_line(app: &App, screen_offset: usize) -> Option<usize> {
 
 /// Returns true if any overlay/modal is active and should consume all mouse events,
 /// preventing them from reaching background panels.
+/// Route a mouse event against the interactive hover modal stack. Returns
+/// `true` when the event was consumed (the caller then returns early).
+///
+/// - Left click on `N refs` → open the references list (pins the popup).
+/// - Left click on a list row → open its code preview.
+/// - Left click on the preview → jump to that location, closing the stack.
+/// - Left click on empty popup padding → kept (consumed).
+/// - Left click anywhere else while pinned → dismiss (swallowed).
+/// - Move over any part → keep alive (cancel the transient grace window).
+/// - Scroll over the list → move the selection.
+fn handle_hover_modal_mouse(app: &mut App, mouse: MouseEvent) -> bool {
+    if !app.hover_info_overlay.is_shown() {
+        return false;
+    }
+    let col = mouse.column;
+    let row = mouse.row;
+    let in_rect = |r: ratatui::layout::Rect| {
+        r.width > 0 && r.height > 0 && col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height
+    };
+    let pinned = app.hover_info_overlay.pinned;
+
+    match mouse.kind {
+        MouseEventKind::Moved => {
+            if app.hover_point_hit(col, row) {
+                app.hover_keep_alive();
+                return true;
+            }
+            // Off the popup: while pinned, still consume so a stray move can't
+            // clobber the modal; while transient, let the normal move handler
+            // manage the candidate/grace.
+            pinned
+        }
+        MouseEventKind::Down(MouseButton::Left) => {
+            // Level 2: click the preview → jump there and close everything.
+            if let Some(pr) = app
+                .hover_info_overlay
+                .refs
+                .as_ref()
+                .and_then(|r| r.preview.as_ref())
+                && in_rect(pr.rect)
+            {
+                app.hover_jump_to_preview();
+                return true;
+            }
+            // Level 1: click a reference row → open its preview.
+            if let Some(refs) = app.hover_info_overlay.refs.as_ref() {
+                if let Some((idx, _)) = refs.row_hits.iter().find(|(_, r)| in_rect(*r)).copied() {
+                    app.open_hover_preview(idx);
+                    return true;
+                }
+                if in_rect(refs.rect) {
+                    return true; // list padding — keep open
+                }
+            }
+            // Base popup: click "N refs" → open the list; click body → keep.
+            if in_rect(app.hover_info_overlay.refs_hit) {
+                app.open_hover_refs();
+                return true;
+            }
+            if in_rect(app.hover_info_overlay.info_rect) {
+                return true;
+            }
+            // Outside everything: a pinned modal dismisses and swallows the
+            // click; a transient popup lets the click through (the top-level
+            // non-Moved clear will drop it).
+            if pinned {
+                app.clear_hover();
+                app.dirty.mark_all();
+                return true;
+            }
+            false
+        }
+        MouseEventKind::ScrollDown => {
+            if app
+                .hover_info_overlay
+                .refs
+                .as_ref()
+                .is_some_and(|r| in_rect(r.rect))
+            {
+                app.hover_refs_move(1);
+                return true;
+            }
+            pinned
+        }
+        MouseEventKind::ScrollUp => {
+            if app
+                .hover_info_overlay
+                .refs
+                .as_ref()
+                .is_some_and(|r| in_rect(r.rect))
+            {
+                app.hover_refs_move(-1);
+                return true;
+            }
+            pinned
+        }
+        _ => pinned,
+    }
+}
+
 fn has_blocking_overlay(app: &App) -> bool {
     use crate::app::{UpdateState, WorktreeInputMode};
     use crate::review_state::ReviewInputMode;
@@ -217,6 +317,13 @@ impl ClickGeometry {
 
 /// Process a single mouse event, updating application state as needed.
 pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui::layout::Rect) {
+    // Interactive hover modal stack (popup → refs list → preview) gets first
+    // crack at the mouse: clicks on its parts drill in, moving over it keeps it
+    // alive, and a pinned modal swallows clicks outside it (to dismiss).
+    if handle_hover_modal_mouse(app, mouse) {
+        return;
+    }
+
     // When any overlay/modal is active, consume all mouse events to prevent
     // them from reaching background panels (scroll, click, etc.).
     if has_blocking_overlay(app) {
@@ -242,6 +349,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
 
     let col = mouse.column;
     let row = mouse.row;
+
+    // Any mouse action other than a plain move (scroll, click, drag) invalidates
+    // the auto-hover popup: it was tied to a now-stale line. Moved manages its
+    // own candidate below.
+    if !matches!(mouse.kind, MouseEventKind::Moved) && app.clear_hover() {
+        app.dirty.mark_all();
+    }
 
     let geom = ClickGeometry {
         main_area,
@@ -445,10 +559,52 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 } else {
                     app.viewer_state.click.hover_symbol = None;
                 }
+
+                // Auto-hover candidate: the symbol under the resting mouse, with
+                // no modifier required. Works in both plain-file and diff mode:
+                // `gutter_total_width()` already accounts for the diff `+/-`
+                // prefix, so the content-start column is the same formula, and
+                // `resolve_screen_line` yields the new-side file line (None on
+                // deletion rows, which we skip). Feeds the idle debounce in
+                // `tick_hover`; blank space / non-identifiers clear it.
+                let auto_cand = {
+                    let gutter_w = app.viewer_state.gutter_total_width();
+                    let inner_x = explorer_end + 1;
+                    let badge_w: u16 = 2;
+                    let content_start_x =
+                        inner_x + crate::viewer::COMMENT_MARKER_W + gutter_w + badge_w;
+                    if col >= content_start_x {
+                        resolve_screen_line(app, line_offset).and_then(|line_1| {
+                            let content_col =
+                                (col - content_start_x) as usize + app.viewer_state.content.h_scroll;
+                            app.viewer_state
+                                .content
+                                .file_content
+                                .get(line_1 - 1)
+                                .and_then(|text| {
+                                    crate::app::extract_symbol_at_column(text, content_col).map(
+                                        |(symbol, start, _)| {
+                                            // Anchor the popup at the symbol's
+                                            // start column and this screen row.
+                                            let anchor_col = content_start_x
+                                                + (start.saturating_sub(
+                                                    app.viewer_state.content.h_scroll,
+                                                )) as u16;
+                                            (symbol, line_1, row, anchor_col)
+                                        },
+                                    )
+                                })
+                        })
+                    } else {
+                        None
+                    }
+                };
+                app.set_mouse_hover_candidate(auto_cand);
             } else {
                 app.viewer_state.click.hover_line = None;
                 app.viewer_state.click.hover_gutter_line = None;
                 app.viewer_state.click.hover_symbol = None;
+                app.set_mouse_hover_candidate(None);
             }
         }
         _ => {}

--- a/src/event/overlay_helpers.rs
+++ b/src/event/overlay_helpers.rs
@@ -37,4 +37,6 @@ pub(super) fn dismiss_overlays(app: &mut App) {
     app.review_state.search_active = false;
     app.review_state.template_picker_active = false;
     app.references_overlay.active = false;
+    // A deliberate focus switch closes the hover modal stack too.
+    app.clear_hover();
 }

--- a/src/event/viewer/mod.rs
+++ b/src/event/viewer/mod.rs
@@ -71,6 +71,16 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
                 handle_find_references(app);
                 return;
             }
+            // gK / gh — hover info. Uppercase K (Vim-LSP convention) plus `h`
+            // for "hover"; both are safe here because hint labels are always
+            // lowercase and never start with these carved-out keys. Works in
+            // both plain-file and diff mode: the diff-mode `g` handler already
+            // synced content.file_scroll to the diff cursor before this.
+            KeyCode::Char('K') | KeyCode::Char('h') => {
+                app.symbol_hint_overlay = Default::default();
+                app.show_hover_info();
+                return;
+            }
             KeyCode::Char('g') => {
                 // gg = go to top
                 app.symbol_hint_overlay = Default::default();
@@ -189,6 +199,9 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::JumpForward) => {
             app.jump_forward();
+        }
+        Some(Action::ShowHoverInfo) => {
+            app.show_hover_info();
         }
         _ => {}
     }
@@ -387,6 +400,10 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
             if let Some(path) = app.viewer_state.content.current_file.clone() {
                 app.toggle_path_viewed(&path);
             }
+        }
+        Some(Action::ShowHoverInfo) => {
+            app.viewer_state.sync_file_scroll_to_diff_scroll();
+            app.show_hover_info();
         }
         _ => {}
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -404,6 +404,10 @@ pub(crate) fn run_loop(
         // Poll all background operations.
         app.poll_all_background_ops();
 
+        // Auto-hover: show the popup once the mouse has rested on a symbol past
+        // the idle debounce, and manage its grace window / invalidation.
+        app.tick_hover();
+
         if app.overlays.active == crate::overlay::ActiveOverlay::GrepSearch
             && app.check_grep_debounce()
         {

--- a/src/hover_info.rs
+++ b/src/hover_info.rs
@@ -1,0 +1,282 @@
+//! Symbol hover info — signature, doc comment, and reference count for the
+//! symbol under the viewer cursor.
+//!
+//! Built on the existing tree-sitter [`SymbolIndex`](crate::symbol_index::SymbolIndex)
+//! (no language server): the index locates the definition, then a bounded read
+//! of the definition file extracts the declaration signature and the doc
+//! comment block directly above it. Lookups that find nothing return `None`
+//! so the caller can stay silent.
+
+use crate::symbol_index::SymbolIndex;
+
+/// Maximum number of signature lines collected before truncating with `…`.
+const MAX_SIGNATURE_LINES: usize = 8;
+/// Maximum number of doc-comment lines collected before truncating with `…`.
+const MAX_DOC_LINES: usize = 12;
+
+/// Hover information for a symbol, ready for rendering.
+pub struct HoverInfo {
+    /// The symbol name (popup title).
+    pub symbol_name: String,
+    /// Definition kind (e.g. "Function", "Struct"), from the symbol index.
+    pub kind: String,
+    /// Definition file path, relative to the repo root.
+    pub file_path: String,
+    /// 1-indexed definition line.
+    pub line: usize,
+    /// Doc-comment lines above the definition, comment markers stripped.
+    pub doc_lines: Vec<String>,
+    /// Declaration signature lines (dedented, body-opening brace stripped).
+    pub signature_lines: Vec<String>,
+    /// Number of definitions matching the name (>1 means the shown one is one of several).
+    pub def_count: usize,
+    /// Number of textual references across the repo.
+    pub ref_count: usize,
+}
+
+/// Build hover info for `symbol`. Prefers a definition in `current_file` when
+/// the name is defined in several places. Returns `None` (quietly) when the
+/// index is not ready, the symbol has no definition, or the file can't be read.
+pub fn build_hover_info(
+    index: &SymbolIndex,
+    symbol: &str,
+    current_file: Option<&str>,
+) -> Option<HoverInfo> {
+    if !index.is_available() {
+        return None;
+    }
+    let defs = index.find_definitions(symbol);
+    let def = defs
+        .iter()
+        .find(|d| Some(d.file_path.as_str()) == current_file)
+        .or_else(|| defs.first())?;
+
+    let root = index.root();
+    let source = std::fs::read_to_string(root.join(&def.file_path)).ok()?;
+    let lines: Vec<&str> = source.lines().collect();
+    let def_idx = def.line.checked_sub(1)?;
+    if def_idx >= lines.len() {
+        return None;
+    }
+
+    let ref_count = index.find_references(symbol, &root).len();
+
+    Some(HoverInfo {
+        symbol_name: symbol.to_string(),
+        kind: format!("{:?}", def.kind),
+        file_path: def.file_path.clone(),
+        line: def.line,
+        doc_lines: extract_doc_comment(&lines, def_idx),
+        signature_lines: extract_signature(&lines, def_idx),
+        def_count: defs.len(),
+        ref_count,
+    })
+}
+
+/// Extract the declaration signature starting at `def_idx` (0-indexed):
+/// lines up to and including the first one that ends with `{` (brace stripped)
+/// or `;`/`=`-terminated declarations, capped at [`MAX_SIGNATURE_LINES`].
+/// Lines are dedented by the first line's indentation.
+fn extract_signature(lines: &[&str], def_idx: usize) -> Vec<String> {
+    let indent = lines[def_idx].len() - lines[def_idx].trim_start().len();
+    let mut out = Vec::new();
+    for raw in lines.iter().skip(def_idx).take(MAX_SIGNATURE_LINES) {
+        let dedented = if raw.len() >= indent && raw[..indent.min(raw.len())].trim().is_empty() {
+            &raw[indent..]
+        } else {
+            raw.trim_start()
+        };
+        let trimmed_end = dedented.trim_end();
+        if let Some(stripped) = trimmed_end.strip_suffix('{') {
+            let s = stripped.trim_end();
+            if !s.is_empty() {
+                out.push(s.to_string());
+            }
+            return out;
+        }
+        out.push(trimmed_end.to_string());
+        if trimmed_end.ends_with(';') {
+            return out;
+        }
+    }
+    if lines.len() > def_idx + MAX_SIGNATURE_LINES {
+        out.push("…".to_string());
+    }
+    out
+}
+
+/// Collect the comment block directly above `def_idx` (0-indexed), skipping
+/// attribute/decorator lines (`#[...]`, `@...`). Handles `///`, `//!`, `//`
+/// (Rust/Go) and `/** ... */` (TS/JS) styles; markers are stripped. Capped at
+/// [`MAX_DOC_LINES`] (keeping the opening lines, which carry the summary).
+fn extract_doc_comment(lines: &[&str], def_idx: usize) -> Vec<String> {
+    let mut collected: Vec<String> = Vec::new();
+    let mut i = def_idx;
+    let mut in_block = false; // inside a `/* ... */` scanned bottom-up
+    while i > 0 {
+        i -= 1;
+        let t = lines[i].trim();
+        if in_block {
+            let body = t
+                .trim_start_matches("/**")
+                .trim_start_matches("/*")
+                .trim_start_matches('*')
+                .trim();
+            collected.push(body.to_string());
+            if t.starts_with("/*") {
+                break;
+            }
+            continue;
+        }
+        // Skip attributes/decorators between the doc block and the item.
+        if collected.is_empty() && (t.starts_with("#[") || t.starts_with('@') || t == "]") {
+            continue;
+        }
+        if t.ends_with("*/") && !t.starts_with("//") {
+            let body = t.trim_end_matches("*/").trim_end();
+            // A `/*` opener on the same line means the block was one line.
+            in_block = !body.starts_with("/*");
+            let body = body
+                .trim_start_matches("/**")
+                .trim_start_matches("/*")
+                .trim_start_matches('*')
+                .trim();
+            collected.push(body.to_string());
+            if !in_block {
+                break;
+            }
+        } else if let Some(rest) = t
+            .strip_prefix("///")
+            .or_else(|| t.strip_prefix("//!"))
+            .or_else(|| t.strip_prefix("//"))
+        {
+            collected.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+        } else {
+            break;
+        }
+    }
+    collected.reverse();
+    // Drop leading/trailing empty lines left by block-comment delimiters.
+    while collected.first().is_some_and(|l| l.is_empty()) {
+        collected.remove(0);
+    }
+    while collected.last().is_some_and(|l| l.is_empty()) {
+        collected.pop();
+    }
+    if collected.len() > MAX_DOC_LINES {
+        collected.truncate(MAX_DOC_LINES);
+        collected.push("…".to_string());
+    }
+    collected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(src: &str, def_line_1: usize) -> Vec<String> {
+        let lines: Vec<&str> = src.lines().collect();
+        extract_signature(&lines, def_line_1 - 1)
+    }
+
+    fn doc(src: &str, def_line_1: usize) -> Vec<String> {
+        let lines: Vec<&str> = src.lines().collect();
+        extract_doc_comment(&lines, def_line_1 - 1)
+    }
+
+    #[test]
+    fn signature_single_line_fn() {
+        let src = "pub fn foo(a: usize) -> bool {\n    true\n}\n";
+        assert_eq!(sig(src, 1), vec!["pub fn foo(a: usize) -> bool"]);
+    }
+
+    #[test]
+    fn signature_multi_line_fn() {
+        let src = "fn foo(\n    a: usize,\n    b: &str,\n) -> bool {\n    true\n}\n";
+        assert_eq!(sig(src, 1), vec!["fn foo(", "    a: usize,", "    b: &str,", ") -> bool"]);
+    }
+
+    #[test]
+    fn signature_dedents_indented_method() {
+        let src = "impl Foo {\n    pub fn bar(&self) -> usize {\n        1\n    }\n}\n";
+        assert_eq!(sig(src, 2), vec!["pub fn bar(&self) -> usize"]);
+    }
+
+    #[test]
+    fn signature_stops_at_semicolon() {
+        let src = "type Alias = Vec<String>;\nfn next() {}\n";
+        assert_eq!(sig(src, 1), vec!["type Alias = Vec<String>;"]);
+    }
+
+    #[test]
+    fn doc_rust_triple_slash_with_attribute() {
+        let src = "/// Does the thing.\n/// Second line.\n#[derive(Debug)]\npub struct Foo;\n";
+        assert_eq!(doc(src, 4), vec!["Does the thing.", "Second line."]);
+    }
+
+    #[test]
+    fn doc_go_double_slash() {
+        let src = "// Foo does the thing.\nfunc Foo() {}\n";
+        assert_eq!(doc(src, 2), vec!["Foo does the thing."]);
+    }
+
+    #[test]
+    fn doc_ts_block_comment() {
+        let src = "/**\n * Does the thing.\n * @param a input\n */\nfunction foo(a) {}\n";
+        assert_eq!(doc(src, 5), vec!["Does the thing.", "@param a input"]);
+    }
+
+    #[test]
+    fn doc_none_when_code_above() {
+        let src = "let x = 1;\nfn foo() {}\n";
+        assert!(doc(src, 2).is_empty());
+    }
+
+    #[test]
+    fn doc_single_line_block_comment() {
+        let src = "/** Does the thing. */\nfunction foo() {}\n";
+        assert_eq!(doc(src, 2), vec!["Does the thing."]);
+    }
+
+    #[test]
+    fn end_to_end_over_real_index() {
+        // Build a real tree-sitter index over a temp repo and resolve hover
+        // info through the full path (find_definitions → read → extract).
+        let dir = std::env::temp_dir().join(format!("hover_e2e_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = "\
+/// Adds two numbers together.
+/// Returns their sum.
+pub fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+fn caller() {
+    let _ = add(1, 2);
+}
+";
+        std::fs::write(dir.join("lib.rs"), src).unwrap();
+
+        let index = SymbolIndex::new(dir.clone());
+        index.build().unwrap();
+
+        let info = build_hover_info(&index, "add", Some("lib.rs")).expect("hover info");
+        assert_eq!(info.symbol_name, "add");
+        assert_eq!(info.kind, "Function");
+        assert_eq!(info.file_path, "lib.rs");
+        assert_eq!(info.line, 3);
+        assert_eq!(
+            info.doc_lines,
+            vec!["Adds two numbers together.", "Returns their sum."]
+        );
+        assert_eq!(info.signature_lines, vec!["pub fn add(a: i64, b: i64) -> i64"]);
+        // "add" appears at the definition and one call site.
+        assert!(info.ref_count >= 2, "ref_count = {}", info.ref_count);
+
+        // A name with no definition returns nothing (silent).
+        assert!(build_hover_info(&index, "nonexistent_symbol", None).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -114,6 +114,9 @@ keymap_suite::actions! {
         // ── Code navigation ─────────────────────────────────────────
         JumpBack => "jump_back",
         JumpForward => "jump_forward",
+        /// Show a hover popup with the type/signature, doc comment, and
+        /// reference count of the symbol under the viewer cursor.
+        ShowHoverInfo => "show_hover_info",
         ToggleInlineThread => "toggle_inline_thread",
         InlineReply => "inline_reply",
 
@@ -258,6 +261,7 @@ impl Action {
             Action::SearchFullText => "Full-text search (grep)",
             Action::JumpBack => "Jump back (history)",
             Action::JumpForward => "Jump forward (history)",
+            Action::ShowHoverInfo => "Show hover info (signature/doc)",
             Action::ToggleInlineThread => "Toggle inline comment thread",
             Action::InlineReply => "Inline reply",
             Action::NextHunk => "Next hunk",

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod gemini_api;
 mod git_engine;
 mod go_test;
 mod grep_search;
+mod hover_info;
 mod jump_history;
 mod keymap;
 mod media_state;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -222,6 +222,110 @@ pub struct SymbolActionOverlay {
     pub source_screen_row: usize,
 }
 
+/// A symbol the mouse/cursor is resting on, awaiting the idle debounce before
+/// its hover popup is resolved. `resolved` flips true once we've attempted the
+/// lookup (whether or not it produced a popup) so the per-frame tick doesn't
+/// recompute every frame while the cursor sits still.
+pub struct HoverCandidate {
+    /// Identifier under the cursor/mouse.
+    pub symbol: String,
+    /// 1-indexed content line the symbol is on.
+    pub line: usize,
+    /// File the symbol is in, for definition disambiguation.
+    pub file: Option<String>,
+    /// Absolute screen row of the symbol — the popup anchors just below (or
+    /// above, if there's no room) this row.
+    pub anchor_row: u16,
+    /// Absolute screen column of the symbol's start, for horizontal placement.
+    pub anchor_col: u16,
+    /// When the cursor/mouse came to rest on this symbol.
+    pub since: std::time::Instant,
+    /// Whether the lookup has already run for this candidate.
+    pub resolved: bool,
+}
+
+/// A code preview (level 2): a window of source lines around a reference,
+/// shown when a row in the references list is clicked.
+pub struct HoverPreview {
+    /// File the preview is from (repo-relative).
+    pub file: String,
+    /// 1-indexed reference line the preview is centered on.
+    pub center_line: usize,
+    /// `(1-indexed line number, text)` for each shown line.
+    pub lines: Vec<(usize, String)>,
+    /// Rendered rect, written by the renderer for hit-testing.
+    pub rect: ratatui::layout::Rect,
+}
+
+/// The references list (level 1), opened by clicking `N refs` in the base hover
+/// popup. Mouse-first: rows are clickable to open a [`HoverPreview`].
+pub struct HoverRefs {
+    /// Symbol whose references these are (list title).
+    pub symbol: String,
+    /// All references found.
+    pub results: Vec<crate::symbol_index::Reference>,
+    /// Highlighted row (for keyboard nav / preview target).
+    pub selected: usize,
+    /// First visible row index.
+    pub scroll: usize,
+    /// Rendered list-popup rect, written by the renderer.
+    pub rect: ratatui::layout::Rect,
+    /// `(result index, row rect)` for each visible row, written by the renderer.
+    pub row_hits: Vec<(usize, ratatui::layout::Rect)>,
+    /// The open preview, if a row was clicked.
+    pub preview: Option<HoverPreview>,
+}
+
+/// Symbol hover-info popup — signature/doc/references for the symbol under the
+/// viewer cursor. Shown automatically when the mouse rests on a symbol or the
+/// keyboard cursor sits idle; `info` is the resolved popup (`None` = hidden),
+/// `pending` is the candidate counting down the idle debounce. `anchor_row`/
+/// `anchor_col` are the screen position of the resolved symbol, for placement.
+///
+/// It can escalate into an interactive modal stack: clicking `N refs` pins the
+/// popup and opens [`HoverRefs`]; clicking a row opens a [`HoverPreview`].
+/// `pinned` popups survive focus/idle loss until Esc or a click outside;
+/// `leave_at` is the short grace window keeping a still-transient popup alive
+/// after the mouse leaves the symbol (so the cursor can reach it to click).
+#[derive(Default)]
+pub struct HoverInfoOverlay {
+    pub info: Option<crate::hover_info::HoverInfo>,
+    pub pending: Option<HoverCandidate>,
+    pub anchor_row: u16,
+    pub anchor_col: u16,
+    pub pinned: bool,
+    pub leave_at: Option<std::time::Instant>,
+    /// The viewed file the current `info` was resolved against. When the viewer
+    /// switches files underneath a (non-pinned) popup, this no longer matches
+    /// `content.current_file`, and the tick drops the now-stale popup.
+    pub shown_file: Option<String>,
+    /// Base popup rect, written by the renderer for hit-testing.
+    pub info_rect: ratatui::layout::Rect,
+    /// The `N refs` clickable region within the base popup (zero-sized if the
+    /// symbol has no references), written by the renderer.
+    pub refs_hit: ratatui::layout::Rect,
+    pub refs: Option<HoverRefs>,
+}
+
+impl HoverInfoOverlay {
+    /// Whether any part of the hover modal stack is showing.
+    pub fn is_shown(&self) -> bool {
+        self.info.is_some()
+    }
+
+    /// Reset the whole hover modal stack to hidden/unpinned.
+    pub fn reset(&mut self) {
+        self.info = None;
+        self.pending = None;
+        self.pinned = false;
+        self.leave_at = None;
+        self.shown_file = None;
+        self.refs = None;
+        self.info_rect = ratatui::layout::Rect::default();
+        self.refs_hit = ratatui::layout::Rect::default();
+    }
+}
+
 /// Help overlay state.
 pub struct HelpOverlay {
     pub context: Focus,

--- a/src/ui/hover_info.rs
+++ b/src/ui/hover_info.rs
@@ -1,0 +1,293 @@
+//! Hover-info popup — renders the symbol's signature, doc comment, and a
+//! clickable reference count (LSP-`hover`-style), and, when the user clicks
+//! into it, the interactive references list (level 1) and code preview (level
+//! 2). The popup anchors to the hovered symbol within the Viewer panel.
+//!
+//! Each level records its rendered `Rect` (and the refs list its per-row rects)
+//! back onto `app.hover_info_overlay` so the mouse layer can hit-test clicks.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use crate::app::App;
+
+/// Render the hover popup and any open child levels over `area` (the frame).
+pub fn render_hover_info_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
+    if app.hover_info_overlay.info.is_none() {
+        return;
+    }
+    let host = {
+        let vr = app.layout_cache.columns[2];
+        if vr.width > 0 && vr.height > 0 { vr } else { area }
+    };
+    render_base_popup(frame, host, app);
+    // Level 1: references list (pinned). Level 2: preview.
+    if app.hover_info_overlay.refs.is_some() {
+        render_refs_list(frame, host, app);
+        if app
+            .hover_info_overlay
+            .refs
+            .as_ref()
+            .is_some_and(|r| r.preview.is_some())
+        {
+            render_preview(frame, host, app);
+        }
+    }
+}
+
+/// The base signature/doc popup, with a clickable `N refs` footer row.
+fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
+    let theme = app.theme.clone();
+    // Pull owned data so the immutable borrow of `info` ends before we write
+    // the hit-test rects back onto `app.hover_info_overlay`.
+    let (symbol_name, signature_lines, doc_lines, loc, ref_count) = {
+        let info = app.hover_info_overlay.info.as_ref().unwrap();
+        let mut loc = format!("{}  {}:{}", info.kind, info.file_path, info.line);
+        if info.def_count > 1 {
+            loc.push_str(&format!("  (+{} defs)", info.def_count - 1));
+        }
+        (
+            info.symbol_name.clone(),
+            info.signature_lines.clone(),
+            info.doc_lines.clone(),
+            loc,
+            info.ref_count,
+        )
+    };
+    let refs_present = ref_count > 0;
+
+    // Body lines: signature, doc, then a location footer.
+    let mut body: Vec<Line> = Vec::new();
+    for sig in &signature_lines {
+        body.push(Line::from(Span::styled(
+            sig.clone(),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        )));
+    }
+    if !doc_lines.is_empty() {
+        body.push(Line::from(""));
+        for doc in &doc_lines {
+            body.push(Line::from(Span::styled(doc.clone(), Style::default().fg(theme.fg))));
+        }
+    }
+    body.push(Line::from(""));
+    body.push(Line::from(Span::styled(loc, Style::default().fg(theme.muted))));
+
+    // The clickable refs row (drawn on its own reserved bottom line).
+    let refs_label = format!("▸ {ref_count} refs — click to list");
+
+    // Width fits the widest of body + refs row.
+    let content_w = body
+        .iter()
+        .map(|l| l.width())
+        .chain(std::iter::once(refs_label.chars().count()))
+        .max()
+        .unwrap_or(20)
+        .clamp(20, 100) as u16;
+    let popup_width = (content_w + 4).min(host.width.saturating_sub(2)).max(4);
+    let inner_w = popup_width.saturating_sub(4).max(1) as usize;
+    let body_h: usize = body
+        .iter()
+        .map(|l| {
+            let w = l.width();
+            if w == 0 { 1 } else { w.div_ceil(inner_w).max(1) }
+        })
+        .sum();
+    let inner_h = (body_h + if refs_present { 1 } else { 0 }).max(1);
+    let popup_height = (inner_h as u16 + 2).min(host.height.saturating_sub(2)).max(3);
+
+    let popup_area = place(host, app.hover_info_overlay.anchor_row, app.hover_info_overlay.anchor_col, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+    let block = Block::default()
+        .title(format!(" {symbol_name} "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_focused));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let refs_hit = if refs_present && inner.height >= 1 {
+        let body_area = Rect::new(inner.x, inner.y, inner.width, inner.height - 1);
+        let refs_row = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
+        frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), body_area);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                refs_label,
+                Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            ))),
+            refs_row,
+        );
+        refs_row
+    } else {
+        frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), inner);
+        Rect::default()
+    };
+
+    app.hover_info_overlay.info_rect = popup_area;
+    app.hover_info_overlay.refs_hit = refs_hit;
+}
+
+/// The references list (level 1) — anchored below the base popup (above if no
+/// room), with clickable rows.
+fn render_refs_list(frame: &mut Frame, host: Rect, app: &mut App) {
+    let theme = app.theme.clone();
+    let base = app.hover_info_overlay.info_rect;
+    let Some(refs) = app.hover_info_overlay.refs.as_mut() else {
+        return;
+    };
+
+    let count = refs.results.len();
+    let title = format!(" {} · {} refs ", refs.symbol, count);
+
+    // Width: fit the host, capped.
+    let popup_width = host.width.saturating_sub(2).min(90).max(20);
+    let inner_w = popup_width.saturating_sub(2).max(1) as usize;
+    let max_rows = (host.height / 2).clamp(3, 14);
+    let visible = (count as u16).min(max_rows).max(1);
+    let popup_height = visible + 2;
+
+    // Prefer below the base popup; else above; clamp into host.
+    let below_y = base.y + base.height;
+    let y = if below_y + popup_height <= host.y + host.height {
+        below_y
+    } else {
+        base.y.saturating_sub(popup_height).max(host.y)
+    };
+    let x = base
+        .x
+        .min((host.x + host.width).saturating_sub(popup_width))
+        .max(host.x);
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    // Keep the selection visible.
+    let vis = visible as usize;
+    if refs.selected < refs.scroll {
+        refs.scroll = refs.selected;
+    } else if refs.selected >= refs.scroll + vis {
+        refs.scroll = refs.selected + 1 - vis;
+    }
+
+    frame.render_widget(Clear, popup_area);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_focused));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let mut row_hits = Vec::new();
+    for (row, idx) in (refs.scroll..(refs.scroll + vis).min(count)).enumerate() {
+        let r = &refs.results[idx];
+        let text = format!("{}:{}  {}", r.file_path, r.line, r.content.trim());
+        let text: String = text.chars().take(inner_w).collect();
+        let selected = idx == refs.selected;
+        let style = if selected {
+            Style::default().fg(theme.selected_fg).bg(theme.selected_bg)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        let row_area = Rect::new(inner.x, inner.y + row as u16, inner.width, 1);
+        frame.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), row_area);
+        row_hits.push((idx, row_area));
+    }
+    refs.rect = popup_area;
+    refs.row_hits = row_hits;
+}
+
+/// The code preview (level 2) — surrounding source lines around the clicked
+/// reference, anchored to the right of the list if it fits, else below.
+fn render_preview(frame: &mut Frame, host: Rect, app: &mut App) {
+    let theme = app.theme.clone();
+    let list_rect = app
+        .hover_info_overlay
+        .refs
+        .as_ref()
+        .map(|r| r.rect)
+        .unwrap_or_default();
+    let Some(preview) = app
+        .hover_info_overlay
+        .refs
+        .as_mut()
+        .and_then(|r| r.preview.as_mut())
+    else {
+        return;
+    };
+
+    let title = format!(" {}:{} ", preview.file, preview.center_line);
+    let content_w = preview
+        .lines
+        .iter()
+        .map(|(n, t)| format!("{n:>5} {t}").chars().count())
+        .chain(std::iter::once(title.chars().count()))
+        .max()
+        .unwrap_or(30) as u16;
+    let popup_width = (content_w + 2).min(host.width.saturating_sub(2)).max(10);
+    let popup_height = (preview.lines.len() as u16 + 2).min(host.height.saturating_sub(2)).max(3);
+
+    // Right of the list if it fits, else below it, clamped into host.
+    let right_x = list_rect.x + list_rect.width;
+    let (x, y) = if right_x + popup_width <= host.x + host.width {
+        (right_x, list_rect.y)
+    } else {
+        let below = list_rect.y + list_rect.height;
+        let y = if below + popup_height <= host.y + host.height {
+            below
+        } else {
+            (host.y + host.height).saturating_sub(popup_height).max(host.y)
+        };
+        let x = list_rect
+            .x
+            .min((host.x + host.width).saturating_sub(popup_width))
+            .max(host.x);
+        (x, y)
+    };
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let lines: Vec<Line> = preview
+        .lines
+        .iter()
+        .map(|(n, t)| {
+            let is_center = *n == preview.center_line;
+            let num_style = Style::default().fg(theme.muted);
+            let text_style = if is_center {
+                Style::default().fg(theme.fg).bg(theme.selected_bg).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.fg)
+            };
+            Line::from(vec![
+                Span::styled(format!("{n:>5} "), num_style),
+                Span::styled(t.clone(), text_style),
+            ])
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(lines), inner);
+    preview.rect = popup_area;
+}
+
+/// Place a popup of the given size within `host`, anchored to a symbol screen
+/// position: just below the anchor row when there's room, otherwise above.
+fn place(host: Rect, anchor_row: u16, anchor_col: u16, w: u16, h: u16) -> Rect {
+    let host_top = host.y + 1;
+    let host_bottom = host.y + host.height.saturating_sub(1);
+    let anchor_row = anchor_row.clamp(host_top, host_bottom.saturating_sub(1));
+    let room_below = host_bottom.saturating_sub(anchor_row + 1);
+    let y = if room_below >= h {
+        anchor_row + 1
+    } else {
+        anchor_row.saturating_sub(h).max(host_top)
+    };
+    let max_x = (host.x + host.width).saturating_sub(w);
+    let x = anchor_col.clamp(host.x, max_x.max(host.x));
+    Rect::new(x, y, w, h)
+}

--- a/src/ui/layout/overlays.rs
+++ b/src/ui/layout/overlays.rs
@@ -150,6 +150,11 @@ pub(super) fn render_overlays(frame: &mut Frame, area: Rect, app: &mut App) {
         crate::ui::symbol_action::render_symbol_action_overlay(frame, area, app);
     }
 
+    // ── Hover-info popup (K in the viewer) ──
+    if app.hover_info_overlay.info.is_some() {
+        crate::ui::hover_info::render_hover_info_overlay(frame, area, app);
+    }
+
     // ── Skip reason modal ────────────────────────────────────────────
     if let Some(ref reason) = app.worktree_mgr.skip_reason {
         render_skip_reason_overlay(frame, area, reason, &app.theme);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -27,6 +27,7 @@ pub mod layout;
 // Overlay renderers (used from layout::render_ui overlays).
 pub mod dashboard;
 pub mod grep_search;
+pub mod hover_info;
 pub mod panel_overlay;
 pub mod references;
 pub mod review;


### PR DESCRIPTION
## Summary

Adds an automatic, tree-sitter-based symbol hover popup to the Viewer (no LSP), plus an interactive references modal stack.

- **Auto hover (mouse-driven)**: resting the mouse on a self-defined symbol shows a popup with its kind, signature, doc comment, definition location, and reference count. On whitespace/comments → nothing. Works in both file and diff mode.
- **Symbol-anchored placement**: the popup appears next to the hovered symbol within the Viewer (below if there's room, else above), not fixed top-right.
- **Interactive references (`N refs`)**: clicking `N refs` pins the popup and opens a references list (level 1); clicking a row opens a surrounding-code preview (level 2); clicking the preview or pressing Enter jumps there. Esc pops one level at a time; a short grace window + click-to-pin keep the modal reachable after the mouse leaves.
- **Manual trigger**: `K` explicitly shows hover for the symbol on the cursor (top) line, with status feedback.
- Core builder in `src/hover_info.rs` (signature/doc extraction for Rust/Go/TS/JS, definition-in-current-file preference); rendering in `src/ui/hover_info.rs`.

### Correctness fixes
- `extract_symbol_from_line` now skips comment/attribute lines, so an English word in a doc comment (e.g. `//! Building …`) no longer resolves to a same-named type.
- Auto hover is purely mouse-position driven (dropped the top-line keyboard-idle heuristic, which fired for code the user wasn't pointing at).
- Stale-file guard drops any popup when the viewer switches files underneath it.

Version: 0.89.2 → 0.90.0 (minor — additive feature).

## Test plan

- `cargo test` — 618 passed (includes new unit tests for comment/attribute skipping in symbol extraction and hover-preview windowing).
- `cargo clippy` — clean.
- `cargo build` / `cargo install --path .` — succeed.
- Manual: hover a symbol → popup with signature/doc/refs; hover whitespace or a comment → nothing; click `N refs` → list → row → preview → jump; switch files → stale popup clears.