### PR TITLE
fix: resolve scrollback transcript strictly by pinned session id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.90.0"
+version = "0.90.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.90.0"
+version = "0.90.1"
 edition = "2024"
 
 [dependencies]

--- a/src/app/reflow.rs
+++ b/src/app/reflow.rs
@@ -66,34 +66,53 @@ impl App {
 
     /// Enter the reflow transcript view for the active Claude panel's session.
     ///
-    /// Resolves the session backing the currently displayed Claude panel (via
-    /// its pinned `claude_session_id`), loads and parses that `.jsonl` file, and
-    /// activates the overlay. Falls back to the selected worktree's most recent
-    /// session only when the panel has no tracked id. If no session is found or
-    /// the log is empty, a status flash is shown and the view stays inactive.
+    /// Resolves the log of the session backing the currently displayed Claude
+    /// panel — strictly by its pinned `claude_session_id` — then loads and parses
+    /// that `.jsonl` and activates the overlay. When the id does not resolve to a
+    /// log, or the log holds no displayable turn, a status flash explains why and
+    /// the view stays inactive; no other session's history is ever substituted.
     pub fn open_reflow(&mut self) {
-        // Prefer the session backing the *currently displayed* Claude panel. A
-        // worktree can host several Claude panels (CC:1, CC:2, …), so resolving
-        // "the worktree's latest session" would open whichever log was written
-        // most recently regardless of which panel is on screen — that is the
-        // cross-panel scroll bleed this view used to suffer from. The pinned
-        // per-session id (see `PtySession::claude_session_id`) ties the
-        // transcript to the panel the user is actually looking at.
-        let resolved = self
+        // The transcript source is the session backing the *currently displayed*
+        // Claude panel, identified only by its pinned session id (see
+        // `PtySession::claude_session_id`).
+        //
+        // Nothing here may widen to a directory-level criterion. One Claude
+        // project dir holds the logs of every session ever run in that worktree
+        // — sibling Conductor panels (CC:1, CC:2, …), earlier runs, plain
+        // `claude` invocations — so "the freshest log" or "the log whose first
+        // turn follows this one's last turn" can name a different conversation.
+        // The latter is how this view used to show the wrong session's history:
+        // it treated a later-starting log as the continuation of a `/clear`
+        // rotation, which held only while the pinned session kept writing turns.
+        // A panel whose main agent is stopped while a subagent still works
+        // writes nothing to its session log (subagent turns go to
+        // `<session-id>/subagents/*.jsonl`), so its last turn froze and any
+        // session started later in the same worktree passed the test and
+        // hijacked the view for as long as the subagent ran.
+        //
+        // Consequence worth knowing: a mid-session `/clear` or an in-app
+        // `/resume` rotates Claude Code's live log to a new session id that
+        // Conductor cannot observe, so scrolling up then shows this session's
+        // pre-rotation transcript. Stale-but-own beats fresh-but-someone-else's.
+        let Some((working_dir, session_id)) = self
             .terminal
             .active_claude_session
-            .and_then(|idx| self.terminal.pty_manager.claude_session_ref(idx));
+            .and_then(|idx| self.terminal.pty_manager.claude_session_ref(idx))
+        else {
+            self.set_status(
+                "No Claude session for this panel; transcript unavailable".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        };
 
-        // Working dir of the selected worktree, used for the mtime fallback.
-        let working_dir = match self.worktrees.get(self.selected_worktree) {
-            Some(wt) => wt.path.clone(),
-            None => {
-                self.set_status(
-                    "No worktree selected for transcript view".to_string(),
-                    StatusLevel::Warning,
-                );
-                return;
-            }
+        let Some(path) = crate::claude_sessions::session_jsonl_path(&working_dir, &session_id)
+        else {
+            self.set_status(
+                format!("No session log on disk for {session_id}"),
+                StatusLevel::Warning,
+            );
+            return;
         };
 
         // Parse the log on a background thread: `load_session` reads and
@@ -102,65 +121,7 @@ impl App {
         // activates immediately with a "Loading…" placeholder and
         // `poll_reflow_load` swaps the entries in when they arrive.
         self.bg.reflow_load.start(move |tx| {
-            // 1. Prefer the active panel's pinned session id. When a worktree
-            //    hosts several Claude panels (CC:1, CC:2, …) this ties the
-            //    transcript to the panel actually on screen, avoiding
-            //    cross-panel scroll bleed.
-            let pinned_path = resolved
-                .and_then(|(wd, sid)| crate::claude_sessions::session_jsonl_path(&wd, &sid));
-            let mut entries = pinned_path
-                .as_ref()
-                .map(|path| crate::claude_log::load_session(path))
-                .unwrap_or_default();
-
-            // 1b. Follow a mid-session `/clear` (or in-app `/resume`). Claude
-            //     Code mints a *new* session file on `/clear`, so the pinned
-            //     file freezes with the pre-clear conversation while the live
-            //     turns land in a different log — scrolling up would otherwise
-            //     open onto the stale pre-clear transcript. Prefer the freshest
-            //     log in the project dir that is a *temporal continuation* of
-            //     the pinned session: one whose first turn is at/after the
-            //     pinned session's last turn. Because a concurrently-active
-            //     sibling panel overlaps the pinned session in time, its first
-            //     turn predates the pinned session's last turn and it is never
-            //     mistaken for the continuation — the per-panel pin (and its
-            //     cross-panel-bleed guarantee) is preserved.
-            if let Some(pinned) = pinned_path.as_ref()
-                && !entries.is_empty()
-                && let Some(pinned_last) = crate::claude_log::session_last_timestamp(pinned)
-            {
-                let live = crate::claude_sessions::session_logs_by_mtime(&working_dir)
-                    .into_iter()
-                    .filter(|p| p.as_path() != pinned.as_path())
-                    .find(|p| {
-                        crate::claude_log::session_first_timestamp(p)
-                            .is_some_and(|first| first >= pinned_last)
-                    });
-                if let Some(live_path) = live {
-                    let live_entries = crate::claude_log::load_session(&live_path);
-                    if !live_entries.is_empty() {
-                        entries = live_entries;
-                    }
-                }
-            }
-
-            // 2. Fall back to the most-recently-written log in this worktree's
-            //    project dir when the pinned session is missing or empty. This
-            //    is what catches a manual in-app `/resume` sent before any turn
-            //    was typed: it switches the live session id away from the
-            //    conductor-launched (pinned) one, so the pinned file is
-            //    stale/empty while the real transcript is whatever Claude is now
-            //    appending to (= freshest mtime). Empty/aux logs (e.g. one-shot
-            //    security-review runs sharing the dir) are skipped.
-            if entries.is_empty() {
-                entries = crate::claude_sessions::session_logs_by_mtime(&working_dir)
-                    .iter()
-                    .map(|path| crate::claude_log::load_session(path))
-                    .find(|e| !e.is_empty())
-                    .unwrap_or_default();
-            }
-
-            let _ = tx.send(entries);
+            let _ = tx.send(crate::claude_log::load_session(&path));
         });
 
         self.reflow = ReflowView {

--- a/src/claude_log/mod.rs
+++ b/src/claude_log/mod.rs
@@ -10,8 +10,7 @@
 //! Split by responsibility: [`schema`] holds the raw serde types (one-to-one
 //! with the JSONL schema), [`model`] holds the display-ready types, [`convert`]
 //! normalises raw records into display blocks, and [`session`] is the public
-//! file-reading API ([`load_session`], [`session_first_timestamp`],
-//! [`session_last_timestamp`]).
+//! file-reading API ([`load_session`]).
 
 mod convert;
 mod model;
@@ -20,7 +19,7 @@ mod session;
 #[cfg(test)]
 mod tests;
 
-pub use session::{load_session, session_first_timestamp, session_last_timestamp};
+pub use session::load_session;
 
 // `DisplayBlock` and `Role` are consumed externally (via `crate::claude_log::X`)
 // by `ui/reflow_view.rs`; `LogEntry` likewise by `app/reflow.rs`. The rest of

--- a/src/claude_log/schema.rs
+++ b/src/claude_log/schema.rs
@@ -28,13 +28,6 @@ pub struct LogRecord {
     pub operation: Option<String>,
     #[serde(default)]
     pub content: Option<String>,
-    /// ISO-8601 UTC (`…Z`) wall-clock stamp on turn records. Used to detect a
-    /// mid-session `/clear` (or in-app `/resume`), which rotates Claude Code's
-    /// live log to a *new* session file: the continuation begins at/after the
-    /// pinned session's last turn. All stamps share one machine-clock UTC
-    /// format, so lexicographic string order equals chronological order.
-    #[serde(default)]
-    pub timestamp: Option<String>,
 }
 
 /// The `message` field present on `user` and `assistant` records.

--- a/src/claude_log/session.rs
+++ b/src/claude_log/session.rs
@@ -1,6 +1,4 @@
-//! Public file-reading API: parse a session log into display entries, and
-//! read its first/last top-level timestamps for mid-session rotation
-//! detection.
+//! Public file-reading API: parse a session log into display entries.
 
 use std::path::Path;
 
@@ -88,47 +86,4 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
         });
     }
     entries
-}
-
-/// First top-level `timestamp` in a session log (the session's start time).
-///
-/// Scans from the top and stops at the first record that carries one — the
-/// leading `mode` / `file-history-snapshot` bookkeeping records have none, so a
-/// few lines are read before the first real turn. Returns `None` for an
-/// unreadable file or one with no timestamps (a pre-timestamp log format).
-pub fn session_first_timestamp(path: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(path).ok()?;
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Ok(record) = serde_json::from_str::<LogRecord>(line)
-            && let Some(ts) = record.timestamp
-        {
-            return Some(ts);
-        }
-    }
-    None
-}
-
-/// Last top-level `timestamp` in a session log (the session's last activity).
-///
-/// Reads the whole file and keeps the final timestamp seen. Returns `None` for
-/// an unreadable file or one with no timestamps.
-pub fn session_last_timestamp(path: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(path).ok()?;
-    let mut last = None;
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Ok(record) = serde_json::from_str::<LogRecord>(line)
-            && let Some(ts) = record.timestamp
-        {
-            last = Some(ts);
-        }
-    }
-    last
 }

--- a/src/claude_log/tests.rs
+++ b/src/claude_log/tests.rs
@@ -1,10 +1,10 @@
 //! Unit tests for claude_log: wrapper-tag normalisation, content-to-block
-//! conversion, `load_session` integration, and session timestamp bounds.
+//! conversion, and `load_session` integration.
 
 use super::convert::{content_to_display_blocks, result_lines, summarise_tool_input};
 use super::model::{DisplayBlock, Role, TOOL_RESULT_PREVIEW_LINES};
 use super::schema::{LogRecord, TextOnly, ToolResultContent};
-use super::session::{load_session, session_first_timestamp, session_last_timestamp};
+use super::session::load_session;
 
 fn parse_msg_content(json: &str) -> Vec<DisplayBlock> {
     let r: LogRecord = serde_json::from_str(json).expect("valid test json");
@@ -399,59 +399,4 @@ fn load_session_includes_enqueued_prompts_skips_removes() {
 fn load_session_missing_file_returns_empty() {
     let entries = load_session(std::path::Path::new("/nonexistent/path.jsonl"));
     assert!(entries.is_empty());
-}
-
-// ── Session timestamp bounds (mid-session /clear rotation detection) ──────
-
-#[test]
-fn timestamp_bounds_skip_leading_bookkeeping_records() {
-    // A fresh session opens with `mode` / `file-history-snapshot` records
-    // that carry no top-level timestamp; the bounds must come from the
-    // first and last *turn* records instead.
-    let f = write_jsonl(&[
-        r#"{"type":"mode","mode":"normal","sessionId":"s"}"#,
-        r#"{"type":"file-history-snapshot","messageId":"m"}"#,
-        r#"{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-07-06T03:15:21.896Z"}"#,
-        r#"{"type":"assistant","message":{"role":"assistant","content":"yo"},"timestamp":"2026-07-06T03:16:00.000Z"}"#,
-    ]);
-    assert_eq!(
-        session_first_timestamp(f.path()).as_deref(),
-        Some("2026-07-06T03:15:21.896Z")
-    );
-    assert_eq!(
-        session_last_timestamp(f.path()).as_deref(),
-        Some("2026-07-06T03:16:00.000Z")
-    );
-}
-
-#[test]
-fn timestamp_bounds_none_for_timestampless_log() {
-    // A pre-timestamp log format yields None, which disables rotation
-    // detection (the caller falls back to the pinned session).
-    let f = write_jsonl(&[
-        r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
-    ]);
-    assert!(session_first_timestamp(f.path()).is_none());
-    assert!(session_last_timestamp(f.path()).is_none());
-}
-
-#[test]
-fn continuation_starts_at_or_after_pinned_last_turn() {
-    // The rotation-detection predicate: a post-`/clear` continuation begins
-    // at/after the pinned session's last turn (string compare == chrono
-    // order for uniform UTC stamps), while a concurrent sibling panel's
-    // first turn predates it and is rejected.
-    let pinned = write_jsonl(&[
-        r#"{"type":"user","message":{"role":"user","content":"a"},"timestamp":"2026-07-06T03:00:00.000Z"}"#,
-        r#"{"type":"assistant","message":{"role":"assistant","content":"b"},"timestamp":"2026-07-06T03:10:00.000Z"}"#,
-    ]);
-    let continuation = write_jsonl(&[
-        r#"{"type":"user","message":{"role":"user","content":"c"},"timestamp":"2026-07-06T03:10:00.000Z"}"#,
-    ]);
-    let sibling = write_jsonl(&[
-        r#"{"type":"user","message":{"role":"user","content":"d"},"timestamp":"2026-07-06T03:05:00.000Z"}"#,
-    ]);
-    let pinned_last = session_last_timestamp(pinned.path()).unwrap();
-    assert!(session_first_timestamp(continuation.path()).unwrap() >= pinned_last);
-    assert!(session_first_timestamp(sibling.path()).unwrap() < pinned_last);
 }

--- a/src/claude_sessions/discovery.rs
+++ b/src/claude_sessions/discovery.rs
@@ -1,5 +1,5 @@
-//! Listing resumable sessions: full history scan, per-worktree latest-session
-//! lookup, and mtime-ordered session logs for the reflow transcript view.
+//! Listing resumable sessions: full history scan and per-worktree
+//! latest-session lookup.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -7,8 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use super::{
-    ClaudeHistoryEntry, ResumableSession, format_time_ago, history_file_path, projects_dir_for,
-    session_file_exists,
+    ClaudeHistoryEntry, ResumableSession, format_time_ago, history_file_path, session_file_exists,
 };
 
 /// Load all resumable Claude sessions, optionally filtered to a specific project path.
@@ -195,49 +194,8 @@ pub fn find_latest_sessions_for_paths(
     Ok(result)
 }
 
-/// List the session `.jsonl` files in a worktree's Claude project directory,
-/// most recently modified first.
-///
-/// This is the basis for the reflow transcript view's session selection: the
-/// file Claude is *currently appending to* always has the freshest mtime, so
-/// picking by mtime tracks whatever session the live pane shows — including a
-/// session the user switched to with a manual `/resume` (which can mint a new
-/// session ID). That is more reliable than re-deriving the session from
-/// `history.jsonl`, whose newest entry can point at an unrelated auxiliary
-/// session (e.g. a one-shot security review run in the same directory) or at a
-/// freshly-spawned-but-empty session.
-///
-/// The working dir is canonicalized first because Claude Code encodes its
-/// *resolved* cwd; symlinked worktree paths would otherwise miss the directory.
-/// Symlinked session files (created by `migrate_session` for grabbed branches)
-/// are followed via `metadata()`; dangling or unreadable entries are skipped.
-pub fn session_logs_by_mtime(working_dir: &Path) -> Vec<PathBuf> {
-    let canonical = std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
-    let dir = match projects_dir_for(&canonical) {
-        Some(d) => d,
-        None => return Vec::new(),
-    };
-
-    let read_dir = match std::fs::read_dir(&dir) {
-        Ok(rd) => rd,
-        Err(_) => return Vec::new(),
-    };
-
-    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        // metadata() follows symlinks, so a migrated session resolves to its
-        // real file's mtime; a dangling symlink errors out and is skipped.
-        if let Ok(meta) = std::fs::metadata(&path)
-            && let Ok(mtime) = meta.modified()
-        {
-            files.push((mtime, path));
-        }
-    }
-
-    files.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
-    files.into_iter().map(|(_, p)| p).collect()
-}
+// NOTE: there is deliberately no "list the project dir's logs by mtime" helper
+// here. The reflow transcript view used to select its source that way and it
+// leaked other sessions' conversations into the view (see `App::open_reflow`);
+// a transcript is resolved from the panel's own session id via
+// `session_jsonl_path` instead.

--- a/src/claude_sessions/mod.rs
+++ b/src/claude_sessions/mod.rs
@@ -13,8 +13,10 @@ use serde::Deserialize;
 
 mod discovery;
 mod migrate;
+#[cfg(test)]
+mod tests;
 
-pub use discovery::{find_latest_sessions_for_paths, load_resumable_sessions, session_logs_by_mtime};
+pub use discovery::{find_latest_sessions_for_paths, load_resumable_sessions};
 pub use migrate::{migrate_session, unmigrate_session};
 
 /// A single entry from `~/.claude/history.jsonl`.
@@ -71,11 +73,41 @@ fn session_file_exists(session_id: &str, project: &str) -> bool {
 
 /// Return the `.jsonl` path for the given working directory and session ID.
 ///
-/// Mirrors the path that `session_file_exists` checks so callers can open
-/// the file directly. Returns `None` if the home directory is unavailable.
+/// The session id is the only key: one project directory holds the logs of
+/// *every* session ever run in that directory, so resolution must never widen to
+/// a directory-level criterion (see [`session_log_in_dir`]). Returns `None` when
+/// the home directory is unavailable or that session has no log on disk.
+///
+/// The working dir is canonicalized first because Claude Code encodes its
+/// *resolved* cwd; a symlinked worktree path would otherwise miss the directory.
+/// The raw path is tried as a second encoding so a worktree that no longer
+/// resolves (deleted, unmounted) still finds its log — both attempts look up the
+/// same session id, so this widens only *where* the log is looked for, never
+/// *which* session is shown.
 pub fn session_jsonl_path(working_dir: &Path, session_id: &str) -> Option<PathBuf> {
-    let dir = projects_dir_for(working_dir)?;
-    Some(dir.join(format!("{session_id}.jsonl")))
+    let canonical =
+        std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
+    for dir in [canonical.as_path(), working_dir] {
+        if let Some(project_dir) = projects_dir_for(dir)
+            && let Some(path) = session_log_in_dir(&project_dir, session_id)
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// The log of exactly `session_id` inside an already-resolved Claude project
+/// directory, or `None` when that session has no log there.
+///
+/// Deliberately ignores every sibling `.jsonl` in the directory. Siblings are
+/// *different conversations* — other Conductor panels on the same worktree,
+/// earlier runs, plain `claude` invocations — so picking one by mtime or by any
+/// other directory-level heuristic shows the user someone else's history. When
+/// the id does not resolve, the answer is "no history", not "some history".
+pub fn session_log_in_dir(project_dir: &Path, session_id: &str) -> Option<PathBuf> {
+    let path = project_dir.join(format!("{session_id}.jsonl"));
+    path.exists().then_some(path)
 }
 
 /// Return the Claude projects directory for a given working directory path.

--- a/src/claude_sessions/tests.rs
+++ b/src/claude_sessions/tests.rs
@@ -1,0 +1,121 @@
+//! Tests for transcript-source resolution.
+//!
+//! One Claude project directory holds the logs of every session ever run in a
+//! worktree, so these tests pin down the property the reflow transcript view
+//! depends on: the *session id* selects the log, and nothing about the sibling
+//! logs sharing the directory (count, mtime, first/last turn time) can change
+//! which one is picked.
+
+use std::fs::{File, FileTimes};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use super::session_log_in_dir;
+use crate::claude_log::{DisplayBlock, load_session};
+
+/// Write `<session_id>.jsonl` into `dir` with one user turn per line of `turns`,
+/// and force its mtime to `now - age`.
+fn write_log(dir: &Path, session_id: &str, turns: &[&str], age: Duration) -> PathBuf {
+    let path = dir.join(format!("{session_id}.jsonl"));
+    let mut f = File::create(&path).expect("create log");
+    for turn in turns {
+        writeln!(
+            f,
+            r#"{{"type":"user","sessionId":"{session_id}","message":{{"role":"user","content":"{turn}"}}}}"#
+        )
+        .expect("write turn");
+    }
+    let mtime = SystemTime::now() - age;
+    f.set_times(FileTimes::new().set_modified(mtime))
+        .expect("set mtime");
+    path
+}
+
+/// The text of every entry in the transcript resolved for `session_id`.
+fn transcript_texts(dir: &Path, session_id: &str) -> Vec<String> {
+    let path = session_log_in_dir(dir, session_id).expect("session log resolves");
+    load_session(&path)
+        .iter()
+        .flat_map(|e| e.blocks.clone())
+        .map(|b| match b {
+            DisplayBlock::Text(t) => t,
+            other => panic!("unexpected block: {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn session_id_selects_the_log_among_siblings() {
+    // Three sessions share the project dir (three Claude panels on the same
+    // worktree). Each id must resolve to its own log, whatever the mtimes.
+    let dir = tempfile::tempdir().expect("tmp dir");
+    write_log(dir.path(), "aaa", &["from aaa"], Duration::from_secs(3600));
+    write_log(dir.path(), "bbb", &["from bbb"], Duration::from_secs(60));
+    write_log(dir.path(), "ccc", &["from ccc"], Duration::ZERO);
+
+    assert_eq!(transcript_texts(dir.path(), "aaa"), vec!["from aaa"]);
+    assert_eq!(transcript_texts(dir.path(), "bbb"), vec!["from bbb"]);
+    assert_eq!(transcript_texts(dir.path(), "ccc"), vec!["from ccc"]);
+}
+
+#[test]
+fn idle_session_is_not_displaced_by_a_newer_sibling() {
+    // Regression: a panel whose main agent is stopped while a subagent still
+    // works writes nothing to its session log (subagent turns land in
+    // `<session-id>/subagents/*.jsonl`), so its log is both the stalest in the
+    // directory and frozen before a session started later in the same worktree.
+    // Resolution must still return *this* panel's log — the old view followed
+    // the freshest log, or the one starting after this one's last turn, and
+    // opened onto the other session's conversation.
+    let dir = tempfile::tempdir().expect("tmp dir");
+    write_log(
+        dir.path(),
+        "idle-with-subagent",
+        &["my prompt", "my later prompt"],
+        Duration::from_secs(3600),
+    );
+    write_log(
+        dir.path(),
+        "other-live-session",
+        &["someone else's prompt"],
+        Duration::ZERO,
+    );
+    // A subagent transcript of the idle session, in its own subdirectory.
+    let sub = dir.path().join("idle-with-subagent").join("subagents");
+    std::fs::create_dir_all(&sub).expect("subagent dir");
+    write_log(&sub, "agent-aivy-1234", &["subagent work"], Duration::ZERO);
+
+    assert_eq!(
+        transcript_texts(dir.path(), "idle-with-subagent"),
+        vec!["my prompt", "my later prompt"]
+    );
+}
+
+#[test]
+fn unknown_session_id_resolves_to_nothing() {
+    // No history is the correct answer for an unresolvable id: falling back to
+    // whatever log the directory happens to hold shows another conversation.
+    let dir = tempfile::tempdir().expect("tmp dir");
+    write_log(dir.path(), "aaa", &["from aaa"], Duration::ZERO);
+
+    assert!(session_log_in_dir(dir.path(), "no-such-session").is_none());
+}
+
+#[test]
+fn empty_project_dir_resolves_to_nothing() {
+    let dir = tempfile::tempdir().expect("tmp dir");
+    assert!(session_log_in_dir(dir.path(), "aaa").is_none());
+}
+
+#[test]
+fn symlinked_session_log_resolves() {
+    // `migrate_session` symlinks a grabbed branch's session into the new
+    // worktree's project dir; resolution must follow the link.
+    let source = tempfile::tempdir().expect("tmp dir");
+    let target = tempfile::tempdir().expect("tmp dir");
+    let real = write_log(source.path(), "aaa", &["from aaa"], Duration::ZERO);
+    std::os::unix::fs::symlink(&real, target.path().join("aaa.jsonl")).expect("symlink");
+
+    assert_eq!(transcript_texts(target.path(), "aaa"), vec!["from aaa"]);
+}


### PR DESCRIPTION
## Summary

スクロールアップ（reflow transcript view）で、**main 停止＋subagent 稼働中の session が同一ディレクトリの別 session の履歴を表示してしまう**不具合を修正。

原因は `App::open_reflow` の "`/clear` 追従" ヒューリスティック（旧 step 1b）。同一プロジェクトディレクトリ内で「first timestamp ≥ pinned session の last timestamp」を満たす最新 mtime のログを *継続* とみなして差し替えていた。この判定の安全性は「同時稼働している別パネルは pinned と時間的に重なる」前提に依存していたが、実データで確認したところ:

- subagent の会話は `<session-id>/subagents/agent-*.jsonl`（サブディレクトリ）に書かれ、main の session log には入らない（`isSidechain:true` レコードは 0 件）
- したがって **main 停止中は自分の session log が完全に凍結**し、`pinned_last` が過去に固定される
- その状態で同じ worktree に後から起動した別 session は `first ≥ pinned_last` を満たすため "継続" と誤判定され、subagent が走っている間ずっと他 session の履歴を掴む

`entries` が空のときに「同ディレクトリの mtime 最新ログ」へ落ちる旧 step 2 も同じ漏れ経路だった。

### 変更内容

- **履歴ソースを pin された sessionId のみで解決**。`claude_sessions::session_log_in_dir(project_dir, session_id)` を追加し、`session_jsonl_path` を存在確認付きに（migrate 済み session の symlink も追従）。worktree パスは canonicalize 後の encoding と生パスの両方を試すが、探すのは常に同じ session id — 探す *場所* だけを広げ、*どの session か* は広げない
- 曖昧なフォールバックを実装ごと削除: `session_logs_by_mtime`、`claude_log::session_first_timestamp` / `session_last_timestamp`、`LogRecord.timestamp`
- 解決できない場合は別 session を出さず、ステータス表示してビューを開かない（`No Claude session for this panel; transcript unavailable` / `No session log on disk for <id>`）
- working_dir を `selected_worktree` ではなく該当パネル自身の `PtySession::working_dir` から取得（選択中ワークツリーと表示中パネルのズレも起点にならないようにした）
- version 0.90.0 → 0.90.1 (PATCH: バグ修正)

### トレードオフ

`/clear` 追従を落としたため、パネル内で `/clear` やアプリ内 `/resume` を打った後のスクロールアップは**回転前（自分の）履歴**を表示する。Claude Code は回転後ファイルに前 session への back-link を書かないため、ファイル内容から安全に追う手段がない。将来対応するなら PTY ごとに一意の env を渡し、hook（`session_id` を受け取れる）経由で live session id を panel に紐付ける形になる。「古くても自分の履歴 > 新しくても他人の履歴」を選択した。

## Test plan

- [x] `cargo test` — 620 passed / 0 failed
- [x] `cargo clippy --all-targets` — 新規 warning なし（既存 3 件は無関係ファイル）
- [x] 回帰テスト `src/claude_sessions/tests.rs` を追加（6 本）
  - `idle_session_is_not_displaced_by_a_newer_sibling` — 本命。pinned ログをディレクトリ内で最も古い mtime かつ最終ターンが相手より前にし、subagent サブディレクトリも配置した上で、自分のログだけが解決されることを検証（旧ロジックが誤選択する条件そのもの）
  - `session_id_selects_the_log_among_siblings` — 同一ディレクトリの 3 session が各々自分のログに解決される
  - `unknown_session_id_resolves_to_nothing` / `empty_project_dir_resolves_to_nothing` — 未解決時に最新ログへ落ちない
  - `symlinked_session_log_resolves` — grab 済み session の symlink 追従
- [x] 実データでの本番経路確認: `session_jsonl_path(worktree, 実 session id)` が自分のログ（130 entries、先頭が実際の依頼文）に解決、存在しない id は `None`（確認用の一時テストは削除済み）
- [x] `cargo install --path .` 済み
- [ ] **実機確認（未実施 / 要お願い）**: 同一ディレクトリで 2 session 起動 → 片方を main 停止＋subagent 稼働にしてスクロールアップし自分の履歴だけが出ること、および main 稼働中の従来動作。TUI の PTY に入力を注入できないため手動確認が必要
