### PR TITLE
fix: SUMMARY ビューの自動切り替わりを修正し、walkthrough から change summary を書く

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.90.1"
+version = "0.91.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.90.1"
+version = "0.91.0"
 edition = "2024"
 
 [dependencies]

--- a/plugins/conductor/commands/conductor-walkthrough.md
+++ b/plugins/conductor/commands/conductor-walkthrough.md
@@ -30,7 +30,10 @@ description: Generate a PR walkthrough (intent -> core -> ripple -> test) and sa
 
 - `branch`: 現在の worktree のブランチ名（`git rev-parse --abbrev-ref HEAD` で取得できるもの）
 - `title`: ウォークスルー全体の一行タイトル
-- `summary`: 変更全体の短い概要（intent の要約でよい）
+- `summary`: 変更全体の概要。**これはブランチの change summary として保存され、Conductor の
+  SUMMARY 疑似ファイルに全画面で表示される** ので、PR description のつもりで書く — 何のための
+  変更か、なぜこれらのファイルを触っているか、レビュアーに先に知っておいてほしい前提や
+  スコープ外のこと。Markdown が描画される
 - `steps`: 上記で組み立てたステップ列（`seq` は 0 始まりの通し番号）
 
 ## 4. 難所にインラインコメントを付ける（任意）

--- a/plugins/conductor/mcp/conductor-comment/package-lock.json
+++ b/plugins/conductor/mcp/conductor-comment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conductor-mcp",
-  "version": "0.2.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conductor-mcp",
-      "version": "0.2.0",
+      "version": "0.6.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
         "better-sqlite3": "^12.8.0",

--- a/plugins/conductor/mcp/conductor-comment/src/index.ts
+++ b/plugins/conductor/mcp/conductor-comment/src/index.ts
@@ -589,6 +589,42 @@ server.tool(
   }
 );
 
+/**
+ * Upsert the branch-level change summary — the body behind Conductor's SUMMARY
+ * pseudo-file. Two tools write it: `set_change_summary` (a standalone overview)
+ * and `save_walkthrough` (its `summary` argument, so generating a walkthrough
+ * fills the pane in as a side effect). Shared here so those two can never drift
+ * apart; must stay in sync with Rust's `ReviewStore::save_change_summary`
+ * (`src/review_store/worktree_metadata.rs`).
+ *
+ * Safe to call inside a caller's transaction — it issues no BEGIN of its own.
+ */
+function upsertChangeSummary(d: Database.Database, branch: string, body: string): void {
+  // Defensive: the table is created by the Rust TUI's v5 migration, but the
+  // MCP server may run against a DB an older binary hasn't migrated yet.
+  // Mirror the Rust schema so a fresh write never fails on a missing table.
+  d.exec(
+    `CREATE TABLE IF NOT EXISTS change_summary (
+       branch      TEXT PRIMARY KEY,
+       body        TEXT NOT NULL,
+       author      TEXT NOT NULL DEFAULT 'claude'
+                     CHECK (author IN ('user', 'claude')),
+       created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+       updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+     )`
+  );
+  d.prepare(
+    `INSERT INTO change_summary (branch, body, author, created_at, updated_at)
+     VALUES (@branch, @body, 'claude',
+             COALESCE((SELECT created_at FROM change_summary WHERE branch = @branch), datetime('now')),
+             datetime('now'))
+     ON CONFLICT(branch) DO UPDATE SET
+       body = excluded.body,
+       author = 'claude',
+       updated_at = datetime('now')`
+  ).run({ branch, body });
+}
+
 server.tool(
   "set_change_summary",
   "Set the branch-level change summary — the 'what & why' of the whole diff (the PR-description counterpart to line-anchored comments). " +
@@ -618,31 +654,8 @@ server.tool(
       };
     }
 
-    // Defensive: the table is created by the Rust TUI's v5 migration, but the
-    // MCP server may run against a DB an older binary hasn't migrated yet.
-    // Mirror the Rust schema so a fresh write never fails on a missing table.
-    d.exec(
-      `CREATE TABLE IF NOT EXISTS change_summary (
-         branch      TEXT PRIMARY KEY,
-         body        TEXT NOT NULL,
-         author      TEXT NOT NULL DEFAULT 'claude'
-                       CHECK (author IN ('user', 'claude')),
-         created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-         updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
-       )`
-    );
-
     try {
-      d.prepare(
-        `INSERT INTO change_summary (branch, body, author, created_at, updated_at)
-         VALUES (@branch, @body, 'claude',
-                 COALESCE((SELECT created_at FROM change_summary WHERE branch = @branch), datetime('now')),
-                 datetime('now'))
-         ON CONFLICT(branch) DO UPDATE SET
-           body = excluded.body,
-           author = 'claude',
-           updated_at = datetime('now')`
-      ).run({ branch, body });
+      upsertChangeSummary(d, branch, body);
     } catch (err) {
       return {
         content: [
@@ -670,7 +683,7 @@ server.tool(
 
 server.tool(
   "get_change_summary",
-  "Get the branch-level change summary (the 'what & why' overview set by set_change_summary) for the current branch, or a specified branch. " +
+  "Get the branch-level change summary (the 'what & why' overview written by set_change_summary or save_walkthrough) for the current branch, or a specified branch. " +
     "Useful for reusing the summary as a PR description body.",
   {
     branch: z
@@ -772,7 +785,12 @@ server.tool(
   {
     branch: z.string().min(1).describe("Branch the walkthrough belongs to"),
     title: z.string().min(1).describe("One-line walkthrough title"),
-    summary: z.string().min(1).describe("Short overview of the change, shown above the steps"),
+    summary: z
+      .string()
+      .min(1)
+      .describe(
+        "Overview of the change. Also stored as the branch's change summary and shown full-panel as Conductor's SUMMARY pseudo-file, so write it like a PR description (what the change is for, why these files, what is out of scope). Markdown is rendered."
+      ),
     steps: z
       .array(walkthroughStepSchema)
       .min(1)
@@ -827,6 +845,11 @@ server.tool(
            error = NULL,
            updated_at = datetime('now')`
       ).run({ id: walkthroughId, branch, title, summary });
+
+      // The same overview also backs the SUMMARY pseudo-file. Writing it here,
+      // inside the transaction, is what keeps that pane from going permanently
+      // empty: nothing else writes `change_summary` in the normal review flow.
+      upsertChangeSummary(d, branch, summary);
 
       const { id: resolvedId } = d
         .prepare("SELECT id FROM walkthroughs WHERE branch = ?")

--- a/src/app/repo.rs
+++ b/src/app/repo.rs
@@ -102,6 +102,10 @@ impl App {
                 self.selected_worktree = 0;
                 self.refresh_worktrees();
                 self.viewer_state = ViewerState::default();
+                // This repo gets no view restore, so drop any restore still
+                // armed for the *previous* repo — otherwise it could fire here
+                // and open a same-named path in the newly opened tree.
+                self.pending_view_restore = None;
                 self.diff_state =
                     crate::diff_state::DiffState::new(&self.config.general.main_branch, self.diff_state.view_mode);
                 self.refresh_reviews();
@@ -226,7 +230,14 @@ impl App {
         // often the main worktree), reload the review state. Otherwise the
         // previous branch's change summary and comments linger and get shown
         // against the wrong branch (e.g. a merged PR's summary on `main`).
-        if self.selected_worktree_branch() != prev_selected_branch {
+        //
+        // An *empty* branch is excluded: `list_worktrees` logs and skips a
+        // worktree it fails to inspect (see `git_engine::worktree_ops`), so a
+        // transient git error can empty the list for one poll. That is a failed
+        // read, not a selection change, and reloading reviews against `""`
+        // would blank out the panel every few seconds until it recovered.
+        let new_branch = self.selected_worktree_branch();
+        if !new_branch.is_empty() && new_branch != prev_selected_branch {
             self.refresh_reviews();
         }
         changed

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -30,12 +30,13 @@ impl App {
             if self.diff_state.has_summary != has_summary {
                 self.diff_state.has_summary = has_summary;
                 self.diff_state.rebuild_display_list();
-                // If the summary vanished while its pseudo-file was open, leave
-                // the now-orphaned summary view so the Viewer and the list agree.
-                if !has_summary && self.viewer_state.is_summary() {
-                    self.viewer_state.exit_diff_mode();
-                }
             }
+            // Deliberately no "summary vanished, so close the view" branch here.
+            // A data reload must never close a view the user opened: `None` here
+            // means "this reload found no summary", which also covers reloads
+            // against a branch that failed to resolve, and closing on that threw
+            // the user onto an unrelated file. The summary pane renders its own
+            // empty state, so an orphaned view explains itself and Esc closes it.
         }
     }
 

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -114,6 +114,17 @@ impl App {
         let Some(restore) = self.pending_view_restore.take() else {
             return;
         };
+        match restore_disposition(
+            self.viewer_state.content.current_file.is_some(),
+            self.viewer_state.is_summary(),
+        ) {
+            RestoreDisposition::Apply => {}
+            RestoreDisposition::Drop => return,
+            RestoreDisposition::Keep => {
+                self.pending_view_restore = Some(restore);
+                return;
+            }
+        }
         let wt_path = self.selected_worktree_path();
         if !wt_path.join(&restore.file).is_file() {
             return;
@@ -189,6 +200,40 @@ impl App {
     }
 }
 
+/// What to do with a pending [`PendingViewRestore`] that has come due.
+#[derive(Debug, PartialEq, Eq)]
+enum RestoreDisposition {
+    /// Nothing is showing — open the saved file as intended.
+    Apply,
+    /// The user opened a real file during the window between the worktree
+    /// switch and the tree finishing its walk. The saved view is obsolete, so
+    /// forget it; keeping it armed would make [`App::save_view_for`] persist
+    /// the stale pending path instead of the file the user ended up on.
+    Drop,
+    /// Only the SUMMARY pseudo-file is showing, with no file behind it. Don't
+    /// open over it, but stay armed: the view-state schema has no way to say
+    /// "was viewing SUMMARY", so dropping here would persist an empty view and
+    /// lose the saved file outright. The caller re-runs this on every later
+    /// consume, so the restore can still land once the viewer is empty again.
+    Keep,
+}
+
+/// Decide the fate of a due view restore from what the viewer is showing.
+///
+/// Split out from [`App::consume_pending_view_restore`] because both wrong
+/// answers are silent: `Drop` where `Keep` belongs quietly erases a branch's
+/// saved file, and `Keep` where `Drop` belongs quietly freezes it at a stale
+/// value. Neither surfaces as a crash, so the truth table is pinned by tests.
+fn restore_disposition(has_open_file: bool, showing_summary: bool) -> RestoreDisposition {
+    if has_open_file {
+        RestoreDisposition::Drop
+    } else if showing_summary {
+        RestoreDisposition::Keep
+    } else {
+        RestoreDisposition::Apply
+    }
+}
+
 /// Resolve the base branch a diff should be computed against: a worktree's
 /// saved base ref (recorded at PR-intake time — see `save_worktree_base_branch`)
 /// takes priority, since a PR may target something other than the configured
@@ -214,5 +259,23 @@ mod tests {
     #[test]
     fn resolve_diff_base_branch_falls_back_to_main_when_unsaved() {
         assert_eq!(resolve_diff_base_branch(None, "main"), "main");
+    }
+
+    /// The full truth table. Startup and worktree switch both reset the viewer
+    /// before arming a restore, so `Apply` is the ordinary path; the other two
+    /// rows only occur when the user got there first during the tree walk.
+    #[test]
+    fn restore_disposition_truth_table() {
+        use RestoreDisposition::*;
+        // Viewer empty: the restore does its job.
+        assert_eq!(restore_disposition(false, false), Apply);
+        // Only SUMMARY open: don't clobber it, but stay armed so the branch's
+        // saved file isn't erased by a later save.
+        assert_eq!(restore_disposition(false, true), Keep);
+        // A real file is open: the saved view is obsolete either way, including
+        // when SUMMARY is layered over that file — dropping keeps persistence
+        // tracking what the user actually opened.
+        assert_eq!(restore_disposition(true, false), Drop);
+        assert_eq!(restore_disposition(true, true), Drop);
     }
 }

--- a/src/event/mouse/scroll.rs
+++ b/src/event/mouse/scroll.rs
@@ -101,7 +101,26 @@ pub(super) fn handle_mouse_scroll(
         }
     } else if col < viewer_end {
         // Viewer scroll.
-        if app.viewer_state.diff_view.diff_mode {
+        //
+        // The summary pseudo-file is checked first: it renders over the whole
+        // panel while `diff_mode` is false and `current_file` still points at
+        // whatever was open behind it, so without this the wheel would scroll
+        // that hidden file and the summary would sit motionless.
+        if app.viewer_state.is_summary() {
+            let total = app.viewer_state.summary_total_lines;
+            if total > 0 {
+                if delta > 0 {
+                    app.viewer_state.summary_scroll = (app.viewer_state.summary_scroll
+                        + delta.unsigned_abs() as usize)
+                        .min(total.saturating_sub(1));
+                } else {
+                    app.viewer_state.summary_scroll = app
+                        .viewer_state
+                        .summary_scroll
+                        .saturating_sub(delta.unsigned_abs() as usize);
+                }
+            }
+        } else if app.viewer_state.diff_view.diff_mode {
             // Unified diff view scroll.
             let total = app.viewer_state.diff_view.diff_view_lines.len();
             if total > 0 {

--- a/src/review_store/walkthroughs.rs
+++ b/src/review_store/walkthroughs.rs
@@ -9,7 +9,7 @@ use crate::walkthrough::{
     NewWalkthroughStep, Walkthrough, WalkthroughStatus, WalkthroughStep, WalkthroughStepKind,
 };
 
-use super::ReviewStore;
+use super::{Author, ReviewStore};
 
 impl ReviewStore {
     /// Start (or restart) walkthrough generation for a branch: delete any
@@ -44,6 +44,13 @@ impl ReviewStore {
     /// that skipped the "generating" placeholder is treated as an error
     /// rather than silently creating one (the placeholder is what a stuck- or
     /// failed-generation UI depends on existing).
+    ///
+    /// `summary` is written twice on purpose: onto the walkthrough row (for
+    /// round-trip fidelity) and into `change_summary`, which backs the SUMMARY
+    /// pseudo-file. Generating a walkthrough is the only thing that writes that
+    /// table, so the two must land together — hence inside the same
+    /// transaction, so a failed save leaves no summary describing a walkthrough
+    /// that was never stored.
     ///
     /// Not called in production: the actual write path is the conductor MCP
     /// server's `save_walkthrough` tool (`plugins/conductor/mcp/conductor-comment/src/index.ts`),
@@ -80,6 +87,7 @@ impl ReviewStore {
                  WHERE id = ?3",
                 params![title, summary, walkthrough_id],
             )?;
+            self.save_change_summary(branch, summary, Author::Claude)?;
             self.conn.execute(
                 "DELETE FROM walkthrough_steps WHERE walkthrough_id = ?1",
                 params![walkthrough_id],
@@ -315,5 +323,52 @@ mod tests {
                 .save_walkthrough("feat/x", "title", "summary", &[])
                 .is_err()
         );
+    }
+
+    /// The walkthrough's `summary` is also the branch's change summary — the
+    /// SUMMARY pseudo-file's content. Generating a walkthrough is the only
+    /// thing that writes it, so if this link breaks the SUMMARY pane silently
+    /// stays empty forever.
+    #[test]
+    fn save_walkthrough_also_writes_the_change_summary() {
+        let store = test_store();
+        store.begin_walkthrough("feat/x", None).unwrap();
+        assert_eq!(store.get_change_summary("feat/x").unwrap(), None);
+
+        store
+            .save_walkthrough("feat/x", "Fix startup crash", "何をなぜ変えたか。", &[])
+            .unwrap();
+
+        assert_eq!(
+            store.get_change_summary("feat/x").unwrap().as_deref(),
+            Some("何をなぜ変えたか。")
+        );
+
+        // Re-generating replaces it, so the pane always shows the latest
+        // overview rather than accumulating stale ones.
+        store.begin_walkthrough("feat/x", None).unwrap();
+        store
+            .save_walkthrough("feat/x", "Fix startup crash", "更新後の概要。", &[])
+            .unwrap();
+        assert_eq!(
+            store.get_change_summary("feat/x").unwrap().as_deref(),
+            Some("更新後の概要。")
+        );
+    }
+
+    /// A save rejected for want of `begin_walkthrough` must not leave a change
+    /// summary behind describing a walkthrough that was never stored. Note this
+    /// covers only the pre-transaction guard — a failure *inside* the
+    /// transaction is handled by the surrounding BEGIN/ROLLBACK and can't be
+    /// provoked through this API, so it isn't asserted here.
+    #[test]
+    fn save_walkthrough_rejected_before_begin_writes_no_change_summary() {
+        let store = test_store();
+        assert!(
+            store
+                .save_walkthrough("feat/x", "title", "summary", &[])
+                .is_err()
+        );
+        assert_eq!(store.get_change_summary("feat/x").unwrap(), None);
     }
 }

--- a/src/review_store/worktree_metadata.rs
+++ b/src/review_store/worktree_metadata.rs
@@ -33,9 +33,12 @@ impl ReviewStore {
     /// body. `updated_at` is bumped on every write; `created_at` is preserved on
     /// replace via the COALESCE against the existing row.
     ///
-    /// Currently the MCP `set_change_summary` tool is the live writer (raw SQL,
-    /// sibling process); this canonical Rust writer documents the upsert contract
-    /// and backs a future in-TUI summary editor.
+    /// The live writers are both in the MCP server (raw SQL, sibling process):
+    /// `set_change_summary` for a standalone overview, and `save_walkthrough`,
+    /// which writes the walkthrough's summary here so the SUMMARY pseudo-file
+    /// is filled in as a side effect of generating a walkthrough. This Rust
+    /// writer documents the upsert contract, backs the tested Rust mirror of
+    /// `save_walkthrough`, and would back a future in-TUI summary editor.
     #[allow(dead_code)]
     pub fn save_change_summary(&self, branch: &str, body: &str, author: Author) -> Result<()> {
         self.conn.execute(

--- a/src/ui/viewer_panel/summary_view.rs
+++ b/src/ui/viewer_panel/summary_view.rs
@@ -51,8 +51,9 @@ pub(super) fn render_summary_view(frame: &mut Frame, area: Rect, app: &mut App, 
             for (text, _) in [
                 ("(no change summary on this branch)", ()),
                 ("", ()),
-                ("Write one with the conductor `set_change_summary` MCP tool", ()),
-                ("(e.g. via the /self-review skill).", ()),
+                ("Generating a walkthrough writes one — palette:", ()),
+                ("\"Review: Generate Walkthrough\". Claude can also set it", ()),
+                ("directly with the conductor `set_change_summary` MCP tool.", ()),
             ] {
                 lines.push(Line::from(Span::styled(
                     text,

--- a/src/viewer/tree.rs
+++ b/src/viewer/tree.rs
@@ -68,9 +68,11 @@ impl ViewerState {
         if let Some(ref rel_path) = prev_file {
             let full = worktree_path.join(rel_path);
             if full.is_file() {
-                // Preserve diff mode state across tree refreshes so that
-                // file-watcher / periodic refreshes don't kick the user
-                // out of the unified diff view.
+                // Preserve the viewer's *mode* across tree refreshes so that
+                // file-watcher / periodic refreshes don't kick the user out of
+                // the unified diff view or the SUMMARY pseudo-file. `open_file`
+                // below goes through `exit_diff_mode`, which clears both, so
+                // every mode flag has to be captured here and put back after.
                 let was_diff_mode = self.diff_view.diff_mode;
                 let prev_diff_lines = if was_diff_mode {
                     std::mem::take(&mut self.diff_view.diff_view_lines)
@@ -79,6 +81,8 @@ impl ViewerState {
                 };
                 let prev_diff_scroll = self.diff_view.diff_view_scroll;
                 let prev_diff_max_line_no = self.diff_view.diff_view_max_line_no;
+                let was_summary = self.show_summary;
+                let prev_summary_scroll = self.summary_scroll;
 
                 self.open_file(worktree_path, rel_path, tab_width);
                 self.content.file_scroll = prev_file_scroll;
@@ -89,6 +93,12 @@ impl ViewerState {
                     self.diff_view.diff_view_lines = prev_diff_lines;
                     self.diff_view.diff_view_scroll = prev_diff_scroll;
                     self.diff_view.diff_view_max_line_no = prev_diff_max_line_no;
+                }
+                // Mutually exclusive with diff mode (see `enter_summary_view`),
+                // so this can never fight the branch above.
+                if was_summary {
+                    self.show_summary = true;
+                    self.summary_scroll = prev_summary_scroll;
                 }
 
                 // Try to restore tree_selected to point at the file entry.

--- a/src/viewer/tree/tests.rs
+++ b/src/viewer/tree/tests.rs
@@ -64,3 +64,50 @@ fn walk_still_skips_heavy_dirs() {
         "node_modules should be skipped"
     );
 }
+
+/// A periodic / file-watcher tree refresh re-opens the previously viewed file
+/// to pick up on-disk edits, and `open_file` goes through `exit_diff_mode`,
+/// which clears every viewer mode flag. The SUMMARY pseudo-file view must
+/// survive that round trip — otherwise selecting SUMMARY in the Changed-files
+/// list silently flips back to the last opened file within seconds.
+#[test]
+fn tree_refresh_preserves_summary_view() {
+    let root = tempfile::tempdir().unwrap();
+    let root = root.path();
+    std::fs::write(root.join("a.txt"), "hello\nworld\n").unwrap();
+
+    let mut vs = ViewerState::default();
+    vs.load_file_tree(root, 4);
+    vs.open_file(root, "a.txt", 4);
+    vs.enter_summary_view();
+    vs.summary_scroll = 7;
+
+    vs.load_file_tree(root, 4);
+
+    assert!(
+        vs.is_summary(),
+        "summary view must survive a tree refresh (was kicked back to a.txt)"
+    );
+    assert_eq!(vs.summary_scroll, 7, "summary scroll must be preserved");
+}
+
+/// The sibling guarantee for the unified diff view, which the summary fix must
+/// not regress: a refresh keeps diff mode on.
+#[test]
+fn tree_refresh_preserves_diff_mode() {
+    let root = tempfile::tempdir().unwrap();
+    let root = root.path();
+    std::fs::write(root.join("a.txt"), "hello\n").unwrap();
+
+    let mut vs = ViewerState::default();
+    vs.load_file_tree(root, 4);
+    vs.open_file(root, "a.txt", 4);
+    vs.diff_view.diff_mode = true;
+    vs.diff_view.diff_view_scroll = 3;
+
+    vs.load_file_tree(root, 4);
+
+    assert!(vs.diff_view.diff_mode, "diff mode must survive a refresh");
+    assert!(!vs.is_summary(), "diff mode must not turn on summary view");
+    assert_eq!(vs.diff_view.diff_view_scroll, 3);
+}

--- a/src/walkthrough.rs
+++ b/src/walkthrough.rs
@@ -315,7 +315,12 @@ Each step needs: file_path (repo-relative), optional line_start/line_end (new-si
 numbers), kind, title, body. There is no fixed step count — match the actual change.\n\
 \n\
 When all steps are assembled, call the `save_walkthrough` tool exactly once with: \
-branch = `{branch}`, a one-line title, a short summary, and the steps (seq starting at 0).\n\
+branch = `{branch}`, a one-line title, a summary, and the steps (seq starting at 0).\n\
+\n\
+The summary is not throwaway text: it is stored as the branch's change summary and shown \
+full-panel as Conductor's SUMMARY pseudo-file, so write it like a PR description — what the \
+change is for, why these files are touched, and anything a reviewer should know up front \
+(including what is deliberately out of scope). Markdown is rendered.\n\
 \n\
 After saving, for the few spots that are genuinely hard to understand — tricky logic whose \
 intent isn't obvious at a glance, a non-obvious tradeoff, or a subtle edge case a reviewer \


### PR DESCRIPTION
## Summary

Changed files 一覧の SUMMARY 疑似ファイルを選んでも、数秒で勝手に別のファイルの表示に切り替わってしまうバグを直し、あわせて空のままだった SUMMARY ペインに書き手を戻す。

**真因** — `ViewerState::load_file_tree` の「前回開いていたファイルを開き直す」処理が `open_file()` → `exit_diff_mode()` を経由して `show_summary` を落としていた。`diff_mode` は明示的に退避・復元されていたが `show_summary` が漏れていた取りこぼし。この再オープンは差分の有無に関係なく毎回通るため、3秒ごとの `worktree_poll`・file watcher・config watcher のいずれからでも決定的に再現する。修正前スナップショットに対する実行で再現を確認済み。

同じ症状を生む経路をあと3つ塞いだ:

- `consume_pending_view_restore` が、worktree 切替直後の非同期ツリー walk 完了までの窓でユーザーの選んだビューを上書きしていた。3値の判断（適用 / 破棄 / 再武装）を `restore_disposition()` に切り出し、真理値表で固定。破棄すべきところで再武装すると保存済みビューが古い値で固定され、逆だとブランチの「最後に見ていたファイル」が消えるため、どちらの誤りも無言で壊れる。
- `refresh_reviews` にあった「change summary が消えたら SUMMARY ビューを閉じる」分岐を削除。`None` は「今回のリロードでは見つからなかった」でしかなく、ブランチ解決に失敗したリロードも同じ値になる。データのリロードがユーザーの開いたビューを閉じるべきではない。ペインには元から空状態の描画がある。
- `refresh_worktrees` で、新ブランチが空文字のときは `refresh_reviews()` を呼ばない。`list_worktrees` は検査に失敗した worktree をログして飛ばすため、一過性の git エラーで1ポーリング分リストから落ちうる。これは読み取り失敗であって選択変更ではない。

**walkthrough → change summary の統合** — SUMMARY ペインの中身を書いていた `/self-review` skill は 738370c で削除済みで、以降このテーブルに書くものが誰もいなかった（＝ペインが永久に空）。一方 walkthrough は `summary` を受け取りながら未描画のまま `#[allow(dead_code)]` になっていた。`save_walkthrough` がこの `summary` を change summary としても保存するようにして両者を繋いだ。プロンプト側にも「これは SUMMARY ペインに全画面表示されるので PR description のつもりで書く」旨を明記している（書かないと一行要約が返ってペインが貧相になる）。

## Notable decisions

- **walkthrough 生成は既存の change summary を黙って上書きする。** `set_change_summary` 自体が置き換えセマンティクスであることと、再生成は常に最新の全体像を出すべきという理由。手書きを保護したい場合は「無いときだけ書く」に変更可能。
- **SUMMARY 表示中のマウスホイールも同時に修正した。** `src/event/mouse/scroll.rs` に `is_summary()` の分岐が無く、裏に隠れている元ファイルの `file_scroll` が動くだけだった。既存バグだが、これまでは SUMMARY が3秒で閉じていて到達できなかった。「開いたままにする」修正を出す以上、同時に塞ぐのが筋と判断。
- **Node と Rust に二重実装がある `change_summary` の upsert は、Node 側で `upsertChangeSummary()` に共通化した。** `set_change_summary` と `save_walkthrough` が同じ SQL を持つと3つ目のコピーになるため。

## Test plan

- `cargo test` — 625 passed / 0 failed / 1 ignored
- `cargo clippy` — 変更ファイルに新規警告なし
- `npm run build`（MCP サーバ）— 通過
- 追加テスト（いずれも実装前に落ちることを確認済み）
  - `tree_refresh_preserves_summary_view` / `tree_refresh_preserves_diff_mode` — 復元処理を外すと前者だけが落ちることを実測
  - `restore_disposition_truth_table` — 3値判断の全4入力
  - `save_walkthrough_also_writes_the_change_summary` — 再生成時の置き換えも含む
  - `save_walkthrough_rejected_before_begin_writes_no_change_summary`
- **実測による確認**: better-sqlite3 の `d.transaction()` 内で `CREATE TABLE IF NOT EXISTS` を実行して安全か（`save_walkthrough` が該当）を実際に走らせて確認。throw させるとテーブル自体を含めて完全にロールバックされることを確認済み。
- TUI への実キー入力はこの環境からできないため、**エンドツーエンドの実機操作確認は未実施**。ロジック層での再現と修正確認は上記のとおり実行済み。

## Known gaps (この PR では未対応)

- `open_repo_from_path` はパス指定でリポジトリを開く際に `persist_view_state()` を呼ばず `current_view_branch` も更新しないため、終了時に新リポジトリの DB へ旧リポジトリのブランチ名をキーに書き込む。両方に `main` があると次回起動時の worktree 選択がずれる。今回の変更で悪化も改善もしていない既存の非対称。
- `list_worktrees` の部分失敗握り潰しそのもの。今回は空ブランチガードで SUMMARY への影響だけ遮断しており、一過性 git エラーで worktree がリストから落ちる根本は残る。再現手段が無く未検証のため、構造変更のリスクの方が大きいと判断した。
