### PR TITLE
fix: resolve diff base refs with revparse so remote-tracking bases work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.91.0"
+version = "0.91.1"
 edition = "2024"
 
 [dependencies]

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -143,22 +143,33 @@ impl App {
         self.viewer_state.highlight_content(syntax_set, theme);
     }
 
+    /// The ref `branch`'s diff should be computed against.
+    ///
+    /// Every diff path must go through here. There are two of them — this one,
+    /// reached by `refresh_diff`, and the background computation on worktree
+    /// switch — and they used to decide the base differently, so the same
+    /// worktree showed one file list right after the switch and a different one
+    /// after the next refresh. Keeping the decision in a single method is what
+    /// stops that from silently coming back.
+    pub(super) fn diff_base_for(&self, branch: &str) -> String {
+        // A PR-review worktree may target a base other than the configured main
+        // branch (e.g. a release/develop branch); prefer the base ref recorded
+        // at intake time and only fall back to main_branch when none was saved
+        // (regular worktrees, or DB unavailable).
+        let saved_base = self
+            .review_store
+            .as_ref()
+            .and_then(|store| store.get_worktree_base_branch(branch).ok().flatten());
+        resolve_diff_base_branch(saved_base, &self.config.general.main_branch)
+    }
+
     /// Load (or reload) the diff for the currently selected worktree
-    /// against the configured main branch.
+    /// against its resolved base ref.
     pub fn refresh_diff(&mut self) {
         let word_diff = self.config.diff.word_diff;
         if let Some(wt) = self.worktrees.get(self.selected_worktree) {
             let path = wt.path.clone();
-            // A PR-review worktree may target a base other than the configured
-            // main branch (e.g. a release/develop branch); prefer the base ref
-            // recorded at intake time and only fall back to main_branch when
-            // none was saved (regular worktrees, or DB unavailable).
-            let saved_base = self
-                .review_store
-                .as_ref()
-                .and_then(|store| store.get_worktree_base_branch(&wt.branch).ok().flatten());
-            let base_branch =
-                resolve_diff_base_branch(saved_base, &self.config.general.main_branch);
+            let base_branch = self.diff_base_for(&wt.branch);
             let tab_width = self.config.viewer.tab_width;
             self.diff_state
                 .load_diff(&path, &base_branch, word_diff, tab_width);

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -80,6 +80,13 @@ impl App {
 
         self.viewer_state = ViewerState::default();
 
+        // The file lists deliberately survive until the background diff lands
+        // (swapping them for an empty pane would flicker), but the error must
+        // not: it belongs to the worktree we just left, and leaving a red
+        // banner up would attribute the outgoing worktree's failure to the
+        // incoming one.
+        self.diff_state.error = None;
+
         // Track the worktree now being loaded and seed its saved file/scroll
         // so it gets re-opened once the file tree arrives.
         let new_branch = self.selected_worktree_branch();
@@ -138,6 +145,7 @@ impl App {
         // Dispatch heavy operations to background threads.
         if let Some(wt) = self.worktrees.get(self.selected_worktree) {
             let wt_path = wt.path.clone();
+            let wt_branch = wt.branch.clone();
 
             // Background file tree walk.
             {
@@ -152,48 +160,14 @@ impl App {
             // Background diff computation.
             {
                 let path = wt_path.clone();
-                let base_branch = self.config.general.main_branch.clone();
+                // Same base as `refresh_diff`: using a different one here would
+                // make the file list change out from under the user moments
+                // after the switch. `diff_base_for` is the single decision point.
+                let base_branch = self.diff_base_for(&wt_branch);
                 let word_diff = self.config.diff.word_diff;
                 let tab_width = self.config.viewer.tab_width;
                 self.bg.diff.start(move |tx| {
-                    let mut result = BgDiffResult {
-                        committed: Vec::new(),
-                        uncommitted: Vec::new(),
-                        error: None,
-                    };
-                    match DiffState::compute_diff_range_static(
-                        &path,
-                        &base_branch,
-                        true,
-                        word_diff,
-                        tab_width,
-                    ) {
-                        Ok(mut files) => {
-                            files.sort_by(|a, b| a.path.cmp(&b.path));
-                            result.committed = files;
-                        }
-                        Err(e) => {
-                            result.error = Some(format!("{e:#}"));
-                            let _ = tx.send(result);
-                            return;
-                        }
-                    }
-                    match DiffState::compute_diff_range_static(
-                        &path,
-                        &base_branch,
-                        false,
-                        word_diff,
-                        tab_width,
-                    ) {
-                        Ok(mut files) => {
-                            files.sort_by(|a, b| a.path.cmp(&b.path));
-                            result.uncommitted = files;
-                        }
-                        Err(e) => {
-                            log::warn!("failed to compute uncommitted diff: {e:#}");
-                        }
-                    }
-                    let _ = tx.send(result);
+                    let _ = tx.send(compute_bg_diff(&path, &base_branch, word_diff, tab_width));
                 });
             }
 
@@ -291,16 +265,7 @@ impl App {
 
         // Diff result.
         if let Some(result) = self.bg.diff.poll() {
-            if let Some(error) = result.error {
-                self.diff_state.committed_files.clear();
-                self.diff_state.uncommitted_files.clear();
-                self.diff_state.error = Some(error);
-            } else {
-                self.diff_state.committed_files = result.committed;
-                self.diff_state.uncommitted_files = result.uncommitted;
-                self.diff_state.error = None;
-            }
-            self.diff_state.rebuild_display_list();
+            apply_bg_diff_result(&mut self.diff_state, result);
         }
 
         // Branch details result.
@@ -372,5 +337,198 @@ impl App {
             self.branch_details.pr_url = result;
             self.branch_details.pr_loading = false;
         }
+    }
+}
+
+/// Compute both diff ranges for the background worktree-switch worker.
+///
+/// Lifted out of the worker closure so it can be exercised directly: the rule it
+/// encodes — a committed failure records the error but must not stop the
+/// uncommitted diff, which doesn't depend on the base ref — is the one this
+/// module got wrong, and inside a `bg.diff.start` closure nothing could reach it
+/// to check. Mirrors [`DiffState::load_diff`]'s handling of the same two ranges.
+fn compute_bg_diff(
+    path: &std::path::Path,
+    base_branch: &str,
+    word_diff: bool,
+    tab_width: usize,
+) -> BgDiffResult {
+    let mut result = BgDiffResult {
+        committed: Vec::new(),
+        uncommitted: Vec::new(),
+        error: None,
+    };
+    match DiffState::compute_diff_range_static(path, base_branch, true, word_diff, tab_width) {
+        Ok(mut files) => {
+            files.sort_by(|a, b| a.path.cmp(&b.path));
+            result.committed = files;
+        }
+        Err(e) => result.error = Some(format!("{e:#}")),
+    }
+    match DiffState::compute_diff_range_static(path, base_branch, false, word_diff, tab_width) {
+        Ok(mut files) => {
+            files.sort_by(|a, b| a.path.cmp(&b.path));
+            result.uncommitted = files;
+        }
+        // Non-fatal on its own: the committed half may still be worth showing.
+        Err(e) => log::warn!("failed to compute uncommitted diff: {e:#}"),
+    }
+    result
+}
+
+/// Copy a finished background diff into the [`DiffState`].
+///
+/// A free function rather than a `DiffState` method so it can be unit-tested
+/// without building a whole `App`, and so `diff_state` never has to depend on
+/// `app::types::BgDiffResult` — that would invert the module dependency.
+///
+/// Both file lists are applied unconditionally, including when `error` is set:
+/// the error only ever comes from resolving the base ref, which the uncommitted
+/// list (HEAD vs workdir+index) does not depend on. Clearing it alongside the
+/// committed list is what made a bad base ref look identical to a clean tree.
+fn apply_bg_diff_result(diff_state: &mut DiffState, result: BgDiffResult) {
+    diff_state.committed_files = result.committed;
+    diff_state.uncommitted_files = result.uncommitted;
+    diff_state.error = result.error;
+    diff_state.rebuild_display_list();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff_state::{DiffViewMode, FileDiff};
+
+    fn file(path: &str) -> FileDiff {
+        FileDiff {
+            path: path.to_string(),
+            added_lines: 1,
+            deleted_lines: 0,
+            is_new: false,
+            is_deleted: false,
+            hunks: Vec::new(),
+        }
+    }
+
+    /// The reported bug: a base ref that won't resolve used to wipe the
+    /// uncommitted list too, so 17 modified files rendered as `(0)`.
+    #[test]
+    fn bg_diff_result_with_error_keeps_uncommitted() {
+        let mut ds = DiffState::new("origin/main", DiffViewMode::Unified);
+        apply_bg_diff_result(
+            &mut ds,
+            BgDiffResult {
+                committed: Vec::new(),
+                uncommitted: vec![file("CLAUDE.md"), file("src/config.rs")],
+                error: Some("base ref 'origin/main' not found".to_string()),
+            },
+        );
+
+        assert!(ds.committed_files.is_empty());
+        assert_eq!(
+            ds.uncommitted_files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["CLAUDE.md", "src/config.rs"],
+        );
+        assert!(ds.error.is_some(), "the failure must stay visible");
+
+        // Resolve every File entry back through the display list rather than
+        // just checking it's non-empty. `diff_list.rs` indexes
+        // `committed_files`/`uncommitted_files` by the entry's `file_index`, so
+        // a display list left un-rebuilt after swapping the file vectors is an
+        // out-of-bounds panic waiting for the next render — this pins the
+        // "always rebuild" invariant, not merely "something got listed".
+        let listed: Vec<&str> = (0..ds.display_list.len())
+            .filter_map(|idx| ds.resolve_file(idx))
+            .map(|(f, _section)| f.path.as_str())
+            .collect();
+        // Directory-grouped order, not input order: files under a directory
+        // node come before top-level ones.
+        assert_eq!(listed, vec!["src/config.rs", "CLAUDE.md"]);
+    }
+
+    /// Build a repo with one commit on `main`, HEAD on `feature`, and an
+    /// uncommitted file in the worktree. Returns the tempdir (kept alive by the
+    /// caller) — every path below needs a real repo, not a hand-built struct.
+    fn repo_with_uncommitted_change() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("test", "test@test.com").unwrap();
+        let blob = repo.blob(b"a").unwrap();
+        let mut tb = repo.treebuilder(None).unwrap();
+        tb.insert("a.txt", blob, 0o100644).unwrap();
+        let tree = repo.find_tree(tb.write().unwrap()).unwrap();
+        let oid = repo
+            .commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+        let commit = repo.find_commit(oid).unwrap();
+        repo.branch("feature", &commit, true).unwrap();
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        std::fs::write(dir.path().join("dirty.txt"), b"uncommitted").unwrap();
+        dir
+    }
+
+    /// The bg worker's half of the fix. `apply_bg_diff_result` only proves the
+    /// *reporting* side; this proves the worker still computes the uncommitted
+    /// diff after the committed one fails. Put the `return` back in the Err arm
+    /// and this is the test that catches it.
+    #[test]
+    fn compute_bg_diff_keeps_uncommitted_when_base_is_unresolvable() {
+        let dir = repo_with_uncommitted_change();
+
+        let result = compute_bg_diff(dir.path(), "no-such-base", false, 4);
+
+        let err = result.error.as_deref().expect("base failure must be recorded");
+        assert!(err.contains("no-such-base"), "error was: {err}");
+        assert!(result.committed.is_empty());
+        assert_eq!(
+            result
+                .uncommitted
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["dirty.txt"],
+        );
+    }
+
+    /// A resolvable base leaves no error behind, so the panel shows no banner.
+    #[test]
+    fn compute_bg_diff_reports_no_error_for_a_resolvable_base() {
+        let dir = repo_with_uncommitted_change();
+
+        let result = compute_bg_diff(dir.path(), "main", false, 4);
+
+        assert_eq!(result.error, None);
+        assert!(result.committed.is_empty(), "feature == main, so nothing committed");
+        assert_eq!(
+            result
+                .uncommitted
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["dirty.txt"],
+        );
+    }
+
+    /// A later successful result must clear a stale error, or the panel would
+    /// keep the error marker forever.
+    #[test]
+    fn bg_diff_result_without_error_clears_a_stale_one() {
+        let mut ds = DiffState::new("main", DiffViewMode::Unified);
+        ds.error = Some("previous failure".to_string());
+        apply_bg_diff_result(
+            &mut ds,
+            BgDiffResult {
+                committed: vec![file("src/main.rs")],
+                uncommitted: Vec::new(),
+                error: None,
+            },
+        );
+
+        assert!(ds.error.is_none());
+        assert_eq!(ds.committed_files.len(), 1);
     }
 }

--- a/src/app/worktree_crud.rs
+++ b/src/app/worktree_crud.rs
@@ -299,7 +299,9 @@ impl App {
 
                 self.new_worktree_paths.insert(path.clone());
                 self.record_stat("branches_created");
-                if let Some(store) = &self.review_store {
+                if let Some(store) = &self.review_store
+                    && is_usable_diff_base(&pending.base_ref)
+                {
                     let _ = store.save_worktree_base_branch(&pending.branch, &pending.base_ref);
                 }
                 self.refresh_worktrees();
@@ -433,6 +435,39 @@ impl App {
                     );
                 }
             }
+        }
+    }
+}
+
+/// Whether `base_ref` is meaningful as a *diff* base, as opposed to merely a
+/// valid starting point for `git worktree add`.
+///
+/// `GitEngine::resolve_base_ref` falls back to the literal string `"HEAD"` when
+/// neither `origin/<main>` nor `<main>` exists — correct for creating the
+/// worktree, useless for diffing it. Persisted as a base, `"HEAD"` resolves to
+/// the worktree's *own* head, so `merge-base(HEAD, HEAD) == HEAD` and the
+/// committed section is empty forever with no error to explain it: exactly the
+/// silent `(0)` this whole change exists to kill, arriving by another door.
+/// Dropping it here falls back to `main_branch`, which either works or fails
+/// loudly in the panel.
+fn is_usable_diff_base(base_ref: &str) -> bool {
+    !base_ref.is_empty() && base_ref != "HEAD"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_usable_diff_base;
+
+    #[test]
+    fn head_and_empty_are_rejected_as_diff_bases() {
+        assert!(!is_usable_diff_base("HEAD"));
+        assert!(!is_usable_diff_base(""));
+    }
+
+    #[test]
+    fn real_refs_are_accepted() {
+        for base in ["main", "origin/main", "release/1.0", "v1.2.3"] {
+            assert!(is_usable_diff_base(base), "{base} should be usable");
         }
     }
 }

--- a/src/diff_state/compute.rs
+++ b/src/diff_state/compute.rs
@@ -12,6 +12,44 @@ use similar::{ChangeTag, TextDiff};
 
 use super::model::{DiffHunk, DiffLine, DiffLineTag, DiffRange, DiffState, FileDiff, InlineSegment};
 
+/// Resolve `base` — a branch name, a remote-tracking ref, a tag, or a raw OID —
+/// to the commit the diff should be based on.
+///
+/// `revparse_single` rather than `find_branch` because worktrees Conductor
+/// creates record `origin/<main>` as their base (see
+/// `GitEngine::resolve_base_ref`), and a remote-tracking ref is not a local
+/// branch — that mismatch is what made the changed-files list come back empty.
+///
+/// The name is resolved exactly as recorded, so a base of `origin/main` uses
+/// the remote-tracking ref even when a stale local `main` exists. Note the
+/// converse: PR intake records the PR's base as a bare name (`main`), and that
+/// *does* resolve to the local branch, which may lag the remote. The `origin/`
+/// retry is only for names with no local ref at all — a configured base like
+/// `develop` that exists solely as `refs/remotes/origin/develop`.
+///
+/// Ordering follows git's own revspec rules, so a *tag* named `main` wins over
+/// a branch named `main`, matching what `git rev-parse main` would pick.
+fn resolve_base_commit(repo: &Repository, base: &str) -> Result<git2::Oid> {
+    let resolved = repo.revparse_single(base).or_else(|primary| {
+        // A base recorded as a bare name (`develop`) can exist only as
+        // `refs/remotes/origin/develop`: git's revspec rules stop at
+        // `refs/remotes/<name>` and won't fill in the remote for you. Skip the
+        // retry for an already-qualified name so the error the user reads never
+        // says `origin/origin/main`, and keep the first failure as the cause —
+        // that's the one naming the ref they actually configured.
+        if base.starts_with("origin/") {
+            return Err(primary);
+        }
+        repo.revparse_single(&format!("origin/{base}"))
+            .map_err(|_| primary)
+    });
+    let obj = resolved.with_context(|| format!("base ref '{base}' cannot be resolved"))?;
+    let commit = obj
+        .peel_to_commit()
+        .with_context(|| format!("cannot peel '{base}' to commit"))?;
+    Ok(commit.id())
+}
+
 impl DiffState {
     /// Load the diff between `base_branch` and HEAD for the repository at
     /// `worktree_path`, replacing any previously stored diff data.
@@ -42,10 +80,10 @@ impl DiffState {
             }
             Err(e) => {
                 self.committed_files.clear();
-                self.uncommitted_files.clear();
                 self.error = Some(format!("{e:#}"));
-                self.rebuild_display_list();
-                return;
+                // Fall through to the uncommitted computation below: it
+                // doesn't depend on `base_branch`, so a bad base must not
+                // hide uncommitted changes too.
             }
         }
 
@@ -158,16 +196,6 @@ impl DiffState {
         let repo = Repository::open(worktree_path)
             .with_context(|| format!("cannot open repo at {}", worktree_path.display()))?;
 
-        // Resolve base branch OID.
-        let base_ref = repo
-            .find_branch(base_branch, git2::BranchType::Local)
-            .with_context(|| format!("branch '{base_branch}' not found"))?;
-        let base_oid = base_ref
-            .get()
-            .peel_to_commit()
-            .with_context(|| format!("cannot peel '{base_branch}' to commit"))?
-            .id();
-
         // Resolve HEAD.
         let head_commit = repo
             .head()
@@ -180,6 +208,7 @@ impl DiffState {
         let diff = match range {
             DiffRange::Committed => {
                 // merge-base(base, HEAD)..HEAD
+                let base_oid = resolve_base_commit(&repo, base_branch)?;
                 let merge_base_oid = repo.merge_base(base_oid, head_oid).with_context(|| {
                     format!("cannot find merge-base between '{base_branch}' and HEAD")
                 })?;

--- a/src/diff_state/tests.rs
+++ b/src/diff_state/tests.rs
@@ -1,7 +1,56 @@
 //! Tests for the diff_state module: inline segment emphasis, case-only
-//! rename filtering, and display-list navigation edge cases.
+//! rename filtering, display-list navigation edge cases, and base-ref
+//! resolution (remote-tracking refs, tags, OIDs, and unresolvable bases not
+//! taking down the uncommitted diff with them).
 
 use similar::{ChangeTag, TextDiff};
+
+// ── Shared git-repo builders for the base-ref-resolution tests below ──────
+
+/// A throwaway commit signature; identity doesn't matter for these tests.
+fn test_signature() -> git2::Signature<'static> {
+    git2::Signature::now("test", "test@test.com").unwrap()
+}
+
+/// Create a commit with the given flat file contents on top of `parent`
+/// (root commit if `None`). Files already in the parent's tree are carried
+/// over unchanged. Does not update any ref — callers point branches/tags at
+/// the returned oid explicitly, so a test controls exactly which refs exist.
+fn commit_files(
+    repo: &git2::Repository,
+    parent: Option<&git2::Commit>,
+    files: &[(&str, &[u8])],
+) -> git2::Oid {
+    let base_tree = parent.map(|p| p.tree().unwrap());
+    let mut tb = repo.treebuilder(base_tree.as_ref()).unwrap();
+    for (path, content) in files {
+        let oid = repo.blob(content).unwrap();
+        tb.insert(*path, oid, 0o100644).unwrap();
+    }
+    let tree_oid = tb.write().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let signature = test_signature();
+    let parents: Vec<&git2::Commit> = parent.into_iter().collect();
+    repo.commit(None, &signature, &signature, "test commit", &tree, &parents)
+        .unwrap()
+}
+
+/// Create (or move) local branch `name` to `oid`, make it HEAD, and check it
+/// out so the workdir reflects the commit's tree.
+fn checkout_branch(repo: &git2::Repository, name: &str, oid: git2::Oid) {
+    let commit = repo.find_commit(oid).unwrap();
+    repo.branch(name, &commit, true).unwrap();
+    repo.set_head(&format!("refs/heads/{name}")).unwrap();
+    repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+}
+
+/// Create a remote-tracking ref `refs/remotes/<name>` pointing at `oid`,
+/// without any actual remote configured.
+fn set_remote_tracking_ref(repo: &git2::Repository, name: &str, oid: git2::Oid) {
+    repo.reference(&format!("refs/remotes/{name}"), oid, true, "test")
+        .unwrap();
+}
 
 #[test]
 fn test_inline_segments_populated_for_replace() {
@@ -72,8 +121,8 @@ fn test_case_only_rename_filtered_out() {
         .unwrap();
     repo.set_head("refs/heads/feature").unwrap();
 
-    let files = DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4)
-        .unwrap();
+    let files =
+        DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4).unwrap();
 
     // The case-only rename with identical content should be filtered out.
     assert!(
@@ -130,8 +179,8 @@ fn test_case_rename_with_content_change_kept() {
         .unwrap();
     repo.set_head("refs/heads/feature").unwrap();
 
-    let files = DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4)
-        .unwrap();
+    let files =
+        DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4).unwrap();
 
     // The rename with actual content changes should still appear.
     assert!(
@@ -203,4 +252,559 @@ fn display_index_for_path_finds_committed_and_uncommitted_files() {
     assert_eq!(ds.display_index_for_path("src/a.rs"), Some(0));
     assert_eq!(ds.display_index_for_path("src/b.rs"), Some(1));
     assert_eq!(ds.display_index_for_path("src/missing.rs"), None);
+}
+
+// ── Base ref resolution ────────────────────────────────────────────────
+
+/// A worktree whose base was saved as `origin/main` (Conductor's normal case
+/// since 2026-07-29) must resolve even when no local `main` branch exists.
+#[test]
+fn base_ref_resolves_remote_tracking_ref() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let base_oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    set_remote_tracking_ref(&repo, "origin/main", base_oid);
+    let base_commit = repo.find_commit(base_oid).unwrap();
+
+    let head_oid = commit_files(&repo, Some(&base_commit), &[("b.txt", b"b")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    assert!(
+        repo.find_branch("main", git2::BranchType::Local).is_err(),
+        "test setup invariant: no local 'main' branch should exist"
+    );
+
+    let files =
+        DiffState::compute_diff_range(dir.path(), "origin/main", DiffRange::Committed, false, 4)
+            .unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["b.txt"]);
+}
+
+/// The same resolution must work from a linked worktree's `Repository`, not
+/// just the main worktree's — remote-tracking refs live in the shared
+/// commondir, not per-worktree.
+#[test]
+fn base_ref_resolves_from_linked_worktree() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let base_oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    set_remote_tracking_ref(&repo, "origin/main", base_oid);
+    let base_commit = repo.find_commit(base_oid).unwrap();
+
+    let head_oid = commit_files(&repo, Some(&base_commit), &[("b.txt", b"b")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    // Link a worktree at a fresh branch pointing at the same commit as
+    // "feature" (can't reuse "feature" itself — it's already checked out in
+    // the main worktree). Target a not-yet-created path outside the repo's
+    // own tempdir: `git worktree add` refuses non-empty directories.
+    let wt_parent = tempfile::tempdir().unwrap();
+    let wt_path = wt_parent.path().join("linked-wt");
+    let status = std::process::Command::new("git")
+        // Isolate from the user's global/system git config (e.g. a
+        // core.hooksPath post-checkout hook) so this can't fail for reasons
+        // unrelated to what's under test.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "worktree",
+            "add",
+            "-b",
+            "wt-branch",
+            wt_path.to_str().unwrap(),
+            &head_oid.to_string(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "git worktree add failed");
+
+    let files =
+        DiffState::compute_diff_range(&wt_path, "origin/main", DiffRange::Committed, false, 4)
+            .unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["b.txt"]);
+}
+
+/// Lightweight tags, annotated tags, full OIDs, and short OIDs must all
+/// resolve to the same base commit.
+#[test]
+fn base_ref_resolves_tag_lightweight_annotated_and_oid() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let base_oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    let base_commit = repo.find_commit(base_oid).unwrap();
+    let base_obj = repo.find_object(base_oid, None).unwrap();
+
+    repo.tag_lightweight("v-lw", &base_obj, false).unwrap();
+    let tagger = test_signature();
+    repo.tag("v-ann", &base_obj, &tagger, "annotated tag", false)
+        .unwrap();
+
+    let head_oid = commit_files(&repo, Some(&base_commit), &[("b.txt", b"b")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    let full_oid = base_oid.to_string();
+    let short_oid = &full_oid[..7];
+
+    for base in ["v-lw", "v-ann", full_oid.as_str(), short_oid] {
+        let files = DiffState::compute_diff_range(dir.path(), base, DiffRange::Committed, false, 4)
+            .unwrap_or_else(|e| panic!("base '{base}' failed to resolve: {e:#}"));
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["b.txt"],
+            "base '{base}' produced unexpected diff"
+        );
+    }
+}
+
+/// A configured base like `develop` that exists only as a remote-tracking
+/// ref (no local branch) must resolve via the `origin/` fallback.
+#[test]
+fn base_ref_falls_back_to_origin_prefix() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let base_oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    set_remote_tracking_ref(&repo, "origin/develop", base_oid);
+    let base_commit = repo.find_commit(base_oid).unwrap();
+
+    let head_oid = commit_files(&repo, Some(&base_commit), &[("b.txt", b"b")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    assert!(
+        repo.find_branch("develop", git2::BranchType::Local)
+            .is_err(),
+        "test setup invariant: no local 'develop' branch should exist"
+    );
+
+    let files =
+        DiffState::compute_diff_range(dir.path(), "develop", DiffRange::Committed, false, 4)
+            .unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["b.txt"]);
+}
+
+/// A base that resolves neither directly nor via `origin/` must report an
+/// error that names the base the caller actually asked for.
+#[test]
+fn base_ref_unresolvable_reports_error() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    let err =
+        DiffState::compute_diff_range(dir.path(), "nonexistent", DiffRange::Committed, false, 4)
+            .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("nonexistent"), "error message was: {msg}");
+}
+
+/// A base already qualified as `origin/<name>` must not retry as
+/// `origin/origin/<name>` on failure. Without the guard, a base like
+/// `origin/weird` would silently retry against `origin/origin/weird`, and if
+/// some unrelated ref happens to live at that doubled path, it would resolve
+/// there — diffing against a ref the caller never asked for. This test
+/// creates exactly that trap ref so a missing guard shows up as an
+/// unexpected `Ok`, not just as wording in the error message.
+#[test]
+fn base_ref_error_does_not_double_the_origin_prefix() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+    // Exists only at the doubled path. If the `origin/` guard were missing,
+    // resolving "origin/weird" would retry as "origin/origin/weird" and
+    // land here instead of failing.
+    set_remote_tracking_ref(&repo, "origin/origin/weird", oid);
+
+    let err =
+        DiffState::compute_diff_range(dir.path(), "origin/weird", DiffRange::Committed, false, 4)
+            .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("origin/weird"), "error message was: {msg}");
+    assert!(
+        !msg.contains("origin/origin"),
+        "error message doubled the origin/ prefix: {msg}"
+    );
+}
+
+/// `revparse_single` follows git's own revspec resolution order
+/// (`refs/tags/<name>` before `refs/heads/<name>`; see `gitrevisions(7)`),
+/// so a `dup` naming both a tag and a local branch resolves to the tag. The
+/// previous `find_branch(Local)` resolution picked the branch instead, so this
+/// is a deliberate behavior change: the point is that Conductor's base
+/// resolution never disagrees with what `git rev-parse dup` would print. Adding
+/// a branch-first special case would make the TUI and the shell pick different
+/// bases in the same repo, which is the more confusing of the two options.
+#[test]
+fn base_ref_prefers_tag_over_branch_like_git_rev_parse() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let root_oid = commit_files(&repo, None, &[("base.txt", b"base")]);
+    let root_commit = repo.find_commit(root_oid).unwrap();
+
+    // Local branch "dup" -> a commit that diverges from the tag's target.
+    let branch_oid = commit_files(&repo, Some(&root_commit), &[("from_branch.txt", b"a")]);
+    repo.branch("dup", &repo.find_commit(branch_oid).unwrap(), false)
+        .unwrap();
+
+    // Tag "dup" -> a different commit, also diverging from the branch's.
+    let tag_oid = commit_files(&repo, Some(&root_commit), &[("from_tag.txt", b"b")]);
+    let tag_commit = repo.find_commit(tag_oid).unwrap();
+    let tag_obj = repo.find_object(tag_oid, None).unwrap();
+    repo.tag_lightweight("dup", &tag_obj, false).unwrap();
+
+    // HEAD descends from the tag's commit only, so the two resolutions give
+    // different merge-bases (and thus different diffs): a branch resolution
+    // hits the shared root and picks up "from_tag.txt" too, while a tag
+    // resolution treats the tag's commit itself as the merge-base.
+    let head_oid = commit_files(&repo, Some(&tag_commit), &[("head.txt", b"c")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    let files =
+        DiffState::compute_diff_range(dir.path(), "dup", DiffRange::Committed, false, 4).unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["head.txt"],
+        "expected 'dup' to resolve to the tag (only head.txt ahead of it), \
+         not the branch (which would also include from_tag.txt)"
+    );
+}
+
+/// Uncommitted diffs (HEAD vs workdir+index) don't depend on the base at
+/// all, so an unresolvable base must not prevent them from computing.
+#[test]
+fn uncommitted_range_ignores_unresolvable_base() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    std::fs::write(dir.path().join("c.txt"), b"new file").unwrap();
+
+    let files =
+        DiffState::compute_diff_range(dir.path(), "nonexistent", DiffRange::Uncommitted, false, 4)
+            .unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["c.txt"]);
+}
+
+// ── load_diff must not clear uncommitted when the base fails ──────────────
+
+/// `load_diff` with an unresolvable base must still surface uncommitted
+/// changes and the error, rather than clearing both diff sections.
+#[test]
+fn load_diff_keeps_uncommitted_when_base_unresolvable() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    std::fs::write(dir.path().join("c.txt"), b"new file").unwrap();
+
+    let mut ds = DiffState::new("nonexistent", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "nonexistent", false, 4);
+
+    assert!(ds.committed_files.is_empty());
+    let err = ds.error.as_deref().expect("expected an error to be set");
+    assert!(err.contains("nonexistent"), "error message was: {err}");
+
+    let uncommitted_paths: Vec<&str> = ds
+        .uncommitted_files
+        .iter()
+        .map(|f| f.path.as_str())
+        .collect();
+    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+    assert!(
+        ds.display_index_for_path("c.txt").is_some(),
+        "display_list should still include the uncommitted file"
+    );
+}
+
+/// When HEAD equals the merge-base with the configured base (0 commits
+/// ahead), the committed section is legitimately empty and there is no
+/// error — only uncommitted changes should show up.
+#[test]
+fn load_diff_head_equals_merge_base_shows_uncommitted_only() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+    // "release" points at the same commit as HEAD, so
+    // merge-base(release, HEAD) == HEAD == release.
+    let commit = repo.find_commit(oid).unwrap();
+    repo.branch("release", &commit, false).unwrap();
+
+    std::fs::write(dir.path().join("c.txt"), b"new file").unwrap();
+
+    let mut ds = DiffState::new("release", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "release", false, 4);
+
+    assert!(ds.committed_files.is_empty());
+    assert!(ds.error.is_none());
+
+    let uncommitted_paths: Vec<&str> = ds
+        .uncommitted_files
+        .iter()
+        .map(|f| f.path.as_str())
+        .collect();
+    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+}
+
+/// Reproduces the original bug report end to end: a worktree whose base was
+/// saved as `origin/main` (no local `main` branch), sitting 1 commit behind
+/// `origin/main` with a pile of uncommitted changes. Before the fix, `main`
+/// failed to resolve via `find_branch(Local)`, and that failure wiped
+/// *both* diff sections — reporting "Changed files (0)" even though the
+/// modified/untracked files were all still there.
+///
+/// The subtlety this test exists to pin down: **committed being 0 here is
+/// correct, not a symptom of the bug.** 1-behind means
+/// `merge-base(origin/main, HEAD) == HEAD`, so the committed section is
+/// legitimately empty regardless of the fix. What the fix changes is that
+/// `ds.error` is now `None` (the base resolved) and `uncommitted_files`
+/// keeps every modified/untracked file — pre-fix, both would have been
+/// cleared alongside the committed section, collapsing everything to a
+/// silent (0). Don't read the committed-empty assertion below as "the bug
+/// is that committed shows 0"; it never should have shown anything else.
+#[test]
+fn load_diff_reproduces_the_silent_zero_files_report() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    // C0 -> C1 (HEAD, "feature") -> C2 (origin/main only, no local branch).
+    let root_oid = commit_files(&repo, None, &[("base.txt", b"base")]);
+    let root_commit = repo.find_commit(root_oid).unwrap();
+
+    let head_oid = commit_files(
+        &repo,
+        Some(&root_commit),
+        &[("tracked1.txt", b"orig1"), ("tracked2.txt", b"orig2")],
+    );
+    checkout_branch(&repo, "feature", head_oid);
+    let head_commit = repo.find_commit(head_oid).unwrap();
+
+    let origin_main_oid = commit_files(&repo, Some(&head_commit), &[("future.txt", b"ahead")]);
+    set_remote_tracking_ref(&repo, "origin/main", origin_main_oid);
+
+    assert!(
+        repo.find_branch("main", git2::BranchType::Local).is_err(),
+        "test setup invariant: no local 'main' branch should exist"
+    );
+
+    // Modified tracked files + untracked new files, matching the report's
+    // shape (there it was 15 modified + 2 untracked; 2 + 2 is enough here).
+    std::fs::write(dir.path().join("tracked1.txt"), b"modified1").unwrap();
+    std::fs::write(dir.path().join("tracked2.txt"), b"modified2").unwrap();
+    std::fs::write(dir.path().join("untracked1.txt"), b"new1").unwrap();
+    std::fs::write(dir.path().join("untracked2.txt"), b"new2").unwrap();
+
+    let mut ds = DiffState::new("origin/main", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "origin/main", false, 4);
+
+    // The fix: base resolved, so no error.
+    assert_eq!(ds.error, None);
+    // Legitimately empty (1-behind), not a bug.
+    assert!(ds.committed_files.is_empty());
+
+    let uncommitted_paths: Vec<&str> = ds
+        .uncommitted_files
+        .iter()
+        .map(|f| f.path.as_str())
+        .collect();
+    assert_eq!(
+        uncommitted_paths,
+        vec!["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"]
+    );
+    for path in ["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"] {
+        assert!(
+            ds.display_index_for_path(path).is_some(),
+            "display_list should include '{path}'"
+        );
+    }
+}
+
+// ── Edge cases the plan's NFR checklist calls out but didn't have coverage ──
+
+/// `repo.merge_base()` fails when the base and HEAD share no history (two
+/// unrelated root commits — the same shape a shallow clone produces). The
+/// plan's "not doing" list promises that this can't take committed down
+/// with uncommitted, and that the reason is visible; this pins both.
+#[test]
+fn load_diff_keeps_uncommitted_when_merge_base_is_unrelated() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    // Two root commits with no common ancestor.
+    let other_oid = commit_files(&repo, None, &[("other.txt", b"other")]);
+    repo.branch("other", &repo.find_commit(other_oid).unwrap(), false)
+        .unwrap();
+
+    let head_oid = commit_files(&repo, None, &[("head.txt", b"head")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    std::fs::write(dir.path().join("c.txt"), b"new file").unwrap();
+
+    let mut ds = DiffState::new("other", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "other", false, 4);
+
+    assert!(ds.committed_files.is_empty());
+    let err = ds.error.as_deref().expect("expected an error to be set");
+    // Must name both the failure mode and the base, so it reads distinctly
+    // from the unresolvable-ref error in
+    // `base_ref_unresolvable_reports_error` — otherwise the banner can't tell
+    // "no such ref" apart from "no common ancestor".
+    assert!(err.contains("merge-base"), "error message was: {err}");
+    assert!(err.contains("other"), "error message was: {err}");
+
+    let uncommitted_paths: Vec<&str> = ds
+        .uncommitted_files
+        .iter()
+        .map(|f| f.path.as_str())
+        .collect();
+    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+}
+
+/// A worktree with zero commits (`git init` only — HEAD is "unborn") must
+/// not panic, and must surface an error rather than silently reporting zero
+/// changes.
+///
+/// This is an existing limitation, not something this change regresses:
+/// every workdir file here is technically untracked, but the uncommitted
+/// diff still needs a HEAD tree to compare against and there isn't one. What
+/// this change buys is that the reason now lands in `error` instead of an
+/// unexplained "Changed files (0)".
+#[test]
+fn load_diff_on_unborn_head_reports_error_without_panicking() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let _repo = git2::Repository::init(dir.path()).unwrap();
+    std::fs::write(dir.path().join("untracked.txt"), b"new").unwrap();
+
+    let mut ds = DiffState::new("main", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "main", false, 4);
+
+    let err = ds.error.as_deref().expect("expected an error to be set");
+    assert!(err.contains("HEAD"), "error message was: {err}");
+    assert!(ds.committed_files.is_empty());
+    assert!(ds.uncommitted_files.is_empty());
+    assert!(ds.display_list.is_empty());
+}
+
+/// `"HEAD"` as a base is a diff-engine no-op: `merge-base(HEAD, HEAD) ==
+/// HEAD`, so the committed diff is always empty and never errors. That's
+/// correct for the diff engine — `"HEAD"` just isn't a useful base to have.
+/// Keeping a worktree from ever *saving* `"HEAD"` as its base is a
+/// write-side responsibility (`GitEngine::resolve_base_ref` /
+/// `worktree_crud.rs`), not something this function should special-case.
+#[test]
+fn base_ref_head_yields_an_empty_committed_diff() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    let files =
+        DiffState::compute_diff_range(dir.path(), "HEAD", DiffRange::Committed, false, 4).unwrap();
+    assert!(files.is_empty());
+}
+
+/// A base that resolves to a non-commit object (here, a lightweight tag
+/// pointing straight at a blob) must report an error rather than silently
+/// returning an empty diff — the two look identical to a caller that only
+/// checks `Ok(vec![])`.
+#[test]
+fn base_ref_pointing_at_a_blob_reports_error() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    let blob_oid = repo.blob(b"not a commit").unwrap();
+    let blob_obj = repo.find_object(blob_oid, None).unwrap();
+    repo.tag_lightweight("blob-tag", &blob_obj, false).unwrap();
+
+    let err =
+        DiffState::compute_diff_range(dir.path(), "blob-tag", DiffRange::Committed, false, 4)
+            .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("blob-tag"), "error message was: {msg}");
+}
+
+/// `config.general.main_branch = ""` isn't rejected at the TOML layer, so an
+/// empty-string base can reach diff computation. Confirmed against git2
+/// directly before writing this: `revparse_single("")` errors with
+/// `InvalidSpec` rather than resolving to anything, so this is already safe
+/// — this test just pins that so a future git2 upgrade can't silently change
+/// it into the same "HEAD" trap as
+/// `base_ref_head_yields_an_empty_committed_diff`.
+#[test]
+fn base_ref_empty_string_reports_error() {
+    use super::model::DiffRange;
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
+    checkout_branch(&repo, "main", oid);
+
+    let result = DiffState::compute_diff_range(dir.path(), "", DiffRange::Committed, false, 4);
+    assert!(result.is_err(), "empty-string base should not resolve");
 }

--- a/src/event/mouse/explorer_panel.rs
+++ b/src/event/mouse/explorer_panel.rs
@@ -89,6 +89,16 @@ pub(super) fn handle_explorer_column_click(app: &mut App, col: u16, row: u16, ge
                 == crate::viewer::ExplorerBottomView::DiffList
             {
                 // Diff list is displayed — handle diff selection.
+                // The error banner occupies the top row(s) without being in
+                // `display_list`, so every entry sits that much lower on screen
+                // than its index suggests. Without this the click lands one file
+                // off, and clicking the message itself opens whatever happens to
+                // be scrolled to the top.
+                let Some(click_offset) =
+                    click_offset.checked_sub(app.viewer_state.explorer.explorer_diff_banner_rows)
+                else {
+                    return;
+                };
                 let idx = app.viewer_state.explorer.diff_list_scroll + click_offset;
                 if idx < app.diff_state.display_list.len() {
                     app.viewer_state.explorer.diff_list_selected = idx;

--- a/src/ui/explorer_panel/diff_list.rs
+++ b/src/ui/explorer_panel/diff_list.rs
@@ -28,7 +28,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     };
 
     let total = app.diff_state.committed_files.len() + app.diff_state.uncommitted_files.len();
-    let title = format!(" Changed files ({total}) ");
+    let title = diff_list_title(total, app.diff_state.error.is_some());
 
     let border_type = if panel_focused {
         BorderType::Thick
@@ -50,13 +50,29 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     let inner_height = area.height.saturating_sub(2) as usize;
     let scroll = vs_explorer.diff_list_scroll;
 
-    let items: Vec<ListItem> = app
+    // Base-resolution failures used to be completely silent: the committed
+    // section just came back empty and read as "no changes". Pin the message to
+    // the top row so the two are never confused. The banner is not part of
+    // `display_list`, so it can't be selected and doesn't shift any index the
+    // navigation keys work with — it only costs one row of list height.
+    // Newlines are flattened because a multi-line `ListItem` would silently
+    // consume more rows than the one reserved here; the List widget clips the
+    // overflow at the panel edge.
+    let error_banner: Option<ListItem> = app.diff_state.error.as_deref().map(|msg| {
+        ListItem::new(Span::styled(
+            format!("  \u{26a0} {}", msg.replace('\n', " ")),
+            Style::default().fg(theme.error),
+        ))
+    });
+    let list_height = inner_height.saturating_sub(diff_list_banner_rows(error_banner.is_some()));
+
+    let entry_items = app
         .diff_state
         .display_list
         .iter()
         .enumerate()
         .skip(scroll)
-        .take(inner_height)
+        .take(list_height)
         .map(|(idx, entry)| match entry {
             DiffListEntry::Directory {
                 name,
@@ -158,8 +174,8 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                 };
                 ListItem::new(Span::styled("  \u{25A3} SUMMARY", style))
             }
-        })
-        .collect();
+        });
+    let items: Vec<ListItem> = error_banner.into_iter().chain(entry_items).collect();
 
     // Clear first so rows below the last item (or stale rows after scrolling /
     // a height change) don't show the previous frame's glyphs — the same
@@ -167,6 +183,30 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     frame.render_widget(ratatui::widgets::Clear, area);
     let list = List::new(items).block(block);
     frame.render_widget(list, area);
+}
+
+/// Title for the changed-files block. The `— diff error` suffix distinguishes
+/// "the committed section is missing because something failed" from a genuine
+/// `(0)`; without it the two render identically. Deliberately not "base error":
+/// resolving the base ref is the common failure but not the only one — an
+/// unresolvable HEAD or a missing merge-base land here too.
+fn diff_list_title(total: usize, has_error: bool) -> String {
+    if has_error {
+        format!(" Changed files ({total}) — diff error ")
+    } else {
+        format!(" Changed files ({total}) ")
+    }
+}
+
+/// Rows the error banner occupies at the top of the changed-files list.
+///
+/// The single source of truth for that geometry. Three places have to agree on
+/// it: the renderer (how many entry rows fit), the scroll page size, and the
+/// mouse handler (which screen row maps to which `display_list` index). They
+/// used to be able to drift, and a one-row disagreement silently opens the
+/// wrong file on click.
+pub(super) fn diff_list_banner_rows(has_error: bool) -> usize {
+    usize::from(has_error)
 }
 
 /// Build a GitHub-style comment-count badge (e.g. ` 💬3`) for a file path, or
@@ -198,4 +238,36 @@ pub(crate) fn comment_badge<'a>(
         format!("  \u{1f4ac}{total}"),
         Style::default().fg(color),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{diff_list_banner_rows, diff_list_title};
+
+    /// The whole point of the error suffix: a failed base resolution and a
+    /// genuinely clean tree must not render the same title.
+    #[test]
+    fn error_title_differs_from_a_genuine_zero() {
+        assert_ne!(diff_list_title(0, true), diff_list_title(0, false));
+        assert_eq!(diff_list_title(0, false), " Changed files (0) ");
+        assert!(diff_list_title(0, true).contains("error"));
+    }
+
+    /// With the uncommitted section surviving a base failure, the count is
+    /// non-zero *and* the error marker is present — both must show.
+    #[test]
+    fn error_title_keeps_the_count() {
+        let title = diff_list_title(17, true);
+        assert!(title.contains("(17)"), "{title}");
+        assert!(title.contains("error"), "{title}");
+    }
+
+    /// The renderer, the scroll page size, and the mouse row→index conversion
+    /// all derive the banner's row cost from here. If they ever disagree by one,
+    /// a click opens the wrong file — so pin the contract.
+    #[test]
+    fn banner_costs_exactly_one_row_and_only_when_erroring() {
+        assert_eq!(diff_list_banner_rows(false), 0);
+        assert_eq!(diff_list_banner_rows(true), 1);
+    }
 }

--- a/src/ui/explorer_panel/mod.rs
+++ b/src/ui/explorer_panel/mod.rs
@@ -41,9 +41,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // Record actual panel heights for scroll calculations in event handling.
     let tree_inner_height = chunks[0].height.saturating_sub(2) as usize;
-    let diff_inner_height = chunks[1].height.saturating_sub(2) as usize;
+    // The diff list gives its top row to the error banner, which is not a
+    // `display_list` entry. Both the scroll page size and the mouse handler's
+    // row→index conversion have to know that, so publish the row count from
+    // here — the one place that also knows which view is on screen.
+    let shows_error_banner = app.viewer_state.explorer.explorer_bottom_view
+        == crate::viewer::ExplorerBottomView::DiffList
+        && app.diff_state.error.is_some();
+    let banner_rows = diff_list::diff_list_banner_rows(shows_error_banner);
+    let diff_inner_height = (chunks[1].height.saturating_sub(2) as usize).saturating_sub(banner_rows);
     app.viewer_state.explorer.explorer_tree_height = tree_inner_height.max(1);
     app.viewer_state.explorer.explorer_diff_list_height = diff_inner_height.max(1);
+    app.viewer_state.explorer.explorer_diff_banner_rows = banner_rows;
 
     file_tree::render_file_tree(frame, chunks[0], app, focused);
     match app.viewer_state.explorer.explorer_bottom_view {

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -135,6 +135,11 @@ pub struct ExplorerState {
     pub explorer_tree_height: usize,
     /// Last known inner height of the explorer diff-list pane (updated during render).
     pub explorer_diff_list_height: usize,
+    /// Rows the diff list spends on its base-error banner (0 or 1, updated
+    /// during render). The banner is not a `display_list` entry, so anything
+    /// converting a screen row back into a list index — mouse clicks — has to
+    /// subtract it or it selects the wrong file.
+    pub explorer_diff_banner_rows: usize,
     /// Which view the explorer's bottom pane is currently showing.
     pub explorer_bottom_view: ExplorerBottomView,
     /// Index of the selected comment in the explorer comment list.
@@ -177,6 +182,7 @@ impl Default for ExplorerState {
             explorer_focus_on_diff_list: false,
             explorer_tree_height: 20,
             explorer_diff_list_height: 20,
+            explorer_diff_banner_rows: 0,
             explorer_bottom_view: ExplorerBottomView::default(),
             comment_list_selected: 0,
             comment_list_scroll: 0,


### PR DESCRIPTION
## Summary

`origin/main` をベースに持つ worktree で「Changed files」が**無言で 0 件**になっていた問題を修正します。`git status` に 17 ファイルの差分があってもエラー表示すら出ない状態でした。

原因は 2 つ:

1. `compute_diff_range` が `find_branch(base, BranchType::Local)` でしかベースを引いておらず、`origin/main`（remote-tracking ref）が解決できず `Err`。`GitEngine::resolve_base_ref` は remote がある限り `origin/<main>` を返してDBに保存するので、**リモートを持つリポジトリで作られた worktree はほぼ全部この経路に乗る**。
2. その `Err` が uncommitted 差分まで巻き添えで消していた。uncommitted は HEAD ↔ workdir+index でベースに一切依存しないのに。

### 修正内容

| | 内容 |
|---|---|
| **ベース ref 解決** | `find_branch(.., Local)` → `revparse_single`。`main` / `origin/main` / タグ / 生OID / 短縮OID が通る。解決できない場合のみ `origin/<name>` を再試行（ローカル `develop` が無く `refs/remotes/origin/develop` だけある場合の救済）。`origin/` 始まりの名前では再試行せず、エラーの cause は常に**ユーザが指定した名前での失敗**を残す |
| **巻き添え停止** | ベース解決を `DiffRange::Committed` アーム内へ移動。`load_diff` / bg ワーカー / 結果反映の 3 箇所で uncommitted を捨てるのをやめた |
| **失敗の可視化** | `diff_state.error` は従来 `src/ui/` のどこからも読まれていなかった。タイトルに `— diff error`、リスト先頭に `⚠ base ref '...' cannot be resolved` を表示 |
| **ベース決定の一本化** | `refresh_diff` と worktree 切替時の bg 計算でベースの決め方が食い違っていた（保存値 vs config 固定）ため、切替直後とリフレッシュ後で件数が変わっていた。`App::diff_base_for()` に集約 |
| **`"HEAD"` を diff ベースとして保存しない** | `resolve_base_ref` は remote もローカル main も無いとき `"HEAD"` を返す。保存されると `merge_base(HEAD, HEAD) == HEAD` で committed が常に空・error も None になり、**同じ「無言の 0 件」が別経路で残る**ため塞いだ |

### ベース解決方式の選定

`revparse_single` 方式（完全一致優先＋`origin/` 補完）を採用しました。「ローカルブランチ優先」系の案は、**ローカル `main` が古いまま `origin/main` から分岐した worktree で merge-base が古い方に落ち、他人のコミットが自分の差分に混ざる**ため却下しています（Conductor は branch overlay で `fetch_origin()` するがローカル `main` を fast-forward しないので、この状態は常態的に発生）。upstream `@{u}` 由来の案は `git push -u` 後に upstream が自分のブランチに変わり committed が恒久的に空になるため、作成時 OID のピン留めは rebase 後に陳腐化するため、それぞれ却下しました。

なお `revparse_single` は git の revspec 解決順に従うため、`main` と同名のタグがあるリポジトリではタグが優先されます。`git rev-parse main` と一致する挙動なのでこれを正とし、テストで固定しています。

## Test plan

- `cargo test` — **650 passed / 0 failed**（ベースライン 625 から +25）
- `cargo clippy --all-targets` — 新規警告ゼロ（既存 3 件は `code_nav.rs` / `hover_info.rs` で本変更と無関係）

主な追加テスト:

- remote-tracking ref / 軽量タグ / 注釈付きタグ / フル OID / 短縮 OID / `origin/` 補完 / **リンク worktree 経由**の解決
- ベース解決不能時に uncommitted が残ること（`load_diff` と bg ワーカーの両経路）
- **merge-base が引けない場合**（無関係な履歴）でも uncommitted が残り、エラーが `merge-base` と base 名の両方を含んで ref 解決失敗と判別できること
- unborn HEAD（コミット 0 件）でパニックしないこと
- 元の障害報告そのものの回帰テスト（`origin/main` のみ・1 behind/0 ahead・modified+untracked）

### 実機検証

pty 経由で実際の TUI を起動し、合成リポジトリ（`origin/main` のみ・1 behind/0 ahead・dirty 3 件、DB の `base_branch` は `origin/main`）に対し**同一 worktree・同一キー操作**（`Diff: Refresh`）で修正前後を比較:

| | Changed files |
|---|---|
| 修正前（`c2739e2` をビルド） | `(0)` — メッセージ無し |
| 修正後 | `(3)` — 全ファイル列挙 |

ベースを解決不能な値にした場合も確認済み:

```
┏ Changed files (3) — diff error ┓
┃  ⚠ base ref 'release/nope' cann┃
┃  U 📃  a.txt +1 -0              ┃
┃  U 📃  new1.txt +1 -0           ┃
┃  U 📃  new2.txt +1 -0           ┃
```

committed が出せない状態でも uncommitted が生き残り、かつ理由が見えている。

## Notes

- バージョン: `0.91.0` → `0.91.1`（PATCH。バグ修正のみで API・設定・DB スキーマの変更なし）
- DB マイグレーションは不要。`origin/main` を保存する現行設計を**正**として温存しています
- エラー表示行の追加に伴い、マウスクリックの行→index 変換にバナー行分のオフセット補正を入れています（未補正だとエラー表示中にクリックが 1 行ズレる）
