### PR TITLE
feat: add a Raw/Rendered toggle for markdown files in the Viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.91.1"
+version = "0.92.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -399,6 +399,7 @@ impl App {
             .min(total.saturating_sub(1));
         self.viewer_state.content.file_scroll = scroll;
         self.viewer_state.content.h_scroll = 0;
+        self.viewer_state.show_raw_for_line_target();
         self.set_focus(Focus::Viewer);
     }
 
@@ -426,6 +427,7 @@ impl App {
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;
+            self.viewer_state.show_raw_for_line_target();
         }
     }
 
@@ -453,6 +455,7 @@ impl App {
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;
+            self.viewer_state.show_raw_for_line_target();
         }
     }
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -42,6 +42,7 @@ impl App {
             CommandId::RefreshDiff => self.refresh_diff(),
             CommandId::SearchInFile => self.cmd_search_in_file(),
             CommandId::ToggleHelp => self.cmd_toggle_help(),
+            CommandId::ToggleMarkdownRender => self.cmd_toggle_markdown_render(),
             CommandId::ShowReviewComments => self.cmd_show_review_comments(),
             CommandId::ShowReviewTemplates => {
                 self.review_state.template_picker_active = true;

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -177,6 +177,28 @@ impl App {
         }
     }
 
+    /// Switch the Viewer between raw markdown source and rendered prose.
+    ///
+    /// Only meaningful for a markdown file in the plain-file view; anywhere else
+    /// it flashes a hint rather than silently latching a mode the user can't
+    /// see, since the header toggle is hidden in exactly those cases.
+    pub fn cmd_toggle_markdown_render(&mut self) {
+        if !self.viewer_state.markdown_toggle_available() {
+            self.set_status(
+                "Raw/Rendered applies to a markdown file in the Viewer".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        }
+        self.viewer_state.toggle_markdown_rendered();
+        let msg = if self.viewer_state.md_rendered {
+            "Markdown: Rendered"
+        } else {
+            "Markdown: Raw"
+        };
+        self.set_status(msg.to_string(), StatusLevel::Info);
+    }
+
     /// Open a file path (relative to the current worktree) in the Viewer panel.
     ///
     /// Optionally jumps to `line` (1-indexed). Reveals the file in the explorer
@@ -198,6 +220,7 @@ impl App {
                 .len()
                 .saturating_sub(1);
             self.viewer_state.content.file_scroll = (ln.saturating_sub(1)).min(max);
+            self.viewer_state.show_raw_for_line_target();
         }
 
         self.set_focus(Focus::Viewer);

--- a/src/command_palette/commands.rs
+++ b/src/command_palette/commands.rs
@@ -215,6 +215,13 @@ pub const COMMANDS: &[PaletteCommand] = &[
         keywords: "grep search find text content regex ripgrep fulltext",
     },
     PaletteCommand {
+        id: CommandId::ToggleMarkdownRender,
+        label: "Viewer: Toggle Markdown Raw / Rendered",
+        category: CommandCategory::View,
+        action: Some(Action::ToggleMarkdownRender),
+        keywords: "markdown md render raw preview prose readme",
+    },
+    PaletteCommand {
         id: CommandId::ToggleHelp,
         label: "Show Help",
         category: CommandCategory::View,

--- a/src/command_palette/types.rs
+++ b/src/command_palette/types.rs
@@ -42,6 +42,7 @@ pub enum CommandId {
     // View
     SearchInFile,
     ToggleHelp,
+    ToggleMarkdownRender,
 
     // Review
     ShowReviewComments,

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -245,6 +245,10 @@
 # 'e' for "edit": hand off to $VISUAL/$EDITOR for a quick manual touch-up,
 # then drop back into the viewer (the file reloads on return).
 "e" = "open_in_editor"
+# 'm' for "markdown": switch a .md/.markdown file between raw source and
+# rendered prose. Bound in this layer only — the rendered view resolves its keys
+# against it too, so one binding covers both directions.
+"m" = "toggle_markdown_render"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 # Ctrl+Esc is the app-wide "leave focus" chord (it is the only way out of the

--- a/src/event/explorer/comment_list.rs
+++ b/src/event/explorer/comment_list.rs
@@ -184,6 +184,10 @@ pub(in crate::event) fn navigate_to_comment_with_focus(
             app.viewer_state.open_file(&wt_path, &file_path, tab_width);
             app.rehighlight_viewer();
             app.viewer_state.content.file_scroll = line.saturating_sub(1);
+            // A comment lives on a source line, so show source: rendered
+            // markdown would drop the reader at the top of the prose with the
+            // selection below invisible.
+            app.viewer_state.show_raw_for_line_target();
             app.viewer_state.selection = crate::viewer::LineSelection::Selected {
                 start: line,
                 end: line,

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -315,6 +315,35 @@ impl ClickGeometry {
     }
 }
 
+/// Handle a click on the Viewer header's `[Raw|Rendered]` toggle, returning
+/// whether it was consumed.
+///
+/// Each half selects its mode outright instead of flipping the current one, so
+/// clicking the label you can already see is a no-op rather than a surprise.
+/// The chip's columns come from the same `toggle_segments` the renderer uses,
+/// and `markdown_toggle_available` gates it exactly as the renderer does — so a
+/// toggle that isn't on screen has no click target.
+fn handle_md_toggle_click(app: &mut App, col: u16, geom: &ClickGeometry) -> bool {
+    if !app.viewer_state.markdown_toggle_available() {
+        return false;
+    }
+    let viewer_x = geom.explorer_end;
+    let Some(seg) = crate::ui::viewer_panel::toggle_segments(viewer_x, geom.viewer_w) else {
+        return false;
+    };
+    let want_rendered = if seg.raw.contains(&col) {
+        false
+    } else if seg.rendered.contains(&col) {
+        true
+    } else {
+        return false;
+    };
+    if app.viewer_state.md_rendered != want_rendered {
+        app.cmd_toggle_markdown_render();
+    }
+    true
+}
+
 /// Process a single mouse event, updating application state as needed.
 pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui::layout::Rect) {
     // Interactive hover modal stack (popup → refs list → preview) gets first
@@ -436,7 +465,12 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 return;
             }
 
-            // Check for [<=>] expand button clicks on the top border row.
+            // Check for the Viewer's Raw/Rendered toggle and the [<=>] expand
+            // button, both on the top border row. The toggle is checked first;
+            // it sits left of the expand button and the two never overlap.
+            if row == main_area.y && handle_md_toggle_click(app, col, &geom) {
+                return;
+            }
             if row == main_area.y
                 && let Some(target) = geom.expand_button_at(col) {
                     app.expanded_panel = if app.expanded_panel == Some(target) {
@@ -503,8 +537,11 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 .filter(|&d| divider_draggable(app, d));
 
             // Track hover line for gutter highlight in the viewer panel.
+            // Rendered markdown draws no gutter and no per-line highlight, and
+            // its rows aren't source lines, so it takes the clear-everything
+            // branch below exactly as if the cursor were outside the panel.
             let inner_y = main_area.y + 1;
-            if col >= explorer_end && col < viewer_end && row >= inner_y && row < main_area.y + main_area.height.saturating_sub(1) {
+            if !app.viewer_state.is_showing_rendered_markdown() && col >= explorer_end && col < viewer_end && row >= inner_y && row < main_area.y + main_area.height.saturating_sub(1) {
                 let line_offset = (row - inner_y) as usize;
                 let inner_x = explorer_end + 1;
                 let gutter_w = app.viewer_state.gutter_total_width();

--- a/src/event/mouse/scroll.rs
+++ b/src/event/mouse/scroll.rs
@@ -120,6 +120,22 @@ pub(super) fn handle_mouse_scroll(
                         .saturating_sub(delta.unsigned_abs() as usize);
                 }
             }
+        } else if app.viewer_state.is_showing_rendered_markdown() {
+            // Rendered markdown scrolls its own wrapped-line count, which has no
+            // relation to the source line count `file_scroll` indexes.
+            let total = app.viewer_state.md_total_lines;
+            if total > 0 {
+                if delta > 0 {
+                    app.viewer_state.md_scroll = (app.viewer_state.md_scroll
+                        + delta.unsigned_abs() as usize)
+                        .min(total.saturating_sub(1));
+                } else {
+                    app.viewer_state.md_scroll = app
+                        .viewer_state
+                        .md_scroll
+                        .saturating_sub(delta.unsigned_abs() as usize);
+                }
+            }
         } else if app.viewer_state.diff_view.diff_mode {
             // Unified diff view scroll.
             let total = app.viewer_state.diff_view.diff_view_lines.len();

--- a/src/event/mouse/viewer_panel.rs
+++ b/src/event/mouse/viewer_panel.rs
@@ -86,6 +86,13 @@ pub(super) fn handle_viewer_column_click(
 
     app.set_focus(Focus::Viewer);
 
+    // Rendered markdown has no line numbers, so none of what follows (symbol
+    // jump, comment threads, the gutter's comment/run-test zones) has a line to
+    // resolve against. A click is a plain focus change and nothing more.
+    if app.viewer_state.is_showing_rendered_markdown() {
+        return;
+    }
+
     let inner_x = explorer_end + 1; // inside left border
     let inner_y = main_area.y + 1; // inside top border
     let marker_w = crate::viewer::COMMENT_MARKER_W;

--- a/src/event/overlay/search.rs
+++ b/src/event/overlay/search.rs
@@ -209,6 +209,7 @@ pub(in crate::event) fn handle_grep_search_key(app: &mut App, key: KeyEvent) {
                     if app.viewer_state.content.file_scroll > hit_0 {
                         app.viewer_state.content.file_scroll = hit_0;
                     }
+                    app.viewer_state.show_raw_for_line_target();
                     app.set_focus(Focus::Viewer);
                 }
             } else {

--- a/src/event/viewer/mod.rs
+++ b/src/event/viewer/mod.rs
@@ -50,6 +50,14 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Rendered markdown: the prose carries no line numbers, so only whole-view
+    // navigation applies. Checked before everything below — including the `g`
+    // symbol-hint prefix, which resolves hints by line.
+    if app.viewer_state.is_showing_rendered_markdown() {
+        handle_viewer_markdown_mode_key(app, key);
+        return;
+    }
+
     // ── pending 'g' key — symbol hints are shown, waiting for second key ──
     // Checked before the diff-mode dispatch below since gd/gi/gr/gg apply the
     // same way whether the viewer is showing a plain file or a unified diff.
@@ -202,6 +210,49 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::ShowHoverInfo) => {
             app.show_hover_info();
+        }
+        Some(Action::ToggleMarkdownRender) => {
+            app.cmd_toggle_markdown_render();
+        }
+        _ => {}
+    }
+}
+
+/// Navigate the rendered-markdown view: scroll, jump to ends, switch back to
+/// raw, or leave the panel.
+///
+/// Deliberately an allowlist rather than the full viewer dispatch: every action
+/// omitted here (comment creation, inline threads, in-file search, hover/symbol
+/// jumps, horizontal scroll) addresses content by *source line*, and rendered
+/// prose has no line numbers to address. Resolution still uses the ordinary
+/// `Viewer` context so the toggle keeps one binding across both modes.
+pub(super) fn handle_viewer_markdown_mode_key(app: &mut App, key: KeyEvent) {
+    let total = app.viewer_state.md_total_lines;
+    let action = app.keymap.resolve(&key, KeyContext::Viewer);
+
+    match action {
+        Some(Action::ToggleMarkdownRender) => app.cmd_toggle_markdown_render(),
+        Some(Action::ExitToExplorer) => app.set_focus(crate::app::Focus::Explorer),
+        Some(Action::SearchFilename) => super::open_filename_search(app),
+        // File-level, not line-level: handing the file to $EDITOR is just as
+        // meaningful from the rendered view.
+        Some(Action::OpenInEditor) => app.open_in_editor(),
+        Some(Action::NavigateDown) if app.viewer_state.md_scroll + 1 < total => {
+            app.viewer_state.md_scroll += 1;
+        }
+        Some(Action::NavigateUp) => {
+            app.viewer_state.md_scroll = app.viewer_state.md_scroll.saturating_sub(1);
+        }
+        Some(Action::ScrollHalfPageDown) => {
+            app.viewer_state.md_scroll =
+                (app.viewer_state.md_scroll + 15).min(total.saturating_sub(1));
+        }
+        Some(Action::ScrollHalfPageUp) => {
+            app.viewer_state.md_scroll = app.viewer_state.md_scroll.saturating_sub(15);
+        }
+        Some(Action::GoToTop) => app.viewer_state.md_scroll = 0,
+        Some(Action::GoToBottom) => {
+            app.viewer_state.md_scroll = total.saturating_sub(1);
         }
         _ => {}
     }

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -92,6 +92,10 @@ keymap_suite::actions! {
         /// Open the file shown in the Viewer in an external editor ($VISUAL /
         /// $EDITOR): suspend the TUI, run the editor, then restore and reload.
         OpenInEditor => "open_in_editor",
+        /// Switch a markdown file in the Viewer between raw source and rendered
+        /// prose. No-op on any other file (and in diff mode), since the two
+        /// views only differ for markdown.
+        ToggleMarkdownRender => "toggle_markdown_render",
 
         // ── Terminal panel ────────────────────────────────────────────
         LeaveTerminal => "leave_terminal",
@@ -249,6 +253,7 @@ impl Action {
             Action::AddComment => "Add comment on line",
             Action::ExitToExplorer => "Back to Explorer",
             Action::OpenInEditor => "Open in $EDITOR",
+            Action::ToggleMarkdownRender => "Toggle markdown Raw / Rendered",
             Action::LeaveTerminal => "Leave terminal (keep session)",
             Action::ScrollbackUp => "Scrollback up",
             Action::ScrollbackDown => "Scrollback down",

--- a/src/ui/markdown/mod.rs
+++ b/src/ui/markdown/mod.rs
@@ -19,10 +19,10 @@
 //! - **Strikethrough `~~x~~`** applies `CROSSED_OUT` *and* a muted colour, so
 //!   the "removed/deprecated" meaning survives even where the terminal ignores
 //!   the SGR 9 escape.
-//! - **Tables** render borderless (bold header, a rule, aligned rows) rather
-//!   than with box-drawing — borders are too width-hungry for the narrow
-//!   summary column. Over-wide cells truncate with `…`. A future refinement
-//!   could fall back to a `key: value` list when even truncation can't fit.
+//!   summary column. A cell too wide for its column **wraps** onto extra lines
+//!   (the row grows to its tallest cell) rather than truncating — in a table
+//!   the cut text is usually the point of the row, and nothing in these views
+//!   can reveal it afterwards.
 //! - **Headings** colour and bold their text; H1/H2 also get a full-width
 //!   underline rule, echoing GitHub's bottom border on top-level sections.
 //! - **Code — fenced and inline `code`** sits on a shaded `code_bg` "card"
@@ -228,6 +228,66 @@ impl MarkdownCache {
         syntect_theme: &SyntectTheme,
         flavor: MarkdownFlavor,
     ) -> Vec<Line<'static>> {
+        self.ensure(key, body, width, theme, syntax_set, syntect_theme, flavor);
+        self.entries.borrow()[key].lines.clone()
+    }
+
+    /// Render a scrollable document and return only the visible window:
+    /// `(total_lines, clamped_skip, lines[clamped_skip..][..take])`.
+    ///
+    /// Same caching and invalidation as [`render`](Self::render); it exists
+    /// because the Viewer's rendered-markdown mode re-draws a whole file every
+    /// frame, where `render`'s clone-the-entire-document cost would scale with
+    /// file length instead of with the viewport.
+    ///
+    /// `skip` is clamped to the last line *here*, where the true total is known.
+    /// A caller clamping beforehand would have to use the previous frame's total
+    /// — stale exactly when it matters (the document or the wrap width just
+    /// changed), which shows up as a blank viewport the user can't scroll out of.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_window(
+        &self,
+        key: &str,
+        body: &str,
+        width: usize,
+        theme: &Theme,
+        syntax_set: &SyntaxSet,
+        syntect_theme: &SyntectTheme,
+        skip: usize,
+        take: usize,
+    ) -> (usize, usize, Vec<Line<'static>>) {
+        self.ensure(
+            key,
+            body,
+            width,
+            theme,
+            syntax_set,
+            syntect_theme,
+            MarkdownFlavor::Rich,
+        );
+        let entries = self.entries.borrow();
+        let lines = &entries[key].lines;
+        let skip = skip.min(lines.len().saturating_sub(1));
+        (
+            lines.len(),
+            skip,
+            lines.iter().skip(skip).take(take).cloned().collect(),
+        )
+    }
+
+    /// Populate `key`'s entry if absent or stale. On return the entry is
+    /// guaranteed present and current, so callers may index it directly.
+    #[allow(clippy::too_many_arguments)]
+    fn ensure(
+        &self,
+        key: &str,
+        body: &str,
+        width: usize,
+        theme: &Theme,
+        syntax_set: &SyntaxSet,
+        syntect_theme: &SyntectTheme,
+        flavor: MarkdownFlavor,
+    ) {
         // A theme switch changes colours baked into the cached spans, so drop
         // every entry when the theme fingerprint moves.
         let fp = theme_fingerprint(theme);
@@ -239,7 +299,7 @@ impl MarkdownCache {
             && e.body == body
             && e.width == width
         {
-            return e.lines.clone();
+            return;
         }
         let lines = render_markdown_flavored(body, width, theme, syntax_set, syntect_theme, flavor);
         self.entries.borrow_mut().insert(
@@ -247,10 +307,9 @@ impl MarkdownCache {
             CacheEntry {
                 body: body.to_string(),
                 width,
-                lines: lines.clone(),
+                lines,
             },
         );
-        lines
     }
 }
 

--- a/src/ui/markdown/table.rs
+++ b/src/ui/markdown/table.rs
@@ -1,6 +1,6 @@
 //! GFM table layout: borderless rendering (bold header, a rule, aligned rows)
-//! with column widths fitted — and over-wide cells truncated — to the panel
-//! width.
+//! with column widths fitted to the panel width and over-wide cells wrapped
+//! onto extra lines.
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -9,13 +9,19 @@ use crate::theme::Theme;
 
 use super::inline::inline_spans;
 use super::parse::Align;
-use super::wrap::{Cell, cells_to_line, char_width, spans_to_cells};
+use super::wrap::{Cell, cells_to_line, char_width, spans_to_cells, wrap_cells_raw};
 
 /// Render a GFM table borderless: a bold header row, a horizontal rule, then
 /// aligned body rows with columns separated by two spaces. Box-drawing borders
 /// are intentionally omitted — they cost too much width in the narrow summary
-/// column. Over-wide cells are truncated with `…`. (A future refinement could
-/// fall back to a `key: value` list when even truncation can't fit.)
+/// column.
+///
+/// A cell too wide for its column **wraps** rather than truncating, so a row
+/// occupies as many lines as its tallest cell needs. Truncation was the earlier
+/// behaviour and silently destroyed content — in a table the cut text is often
+/// the whole point of the row, and there is no way to reveal it (no horizontal
+/// scroll, no expand). Height is the cheaper thing to spend: the views that
+/// render markdown all scroll vertically.
 pub(crate) fn render_table(
     headers: &[String],
     aligns: &[Align],
@@ -48,7 +54,7 @@ pub(crate) fn render_table(
     let body_style = Style::default().fg(theme.fg);
 
     let mut out = Vec::with_capacity(rows.len() + 2);
-    out.push(render_table_row(
+    out.extend(render_table_row(
         headers,
         &widths,
         &aligns,
@@ -63,7 +69,7 @@ pub(crate) fn render_table(
         Style::default().fg(theme.muted),
     )));
     for row in &rows {
-        out.push(render_table_row(
+        out.extend(render_table_row(
             row,
             &widths,
             &aligns,
@@ -117,9 +123,13 @@ fn fit_col_widths(natural: &[usize], width: usize) -> Vec<usize> {
     w
 }
 
-/// Render one table row into a `Line`: each cell fitted to its column width and
-/// alignment, columns joined by two spaces, then the whole hard-clipped to
-/// `width` as a final guard for degenerate (tiny) widths.
+/// Render one table row into as many `Line`s as its tallest cell needs.
+///
+/// Each cell is wrapped to its column width and padded per its alignment, so
+/// every column contributes the same number of columns on every line and the
+/// grid stays aligned. Short cells are padded with blank lines at the bottom.
+/// Each produced line is hard-clipped to `width` as a final guard for
+/// degenerate (tiny) widths.
 fn render_table_row(
     cells: &[String],
     widths: &[usize],
@@ -127,29 +137,63 @@ fn render_table_row(
     base: Style,
     width: usize,
     theme: &Theme,
-) -> Line<'static> {
-    let mut row: Vec<Cell> = Vec::new();
-    for (k, &col_w) in widths.iter().enumerate() {
-        if k > 0 {
-            row.push(Cell { ch: ' ', style: base });
-            row.push(Cell { ch: ' ', style: base });
-        }
-        let text = cells.get(k).map(String::as_str).unwrap_or("");
-        let align = aligns.get(k).copied().unwrap_or(Align::Left);
-        row.extend(fit_cell(text, col_w, align, base, theme));
-    }
-    cells_to_line(&clip_cells(row, width))
+) -> Vec<Line<'static>> {
+    let cols: Vec<Vec<Vec<Cell>>> = widths
+        .iter()
+        .enumerate()
+        .map(|(k, &col_w)| {
+            let text = cells.get(k).map(String::as_str).unwrap_or("");
+            let align = aligns.get(k).copied().unwrap_or(Align::Left);
+            wrap_cell(text, col_w, align, base, theme)
+        })
+        .collect();
+
+    let height = cols.iter().map(Vec::len).max().unwrap_or(0);
+    let blank = |col_w: usize| -> Vec<Cell> {
+        (0..col_w).map(|_| Cell { ch: ' ', style: base }).collect()
+    };
+
+    (0..height)
+        .map(|row_line| {
+            let mut row: Vec<Cell> = Vec::new();
+            for (k, col) in cols.iter().enumerate() {
+                if k > 0 {
+                    row.push(Cell { ch: ' ', style: base });
+                    row.push(Cell { ch: ' ', style: base });
+                }
+                match col.get(row_line) {
+                    Some(line) => row.extend(line.iter().cloned()),
+                    None => row.extend(blank(widths[k])),
+                }
+            }
+            cells_to_line(&clip_cells(row, width))
+        })
+        .collect()
 }
 
-/// Fit `text` into exactly `col_w` display columns: render its inline markup,
-/// truncate (with a trailing `…`) when too wide, then pad per `align`. Returns
-/// cells whose total display width is `col_w` (empty when `col_w` is 0).
-/// Works on `Cell`s, so truncation never splits a multibyte char.
-fn fit_cell(text: &str, col_w: usize, align: Align, base: Style, theme: &Theme) -> Vec<Cell> {
+/// Wrap `text` into lines of exactly `col_w` display columns: render its inline
+/// markup, wrap at word boundaries, then pad each line per `align`. Always
+/// returns at least one line (empty cells become one blank line), so a row's
+/// height is `max` over its cells and never zero.
+fn wrap_cell(
+    text: &str,
+    col_w: usize,
+    align: Align,
+    base: Style,
+    theme: &Theme,
+) -> Vec<Vec<Cell>> {
     if col_w == 0 {
-        return Vec::new();
+        return vec![Vec::new()];
     }
-    let cells = truncate_cells(spans_to_cells(&inline_spans(text, base, theme)), col_w);
+    let cells = spans_to_cells(&inline_spans(text, base, theme));
+    wrap_cells_raw(&cells, col_w, false)
+        .into_iter()
+        .map(|line| pad_cell_line(line, col_w, align, base))
+        .collect()
+}
+
+/// Pad one wrapped line out to `col_w` columns according to `align`.
+fn pad_cell_line(cells: Vec<Cell>, col_w: usize, align: Align, base: Style) -> Vec<Cell> {
     let pad = col_w.saturating_sub(cells_width(&cells));
     let space = |n: usize| -> Vec<Cell> {
         (0..n).map(|_| Cell { ch: ' ', style: base }).collect()
@@ -173,35 +217,6 @@ fn fit_cell(text: &str, col_w: usize, align: Align, base: Style, theme: &Theme) 
             out
         }
     }
-}
-
-/// Truncate `cells` to at most `max_w` display columns, appending `…` (in the
-/// last kept cell's style) only when content was actually cut. Truncates by
-/// display width on char boundaries, so multibyte/CJK content never panics.
-fn truncate_cells(cells: Vec<Cell>, max_w: usize) -> Vec<Cell> {
-    if cells_width(&cells) <= max_w {
-        return cells;
-    }
-    if max_w == 0 {
-        return Vec::new();
-    }
-    let budget = max_w - 1; // reserve one column for the ellipsis
-    let mut out: Vec<Cell> = Vec::new();
-    let mut w = 0;
-    for cell in cells {
-        let cw = char_width(cell.ch);
-        if w + cw > budget {
-            break;
-        }
-        out.push(cell);
-        w += cw;
-    }
-    let style = out.last().map(|c| c.style).unwrap_or_default();
-    out.push(Cell {
-        ch: '\u{2026}',
-        style,
-    });
-    out
 }
 
 /// Hard-clip `cells` to at most `width` display columns (no ellipsis). The final

--- a/src/ui/markdown/tests/parsing.rs
+++ b/src/ui/markdown/tests/parsing.rs
@@ -338,6 +338,74 @@ fn table_renders_within_width_and_truncates() {
     }
 }
 
+/// The point of wrapping instead of truncating: **no content is lost.** Every
+/// word of an over-wide cell must appear somewhere in the rendered table, at
+/// every width that can hold the column at all.
+#[test]
+fn wide_table_cells_wrap_instead_of_losing_content() {
+    let table = "| feature | notes |\n| --- | --- |\n\
+        | toggle | switches a markdown file between raw source and rendered prose |\n\
+        | scroll | independent of the raw view |";
+    let words = [
+        "switches", "markdown", "between", "source", "rendered", "prose", "independent",
+    ];
+    for width in [20usize, 30, 40, 60, 100] {
+        let text: String = render(table, width)
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for w in words {
+            assert!(
+                text.contains(w),
+                "width {width}: lost {w:?} from the table\n{text}"
+            );
+        }
+        assert!(
+            !text.contains('\u{2026}'),
+            "width {width}: cell was still elided\n{text}"
+        );
+    }
+}
+
+/// Wrapping makes a row taller, so the columns must stay a grid: every line of
+/// a row has to be the same display width, or the second column ends up ragged.
+#[test]
+fn wrapped_table_rows_keep_their_columns_aligned() {
+    let table = "| a | b |\n| --- | --- |\n\
+        | one two three four five | six |\n\
+        | x | seven eight nine ten eleven |";
+    for width in [24usize, 36, 50] {
+        let lines = render(table, width);
+        // Skip the leading blank the renderer puts before a block.
+        let body: Vec<usize> = lines
+            .iter()
+            .map(|l| display_width(&line_text(l)))
+            .filter(|&w| w > 0)
+            .collect();
+        assert!(
+            body.iter().all(|&w| w == body[0]),
+            "width {width}: ragged row widths {body:?}"
+        );
+    }
+}
+
+/// A single unbreakable token wider than its column still has to appear in
+/// full — hard-split across lines rather than cut short.
+#[test]
+fn overlong_unbreakable_cell_is_split_not_cut() {
+    let url = "https://example.com/a/very/long/path/that/never/breaks";
+    let table = format!("| link |\n| --- |\n| {url} |");
+    let text: String = render(&table, 24)
+        .iter()
+        .map(|l| line_text(l))
+        .collect::<Vec<_>>()
+        .join("");
+    // Reassembled across lines (padding stripped), the whole URL is present.
+    let joined: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(joined.contains(url), "URL was cut: {text:?}");
+}
+
 #[test]
 fn table_cell_truncation_never_splits_multibyte() {
     // Force CJK / accented cells below their content width — must not panic

--- a/src/ui/markdown/wrap.rs
+++ b/src/ui/markdown/wrap.rs
@@ -62,14 +62,27 @@ pub(crate) fn cells_to_line(cells: &[Cell]) -> Line<'static> {
 /// and only overlong single words are hard-split. Display width is measured with
 /// `unicode-width`, so full-width (CJK) text wraps correctly.
 pub(crate) fn wrap_cells(cells: &[Cell], width: usize, hard: bool) -> Vec<Line<'static>> {
+    wrap_cells_raw(cells, width, hard)
+        .iter()
+        .map(|l| cells_to_line(l))
+        .collect()
+}
+
+/// [`wrap_cells`] without the final merge into `Line`s — one `Vec<Cell>` per
+/// wrapped line.
+///
+/// Callers that need to keep working at cell granularity after wrapping use
+/// this: table columns, for instance, must pad and align each wrapped line to
+/// the column width before the columns are stitched together side by side,
+/// which is impossible once the cells have collapsed into `Span`s.
+pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Vec<Cell>> {
     let width = width.max(1);
-    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut lines: Vec<Vec<Cell>> = Vec::new();
     let mut cur: Vec<Cell> = Vec::new();
     let mut cur_w = 0usize;
 
     let mut push_line = |cur: &mut Vec<Cell>, cur_w: &mut usize| {
-        lines.push(cells_to_line(cur));
-        cur.clear();
+        lines.push(std::mem::take(cur));
         *cur_w = 0;
     };
 
@@ -86,7 +99,7 @@ pub(crate) fn wrap_cells(cells: &[Cell], width: usize, hard: bool) -> Vec<Line<'
             push_line(&mut cur, &mut cur_w);
         }
         if lines.is_empty() {
-            lines.push(Line::from(""));
+            lines.push(Vec::new());
         }
         return lines;
     }
@@ -146,7 +159,7 @@ pub(crate) fn wrap_cells(cells: &[Cell], width: usize, hard: bool) -> Vec<Line<'
         push_line(&mut cur, &mut cur_w);
     }
     if lines.is_empty() {
-        lines.push(Line::from(""));
+        lines.push(Vec::new());
     }
     lines
 }

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -17,6 +17,7 @@ use ratatui::widgets::{
 use super::code_line::{render_code_line_rows, FileLineRenderCtx};
 use super::comment_thread::new_comment_anchor_end;
 use super::diff_view::{build_walkthrough_banner, render_diff_view, render_walkthrough_banner};
+use super::markdown_view::{render_markdown_view, toggle_segments, toggle_spans, TOGGLE_W};
 use super::media_view::render_media_view;
 use super::search_box::render_search_box;
 use super::span_utils::digit_count;
@@ -58,9 +59,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         ("[<=>]", theme.border_unfocused)
     };
 
-    // Truncate title so it doesn't overlap with the [<=>] button on the right.
-    // Reserve: 2 (borders) + expand_label width + 1 (gap).
-    let max_title_len = (area.width as usize).saturating_sub(2 + expand_label.len() + 1);
+    // Raw/Rendered toggle — markdown files in the plain-file view only, and
+    // only when the column is wide enough to hold it (`toggle_segments`, the
+    // same function the click hit-test consults).
+    let show_md_toggle =
+        vs.markdown_toggle_available() && toggle_segments(area.x, area.width).is_some();
+    let md_toggle_w = if show_md_toggle { TOGGLE_W as usize } else { 0 };
+
+    // Truncate title so it doesn't overlap with the [<=>] button (and the
+    // toggle, when shown) on the right. Reserve: 2 (borders) + toggle +
+    // expand_label width + 1 (gap).
+    let max_title_len =
+        (area.width as usize).saturating_sub(2 + md_toggle_w + expand_label.len() + 1);
     let title = match &vs.content.current_file {
         Some(path) => {
             let raw = if !vs.search.search_matches.is_empty() {
@@ -75,22 +85,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             } else {
                 format!(" {path} ")
             };
-            if raw.len() > max_title_len && max_title_len > 4 {
-                // Truncate with ellipsis: " …<tail> "
-                let inner_max = max_title_len.saturating_sub(2); // leading/trailing spaces
-                let tail: String = raw
-                    .trim()
-                    .chars()
-                    .rev()
-                    .take(inner_max.saturating_sub(1))
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect();
-                format!(" \u{2026}{tail} ")
-            } else {
-                raw
-            }
+            fit_title(&raw, max_title_len)
         }
         None => " (no file selected) ".to_string(),
     };
@@ -106,15 +101,19 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     } else {
         Style::default().fg(theme.muted)
     };
+    // One right-aligned line holds both controls, so `[<=>]` keeps its exact
+    // columns (and its existing hit-test) whether or not the toggle is drawn.
+    let mut right_spans: Vec<Span> = Vec::new();
+    if show_md_toggle {
+        right_spans.extend(toggle_spans(vs.is_showing_rendered_markdown(), theme));
+    }
+    right_spans.push(Span::styled(
+        expand_label,
+        Style::default().fg(expand_color),
+    ));
     let block = Block::default()
         .title(Span::styled(title, title_style))
-        .title_top(
-            Line::from(Span::styled(
-                expand_label,
-                Style::default().fg(expand_color),
-            ))
-            .alignment(Alignment::Right),
-        )
+        .title_top(Line::from(right_spans).alignment(Alignment::Right))
         .borders(Borders::ALL)
         .border_type(border_type)
         .border_style(Style::default().fg(border_color));
@@ -146,6 +145,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // Media file mode: render image/video as ASCII art.
     if vs.is_current_file_media() {
         render_media_view(frame, area, app, block);
+        return;
+    }
+
+    // Rendered-markdown mode. Returns before any of the line-oriented rendering
+    // below, so `screen_row_map` stays empty (cleared at function entry) and no
+    // gutter, comment marker, or thread row is ever drawn — see `markdown_view`.
+    if vs.is_showing_rendered_markdown() {
+        render_markdown_view(frame, area, app, block);
         return;
     }
 
@@ -314,6 +321,44 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     app.viewer_state.content.screen_row_map = screen_row_map;
 }
 
+/// Fit the Viewer's title into `max_w` **display columns**, eliding from the
+/// left (`" …tail "`) so the filename — the informative end of a path —
+/// survives.
+///
+/// Columns, not bytes or chars: a CJK filename costs 2 columns per character
+/// while measuring 3 bytes, so a byte- or char-budgeted cut yields a title
+/// that overruns its allowance and paints over the header controls to its
+/// right (the `[Raw|Rendered]` toggle and `[<=>]`). Below the width of
+/// `" … "` nothing meaningful fits, so the title yields the row entirely
+/// rather than overlapping.
+pub(super) fn fit_title(raw: &str, max_w: usize) -> String {
+    if display_width(raw) <= max_w {
+        return raw.to_string();
+    }
+    if max_w < 4 {
+        return " ".repeat(max_w);
+    }
+    // Leading space + ellipsis + trailing space cost 3 columns.
+    let budget = max_w - 3;
+    let mut tail: Vec<char> = Vec::new();
+    let mut used = 0usize;
+    for ch in raw.trim_end().chars().rev() {
+        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + cw > budget {
+            break;
+        }
+        tail.push(ch);
+        used += cw;
+    }
+    tail.reverse();
+    let tail: String = tail.into_iter().collect();
+    format!(" \u{2026}{tail} ")
+}
+
+fn display_width(s: &str) -> usize {
+    unicode_width::UnicodeWidthStr::width(s)
+}
+
 /// Build the breadcrumb `Line` from jump history + current position.
 /// Returns `None` when there are fewer than 2 entries (no navigation happened).
 fn build_breadcrumb_line(app: &App) -> Option<Line<'static>> {
@@ -368,4 +413,60 @@ fn build_breadcrumb_line(app: &App) -> Option<Line<'static>> {
 fn breadcrumb_label(loc: &crate::jump_history::Location) -> String {
     let filename = loc.file_path.rsplit('/').next().unwrap_or(&loc.file_path);
     format!("{}:{}", filename, loc.line + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The invariant the header controls depend on: whatever comes back never
+    /// exceeds its column budget. Anything wider paints over the toggle and the
+    /// `[<=>]` button sharing that row.
+    #[test]
+    fn fitted_title_never_exceeds_its_budget() {
+        let titles = [
+            " src/main.rs ",
+            " 設計メモ.md ",
+            " docs/日本語/とても長い名前のファイル.markdown ",
+            " a.rs ",
+            " 🦀🦀🦀/emoji.md ",
+            " ",
+        ];
+        for t in titles {
+            for max_w in 0..40usize {
+                let fitted = fit_title(t, max_w);
+                assert!(
+                    display_width(&fitted) <= max_w,
+                    "title={t:?} max_w={max_w} -> {fitted:?} ({} cols)",
+                    display_width(&fitted)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn short_titles_pass_through_untouched() {
+        assert_eq!(fit_title(" a.rs ", 20), " a.rs ");
+        // Exactly at budget still passes through.
+        assert_eq!(fit_title(" a.rs ", 6), " a.rs ");
+    }
+
+    /// Eliding keeps the tail, because the filename is at the end of a path.
+    #[test]
+    fn elision_keeps_the_end_of_the_path() {
+        let fitted = fit_title(" src/ui/viewer_panel/file_view.rs ", 16);
+        assert!(fitted.starts_with(" \u{2026}"), "{fitted:?}");
+        assert!(fitted.ends_with("file_view.rs "), "{fitted:?}");
+    }
+
+    /// A wide-glyph title is budgeted in columns, so it elides *sooner* than a
+    /// byte- or char-count would suggest — this is the case that used to
+    /// overrun into the header controls.
+    #[test]
+    fn wide_glyphs_are_budgeted_by_column() {
+        // 4 CJK chars = 8 columns, but 12 bytes.
+        let fitted = fit_title(" 設計メモ.md ", 10);
+        assert!(display_width(&fitted) <= 10, "{fitted:?}");
+        assert!(fitted.contains('\u{2026}'), "{fitted:?}");
+    }
 }

--- a/src/ui/viewer_panel/markdown_view.rs
+++ b/src/ui/viewer_panel/markdown_view.rs
@@ -1,0 +1,287 @@
+//! Rendered-markdown mode of the viewer panel — the `.md`/`.markdown` file
+//! shown as prose instead of source, plus the header Raw/Rendered toggle that
+//! switches between the two.
+//!
+//! The prose is produced by the same renderer the SUMMARY pseudo-file uses
+//! ([`crate::ui::markdown`], via `App::markdown_cache`), so headings, lists,
+//! tables, and fenced code blocks look identical in both places.
+//!
+//! **This mode has no line numbers, and therefore no line-oriented features.**
+//! Markdown rendering wraps, reflows, drops, and injects rows, so a screen row
+//! no longer corresponds to a source line: gutter, line selection, hover
+//! highlight, comment creation, inline comment threads, and line-anchored jumps
+//! are all meaningless here and are switched off at their sources — see
+//! [`crate::viewer::ViewerState::is_showing_rendered_markdown`], which every one
+//! of them gates on. Notably, this renderer never writes
+//! `content.screen_row_map`, which [`super::render`] clears on entry; that empty
+//! map is what makes every mouse row lookup resolve to "no line".
+
+use std::ops::Range;
+
+use crate::app::App;
+use crate::theme::Theme;
+use ratatui::Frame;
+use ratatui::layout::{Margin, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::{
+    Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
+
+const RAW_LABEL: &str = "Raw";
+const RENDERED_LABEL: &str = "Rendered";
+
+/// Display width of the toggle chip `[Raw|Rendered]`.
+const CHIP_W: u16 = 1 + RAW_LABEL.len() as u16 + 1 + RENDERED_LABEL.len() as u16 + 1;
+
+/// Width the toggle claims in the title row: the chip plus one space of
+/// separation from the `[<=>]` expand button to its right.
+pub(crate) const TOGGLE_W: u16 = CHIP_W + 1;
+
+/// Width of the `[<=>]` expand button the toggle is laid out against. Kept in
+/// sync with `event::mouse::ClickGeometry::expand_button_at`, which owns that
+/// button's own hit-test.
+const EXPAND_BTN_W: u16 = 5;
+
+/// Narrowest Viewer column that still gets a toggle. Below this the title would
+/// have no room left, so the toggle is dropped entirely (keyboard and palette
+/// still switch modes).
+const MIN_VIEWER_W: u16 = TOGGLE_W + EXPAND_BTN_W + 8;
+
+/// Screen columns of the toggle's two halves, in a Viewer column starting at
+/// `viewer_x` and `viewer_w` wide.
+pub(crate) struct ToggleSegments {
+    /// Columns that select raw source (`[Raw`).
+    pub raw: Range<u16>,
+    /// Columns that select rendered markdown (`|Rendered]`).
+    pub rendered: Range<u16>,
+}
+
+/// Where the header toggle sits, or `None` when the Viewer column is too narrow
+/// to draw it.
+///
+/// The renderer ([`toggle_spans`], gated on this returning `Some`) and the mouse
+/// hit-test in `event/mouse` both derive their layout from this one function, so
+/// a toggle that isn't drawn can never be clicked, and a drawn one is always
+/// clickable exactly where it appears.
+///
+/// The title line is right-aligned and ends one cell inside the block's right
+/// border, laid out as `[Raw|Rendered] [<=>]`.
+pub(crate) fn toggle_segments(viewer_x: u16, viewer_w: u16) -> Option<ToggleSegments> {
+    if viewer_w < MIN_VIEWER_W {
+        return None;
+    }
+    // Last drawable cell of the right-aligned title line, then step left past
+    // the expand button and the separating space to the chip's own right edge.
+    let line_end = viewer_x + viewer_w - 1; // exclusive
+    let chip_end = line_end - EXPAND_BTN_W - 1; // exclusive
+    let chip_start = chip_end - CHIP_W;
+    // Split at the `|`: "[Raw" selects raw, "|Rendered]" selects rendered.
+    let split = chip_start + 1 + RAW_LABEL.len() as u16;
+    Some(ToggleSegments {
+        raw: chip_start..split,
+        rendered: split..chip_end,
+    })
+}
+
+/// The toggle chip's spans, with the active mode highlighted, ready to be
+/// appended to the Viewer's right-aligned title line. Caller must have checked
+/// [`toggle_segments`] is `Some` for the current width.
+pub(crate) fn toggle_spans(rendered: bool, theme: &Theme) -> Vec<Span<'static>> {
+    let chrome = Style::default().fg(theme.muted);
+    let active = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+    let inactive = Style::default().fg(theme.muted);
+    vec![
+        Span::styled("[", chrome),
+        Span::styled(RAW_LABEL, if rendered { inactive } else { active }),
+        Span::styled("|", chrome),
+        Span::styled(RENDERED_LABEL, if rendered { active } else { inactive }),
+        Span::styled("] ", chrome),
+    ]
+}
+
+/// Render the open markdown file as prose, filling the whole panel.
+///
+/// `block` is the Viewer's own block (title + toggle already on it), so this
+/// mode keeps the same frame as the raw view — only the contents change.
+pub(super) fn render_markdown_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'_>) {
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_height = area.height.saturating_sub(2) as usize;
+
+    let (total, scroll, visible) = {
+        let key = format!(
+            "viewer-md:{}",
+            app.viewer_state
+                .content
+                .current_file
+                .as_deref()
+                .unwrap_or("")
+        );
+        let body = app.viewer_state.content.file_content.join("\n");
+        // Reserve a column on the right so wrapped prose never collides with
+        // the scrollbar track (matching the summary view's inset).
+        app.markdown_cache.render_window(
+            &key,
+            &body,
+            inner_width.saturating_sub(1),
+            &app.theme,
+            &app.syntax_set,
+            &app.syntect_theme,
+            app.viewer_state.md_scroll,
+            inner_height,
+        )
+    };
+
+    // Record the total so the key handler can clamp scrolling, and write the
+    // clamped scroll back so navigation stays responsive if the document shrank
+    // (or re-wrapped shorter after the panel got wider).
+    app.viewer_state.md_total_lines = total;
+    app.viewer_state.md_scroll = scroll;
+
+    frame.render_widget(ratatui::widgets::Clear, area);
+    frame.render_widget(Paragraph::new(visible).block(block), area);
+
+    if total > inner_height {
+        let scrollbar_area = area.inner(Margin {
+            horizontal: 0,
+            vertical: 1,
+        });
+        let mut scrollbar_state =
+            ScrollbarState::new(total.saturating_sub(inner_height)).position(scroll);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None);
+        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The chip must land immediately left of the `[<=>]` expand button, whose
+    /// hit-test (`expand_button_at`) claims the 5 cells ending 2 before the
+    /// column's right edge. Overlapping them would make one button eat the
+    /// other's clicks.
+    #[test]
+    fn toggle_sits_just_left_of_the_expand_button() {
+        let (x, w) = (40u16, 60u16);
+        let seg = toggle_segments(x, w).expect("60 cols is plenty");
+        let expand_start = x + w - 6;
+        assert_eq!(
+            seg.rendered.end + 1,
+            expand_start,
+            "one space must separate the chip from [<=>]"
+        );
+        assert!(seg.rendered.end <= expand_start);
+    }
+
+    #[test]
+    fn toggle_halves_are_adjacent_and_correctly_sized() {
+        let seg = toggle_segments(0, 80).unwrap();
+        assert_eq!(seg.raw.end, seg.rendered.start, "no dead gap between halves");
+        // "[Raw" and "|Rendered]".
+        assert_eq!(seg.raw.end - seg.raw.start, 1 + RAW_LABEL.len() as u16);
+        assert_eq!(
+            seg.rendered.end - seg.rendered.start,
+            1 + RENDERED_LABEL.len() as u16 + 1
+        );
+        assert_eq!(seg.rendered.end - seg.raw.start, CHIP_W);
+    }
+
+    /// A toggle that isn't drawn must not be clickable: both the renderer and
+    /// the hit-test ask this same function, so `None` disables both at once.
+    #[test]
+    fn narrow_columns_get_no_toggle() {
+        assert!(toggle_segments(0, MIN_VIEWER_W - 1).is_none());
+        assert!(toggle_segments(0, 0).is_none());
+        assert!(toggle_segments(0, MIN_VIEWER_W).is_some());
+    }
+
+    /// Whatever the column offset, the chip stays inside the panel.
+    #[test]
+    fn toggle_stays_within_the_column() {
+        for w in [MIN_VIEWER_W, MIN_VIEWER_W + 1, 100, 300] {
+            let seg = toggle_segments(7, w).unwrap();
+            assert!(seg.raw.start > 7, "must not overlap the left border");
+            assert!(seg.rendered.end < 7 + w, "must not overrun the right border");
+        }
+    }
+
+    /// The decisive check: draw the header exactly as `file_view` does and
+    /// confirm each cell `toggle_segments` claims really holds that part of the
+    /// chip. Arithmetic agreement between the two is not enough — ratatui owns
+    /// where a right-aligned title actually lands, and a drift there would send
+    /// clicks to the wrong half (or into the `[<=>]` button) with nothing in the
+    /// unit maths to show for it. Titles include a wide-glyph case, since a CJK
+    /// filename costs 2 columns per character.
+    #[test]
+    fn drawn_columns_match_the_hit_test() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Alignment;
+        use ratatui::style::Style;
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::{Block, Borders};
+
+        let theme = Theme::default();
+        for title in [" f.md ", " 設計メモ.md ", " a/very/deeply/nested/path/notes.md "] {
+            for w in [MIN_VIEWER_W, MIN_VIEWER_W + 1, 40, 60, 120] {
+                let mut term = Terminal::new(TestBackend::new(w, 5)).unwrap();
+                // Same budget the renderer gives the title: borders + toggle +
+                // `[<=>]` + one column of gap.
+                let budget = (w as usize).saturating_sub(2 + TOGGLE_W as usize + 5 + 1);
+                let fitted = crate::ui::viewer_panel::file_view::fit_title(title, budget);
+                term.draw(|f| {
+                    let mut spans = toggle_spans(false, &theme);
+                    spans.push(Span::styled("[<=>]", Style::default()));
+                    let block = Block::default()
+                        .title(Span::raw(fitted.clone()))
+                        .title_top(Line::from(spans).alignment(Alignment::Right))
+                        .borders(Borders::ALL);
+                    f.render_widget(block, Rect::new(0, 0, w, 5));
+                })
+                .unwrap();
+                let buf = term.backend().buffer().clone();
+                let seg = toggle_segments(0, w).expect("width is at least MIN_VIEWER_W");
+                let cell = |x: u16| buf[(x, 0)].symbol().to_string();
+                let ctx = format!("title={title:?} w={w}");
+
+                assert_eq!(cell(seg.raw.start), "[", "{ctx}: raw half starts at '['");
+                assert_eq!(
+                    cell(seg.rendered.start),
+                    "|",
+                    "{ctx}: rendered half starts at the separator"
+                );
+                assert_eq!(
+                    cell(seg.rendered.end - 1),
+                    "]",
+                    "{ctx}: rendered half ends at ']'"
+                );
+                // And the expand button really is where its own hit-test says.
+                assert_eq!(cell(w - 6), "[", "{ctx}: [<=>] start");
+                assert_eq!(cell(w - 2), "]", "{ctx}: [<=>] end");
+            }
+        }
+    }
+
+    #[test]
+    fn spans_highlight_the_active_mode() {
+        let theme = Theme::default();
+        let raw_mode = toggle_spans(false, &theme);
+        let rendered_mode = toggle_spans(true, &theme);
+        // Index 1 is "Raw", index 3 is "Rendered".
+        assert!(raw_mode[1].style.add_modifier.contains(Modifier::BOLD));
+        assert!(!raw_mode[3].style.add_modifier.contains(Modifier::BOLD));
+        assert!(!rendered_mode[1].style.add_modifier.contains(Modifier::BOLD));
+        assert!(rendered_mode[3].style.add_modifier.contains(Modifier::BOLD));
+        // The drawn width must match what the hit-test reserves.
+        let drawn: usize = raw_mode
+            .iter()
+            .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()))
+            .sum();
+        assert_eq!(drawn as u16, TOGGLE_W);
+    }
+}

--- a/src/ui/viewer_panel/mod.rs
+++ b/src/ui/viewer_panel/mod.rs
@@ -7,16 +7,18 @@
 //! Split by rendering responsibility: [`file_view`] draws the plain/annotated
 //! file content (the panel's default mode), [`diff_view`] the unified-diff
 //! mode, [`summary_view`] the branch change-summary pseudo-file,
-//! [`media_view`] images/video, [`comment_thread`] inline review-comment
-//! threads and the new-comment compose box, [`syntax`] syntax/diff annotation
-//! helpers, [`span_utils`] generic `Span` manipulation, and [`search_box`] the
-//! in-panel search input.
+//! [`markdown_view`] a markdown file rendered as prose (and its Raw/Rendered
+//! header toggle), [`media_view`] images/video, [`comment_thread`] inline
+//! review-comment threads and the new-comment compose box, [`syntax`]
+//! syntax/diff annotation helpers, [`span_utils`] generic `Span` manipulation,
+//! and [`search_box`] the in-panel search input.
 
 mod code_line;
 mod comment_thread;
 mod diff_line;
 mod diff_view;
 mod file_view;
+mod markdown_view;
 mod media_view;
 mod search_box;
 mod span_utils;
@@ -24,6 +26,7 @@ mod summary_view;
 mod syntax;
 
 pub use file_view::render;
+pub(crate) use markdown_view::toggle_segments;
 
 /// Shared definition of the inline-thread action row.
 ///

--- a/src/viewer/content.rs
+++ b/src/viewer/content.rs
@@ -1,5 +1,5 @@
 //! File content loading — opening a file into `content.file_content` and the
-//! small helpers that support it (media detection, tab expansion).
+//! small helpers that support it (media/markdown detection, tab expansion).
 
 use std::fs;
 use std::path::Path;
@@ -18,6 +18,9 @@ impl ViewerState {
     /// Open (read) a file and store its lines in `file_content`.
     pub fn open_file(&mut self, worktree_path: &Path, relative_path: &str, tab_width: usize) {
         self.exit_diff_mode();
+        // `md_rendered` deliberately survives (the mode is sticky across files);
+        // the scroll offset does not, since it indexes into the old document.
+        self.md_scroll = 0;
         self.content.highlighted_lines.clear();
         self.content.highlighted_cache_key = None;
         self.content.grep_highlight_line = None;
@@ -78,6 +81,64 @@ impl ViewerState {
             .is_some_and(media_state::is_media_file)
     }
 
+    /// Whether the Raw/Rendered toggle applies to what the Viewer is showing.
+    ///
+    /// Only the plain-file view of a markdown file offers it: unified-diff mode
+    /// shows a diff (where rendering prose would destroy the +/- structure) and
+    /// the SUMMARY pseudo-file is already rendered markdown by definition. This
+    /// single predicate decides both whether the header toggle is drawn and
+    /// whether its click target is live, so the two can't drift apart.
+    pub fn markdown_toggle_available(&self) -> bool {
+        !self.show_summary
+            && !self.diff_view.diff_mode
+            && self
+                .content
+                .current_file
+                .as_deref()
+                .is_some_and(is_markdown_path)
+    }
+
+    /// Whether the Viewer is currently drawing rendered markdown instead of raw
+    /// source. **Every line-oriented feature must be gated on this**: the
+    /// rendered view has no line numbers, so line selection, hover highlight,
+    /// comment creation/threads, and line-anchored jumps have nothing to anchor
+    /// to (see `ui::viewer_panel::markdown_view`).
+    pub fn is_showing_rendered_markdown(&self) -> bool {
+        self.md_rendered && self.markdown_toggle_available()
+    }
+
+    /// Toggle between raw source and rendered markdown, resetting the rendered
+    /// view's scroll so a toggle always lands at the top of the document.
+    ///
+    /// Also tears down the line-anchored interactions the rendered view can't
+    /// draw. A selection would silently reappear on the way back, and — worse —
+    /// an inline reply left open would keep swallowing every keystroke into a
+    /// compose box that is no longer on screen (the toggle is clickable while
+    /// one is open).
+    pub fn toggle_markdown_rendered(&mut self) {
+        self.md_rendered = !self.md_rendered;
+        self.md_scroll = 0;
+        self.clear_selection();
+        // An in-flight gutter drag would otherwise pop the comment composer on
+        // mouse-up, over a view with no gutter to have dragged in.
+        self.click.gutter_drag_anchor = None;
+        self.explorer.inline_reply_line = None;
+        self.explorer.inline_reply_comment_id = None;
+        self.explorer.inline_reply_buffer.clear();
+    }
+
+    /// Leave rendered markdown so a line-anchored destination is actually
+    /// visible.
+    ///
+    /// Called by every path that positions the Viewer *by line* (jump to
+    /// definition, jump history, grep hit, `file:line` from a terminal). Without
+    /// it those jumps would land on rendered prose, which has no line numbers —
+    /// the requested line would be silently ignored and the reader dropped at
+    /// the top of the document instead.
+    pub fn show_raw_for_line_target(&mut self) {
+        self.md_rendered = false;
+    }
+
     /// Expand tab characters to spaces, respecting tab stop positions.
     fn expand_tabs(line: &str, tab_width: usize) -> String {
         if !line.contains('\t') {
@@ -98,5 +159,122 @@ impl ViewerState {
             }
         }
         result
+    }
+}
+
+/// Whether `path` names a markdown file, i.e. one the Viewer can offer the
+/// Raw/Rendered toggle for.
+///
+/// Extension-only and case-insensitive (`README.MD` counts). Deliberately does
+/// *not* match `.mdx`, `.mdown`, or extensionless `README`: the renderer is the
+/// small CommonMark subset used for change summaries, so widening the net would
+/// silently reformat files it can't represent.
+pub fn is_markdown_path(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_paths_are_detected_case_insensitively() {
+        assert!(is_markdown_path("README.md"));
+        assert!(is_markdown_path("docs/plan.markdown"));
+        assert!(is_markdown_path("README.MD"));
+        assert!(is_markdown_path("a/b/c.Markdown"));
+    }
+
+    #[test]
+    fn non_markdown_paths_are_rejected() {
+        // Neighbours that must NOT get the toggle: a different renderer dialect
+        // (.mdx), a no-extension file, and a name that merely contains "md".
+        assert!(!is_markdown_path("src/main.rs"));
+        assert!(!is_markdown_path("page.mdx"));
+        assert!(!is_markdown_path("README"));
+        assert!(!is_markdown_path("mdbook.toml"));
+        assert!(!is_markdown_path(""));
+    }
+
+    /// The toggle is a plain-file-view affordance. Diff mode and the SUMMARY
+    /// pseudo-file each own the whole panel with their own renderer, so the
+    /// toggle must disappear there — and, critically, `is_showing_rendered_markdown`
+    /// must go false with it even while `md_rendered` stays latched, or the
+    /// diff view would be drawn with the line-oriented features switched off.
+    #[test]
+    fn rendered_markdown_is_confined_to_the_plain_file_view() {
+        let mut vs = ViewerState::default();
+        vs.content.current_file = Some("README.md".to_string());
+        vs.md_rendered = true;
+        assert!(vs.markdown_toggle_available());
+        assert!(vs.is_showing_rendered_markdown());
+
+        vs.diff_view.diff_mode = true;
+        assert!(!vs.markdown_toggle_available());
+        assert!(!vs.is_showing_rendered_markdown());
+        vs.diff_view.diff_mode = false;
+
+        vs.show_summary = true;
+        assert!(!vs.markdown_toggle_available());
+        assert!(!vs.is_showing_rendered_markdown());
+        vs.show_summary = false;
+
+        vs.content.current_file = Some("src/main.rs".to_string());
+        assert!(!vs.markdown_toggle_available());
+        assert!(!vs.is_showing_rendered_markdown());
+
+        // The mode stayed latched through all of that, so coming back to a
+        // markdown file in the plain view resumes rendering (session-sticky).
+        vs.content.current_file = Some("CHANGELOG.md".to_string());
+        assert!(vs.is_showing_rendered_markdown());
+    }
+
+    /// A selection or an open inline reply belongs to the raw view. Carrying
+    /// either into the rendered view is silent: the reply box stops being drawn
+    /// but keeps intercepting every keystroke, and the selection re-materialises
+    /// on the way back.
+    #[test]
+    fn toggling_tears_down_line_anchored_interactions() {
+        let mut vs = ViewerState {
+            selection: crate::viewer::LineSelection::Selected { start: 3, end: 9 },
+            ..Default::default()
+        };
+        vs.explorer.inline_reply_line = Some(7);
+        vs.explorer.inline_reply_comment_id = Some("c1".to_string());
+
+        vs.toggle_markdown_rendered();
+
+        assert_eq!(vs.selection, crate::viewer::LineSelection::None);
+        assert_eq!(vs.explorer.inline_reply_line, None);
+        assert_eq!(vs.explorer.inline_reply_comment_id, None);
+    }
+
+    /// Jumping to `file:line` must show the line. Rendered prose has none, so
+    /// every line-anchored entry point drops back to raw first.
+    #[test]
+    fn line_targets_drop_out_of_rendered_mode() {
+        let mut vs = ViewerState {
+            md_rendered: true,
+            ..Default::default()
+        };
+        vs.content.current_file = Some("README.md".to_string());
+        assert!(vs.is_showing_rendered_markdown());
+        vs.show_raw_for_line_target();
+        assert!(!vs.is_showing_rendered_markdown());
+        assert!(!vs.md_rendered);
+    }
+
+    #[test]
+    fn toggling_resets_the_rendered_scroll() {
+        let mut vs = ViewerState {
+            md_scroll: 42,
+            ..Default::default()
+        };
+        vs.toggle_markdown_rendered();
+        assert!(vs.md_rendered);
+        assert_eq!(vs.md_scroll, 0);
     }
 }

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -331,4 +331,17 @@ pub struct ViewerState {
     /// Total wrapped line count of the summary view, written during render and
     /// read by the key handler to clamp `summary_scroll`.
     pub summary_total_lines: usize,
+    /// Whether markdown files are shown rendered (SUMMARY-style prose) instead
+    /// of as raw source. Sticky for the session: it survives opening another
+    /// markdown file, and is simply ignored while a non-markdown file is open.
+    /// Only takes effect in the plain-file view — see
+    /// `is_showing_rendered_markdown`, which is what every renderer and event
+    /// handler must gate on.
+    pub md_rendered: bool,
+    /// Vertical scroll offset within the rendered-markdown view. Reset per file
+    /// (in `open_file`), unlike `md_rendered`.
+    pub md_scroll: usize,
+    /// Total wrapped line count of the rendered-markdown view, written during
+    /// render and read by the key handler to clamp `md_scroll`.
+    pub md_total_lines: usize,
 }

--- a/src/viewer/tree.rs
+++ b/src/viewer/tree.rs
@@ -83,10 +83,16 @@ impl ViewerState {
                 let prev_diff_max_line_no = self.diff_view.diff_view_max_line_no;
                 let was_summary = self.show_summary;
                 let prev_summary_scroll = self.summary_scroll;
+                // `open_file` resets the rendered-markdown scroll (it indexes a
+                // specific document), which is right when the *user* opens a
+                // file and wrong here — a watcher or the 3s poll would yank a
+                // reader back to the top of the prose mid-read.
+                let prev_md_scroll = self.md_scroll;
 
                 self.open_file(worktree_path, rel_path, tab_width);
                 self.content.file_scroll = prev_file_scroll;
                 self.content.h_scroll = prev_h_scroll;
+                self.md_scroll = prev_md_scroll;
 
                 if was_diff_mode {
                     self.diff_view.diff_mode = true;

--- a/src/viewer/tree/tests.rs
+++ b/src/viewer/tree/tests.rs
@@ -111,3 +111,28 @@ fn tree_refresh_preserves_diff_mode() {
     assert!(!vs.is_summary(), "diff mode must not turn on summary view");
     assert_eq!(vs.diff_view.diff_view_scroll, 3);
 }
+
+/// The same guarantee for the rendered-markdown view. `open_file` resets
+/// `md_scroll` — correct when the *user* opens a file, wrong on the refresh
+/// path, which re-opens the current file every time the watcher fires or the
+/// 3s poll comes round. Without the save/restore, reading a long rendered
+/// README would snap back to the top every few seconds.
+#[test]
+fn tree_refresh_preserves_rendered_markdown_scroll() {
+    let root = tempfile::tempdir().unwrap();
+    let root = root.path();
+    std::fs::write(root.join("README.md"), "# t\n\nbody\n".repeat(50)).unwrap();
+
+    let mut vs = ViewerState::default();
+    vs.load_file_tree(root, 4);
+    vs.open_file(root, "README.md", 4);
+    vs.md_rendered = true;
+    vs.md_scroll = 40;
+    vs.content.file_scroll = 40;
+
+    vs.load_file_tree(root, 4);
+
+    assert_eq!(vs.content.file_scroll, 40, "raw scroll is preserved");
+    assert_eq!(vs.md_scroll, 40, "rendered scroll must be preserved too");
+    assert!(vs.md_rendered, "the mode itself must survive a refresh");
+}


### PR DESCRIPTION
## Summary

Viewer で開いた markdown ファイル (`.md` / `.markdown`) を、**raw ソース**と**レンダリング表示**で切り替えられるようにした。

- レンダリングは SUMMARY 疑似ファイルと**同じレンダラ** (`ui::markdown`、`App::markdown_cache` 経由) をそのまま使う。新規実装なし
- 操作: Viewer で **`m`** キー / ヘッダの **`[Raw|Rendered]`** クリック / コマンドパレット "Viewer: Toggle Markdown Raw / Rendered"
- トグルは markdown ファイルを plain-file ビューで開いているときだけ表示。diff モードと SUMMARY では出ない（それぞれ専用レンダラが全面を持つため）
- デフォルトは従来どおり raw。モードは**セッション内で sticky**（別の markdown を開いても維持）、**スクロール位置はファイルごとにリセット**

### レンダリング中は行依存機能を全無効化

レンダリングされたプロセは折り返し・整形で行がソース行と対応しなくなるため、行番号ガター・行選択・hover ハイライト・コメント作成・インラインコメントスレッド・行アンカージャンプをすべて切る。`ViewerState::is_showing_rendered_markdown()` を単一の判定点として、描画 / キー / クリック / hover / ホイールの各経路でガードしている。このモードは `content.screen_row_map` を一切書かないので、マウスの行解決が構造的に空振りする。

raw に戻すと全機能が元通り使える。

### テーブルセルを省略せず折り返す

共通レンダラのテーブルが、列幅に収まらないセルを `…` で切り捨てていたのを**折り返し**に変更した。テーブルでは切られたテキストがその行の要点であることが多く、横スクロールも展開もないため復元手段が無い。行の高さは最も背の高いセルに合わせ、短いセルは空白で埋めて桁を揃える。折り返しは既存の `wrap.rs` の単語境界ロジックを再利用（`wrap_cells_raw` として切り出し、`Line` に潰す前のセル列を取れるようにした）。

**この変更は共通レンダラなので SUMMARY・レビューコメント・ウォークスルーのテーブルにも効く。**

### 副次的な修正

- **`load_file_tree` の refresh がレンダリング表示のスクロールを復元していなかった** — `file_scroll` / diff / summary は明示的に退避・復元しているのに新フィールドが漏れており、3 秒ポーリングと file-watcher が長文を読んでいる最中に先頭へ引き戻していた
- **Viewer タイトルの切り詰めが表示幅を測っていなかった** — バイト長判定 + 文字数切り出しだったため、CJK ファイル名（3 バイト / 2 桁）でヘッダのコントロールに重なりうる既存バグ。`fit_title()` を display-width ベースに書き直した
- レンダリング表示に切り替えるとき、開いたままのインラインリプライ・行選択・gutter ドラッグを破棄する（見えない compose box にキーが吸われ続けるのを防ぐ）
- **行指定でジャンプする 6 経路**（定義ジャンプ / ジャンプ履歴前後 / `file:line` オープン / grep ヒット / コメント一覧）で raw に落とす。レンダリング中だと指定行が黙って無視されるため

## Test plan

`cargo test` 670 件緑 / `cargo clippy` 新規警告 0。追加したテスト:

- `.md` / `.markdown` 判定（大文字小文字・`.mdx` や拡張子なしを除外）
- レンダリング表示が plain-file ビューに限定されること（diff / SUMMARY / 非 markdown では false、かつモードは latch されたまま）
- トグルが選択・インラインリプライ・gutter ドラッグを破棄すること
- 行指定ジャンプが raw に落ちること
- ツリー再読込がレンダリング表示のスクロールとモードを保持すること
- **ヘッダトグルの描画桁と hit-test の一致** — `TestBackend` で実際に描いて、`toggle_segments` が主張する各セルが本当に `[` / `|` / `]` を持つことを確認（ASCII / CJK / 長いパス × 幅 28/29/40/60/120）。既存の `[<=>]` ボタンと重ならないことも同時に検証
- `fit_title` が常に列予算を超えないこと（ASCII / CJK / emoji / 空 × 幅 0..40 の property test）
- テーブル: 幅 20/30/40/60/100 で全単語が消えず `…` が出ないこと / 折り返した行でも全物理行の表示幅が一致すること / 区切れない長い URL が分割されて全長残ること

実機検証: PTY 上で起動して `CLAUDE.md` を開き、raw → rendered → raw を往復。行番号ガターの消失、生の `##` が 0 個になること、トグルの桁位置と bold 強調を生エスケープ列で確認。非 markdown (`Cargo.toml`) ではトグルが描画されず `m` はヒントのみ。テーブルは Viewer 幅 35 桁でも `…` 0 個で折り返し表示。

**未検証**: マウス操作（トグルのクリック、hover）はサンドボックスから注入できないため実端末で確認 → 動作確認済みとの報告を受領。
