### PR TITLE
feat: match Claude Code's native transcript rendering in the reflow scrollback view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -486,6 +486,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "two-face",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
  "uuid",
  "vt100",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.95.0"
+version = "0.96.0"
 edition = "2024"
 
 [dependencies]
@@ -24,6 +24,7 @@ copypasta = "0.10"
 log = "0.4"
 env_logger = "0.11"
 notify = "8"
+unicode-segmentation = "1"
 unicode-width = "0.2"
 vt100 = "0.15"
 open = "5"

--- a/docs/native-scrollup-parity-test-design.md
+++ b/docs/native-scrollup-parity-test-design.md
@@ -1,0 +1,526 @@
+# Claude パネル scroll-up のネイティブ完全一致 — テスト設計
+
+**ステータス**: 設計のみ（実装なし）
+**対象バージョン**: Claude Code v2.1.220 / conductor 現在の HEAD
+**日付**: 2026-07-31
+
+---
+
+## 0. 3行サマリ
+
+1. scroll-up は**必ず** reflow view（`.jsonl` からの自前再描画）に入る。したがって「完全一致」とは **Claude Code のレンダラを Rust で再実装し、それを証明すること**である。
+2. ネイティブは alt-screen を使わず、**単語ごとに絶対列(CHA `ESC[nG`)を宣言して** pre-wrap 済みの行を emit する。つまり**正解の列番号はバイト列に書いてある** — 幅モデルを推定する必要がない。
+3. `claude --resume <uuid>` + `pty.fork` で、**API 課金ゼロ・バイト単位で決定的に**正解データを採取できる。しかも**手書き合成 `.jsonl` でも動く**ので、任意のコンテンツ種別の正解を生成できる。→ 人手採取はほぼ不要（§5）。
+
+---
+
+## 1. 現状把握
+
+### 1.1 scroll-up の経路
+
+Claude パネルで上スクロールすると、初回で**必ず** reflow view にハイジャックされる。
+
+| 入口 | file:line |
+|---|---|
+| キーボード `ScrollbackUp` | `src/event/mod.rs:477-487` |
+| キーボード `ScrollbackTop` | `src/event/mod.rs:513-521` |
+| マウスホイール | `src/event/mouse/scroll.rs:255-262` |
+
+```rust
+// src/event/mod.rs:481-487
+if app.focus == Focus::TerminalClaude
+    && app.terminal.scroll_claude == 0
+    && !app.reflow.active
+{ app.open_reflow(); return true; }
+```
+
+**唯一の例外**: worktree が grabbed のときのみ、マウスホイールが hijack をスキップし vt100 スクロールバックに入る（`src/event/mouse/scroll.rs:257` の `!app.is_selected_worktree_grabbed()`）。キーボードは grabbed 時は全ブロック（`src/event/mod.rs:409-415`）。
+
+→ **テスト対象は実質 100% が reflow view (`src/ui/reflow_view/`)。**
+
+### 1.2 レンダリング経路
+
+```
+Claude セッション .jsonl
+  → src/claude_log/{schema,convert,session}.rs   … パース＋正規化
+  → LogEntry / DisplayBlock (src/claude_log/model.rs)
+  → src/ui/reflow_view/build.rs:23 build_lines()  … 幅変更時のみ再構築
+      └ src/ui/markdown/ (MarkdownFlavor::Transcript)  … 本文の md レンダリング
+  → Vec<Line<'static>> を app.reflow.cached_lines にキャッシュ
+  → src/ui/reflow_view/render.rs:112-127  … buf.set_line で Buffer に直書き
+```
+
+主要関数:
+
+| 役割 | file:line |
+|---|---|
+| 行構築 | `src/ui/reflow_view/build.rs:23` `build_lines` |
+| tool_result 描画 | `src/ui/reflow_view/build.rs:161` `render_tool_result` |
+| マーカー付与 | `src/ui/reflow_view/helpers.rs:16` `with_marker` |
+| 幅切り詰め | `src/ui/reflow_view/helpers.rs:60` `truncate_to_width` |
+| 描画 | `src/ui/reflow_view/render.rs:22` `render` |
+| スクロール算術 | `src/event/reflow.rs:14` `clamp_scroll` / `:22` `at_bottom` |
+| キー処理 | `src/event/reflow_key.rs:21` `handle_reflow_key` |
+| 折り返し | `src/ui/markdown/wrap.rs:60` `wrap_cells` |
+| ANSI 除去 | `src/claude_log/convert.rs:34` `sanitize_preview_line` |
+| tool 要約 | `src/claude_log/convert.rs:12` `summarise_tool_input` |
+| user ターン正規化 | `src/claude_log/convert.rs:139` `normalise_user_text` |
+| 起動 | `src/app/reflow.rs:97-116` `open_reflow`（早期 return 2箇所） |
+
+### 1.3 既存テストのカバレッジ
+
+`cargo test` → **726 passed / 0 failed / 1 ignored**。`tests/` ディレクトリなし、golden/snapshot ファイル **0件**。
+
+| カバー済み | 未カバー |
+|---|---|
+| `pad_glyph_to` / `with_marker` / `truncate_to_width`（`src/ui/reflow_view/tests.rs`、10本） | **レンダリング済みグリッドの assert（0件）** |
+| `clamp_scroll` / `at_bottom` / `sweep_progress`（`src/event/reflow.rs:66-105`） | **ネイティブとの一致検証（0件）** |
+| `sanitize_preview_line` の ANSI/OSC/タブ（`src/claude_log/tests.rs:195-213`） | `build_lines` 全体（`&mut App` 依存でテスト不能） |
+| markdown レンダリング（`src/ui/markdown/tests/`） | `render` 全体（同上 + `Instant::now()`） |
+| — | Unicode 境界（ZWJ・結合文字・VS） |
+| — | リサイズ時のスクロール位置保持 |
+| — | tool_result の truncate 境界 |
+
+**`TestBackend` は既に実使用されている**（`src/ui/tab_bar.rs:301,325,346,353` が `terminal.backend().buffer().clone()` でセル比較、`src/ui/viewer_panel/markdown_view.rs:223-247` も同様）→ **新規依存ゼロでグリッド assert が書ける。**
+
+### 1.4 ネイティブの実描画（実測）
+
+`claude --resume <uuid>` を pty(100x30) で走らせ master の生バイトを採取。
+
+```
+# assistant テキスト
+\x1b[38;2;255;255;255m⏺\x1b[3G\x1b[39mThe\x1b[7Gdiff\x1b[12Gis\x1b[15Ga\x1b[17Gsingle-line\r\r\n\x1b[3Gchanged,\x1b[12Gno
+
+# tool_use（--verbose）
+\x1b[38;2;78;186;101m⏺\x1b[3G\x1b[39m\x1b[1mBash\x1b[22m(ls\x1b[11G-la\x1b[15G/tmp)
+
+# tool_result（--verbose）— 全12行、cap なし
+\x1b[38;2;153;153;153m \x1b[3G⎿\x1b[5G\xa0\x1b[39mline1\r\r\n\x1b[6Gline2\r\r\n … \x1b[6Gline12
+
+# tool_result（--verbose なし）— 1行に畳む
+\x1b[3G\x1b[38;2;153;153;153mRead\x1b[8G\x1b[1m1\x1b[22m file\x1b[15G(ctrl+o\x1b[23Gto\x1b[26Gexpand)\x1b[39m
+
+# user ターン — 全幅の背景ブロック
+\x1b[48;2;55;55;55m  \x1b[38;2;255;255;255mInvestigate per the method…\x1b[39m<空白パディング>\x1b[49m
+
+# 動的フレームの境界（seam の整列マーカー）
+\x1b[38;2;136;136;136m────…────\x1b[39m\r\r\n❯\xa0
+```
+
+読み取れる性質:
+- **alt-screen に入らない**（`ESC[?1049h`/`[?47h`/`[?1047h` = 0、`ESC[2J` = 0、`ESC[3J` = 0、CUP = 0）。行送りは `\r\r\n` → 履歴は端末の scrollback に流れる。
+- **単語ごとに絶対列 CHA を発行**。端末の autowrap に頼らず**自分で折り返して確定した行を emit** する（分割不能な `X`×200 をネイティブ側が3行に割って出力することを実測）。
+- ガターは 2 列（本文は col 3）、tool_result 本文は col 6。
+
+### 1.5 台帳 — 「寄せるために頑張っていた」既存ロジックと、一致しない理由
+
+| # | 項目 | ネイティブ（実測） | conductor | file:line | 一致しない理由（仮説→実測で確定したもの） |
+|---|---|---|---|---|---|
+| D1 | tool_result の行数 | verbose: **全行**／既定: **1行に畳む** | **4行 cap + `… +N lines`** | `model.rs:45`, `build.rs:196` | **確定**: 独自の折り畳み規則。ネイティブは二重描画を持つ（verbose 切替） |
+| D2 | tool_result の各行 | **折り返す**（col6..幅） | **`…` で切り捨て** | `build.rs:183`, `helpers.rs:60` | **確定**: 実装差 |
+| D3 | user ターン | **全幅 bg RGB(55,55,55)** + 2列インデント + 白文字 | `> ` + coral | `glyphs.rs:24`, `build.rs:71` | **確定**: 表現形式が別物 |
+| D4 | 本文色 | 純白 **RGB(255,255,255)** | `Color::Reset`（端末既定） | `palette.rs:17` | **意図的逸脱**。コメントに「hardcoded pure white read as harsh」と明記 |
+| D5 | assistant/tool グリフ | `⏺` U+23FA | `*` | `glyphs.rs:21` | **意図的逸脱**。端末2列描画による bleed 対策。ネイティブは**絶対列指定で同じ問題を回避している** |
+| D6 | thinking グリフ | **`✻` U+273B**（実セッションで確認。畳んだ形は `✻ Crunched for 7s` 等、動詞はランダム） | `*` | `glyphs.rs:31` | 意図的逸脱。**`glyphs.rs:31` のコメント「Claude Code uses ✻」は正しい**（`∴` は合成 fixture 由来の誤検出だった） |
+| D7 | tool_result グリフ | `⎿` U+23BF | `└` U+2514 | `glyphs.rs:28` | 意図的逸脱（同上） |
+| D8 | 有効幅 | **全幅** | **width − 1** | `render.rs:36-39` | **意図的逸脱**。本文中の絵文字の under-count 1列ぶんを吸収する安全余白 |
+| D9 | tool_result 本文色 | default fg（`ESC[39m`）。灰は `⎿` のみ | 全体 dim(INACTIVE) | `build.rs:192` | 実装差 |
+| D10 | tool 引数の要約 | ツール別（`Bash(ls -la /tmp)`, `Read 1 file`） | 4キー先頭一致のみ | `convert.rs:12-25` | 実装差 |
+| D11 | エントリ間の空行 | 文脈依存 | **無条件で1行** | `build.rs:152` | 実装差 |
+| D12 | 見出し/リスト | 未突合 | Transcript flavor（見出し=太字のみ、`- `、マーカー色=fg） | `markdown/render.rs:35-39,96-113` | **未検証**。コメントの主張のみ |
+| D13 | tool_result の ANSI | 保持（色付き diff 等） | **全除去** | `convert.rs:34-76` | 実装差 |
+| D14 | ガター幅 / 本文列 | col 3 / col 6 | col 3 / col 6 | `glyphs.rs:6`, `build.rs:171` | **✓ 一致** |
+| D15 | tool bullet の色 | RGB(78,186,101) | `palette::SUCCESS` = RGB(78,186,101) | `palette.rs:19` | **✓ 一致** |
+| D16 | 灰色トークン | RGB(153,153,153) | `palette::INACTIVE` = RGB(153,153,153) | `palette.rs:23` | **✓ 一致** |
+
+**幅計算は差異要因ではない**（実測）。`unicode-width 0.2.0`(Rust) と `string-width@8.2.2`(Node) を全 1,112,064 コードポイントで突合した結果、相違は **379個のみ**（Hangul jungseong U+1161-11FF、Indic 母音記号、U+0600-0604 等の書式文字）。`👨‍👩‍👧‍👦` は**両方 2**、`👋🏽` も**両方 2**。East Asian Ambiguous・CJK・半角カナ・VS16・keycap・国旗はすべて一致。ASCII 圏で効く唯一の差は **TAB**（rust=1 / node=0）。
+
+### 1.6 テストを書いた瞬間に落ちる既知欠陥（コード確認済み）
+
+| # | 箇所 | 内容 |
+|---|---|---|
+| B1 | `helpers.rs:60-78` | `budget = max_cols − 1` を常に確保するため**ぴったり収まる文字列まで切る**。`truncate_to_width("hello", 5)` → `"hell…"` |
+| B2 | `build.rs:88-96` | summary 非空の枝で `name` が無検査 push。長いツール名×狭幅で `summary_budget` が 0 に飽和し**行が幅を超える**（bleed 再発経路） |
+| B3 | `build.rs:174,186-192` | `is_error` がコネクタ `└` だけを赤くし、本文は常に dim |
+| B4 | `build.rs:171-183` | 幅 < 5 で `  └  ` 固定5列が truncate されず幅超過 |
+| B5 | `render.rs:62-69` | 幅変更で `cached_lines` を作り直すが `scroll` は**生の行番号のまま** → 再折り返しで表示位置が飛ぶ |
+| B6 | `app/reflow.rs:97-116` | session 未 pin / ログ未生成だと `open_reflow` が早期 return。A経路が実質到達不能なので **scroll-up が完全に無反応になる**（可用性バグ、parity 以前） |
+
+---
+
+## 2. 判定器（oracle）の設計
+
+### 2.1 粒度の選択 → **セル単位グリッド。char 面と属性面を別ファイルに分ける**
+
+| 候補 | 判定 | 理由 |
+|---|---|---|
+| 生 ANSI 文字列 | ✗（conductor 側） | reflow_view は ANSI を出力しない。`render.rs:112-127` は `buf.set_line` で ratatui `Buffer` に直書き。ANSI 化は crossterm backend の仕事でテスト対象外の層 |
+| **セル単位グリッド** | **◎ 推奨** | ユーザーが見るものと 1:1。bleed（幅超過）・全角の割れ・折り返し位置・末尾スペースが全部見える。`TestBackend` で完全に決定論的 |
+| `Line` + `Span` 構造 | △ | 過剰に厳しい。`cells_to_line`(`wrap.rs:34-58`) の coalesce 規則が変わるだけで落ちるが画面は変わらない。**偽陽性の温床** |
+| 構造的アサーション | ○（併用） | 不変条件層でのみ使う。「幅を超えない」「論理行数==視覚行数」は property に向く |
+
+**char 面 / 属性面を分離する理由**: 1枚に混ぜるとテーマ調整（色）とレイアウト回帰（バグ）が同じ差分に埋もれ、golden 更新時に人間がレビューを放棄する。char 面は各行を `|` で囲む（**末尾スペースの有無が bleed の主要シグナル**）。
+
+**ネイティブ側の非対称に注意**: ネイティブ真値は生 ANSI（列宣言込み）、conductor 出力は `Buffer`。共通形式に落とすには生 ANSI → `vt100`（既に依存にある `vt100 = "0.15"`）→ セルグリッド、conductor `Buffer` → セルグリッド、で揃える。**ただしグリッド化するとネイティブが宣言した列番号という情報が失われる**ので、CHA 列は別途パースして保持する（§2.3）。
+
+### 2.2 seam oracle — ネイティブ真値を**プロセス内で**得る
+
+ハイジャックは `scroll_claude == 0`（`event/mod.rs:481`）、つまり**ライブ PTY の最下部を見ている瞬間**に発火する。直前フレームの vt100 グリッドは**ネイティブ自身が描いた本物**。よって:
+
+> **reflow view の該当行 == ハイジャック直前の vt100 グリッドの対応行**
+
+が Node もスクショも無しに機械判定できる。一致しなければユーザーは**必ず画面の飛びとして知覚する**（同じ瞬間の同じ内容だから）ので、これが体験上の「完全一致」の定義そのもの。
+
+**成立条件（実測で PASS）**: ネイティブが alt-screen を使わない → 確認済み。
+
+**必須の修正2点**（これがないと必ず落ちる）:
+
+- **修正A — 単純な「末尾H行」比較は不成立。** ハイジャック時点の vt100 末尾は transcript ではなく**ライブの動的フレーム**（`────` / `❯` / `────` / `⏵⏵ auto mode on … N tokens` / `● high · /effort`）。reflow はこれを一切描かない。しかも動的フレーム行数は幅で変わる（幅100 で5行、幅60 でフッタが折返して7行）。さらに reflow は `pending_bottom` で「最後の内容行=最下行」に固定（`render.rs:74-80`）。
+  → **全幅 `────`（`ESC[38;2;136;136;136m` + `─`×幅）を動的フレーム開始マーカーとして検出し、その直前の transcript 行で整列する。**
+- **修正B — リサイズ後は oracle 無効。** ネイティブは自分で折り返して確定した行を CHA 付きで emit するので、vt100 に残る過去行は **emit 当時の幅で焼き付く**。reflow は現在幅で組み直す（`render.rs:62-69`）。既存コードもこれを認識している（`src/pty_manager/spawn.rs:186-192`「Claude and the transient editor repaint in place at a fixed width, so replay would cost memory without ever reflowing — skip it for them.」）。
+  → **seam の適用条件は「最後の resize 以降」。**
+
+**射程の上限**: vt100 パーサのスクロールバックは **1,000 行**。`src/pty_manager/spawn.rs:180-184` が `vt100::Parser::new(rows, cols, self.inactive_scrollback)`、`src/config/sections.rs:71` で `inactive_scrollback: 1000`。`activate_session`(`mod.rs:190-200`) が書く `active_scrollback: 10000` は `session.max_buffer_lines` と `buffer_limits`（プレーンテキストの `output_buffer`）にしか効かず**パーサには反映されない**。`[terminal] inactive_scrollback` で変更可。
+
+→ **seam oracle が守れるのは「ライブ tail に接する 1,000 行以内・リサイズなし」だけ。** それより古い履歴（そもそも vt100 に無いから reflow を作った）は §2.3 の採取 oracle で覆う。
+
+### 2.3 採取 oracle — `--resume` 再描画を正解データにする
+
+`claude --resume <uuid>` を pty で走らせると**過去の会話をそのまま端末に描き直す**。API 課金なし、resume だけでは `.jsonl` に追記されない（mtime のみ更新）。
+
+**決定性は実測でバイト完全一致**:
+
+| 条件 | 結果 |
+|---|---|
+| 100x40 ×3回 | 5008B **完全一致** |
+| 60x40 ×2 / 80x40 ×2 / 120x40 ×2 | すべて**完全一致** |
+| tool_use fixture ×2 / `--verbose` ×2 | **完全一致** |
+
+**最大の落とし穴 — `--verbose` の有無で別物**:
+
+```
+[resume 既定]                            [resume --verbose]
+❯ run a command                          ❯ run a command
+  Thought for 1s (ctrl+o to expand)      ∴ I should think about this carefully...
+⏺ Running it now.                        ⏺ Running it now.
+  Listed 1 directory (ctrl+o to expand)  ⏺ Bash(ls -la /tmp)
+⏺ Done.                                    ⎿  line1 … line12（全12行）
+                                         ⏺ Done.
+```
+
+**どちらを正解とするかは仕様判断**（§6 Q2）。
+
+**合成 `.jsonl` が使える**: 手書き `.jsonl` を `~/.claude/projects/<cwd の / を - に置換>/<uuid>.jsonl` に置けばネイティブが読んで描画する（実測済み）。→ **任意のコンテンツ種別の正解を、実会話なしで生成できる。** これが人手採取をほぼ不要にする鍵。
+
+**CHA 列の抽出**: ネイティブは折り返し位置を `ESC[nG` で宣言するので、**「ネイティブが置いた列 == conductor が置いた列」**を直接比較できる。幅モデルを一致させる必要はない。
+
+### 2.4 差分の可視化
+
+char 面はこの形式で出す（列尺は 10 列ごと、`|` で行端を明示）:
+
+```
+=== char plane: tool_result / width=40 / native(--verbose) vs conductor ===
+          1         2         3         4
+ col ....5....0....5....0....5....0....5....0
+ r12 native   | ⏺ Bash(ls -la /tmp)                   |
+ r12 conductor| * Bash(ls -la /tmp)                   |
+ r12 diff     | ^                                     |
+                ↑ col1: '⏺'(U+23FA) != '*'(U+002A)
+
+ r13 native   |  ⎿ line1                              |
+ r13 conductor|  └  line1                             |
+ r13 diff     |  ^^^^                                 |
+                ↑ col2: '⎿' != '└' / col3-5: 本文開始 col6 vs col6 (一致)
+
+ r17 native   |  ⎿ line5                              |
+ r17 conductor|  … +8 lines                           |
+ r17 diff     |  ^^^^^^^^^^^                          |
+                ↑ D1: conductor は4行 cap（native は全12行）
+```
+
+全角の桁ズレは**セル占有を明示**する（`▓` = 全角の後続セル）:
+
+```
+ r04 native   | 日本語のテキストです                   |
+ r04 cells    | 日▓本▓語▓の▓テ▓キ▓ス▓ト▓で▓す▓      |
+ r04 conductor| 日本語のテキストで…                    |
+ r04 diff     |                    ^^^^                |
+                ↑ col18: native は col20 まで、conductor は col18 で truncate（B1）
+```
+
+属性面は別ファイルに、変化点だけを列挙する（全セル出すと読めない）:
+
+```
+=== attr plane: r12 ===
+ col  native                    conductor
+   0  fg=#4EBA65               fg=#4EBA65        ok
+   2  fg=default bold          fg=default bold   ok
+   6  fg=default               fg=#999999        DIFF  ← D9
+```
+
+実装: `similar`（`inline` feature 付きで**既に依存にある**）で行内差分を取り、`^` マーカーを生成する。
+
+---
+
+## 3. テストケース網羅
+
+凡例: **[P]**=不変条件(property) / **[G]**=自己 golden / **[N]**=ネイティブ台帳比較 / **[S]**=seam
+
+### 3.1 基本表示
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| プレーン1行 assistant [G][N] | マーカー + 本文が col3 から | char 面 golden | 低 |
+| 複数行テキスト [G] | 2行目以降が2列インデント | char 面 | `with_marker` の `i==0` 分岐(`helpers.rs:28`) |
+| 本文中の空行 [P][N] | md が空行を保持するか | 行数 assert | `MdBlock::Blank` の扱い |
+| blocks が空の entry [P] | `build.rs:152` の空行だけ残る | 行数 == 1 | 誰も試さない |
+| entries 0件 [P] | `total_lines == 0`、パニックなし | 数値 | 既存カバーあり |
+| loading 状態 [G] | 中央寄せプレースホルダ | char 面 | `render.rs:48-59` の x 座標算術、幅0時 |
+| 連続 tool_use 間の空行 [N] | ネイティブは入れるか | 台帳 D11 | `build.rs:152` は無条件 |
+| **`open_reflow` 失敗** [P] | `app/reflow.rs:97-116` の2つの早期 return | 状態遷移 assert | **B6 可用性バグ。scroll-up が無反応になる** |
+
+### 3.2 折り返し境界（最優先。`wrap_cells` と `truncate_to_width` の**両方**に同じ境界を当てる）
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| **幅ちょうど (w == width)** [P] | 切らない・折らない | `…` なし、1行 | **B1 で現在落ちる** |
+| 幅 −1 [P] | 1行 | char 面 | 低 |
+| 幅 +1 [P] | 2行、2行目1文字 | char 面 | `cur_w + cw > width && !cur.is_empty()`(`wrap.rs:92,142,149`) |
+| 全角が境界に半分だけ入る [P] | 全角を割らない | 前行が width−1 で終わる | `char_width` 2 の飛び越え |
+| 単語長 == width ちょうど [P] | `word_w > width` が false → 通常枝 | 1行 | `wrap.rs:135` の `>` vs `>=` |
+| 単語 > width（ハード分割） [P] | セル境界で分割 | 各行 ≤ width | `wrap.rs:135-147` |
+| 連続する長行 × N [P] | 全行 ≤ body_width | property | 累積誤差 |
+| 行末スペースの消失 [N] | `wrap.rs:110-124` はスペースを落とす | 台帳 | 空白位置ズレ |
+| body_width == 0（panel ≤ 2） [P] | `wrap_cells` は `.max(1)` で救われるが `truncate_to_width(_,0)` は `""` | 幅超えなし | 極小幅は誰も試さない |
+| width 1,2,3 / height 0,1 [P] | 早期 return と `.max(1)` | パニックなし | `render.rs:23,36-39` |
+| **width−1 マージンによる恒常ズレ** [N] | ネイティブ比で常に1列狭い | 台帳 D8 | `render.rs:36-39` |
+| **ネイティブ宣言列との一致** [N] | `ESC[nG` の n == conductor の列 | 列番号の直接比較 | **これが折り返し parity の本命 oracle** |
+
+### 3.3 Unicode
+
+**方針の訂正**: 幅モデルは実測で一致しているため（§1.5）、ネイティブ一致を oracle にできる。自己整合性が要るのは**クラスタ境界の扱い**のみ。
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| 全角 CJK [P][N] | 幅2で折り返す | char 面 + 列比較 | 中 |
+| **ZWJ 絵文字** [P][N] | (i)パニックなし (ii)幅超えなし (iii)**ZWJ 途中で切らない** | 不変条件 | **`truncate_to_width` は `char_indices` で切る = 宙ぶらりんの ZWJ が残る** |
+| 肌色修飾子 `👋🏽` [P] | 同上 | 同上 | 同上 |
+| VS16 / VS15 [P] | 異体字セレクタ幅0 | 幅計算が壊れない | `glyphs.rs` の教訓そのもの |
+| 結合文字（`e`+U+0301） [P] | 幅1・分離しない | 不変条件 | `char_indices` で分離される |
+| East Asian Ambiguous [N] | **実測で両者一致** | 列比較 | 端末設定依存は残るが実装差はない |
+| Hangul jungseong / Indic 母音記号 [N] | **379個の既知相違に含まれる** | 台帳に明記 | rust=0 / node=1 |
+| **TAB** [N] | rust=1 / node=0。`sanitize` は空白4つに展開(`convert.rs:70`) | 台帳 | assistant text は sanitize されない（下記） |
+| 不正 UTF-8 の jsonl 行 [P] | パースが落ちない | Err か lossy | 実ログコーパスで自動検出 |
+| RTL / bidi [P] | パニックなし・幅超えなし | 不変条件 | 論理順序と表示順序の乖離 |
+
+### 3.4 ANSI
+
+**重要な非対称性**: `sanitize_preview_line`(`convert.rs:34-76`) は tool_result と local-command-stdout にしか適用されず、**assistant text はそのまま markdown へ流れる**。
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| tool_result の SGR / OSC8(BEL,ST) / タブ [P] | 剥がされる | 文字列 | 既存 `claude_log/tests.rs:195-213` でカバー済 |
+| **CSI 未終端** [P] | 残りを食い切る | 無限ループなし | `convert.rs:44-48` |
+| 単独 ESC・不明エスケープ形 [P] | 次バイトも捨てる | 文字列 | `convert.rs:66-68` |
+| **assistant text 中の ANSI** [P] | sanitize されず markdown へ | 現挙動を固定 or バグ判定 | **未検証の穴** |
+| **折り返しをまたぐスタイル継続** [P][G] | Cell 単位なので継続する | 属性面 golden で2行目==1行目 | `spans_to_cells`→`cells_to_line` 往復(`wrap.rs:25-58`) |
+| リセット直後の折り返し [G] | span 分割位置 | 属性面 | `cells_to_line` の coalesce |
+| tool_result の色保持 [N] | ネイティブは色付き diff を出すか | 台帳 D13 | conductor は全除去 |
+
+### 3.5 コンテンツ種別
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| user 入力 [N] | **全幅 bg ブロック vs `> `** | 台帳 D3・大差分 | **表現が別物** |
+| `<command-name>` 正常 [P] | `/foo bar` に正規化 | 文字列 | `convert.rs:147-158` |
+| **`<command-name>` 未終端** [P] | 正規化せず素通し | 全文が残る | 意図的に守っている挙動、回帰しやすい |
+| `<local-command-stdout>` [P] | 展開 + sanitize | 文字列 | 中 |
+| `<system-reminder>` 全除去で空 [P] | エントリが消え空行だけ残る | 行数 | `build.rs:152` との相互作用 |
+| **本文中の `<system-reminder>` 言及** [P] | `strip_tag_spans` は位置無関係に消す | 現挙動 | `convert.rs:166` は先頭限定でない = 仕様バグ候補 |
+| tool_use（4キー各々 + 該当なし） [P] | 要約抽出 | 文字列 | 既存テストあり |
+| **tool_use: name 超長 × 狭幅** [P] | 幅を超えない | 不変条件 | **B2 で現在落ちる** |
+| tool_use: ツール別表現 [N] | `Bash(...)`, `Read 1 file` 等 | 台帳 D10 | **ネイティブ一致の主戦場** |
+| tool_use の bold 範囲 [N] | name のみ bold、`(args)` は非 bold | 属性面 | conductor は `(args)` を dim（`build.rs:95`） |
+| tool_result 正常 [N] | col6 本文・全行 vs 4行 cap | 台帳 D1/D2 | **最大の差分** |
+| tool_result `total==0` [P] | `(no content)` | 文字列 | `build.rs:176-179` |
+| **tool_result: is_error** [P] | 本文も赤か | 属性面 | **B3 で現在落ちる** |
+| diff 出力 [N] | ネイティブは色付き diff | 台帳・大差分 | 高 |
+| コードブロック [G] | syntect + hard wrap | char + 属性面 | **syntect テーマ固定が必須**（さもなくば golden がぶれる） |
+| thinking（空 text） [P] | ヘッダのみ | 行数1 | `build.rs:121` |
+| thinking（長文） [G] | dim italic + 2列インデント | 属性面 | `build.rs:134-145` が span style を**全上書き**しコードブロック色を潰す |
+| thinking の畳み込み [N] | 既定は `Thought for 1s (ctrl+o to expand)` | 台帳 | verbose 依存 |
+| **todo リスト** [N] | Transcript flavor の `- `/`[x]`(`markdown/render.rs:96-113`) vs ネイティブ | 台帳 D12 | 未検証の近似面 |
+| 見出し [N] | Transcript flavor は太字のみ(`render.rs:35-39`) | 台帳 D12 | 同上 |
+| 表 [N] | `render_table` にネイティブ対応物があるか | 台帳 D12 | 同上 |
+| エラー表示 [N] | is_error の見せ方 | 台帳 | 未検証 |
+
+### 3.6 スクロール
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| 上端/下端の飽和、total<inner、total==inner、scroll>total [P] | clamp | 数値 | **既存カバー済**(`event/reflow.rs:66-105`) |
+| 1行スクロール [P] | ±1 | 数値 | 低 |
+| ページ単位 [P][N] | `mod.rs:489` は `size/2`（**半ページ**） | 台帳 | ネイティブのページ量と比較 |
+| スクロール中の新規出力 [P] | entries は open 時 snapshot → **追記されない** | 現挙動を記録 | ネイティブは追従する。台帳 or バグ |
+| 長い履歴の途中復帰 [P] | 4.8MB / 10万行の性能・メモリ | 実測 | `cached_lines` が全行 `Vec<Line>` |
+| **`/clear`・`/resume` 後の内容不一致** [S] | 別セッションIDに回転し**回転前の transcript が出る**（`app/reflow.rs:90-96` に明記） | seam で検出 | **幅テストでは絶対に捕まらない内容不一致。seam の独自価値** |
+
+### 3.7 リサイズ
+
+| ケース | 何を検証 | 期待出力の形 | なぜ壊れやすいか |
+|---|---|---|---|
+| **幅変更でスクロール位置が飛ぶ** [P] | `render.rs:62-69` は `cached_lines` を作り直すが `scroll` は行番号のまま | **B5 の破綻を明示的に assert し「直したら反転させる」とコメント** | **高。アンカー `(entry_idx, block_idx, offset)` 方式にしないと直らない** |
+| width 1 と 2 が同じキャッシュ [P] | `render_area.width` が両方1 → 正しく共有 | 数値 | 低 |
+| **幅 W1→W2→W1 の冪等性** [P] | 初回と一致 | char 面完全一致 | markdown cache キー `{ei}:{bi}`(`build.rs:57,122`) が**幅を含まない** — 衝突を要検証 |
+| 高さのみ変更 [P] | 再ビルドなし、clamp のみ | 数値 | 中 |
+| リサイズ後の seam 無効化 [S] | oracle を適用しないこと | ガード assert | 修正B |
+
+### 3.8 省略・切り詰め
+
+| ケース | 何を検証 | 期待出力の形 |
+|---|---|---|
+| `total == 4`（cap ちょうど） [P] | `… +N` を出さない | 行数（`build.rs:196` は `>` なので正しい） |
+| `total == 5` [P] | `… +1 lines` | 文字列 |
+| `+1 lines` の単複 [N] | ネイティブは `+1 line` か | 台帳 |
+| `… +N lines` 自体が幅超過 [P] | truncate 済 | 幅 assert |
+| **幅 < 5 で `  └  ` が幅超過** [P] | 固定5列が truncate されない | 不変条件 | **B4 で現在落ちる** |
+| tool_result 各行の truncate [N] | ネイティブは折り返す | 台帳 D2 の主要差分 |
+| `(ctrl+o to expand)` [N] | 既定 resume の畳み表現 | 台帳 D1 |
+
+### 3.9 実ログ 27本を使った不変条件 fuzzing（**最も費用対効果が高い**）
+
+期待出力を**一切書かずに**、27本 × 幅 {20,40,60,80,120,200} で `build_lines` を回し次を assert:
+
+1. 全行の `display_width` ≤ `render_area.width`（**bleed の直接検出**）
+2. パニックしない・無限ループしない
+3. `total_lines == cached_lines.len()`
+4. 同一幅で2回ビルドして一致（決定性）
+5. 幅 W1→W2→W1 の往復で初回と一致（冪等性）
+
+4.8MB のログには人間が思いつかない入力（壊れた UTF-8、巨大 tool_result、ネストしたコードフェンス、ZWJ 絵文字）が確実に含まれている。
+
+**成立条件**: ログを**リポジトリに入れない**。`CONDUCTOR_TRANSCRIPT_CORPUS=<dir>` で参照し未設定なら skip。パス・トークン・プロンプトが混入するのでコミット不可。
+
+---
+
+## 4. テストプラン（レベルと規模）
+
+| レベル | 対象 | 前提 | 目安 |
+|---|---|---|---|
+| 単体（純粋） | `truncate_to_width` / `pad_glyph_to` / `wrap_cells` / `sanitize_preview_line` / `summarise_tool_input` / `normalise_user_text` | なし | 60〜80 |
+| Property (`proptest` 追加) | 任意 String × width 1..200 で「wrap 行 ≤ width」「truncate ≤ max_cols」「wrap 連結 == 元文字列（スペース除く）」 | 新規依存1 | 6〜10 |
+| **コーパス不変条件** | 実ログ27本 × 幅6種 → §3.9 の5項目 | env var ゲート | 5 assert × 162 組 |
+| 結合(build 層) | 手書き最小 `.jsonl` → char 面ダンプ | **R1 の refactor** | fixture 15〜20 × 幅3 |
+| 結合(render 層) | `TestBackend` → char 面 + 属性面 | **R2 の refactor** | 10〜15 |
+| **ネイティブ台帳** | `--resume` 採取バイト列 → vt100 グリッド + CHA 列 vs conductor。**台帳外差分ゼロ**を判定 | 採取ハーネス | 幅ごと 3〜5 |
+| seam | 動的フレーム除去 → 末尾 transcript 行で整列 → 上方向N行比較 | 修正A/B | 3〜5 |
+| 状態遷移 | `open_reflow` の早期 return、ハイジャック条件 | `pty_manager` を trait 化 or 最小 App | 6〜8 |
+
+### 4.1 テスタビリティ障害と必要な refactor
+
+| # | 障害 | 対応 |
+|---|---|---|
+| **R1** | `build_lines(app: &mut App, width)` が `App` 全体依存（`build.rs:23`）。必要なのは `entries` / markdown cache / `theme` / `syntax_set` / `syntect_theme` の5つ | `BuildCtx` に束ねて分離。**golden 層もコーパス層もこれが前提。最初にやる。** |
+| **R2** | `sweep` が `Instant::now()` 直参照（`render.rs:96`） | 進捗 `f64` を引数化 |
+| R3 | 幅計算が散在（`helpers.rs:60`, `wrap.rs:17`, `build.rs:88,172`） | 単一入口に集約 |
+| R4 | `truncate_to_width` が grapheme 非対応 | B1 の修正と同時に `unicode-segmentation` でクラスタ境界に |
+| R5 | `scroll` が生の行番号 | アンカー方式（今回はテストで現状の破綻を記録するに留める） |
+
+**syntect テーマの固定が必須**（`build.rs:66-67` がコードブロック色に効く）。`insta` の導入は不要（`std::fs` 比較 + `UPDATE_GOLDEN=1` で足りる）。
+
+---
+
+## 5. 【最重要】ネイティブ側から採取するデータ
+
+### 5.1 結論 — **人手採取はほぼ不要**
+
+`--resume` + `pty.fork` + **合成 `.jsonl`** の組み合わせで、**任意のコンテンツ種別の正解データを API 課金ゼロ・バイト単位で決定的に自動生成できる**（実測済み）。
+
+採取ハーネス（実証済み、`scratchpad/altscreen_probe.py` / greta の `ptycap.py`）:
+
+```python
+import os, pty, fcntl, termios, struct, signal, time
+pid, fd = pty.fork()
+if pid == 0:
+    os.chdir(CWD)                              # .jsonl の置き場を決める
+    os.environ["TERM"] = "xterm-256color"
+    os.environ["COLUMNS"], os.environ["LINES"] = str(COLS), str(ROWS)
+    os.execv(CLAUDE, ["claude", "--resume", SESSION_UUID])   # + "--verbose"
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
+# master を N 秒吸って killpg(SIGKILL)
+```
+
+合成 fixture の置き場: `~/.claude/projects/<cwd の / を - に置換した名前>/<uuid>.jsonl`
+
+### 5.2 自動採取するもの（人手不要）
+
+| # | 内容 | 幅 | 保存先 |
+|---|---|---|---|
+| A1 | assistant プレーンテキスト（短文・長文・空行入り） | 40/60/80/100/120/200 | `tests/golden/native/text.<w>.raw` |
+| A2 | tool_use × 各ツール（Bash/Read/Edit/Write/Grep/Glob/Task/TodoWrite） | 同上 | `tool_use.<tool>.<w>.raw` |
+| A3 | tool_result（1行 / 4行 / 5行 / 30行 / 空 / エラー） | 同上 | `tool_result.<n>.<w>.raw` |
+| A4 | thinking（空 / 短 / 長） | 同上 | `thinking.<w>.raw` |
+| A5 | user ターン（短文 / 長文 / 貼り付け複数行 / スラッシュコマンド） | 同上 | `user.<w>.raw` |
+| A6 | markdown（見出し h1-h3 / 箇条書き / 番号付き / チェックボックス / 表 / 引用 / インラインコード） | 同上 | `md.<kind>.<w>.raw` |
+| A7 | コードブロック（言語あり / なし / 幅超過行） | 同上 | `code.<w>.raw` |
+| A8 | diff 出力を含む tool_result | 同上 | `diff.<w>.raw` |
+| A9 | Unicode（CJK / ZWJ 絵文字 / 肌色修飾子 / 結合文字 / VS16 / Ambiguous / RTL / TAB） | 同上 | `unicode.<w>.raw` |
+| A10 | 幅境界（幅ちょうど / −1 / +1 の語長） | 同上 | `boundary.<w>.raw` |
+
+すべて `--verbose` 有無の2系統で採る。**A1〜A10 は合成 `.jsonl` で生成でき、実会話は不要。**
+
+### 5.3 人手が要るもの
+
+> #### ☑ H1【完了・2026-07-31】ライブ scrollback と `--resume` が一致するか → **PASS**
+> 実端末（幅110）で `script -q /tmp/live.raw claude` に「`ls -la /tmp` を実行して」を1回依頼 → `/exit`、続けて `script -q /tmp/resume.raw claude --resume <id>` を採取。
+> 確定後トランスクリプト領域をアンカー `I'll` から比較して **608 バイトがバイト単位で完全一致**。唯一の差分は thinking 要約行の動詞（live `✻ Baked for 7s` / resume `✻ Crunched for 7s`）で、Claude Code がランダムに選ぶ語。**構造・色・CHA 桁位置はすべて一致。**
+> → `--resume` を正解データとして採用可。**マスキング対象に「thinking 要約の動詞」を追加すること。**
+>
+> #### ☑ H2【完了】verbose の使用有無 → **未使用**
+> 正解データは**畳んだ表示**側で固定する。実測された畳み形: `Listed 1 directory (ctrl+o to expand)`（col3、灰 RGB(153,153,153)、件数のみ bold、`⏺` も `⎿` も付かない）。
+>
+> #### ☐ H3【任意・後回し可】極端な幅での実端末確認
+> - **採取するもの**: スクショ 2枚
+> - **再現手順**: 幅 40 桁と幅 200 桁で `claude --resume <id>`、日本語＋絵文字を含む応答が見える位置で撮影
+> - **保存先**: `docs/native-capture/w40.png` / `w200.png`
+> - **なぜ必要か**: グリフの**実描画幅**（`⏺` が1列か2列か）はバイト列からは分からず、フォント依存。台帳 D5/D8 の判断材料
+
+### 5.4 最小セット
+
+**H1 の1件だけあれば着手できる。** H2 は口頭で即答できる。H3 は台帳 D5/D8 を詰める段階まで不要。
+
+A1〜A10 は自動なので、H1 が取れ次第まとめて生成する。
+
+---
+
+## 6. 依頼者に判断を仰ぐ点（優先度順）
+
+| # | 論点 | 選択肢 |
+|---|---|---|
+| **Q1** | **成功基準の定義。** 台帳 D4/D5/D6/D7/D8 は**意図的にネイティブと違えている**箇所で、うち D5/D8 は実バグ（scrollback bleed）の修正として入った。「完全一致」はこれらの巻き戻しを含むか | (a) 完全一致を貫き、D5/D8 はネイティブ方式（絶対列指定）で作り直す／(b) 「明文化された意図的逸脱を除く構造的忠実」に再定義 |
+| **Q2** | **どちらのネイティブ描画を正解とするか** | (a) `--verbose`（全行展開）／(b) 既定（`(ctrl+o to expand)` 畳み）／(c) conductor 側でも切替可能にする |
+| **Q3** | **width−1 マージン（D8）の扱い** | (a) 維持 → 折り返し位置は恒久的に1列ズレる／(b) ネイティブ方式（グリフ後に絶対列で本文配置）に作り替えて撤廃／(c) risky なコードポイントを含むブロックのみ条件付きで適用 |
+| **Q4** | **B1（`truncate_to_width` の off-by-one）を今直すか** | 直すのが正しいが golden 全更新になる。テスト基盤より先に直すか後か |
+| **Q5** | **B6（`open_reflow` 失敗で scroll-up が無反応）** | parity 以前の可用性バグとして別 issue に切るか |
+
+---
+
+## 7. 実施順序
+
+1. **H1 の採取**（依頼者）→ ライブ vs `--resume` の一致を確認
+2. **R1 / R2 の refactor**（`BuildCtx` 分離、`sweep` の引数化）— これが無いと何も書けない
+3. **§3.9 コーパス不変条件 fuzzing** — 期待出力ゼロで bleed 系を刈れる。最高 ROI
+4. **B1〜B6 の欠陥に対する失敗テスト**を先に書く
+5. **§5.2 の自動採取**で台帳 golden を生成 → §3 の [N] ケースを埋める
+6. **seam oracle**（修正A/B 込み）
+7. 残りの [P] / [G] ケース
+
+---
+
+## 付録: 採取済みアーティファクト
+
+scratchpad（セッション限り、必要なら repo に移す）:
+- ハーネス: `altscreen_probe.py`, `ptycap.py`, `ptycap2.py`（フェーズ別キー注入）, `replay.py`（CHA/CUP 解釈でグリッド復元）, `diffwidth.py`
+- 生キャプチャ: `native100.raw`, `resume100.raw`, `verb.a/b.raw`, `tool.a/b.raw`, `w60/80/120.a/b.raw`, `scroll14.raw`, `long.raw`, `ctrlo.00/.01`
+- 合成 fixture: `fixtures/*.jsonl`（3本）
+- 幅テーブル: `rust_widths.txt`, `node_widths.txt`（全 1,112,064 コードポイント）

--- a/src/app/reflow.rs
+++ b/src/app/reflow.rs
@@ -43,8 +43,21 @@ pub struct ReflowView {
     pub last_width: u16,
     /// When `true`, the next render pins scroll to the bottom (most recent turn).
     pub pending_bottom: bool,
-    /// Pre-rendered, width-reflowed lines; rebuilt only when `last_width` changes.
+    /// Pre-rendered, width-reflowed lines; rebuilt only when `last_width`
+    /// changes or `needs_rebuild` is set.
     pub cached_lines: Vec<ratatui::text::Line<'static>>,
+    /// One entry per line of `cached_lines`: where it came from (the scroll
+    /// anchor) and where its gutter glyph forces an unwritten cell.
+    pub line_meta: Vec<crate::ui::reflow_view::LineMeta>,
+    /// Set when something other than a width change invalidates
+    /// `cached_lines` — currently only the expand toggle.
+    pub needs_rebuild: bool,
+    /// Whether an overlay covered the panel on the previous frame. Used to
+    /// force one hard repaint when it closes: cells this view deliberately
+    /// leaves unwritten (see `LineMeta::skip_col`) keep whatever the overlay
+    /// painted there, and ratatui's diff — comparing only its own buffers —
+    /// would never repaint them.
+    pub last_overlay_active: bool,
     /// Inner panel height at the last render — used for page-scroll sizing.
     pub last_inner_height: u16,
     /// Per-session Markdown render cache.
@@ -59,6 +72,13 @@ pub struct ReflowView {
     /// `Default` because `Option<T>: Default` is always `None` without a
     /// `T: Default` bound.
     pub sweep: Option<Sweep>,
+    /// Conductor's own ctrl+o-equivalent toggle: when `true`, tool_use/
+    /// tool_result blocks render fully expanded instead of Claude's default
+    /// collapsed form. A global toggle, not per-block — see ADR-2 in
+    /// `docs/plans/2026-07-31-native-render-parity.md`. Flipping it forces a
+    /// `cached_lines` rebuild (the width-change check in `render.rs` alone
+    /// would not catch it).
+    pub expanded: bool,
 }
 
 impl App {
@@ -120,6 +140,11 @@ impl App {
         // would otherwise block the 60fps loop for several frames. The view
         // activates immediately with a "Loading…" placeholder and
         // `poll_reflow_load` swaps the entries in when they arrive.
+        // Force one hard repaint: the panel currently shows the live PTY, and
+        // the cells this view leaves unwritten after a gutter glyph would keep
+        // that stale content forever otherwise.
+        self.terminal.needs_clear = true;
+
         self.bg.reflow_load.start(move |tx| {
             let _ = tx.send(crate::claude_log::load_session(&path));
         });
@@ -133,6 +158,9 @@ impl App {
             last_width: 0, // Forces a full line rebuild on first render.
             pending_bottom: true,
             cached_lines: Vec::new(),
+            line_meta: Vec::new(),
+            needs_rebuild: false,
+            last_overlay_active: false,
             last_inner_height: 0,
             cache: crate::ui::markdown::MarkdownCache::new(),
             // Start the entry transition: the border glides from the accent to
@@ -141,6 +169,9 @@ impl App {
             sweep: Some(Sweep {
                 start: std::time::Instant::now(),
             }),
+            // Always opens collapsed, matching Claude Code's own default
+            // (non-ctrl+o) transcript view. The toggle keybind is S5.
+            expanded: false,
         };
     }
 

--- a/src/claude_log/convert.rs
+++ b/src/claude_log/convert.rs
@@ -1,28 +1,12 @@
 //! Normalisation of raw session-log records into display-ready blocks: tool
 //! summaries, ANSI/control-code sanitization, and the user-turn wrapper forms
-//! (`<command-name>`, `<local-command-stdout>`, `<system-reminder>`).
+//! (`<command-name>`, `<local-command-stdout>`, `<task-notification>`).
 
-use super::model::{DisplayBlock, TOOL_RESULT_PREVIEW_LINES};
+use std::collections::{HashMap, HashSet};
+
+use super::model::DisplayBlock;
 use super::schema::{Block, Content, ToolResultContent};
-
-/// Extract a one-line summary from a tool call's `input` JSON.
-///
-/// Tries the most common argument keys in priority order (`command`,
-/// `file_path`, `path`, `pattern`) and returns an empty string if none match.
-pub(super) fn summarise_tool_input(input: &serde_json::Value) -> String {
-    const KEYS: &[&str] = &["command", "file_path", "path", "pattern"];
-    let Some(obj) = input.as_object() else {
-        return String::new();
-    };
-    for key in KEYS {
-        if let Some(v) = obj.get(*key)
-            && let Some(s) = v.as_str()
-        {
-            return s.to_string();
-        }
-    }
-    String::new()
-}
+use super::tool_class::{ResultKind, result_kind};
 
 /// Strip characters that would desync terminal rendering from a raw tool-output
 /// line: ANSI escape sequences, tabs (expanded to spaces), and other C0/C1
@@ -31,7 +15,7 @@ pub(super) fn summarise_tool_input(input: &serde_json::Value) -> String {
 /// counts it as one cell, and a color escape is zero-width to the terminal but
 /// byte-width to ratatui; either shifts the rest of the line and garbles the
 /// transcript panel. We render a clean, plain-text preview instead.
-fn sanitize_preview_line(s: &str) -> String {
+pub(super) fn sanitize_preview_line(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
@@ -101,46 +85,92 @@ fn tag_inner<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
     })
 }
 
-/// Remove every `<{tag}>…</{tag}>` span from `text` (an unterminated opening
-/// tag removes through to the end of the string).
-fn strip_tag_spans(text: &str, tag: &str) -> String {
-    let open = format!("<{tag}>");
-    let close = format!("</{tag}>");
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    while let Some(start) = rest.find(&open) {
-        out.push_str(&rest[..start]);
-        rest = &rest[start + open.len()..];
-        match rest.find(&close) {
-            Some(end) => rest = &rest[end + close.len()..],
-            None => {
-                rest = "";
-                break;
-            }
-        }
-    }
-    out.push_str(rest);
-    out
+/// Extract the value of `attr="..."` from a tag's attribute text (the
+/// substring between the tag name and its closing `>`). A simple string
+/// search, not a general attribute parser — matches `tag_inner` above, which
+/// is deliberately not a full XML/HTML parser either.
+fn attr_value<'a>(attrs: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{name}=\"");
+    let start = attrs.find(&needle)? + needle.len();
+    let rest = &attrs[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
 }
 
-/// Normalise a user text block to what Claude Code's live UI actually shows.
+/// Parse a `<teammate-message teammate_id="...">…</teammate-message>`
+/// wrapper — Conductor's own multi-agent construct, not a Claude Code CLI
+/// form — at the start of `lead` into its `(id, body)`. The wrapper's
+/// `summary` attribute, if present, is always ignored (S4): only `body`,
+/// shown when expanded, carries the message. An unterminated closing tag
+/// captures through to the end of the string, matching `tag_inner`'s
+/// convention. Returns `None` if `lead` doesn't open with this tag, or the
+/// tag is malformed (no closing `>` on the opening tag, or no `teammate_id`
+/// attribute) — the caller then falls through to treating the text as
+/// ordinary prose.
+fn parse_teammate_message(lead: &str) -> Option<(String, String)> {
+    const OPEN_PREFIX: &str = "<teammate-message";
+    const CLOSE: &str = "</teammate-message>";
+    if !lead.starts_with(OPEN_PREFIX) {
+        return None;
+    }
+    let tag_end = lead.find('>')?;
+    let id = attr_value(&lead[OPEN_PREFIX.len()..tag_end], "teammate_id")?;
+    let rest = &lead[tag_end + 1..];
+    let body = match rest.find(CLOSE) {
+        Some(end) => &rest[..end],
+        None => rest,
+    };
+    Some((id.to_string(), body.trim().to_string()))
+}
+
+/// Normalise a user text block to what Claude Code's live UI actually shows
+/// (or, for the Conductor-specific `<teammate-message>` wrapper, to the
+/// display block S4 defines for it).
 ///
 /// The session log records several wrapper forms inside plain user turns that
 /// the CLI renders specially (or not at all); left raw they make the reflow
 /// transcript look nothing like the screen the user just scrolled away from:
 ///
+/// * `<teammate-message teammate_id="...">…</teammate-message>` — a message
+///   from another agent teammate; folds into [`DisplayBlock::TeammateMessage`].
 /// * `<command-name>/foo</command-name>…<command-args>bar</command-args>` —
 ///   a slash-command invocation; the CLI shows it as `> /foo bar`.
 /// * `<local-command-stdout>…</local-command-stdout>` — output of a local
 ///   command, shown unwrapped (sanitized here: it can carry raw ANSI).
-/// * `<system-reminder>…</system-reminder>` — hidden context; stripped.
+/// * `<task-notification>…</task-notification>` — a background task finishing;
+///   collapses the whole message to the notification's `<summary>` line.
+///
+/// `<system-reminder>` is *not* in that list — see the comment at the tail of
+/// this function for why it is left in place.
 ///
 /// Returns `None` when nothing displayable remains.
-fn normalise_user_text(text: String) -> Option<String> {
+fn normalise_user_text(text: String) -> Option<DisplayBlock> {
     // The wrapper forms are only recognised at the very start of the message
-    // (that is where the CLI writes them); a user merely *mentioning* one of
+    // (that is where they're written); a user merely *mentioning* one of
     // these tags mid-prompt keeps their text untouched.
     let lead = text.trim_start();
+    if lead.starts_with("<teammate-message")
+        && let Some((id, body)) = parse_teammate_message(lead)
+    {
+        return Some(DisplayBlock::TeammateMessage { id, body });
+    }
+    // Measured: `<task-notification>` is matched *anywhere* in the message, not
+    // just at its start, and collapsing it discards everything else the message
+    // held. Claude Code checks neither the tag's position nor who wrote the
+    // record — a screen dump pasted by hand collapses exactly like the CLI's own
+    // notification, taking the prose typed around it with it. Hence this runs
+    // before the leading-tag forms below, and takes only the *first* summary
+    // when a message carries several.
+    //
+    // With no usable `<summary>` the message vanishes entirely rather than
+    // falling back to its raw text — also measured, for both a missing tag and
+    // an empty one.
+    if lead.contains("<task-notification>") {
+        let summary = tag_inner(lead, "summary")
+            .map(str::trim)
+            .filter(|s| !s.is_empty())?;
+        return Some(DisplayBlock::Notice(sanitize_preview_line(summary)));
+    }
     // The CLI always writes a terminated tag; an unterminated one at the start
     // of a message is user prose, not a command record — leave it alone rather
     // than swallowing the whole message as a "command name".
@@ -154,33 +184,69 @@ fn normalise_user_text(text: String) -> Option<String> {
         } else {
             format!("{} {}", name.trim(), args)
         };
-        return (!display.is_empty()).then_some(display);
+        return (!display.is_empty()).then_some(DisplayBlock::Text(display));
     }
     if lead.starts_with("<local-command-stdout>")
         && let Some(stdout) = tag_inner(lead, "local-command-stdout")
     {
-        let cleaned: Vec<String> = stdout.trim().lines().map(sanitize_preview_line).collect();
-        let joined = cleaned.join("\n").trim().to_string();
-        return (!joined.is_empty()).then_some(joined);
+        // Measured: a command's stdout is drawn as a `⎿` continuation of the
+        // `❯ /command` line above it, not as a user turn of its own.
+        let lines: Vec<String> = stdout
+            .trim()
+            .lines()
+            .map(sanitize_preview_line)
+            .filter(|l| !l.trim().is_empty())
+            .collect();
+        return (!lines.is_empty()).then_some(DisplayBlock::Annotation { lines });
     }
-    let stripped = strip_tag_spans(&text, "system-reminder");
-    let trimmed = stripped.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
+    // `<system-reminder>` spans are deliberately *not* removed: measured, Claude
+    // Code draws them verbatim, whether they sit inline in a turn's text or
+    // arrive as a block of their own. The reminders a reader never sees on
+    // screen are hidden by their record's `isMeta` flag instead (10 of the 11
+    // reminder-only records in the local corpus carry it), which `session.rs`
+    // skips before reaching here.
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| DisplayBlock::Text(trimmed.to_string()))
 }
 
 /// Convert a [`Content`] value into display blocks, normalising the two surface
 /// forms (bare string and typed block array) into the same flat representation.
 ///
 /// `is_user` applies the user-turn wrapper normalisation (slash commands,
-/// local-command stdout, system reminders — see [`normalise_user_text`]).
+/// local-command stdout, task notifications — see [`normalise_user_text`]).
 /// Assistant text is left untouched: it may legitimately *quote* those tags.
-pub(super) fn content_to_display_blocks(content: Content, is_user: bool) -> Vec<DisplayBlock> {
+///
+/// `tool_kinds` is the session-wide `tool_use` id → [`ResultKind`]
+/// pairing map (see `session.rs`): a `Counted`-category `tool_use` block
+/// writes its bucket in under its id; a `tool_result` block looks its id up
+/// to recover it (`None` for `Inline`/`Hidden` calls — their raw tool name is
+/// not retained here, only `log::debug!`-able at classification time if ever
+/// needed — or if pairing failed to find the matching `tool_use`, e.g.
+/// truncated logs). The map outlives a single call — it is threaded through
+/// every record in a session so a `tool_use` in one record can be found by a
+/// `tool_result` in a later one.
+///
+/// `errored_ids` is the session-wide pre-scan of `tool_use_id`s whose
+/// `tool_result` reported an error (see `session.rs::scan_errored_tool_use_ids`),
+/// needed because a `tool_use` renders before its `tool_result` is reached.
+///
+/// `thinking_duration_secs` is this record's precomputed "Thought for Ns"
+/// value (see `session.rs::thinking_duration_secs`), applied to every
+/// `Thinking` block found here — a record carries one timestamp for all its
+/// content blocks, so multiple `Thinking` blocks in one record share it.
+pub(super) fn content_to_display_blocks(
+    content: Content,
+    is_user: bool,
+    tool_kinds: &mut HashMap<String, ResultKind>,
+    errored_ids: &HashSet<String>,
+    thinking_duration_secs: u64,
+) -> Vec<DisplayBlock> {
     let text_block = |text: String| -> Option<DisplayBlock> {
         if text.is_empty() {
             return None;
         }
         if is_user {
-            normalise_user_text(text).map(DisplayBlock::Text)
+            normalise_user_text(text)
         } else {
             Some(DisplayBlock::Text(text))
         }
@@ -191,18 +257,34 @@ pub(super) fn content_to_display_blocks(content: Content, is_user: bool) -> Vec<
             .into_iter()
             .filter_map(|b| match b {
                 Block::Text { text } => text_block(text),
-                Block::Thinking { thinking } => Some(DisplayBlock::Thinking { text: thinking }),
-                Block::ToolUse { name, input } => {
-                    let summary = summarise_tool_input(&input);
-                    Some(DisplayBlock::ToolUse { name, summary })
+                Block::Thinking { thinking } => Some(DisplayBlock::Thinking {
+                    text: thinking,
+                    duration_secs: thinking_duration_secs,
+                }),
+                Block::ToolUse { id, name, input } => {
+                    let errored = !id.is_empty() && errored_ids.contains(&id);
+                    if !id.is_empty() {
+                        tool_kinds.insert(id, result_kind(&name, &input));
+                    }
+                    Some(DisplayBlock::ToolUse { name, input, errored })
                 }
-                Block::ToolResult { content, is_error } => {
+                Block::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                } => {
+                    // An unpaired result (truncated log, id missing) falls back
+                    // to `Hidden`: without its `tool_use` there is no way to
+                    // know which category it belongs to, and guessing `Inline`
+                    // would emit a stray error block.
+                    let kind = tool_kinds
+                        .get(&tool_use_id)
+                        .copied()
+                        .unwrap_or(ResultKind::Hidden);
                     let lines = result_lines(&content);
-                    let total_lines = lines.len();
-                    let preview = lines.into_iter().take(TOOL_RESULT_PREVIEW_LINES).collect();
                     Some(DisplayBlock::ToolResult {
-                        preview,
-                        total_lines,
+                        kind,
+                        lines,
                         is_error,
                     })
                 }

--- a/src/claude_log/mod.rs
+++ b/src/claude_log/mod.rs
@@ -16,6 +16,7 @@ mod convert;
 mod model;
 mod schema;
 mod session;
+mod tool_class;
 #[cfg(test)]
 mod tests;
 
@@ -23,11 +24,18 @@ pub use session::load_session;
 
 // `DisplayBlock` and `Role` are consumed externally (via `crate::claude_log::X`)
 // by `ui/reflow_view.rs`; `LogEntry` likewise by `app/reflow.rs`. The rest of
-// these re-exports (`TOOL_RESULT_PREVIEW_LINES` and the raw schema types) are
-// only used within this module tree today, via `super::model::X` /
-// `super::schema::X`, but stay re-exported at the module root to preserve the
-// pre-split `crate::claude_log::X` path for any future external caller.
+// these re-exports (the raw schema types) are only used within this module
+// tree today, via `super::model::X` / `super::schema::X`, but stay
+// re-exported at the module root to preserve the pre-split
+// `crate::claude_log::X` path for any future external caller.
 #[allow(unused_imports)]
-pub use model::{DisplayBlock, LogEntry, Role, TOOL_RESULT_PREVIEW_LINES};
+pub use model::{DisplayBlock, LogEntry, Role};
 #[allow(unused_imports)]
 pub use schema::{Block, Content, LogRecord, Message, TextOnly, ToolResultContent};
+// `ToolCategory`/`CountedBucket`/`classify`/`unknown_tool_arg` are consumed by
+// `ui/reflow_view/build.rs` to lay out `tool_use`/`tool_result` lines, and by
+// `convert.rs` (within this module tree) to resolve the pairing map's stored
+// bucket — see `tool_class.rs` for why both call sites share one table.
+pub use tool_class::{
+    BUCKET_ORDER, CountedBucket, ResultKind, ToolCategory, classify, unknown_tool_arg,
+};

--- a/src/claude_log/model.rs
+++ b/src/claude_log/model.rs
@@ -1,5 +1,7 @@
 //! Display-ready types normalised from the raw session log schema.
 
+use super::tool_class::ResultKind;
+
 /// Speaker of a conversation turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
@@ -24,22 +26,72 @@ pub struct LogEntry {
 pub enum DisplayBlock {
     /// Markdown prose (user input or assistant text response).
     Text(String),
-    /// A tool invocation — rendered as `⏺ {name}({summary})`.
-    ToolUse { name: String, summary: String },
-    /// The result returned by a tool — a capped preview of the actual output
-    /// plus the total line count, mirroring Claude Code's collapsed `⎿` block.
+    /// A tool invocation. The renderer classifies it (see
+    /// `crate::claude_log::classify`) using `name` and the raw `input` JSON
+    /// to decide how — or whether — it draws a line.
+    ToolUse {
+        name: String,
+        input: serde_json::Value,
+        /// Whether this call's paired `tool_result` reported an error.
+        /// Resolved by a pre-scan pass over the whole session (see
+        /// `session.rs::scan_errored_tool_use_ids`), since the result record
+        /// always comes *after* the call — `false` if the call had no id, or
+        /// no matching result was found (e.g. a truncated log).
+        errored: bool,
+    },
+    /// The result returned by a tool, mirroring Claude Code's collapsed `⎿`
+    /// block (or, for a `Counted` tool, folding into the result-side count).
     ToolResult {
-        /// First [`TOOL_RESULT_PREVIEW_LINES`] lines of output (already capped).
-        preview: Vec<String>,
-        /// Total number of output lines, for the `… +N lines` summary.
-        total_lines: usize,
+        /// What this result draws, resolved from its paired `tool_use` at
+        /// parse time (the call's `input` — which `Bash`'s classification
+        /// depends on — is gone by render time). `Hidden` when pairing failed:
+        /// an unpaired result has no way to know its tool, and drawing a bare
+        /// error block for it would be noise.
+        kind: ResultKind,
+        /// The tool's full output, one entry per line (unlike the old capped
+        /// preview, expansion needs every line).
+        lines: Vec<String>,
         /// Whether the tool reported an error.
         is_error: bool,
     },
     /// A thinking block — the assistant's reasoning text (may be empty).
-    Thinking { text: String },
+    Thinking {
+        text: String,
+        /// Collapsed-mode "Thought for {N}s" duration: the whole-second diff
+        /// between this record's timestamp and the previous *displayed*
+        /// record's (see `session.rs`), minimum 1.
+        duration_secs: u64,
+    },
+    /// A message from another agent teammate, embedded in a user turn via
+    /// Conductor's own `<teammate-message teammate_id="...">` wrapper (not a
+    /// Claude Code CLI construct — see `crate::claude_log::convert`). The
+    /// wrapper's `summary` attribute, if present, is always ignored; `body`
+    /// is the full message text, shown only when expanded.
+    TeammateMessage { id: String, body: String },
+    /// A `⎿`-prefixed annotation attached to the block above it: the output of
+    /// a slash command (`<local-command-stdout>`) or a file the CLI carried
+    /// into the conversation (a `file`/`compact_file_reference` attachment).
+    ///
+    /// Measured — `/model` followed by its stdout renders as
+    /// ```text
+    /// ❯ /model
+    ///   ⎿  Set model to Opus 5
+    /// ```
+    /// with **no** blank line between them, which is why an entry made only of
+    /// these suppresses the separator that would normally precede it (see the
+    /// line builder).
+    ///
+    /// Multi-line stdout is unmeasured; it is laid out like an expanded tool
+    /// result (glyph on the first line, 5-column indent after).
+    Annotation { lines: Vec<String> },
+    /// A one-line `⏺` notice the CLI generated itself rather than the model —
+    /// currently only a background-task completion, whose `<task-notification>`
+    /// wrapper collapses to just its `<summary>` text.
+    ///
+    /// Measured: the whole XML wrapper is replaced by
+    /// `⏺ Background command "…" completed (exit code 0)`.
+    Notice(String),
+    /// The `✻ Conversation compacted` marker written where a `/compact` cut
+    /// the context.
+    CompactBoundary,
 }
-
-/// Maximum number of tool-result output lines shown before collapsing into a
-/// `… +N lines` summary, matching Claude Code's transcript preview.
-pub const TOOL_RESULT_PREVIEW_LINES: usize = 4;

--- a/src/claude_log/schema.rs
+++ b/src/claude_log/schema.rs
@@ -17,17 +17,82 @@ pub struct LogRecord {
     /// the reflow view opens onto walls of text the user has never seen.
     #[serde(default)]
     pub is_meta: bool,
+    /// Set on the pseudo-user turn that carries a `/compact` summary into the
+    /// next context window. Claude Code never draws it (measured: the summary
+    /// body appears nowhere in a resumed transcript — only the
+    /// `⎿ Compacted (ctrl+o to see full summary)` line does), so the reflow
+    /// view must skip it too rather than replaying the whole summary as if the
+    /// user had typed it.
+    ///
+    /// Across the local corpus this flag is always accompanied by
+    /// `isVisibleInTranscriptOnly` (102 of 102 occurrences); keying on this one
+    /// alone is therefore equivalent, and says what it means.
+    #[serde(default)]
+    pub is_compact_summary: bool,
+    /// Discriminator on `type: "system"` records. Only `compact_boundary` is
+    /// displayed (as `✻ Conversation compacted`).
+    #[serde(default)]
+    pub subtype: Option<String>,
+    /// Present on `type: "attachment"` records — context the CLI injected on
+    /// the user's behalf. Claude Code draws a `⎿` one-liner for a couple of
+    /// these; see [`Attachment`].
+    #[serde(default)]
+    pub attachment: Option<Attachment>,
     #[serde(default)]
     pub message: Option<Message>,
-    /// `queue-operation` records carry the queued text at the top level (not in
-    /// `message`) and an `operation` discriminator. A user prompt typed while
-    /// Claude is still working is recorded as `operation: "enqueue"` here and
-    /// never re-emitted as a `user` record, so the transcript must read it from
-    /// these fields or the input is lost from the scrollback.
+    /// RFC3339 wall-clock time the record was written. Used only to compute
+    /// a collapsed `Thinking` block's "Thought for Ns" duration (the diff
+    /// against the previous *displayed* record's timestamp) — see
+    /// `session.rs`. Absent on older/malformed records, in which case the
+    /// duration falls back to a fixed 1s.
     #[serde(default)]
-    pub operation: Option<String>,
+    pub timestamp: Option<String>,
+}
+
+/// A `type: "attachment"` record's payload — context the CLI injected into the
+/// conversation on the user's behalf (files carried across a compact, hook
+/// output, skill listings, …).
+///
+/// Claude Code draws almost none of these. Measured against a resumed
+/// transcript, exactly two produce a visible line:
+///
+/// * `file` → `⎿  Read {displayPath} ({numLines} lines)`
+/// * `compact_file_reference` → `⎿  Referenced file {displayPath}`
+///
+/// The local corpus holds 27 other `type` values (`hook_success` alone appears
+/// ~47k times); none was observed to draw anything, so the renderer works from
+/// an allowlist of the two above rather than trying to cover the rest.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attachment {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    /// Path as Claude Code displays it — already relative to the session's
+    /// `cwd` (with `../` segments when the file lives outside it), so it is
+    /// used verbatim. Absent on some types; [`filename`](Self::filename) is
+    /// the fallback.
     #[serde(default)]
-    pub content: Option<String>,
+    pub display_path: Option<String>,
+    #[serde(default)]
+    pub filename: Option<String>,
+    #[serde(default)]
+    pub content: Option<AttachmentContent>,
+}
+
+/// The `content` wrapper on a `file` attachment.
+#[derive(Deserialize)]
+pub struct AttachmentContent {
+    #[serde(default)]
+    pub file: Option<AttachmentFile>,
+}
+
+/// The file payload of a `file` attachment. Only the line count is displayed;
+/// the file's text is already in the transcript's context and is not drawn.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentFile {
+    #[serde(default)]
+    pub num_lines: Option<u64>,
 }
 
 /// The `message` field present on `user` and `assistant` records.
@@ -63,11 +128,20 @@ pub enum Block {
         thinking: String,
     },
     ToolUse {
+        /// The API's per-call id, used only to pair this call with its
+        /// matching `tool_result` block (by `tool_use_id`) while parsing —
+        /// see `session.rs`. Absent on malformed/older records, in which
+        /// case pairing simply fails for that call.
+        #[serde(default)]
+        id: String,
         name: String,
         #[serde(default)]
         input: serde_json::Value,
     },
     ToolResult {
+        /// The `id` of the `tool_use` block this result answers.
+        #[serde(default)]
+        tool_use_id: String,
         #[serde(default)]
         content: ToolResultContent,
         /// Set when the tool reported an error. Rendered with an error-colored

--- a/src/claude_log/session.rs
+++ b/src/claude_log/session.rs
@@ -1,10 +1,12 @@
 //! Public file-reading API: parse a session log into display entries.
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use super::convert::content_to_display_blocks;
 use super::model::{DisplayBlock, LogEntry, Role};
-use super::schema::LogRecord;
+use super::schema::{Block, Content, LogRecord};
+use super::tool_class::ResultKind;
 
 /// Parse a Claude Code `.jsonl` session file and return display entries.
 ///
@@ -20,38 +22,86 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
         }
     };
 
-    let mut entries = Vec::new();
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let record: LogRecord = match serde_json::from_str(line) {
-            Ok(r) => r,
-            Err(e) => {
-                log::warn!("reflow: skipping malformed jsonl line: {e}");
-                continue;
+    let records: Vec<LogRecord> = text
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
             }
-        };
+            match serde_json::from_str(line) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    log::warn!("reflow: skipping malformed jsonl line: {e}");
+                    None
+                }
+            }
+        })
+        .collect();
 
-        // A prompt queued while Claude is working is stored as a
-        // `queue-operation` enqueue, with the text at the top level. Surface it
-        // as a user turn so the user's own input appears in the transcript; the
-        // matching `remove` (dequeue) carries no text and is ignored.
-        if record.kind == "queue-operation" {
-            if record.operation.as_deref() == Some("enqueue")
-                && let Some(text) = record.content.filter(|s| !s.is_empty())
-            {
+    // Pre-scan pass: a `tool_use`'s marker must render error-colored when its
+    // paired `tool_result` reported an error, but that result record always
+    // comes *after* the call in the log (they land in consecutive
+    // assistant/user records) — this first pass collects every errored
+    // `tool_use_id` so the entry-building pass below can look each one up
+    // before it gets there, instead of needing a lookahead.
+    let errored_ids = scan_errored_tool_use_ids(&records);
+
+    let mut entries = Vec::new();
+    // tool_use id → its Counted bucket (Inline/Hidden calls are not
+    // inserted — their raw tool name is not retained past classification).
+    let mut tool_kinds: HashMap<String, ResultKind> = HashMap::new();
+    // The previous *displayed* record's timestamp — used to compute a
+    // collapsed `Thinking` block's "Thought for Ns" duration. Judgment call:
+    // "previous" means the previous entry that actually made it into
+    // `entries`, so a skipped record (isMeta/isSidechain/empty-blocks/a
+    // dequeue with no text) never becomes the diff's baseline — an assistant
+    // turn immediately after a skipped one still measures its thinking time
+    // against the last turn the user actually saw, not a hidden one.
+    let mut prev_displayed_ts: Option<String> = None;
+    for record in records {
+        // Context the CLI injected on the user's behalf. Two kinds draw a `⎿`
+        // one-liner; every other kind (hook output, skill listings, …) is
+        // invisible in Claude Code and stays invisible here.
+        if record.kind == "attachment" {
+            if let Some(text) = record.attachment.as_ref().and_then(attachment_line) {
                 entries.push(LogEntry {
                     role: Role::User,
                     model: None,
-                    blocks: vec![DisplayBlock::Text(text)],
+                    blocks: vec![DisplayBlock::Annotation { lines: vec![text] }],
+                });
+                // Deliberately does NOT advance `prev_displayed_ts`: an
+                // attachment carries the timestamp of the compact that emitted
+                // it, which would otherwise be charged to the next assistant
+                // turn as thinking time.
+            }
+            continue;
+        }
+
+        // `✻ Conversation compacted` — the only `system` record that draws.
+        if record.kind == "system" {
+            if record.subtype.as_deref() == Some("compact_boundary") {
+                entries.push(LogEntry {
+                    role: Role::Assistant,
+                    model: None,
+                    blocks: vec![DisplayBlock::CompactBoundary],
                 });
             }
             continue;
         }
 
-        // Only process `user` and `assistant` turns; skip sidechain records.
+        // Only `user` and `assistant` turns carry conversation. Every other
+        // record type in the schema is a session-metadata journal that Claude
+        // Code never draws — `queue-operation` (enqueue/remove bookkeeping for
+        // the input queue), `mode`, `permission-mode`, `last-prompt`,
+        // `ai-title`, `custom-title`, `agent-name`, `pr-link`,
+        // `file-history-snapshot`, `file-history-delta`. Measured for
+        // `queue-operation` specifically, because it is the one that *looks*
+        // displayable: it carries the queued prompt as a bare top-level
+        // `content` string. Claude Code still draws nothing for it — a prompt
+        // typed while it is working is re-emitted as an ordinary `user` record
+        // (`promptSource: "queued"`) once accepted, so honouring the journal
+        // too would print that turn twice.
         if record.kind != "user" && record.kind != "assistant" {
             continue;
         }
@@ -63,6 +113,16 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
         if record.is_meta {
             continue;
         }
+        // The `/compact` summary is threaded into the next context window as a
+        // pseudo-user turn. Claude Code draws none of it — only the
+        // `⎿ Compacted (ctrl+o to see full summary)` line stands in for it —
+        // so replaying the body here would open the transcript onto a wall of
+        // text the user never saw.
+        if record.is_compact_summary {
+            continue;
+        }
+
+        let this_ts = record.timestamp.clone();
 
         let Some(msg) = record.message else {
             continue;
@@ -74,7 +134,15 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
             _ => continue,
         };
 
-        let blocks = content_to_display_blocks(msg.content, role == Role::User);
+        let duration_secs = thinking_duration_secs(prev_displayed_ts.as_deref(), this_ts.as_deref());
+
+        let blocks = content_to_display_blocks(
+            msg.content,
+            role == Role::User,
+            &mut tool_kinds,
+            &errored_ids,
+            duration_secs,
+        );
         if blocks.is_empty() {
             continue;
         }
@@ -84,6 +152,89 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
             model: msg.model,
             blocks,
         });
+        prev_displayed_ts = this_ts;
     }
     entries
+}
+
+/// The single `⎿` line an attachment draws, or `None` for the ~27 kinds that
+/// draw nothing.
+///
+/// Measured against a resumed transcript:
+/// ```text
+///   ⎿  Read alpha.rs (42 lines)
+///   ⎿  Referenced file beta.yml
+/// ```
+/// `displayPath` is used verbatim — Claude Code has already relativised it
+/// against the session's `cwd`, including the long `../../..` prefixes a file
+/// outside the worktree gets. A `file` attachment with no line count drops the
+/// parenthesised clause rather than printing a zero.
+fn attachment_line(attachment: &super::schema::Attachment) -> Option<String> {
+    let path = attachment
+        .display_path
+        .as_deref()
+        .or(attachment.filename.as_deref())
+        .map(str::trim)
+        .filter(|p| !p.is_empty())?;
+    match attachment.kind.as_str() {
+        "file" => {
+            let n = attachment
+                .content
+                .as_ref()
+                .and_then(|c| c.file.as_ref())
+                .and_then(|f| f.num_lines);
+            Some(match n {
+                Some(1) => format!("Read {path} (1 line)"),
+                Some(n) => format!("Read {path} ({n} lines)"),
+                None => format!("Read {path}"),
+            })
+        }
+        "compact_file_reference" => Some(format!("Referenced file {path}")),
+        _ => None,
+    }
+}
+
+/// Whole-second diff between `prev` and `this` RFC3339 timestamps, for a
+/// collapsed `Thinking` block's "Thought for Ns" line. Falls back to `1`
+/// (never `0`, per the spec) when either timestamp is missing or fails to
+/// parse, or when the computed difference is zero or negative (e.g. clock
+/// skew, or two records landing in the same second).
+fn thinking_duration_secs(prev: Option<&str>, this: Option<&str>) -> u64 {
+    let (Some(prev), Some(this)) = (prev, this) else {
+        return 1;
+    };
+    let (Ok(prev), Ok(this)) = (
+        chrono::DateTime::parse_from_rfc3339(prev),
+        chrono::DateTime::parse_from_rfc3339(this),
+    ) else {
+        return 1;
+    };
+    let diff = this.signed_duration_since(prev).num_seconds();
+    if diff <= 0 { 1 } else { diff as u64 }
+}
+
+/// Collect every `tool_use_id` whose paired `tool_result` block reported an
+/// error, across the whole (unfiltered) record list. Used to resolve a
+/// `tool_use`'s marker color before the entry-building pass reaches its
+/// (later) `tool_result` record — see the pre-scan comment in
+/// [`load_session`].
+fn scan_errored_tool_use_ids(records: &[LogRecord]) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    for record in records {
+        let Some(msg) = &record.message else { continue };
+        let Content::Blocks(blocks) = &msg.content else {
+            continue;
+        };
+        for block in blocks {
+            if let Block::ToolResult {
+                tool_use_id,
+                is_error: true,
+                ..
+            } = block
+            {
+                ids.insert(tool_use_id.clone());
+            }
+        }
+    }
+    ids
 }

--- a/src/claude_log/tests.rs
+++ b/src/claude_log/tests.rs
@@ -1,16 +1,22 @@
 //! Unit tests for claude_log: wrapper-tag normalisation, content-to-block
 //! conversion, and `load_session` integration.
 
-use super::convert::{content_to_display_blocks, result_lines, summarise_tool_input};
-use super::model::{DisplayBlock, Role, TOOL_RESULT_PREVIEW_LINES};
+use std::collections::{HashMap, HashSet};
+
+use super::convert::{content_to_display_blocks, result_lines};
+use super::model::{DisplayBlock, Role};
 use super::schema::{LogRecord, TextOnly, ToolResultContent};
 use super::session::load_session;
+use super::tool_class::{CountedBucket, ResultKind};
 
 fn parse_msg_content(json: &str) -> Vec<DisplayBlock> {
     let r: LogRecord = serde_json::from_str(json).expect("valid test json");
     let msg = r.message.unwrap();
     let is_user = msg.role.as_deref() == Some("user");
-    content_to_display_blocks(msg.content, is_user)
+    // The duration value doesn't matter to any test using this helper except
+    // `thinking_text_is_captured`, which checks the text field, not the
+    // duration — 1 is an arbitrary placeholder.
+    content_to_display_blocks(msg.content, is_user, &mut HashMap::new(), &HashSet::new(), 1)
 }
 
 // ── Hidden-context normalisation (isMeta / wrappers) ─────────────────────
@@ -50,7 +56,68 @@ fn local_command_stdout_is_unwrapped_and_sanitized() {
     let blocks = parse_msg_content(
         r#"{"type":"user","message":{"role":"user","content":"<local-command-stdout>\u001b[2mCompacted\u001b[22m</local-command-stdout>"}}"#,
     );
-    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == "Compacted"));
+    match &blocks[0] {
+        DisplayBlock::Annotation { lines } => assert_eq!(lines, &["Compacted".to_string()]),
+        other => panic!("expected Annotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn task_notification_collapses_to_its_summary() {
+    // Measured: the whole wrapper is replaced by an `⏺` line carrying only the
+    // `<summary>` text — the task id, output path and status never appear.
+    let blocks = parse_msg_content(
+        r#"{"type":"user","message":{"role":"user","content":"<task-notification>\n<task-id>bh15vvqha</task-id>\n<output-file>/private/tmp/x.output</output-file>\n<status>completed</status>\n<summary>Background command \"Run brew audit\" completed (exit code 0)</summary>\n</task-notification>"}}"#,
+    );
+    match &blocks[0] {
+        DisplayBlock::Notice(t) => {
+            assert_eq!(t, "Background command \"Run brew audit\" completed (exit code 0)");
+        }
+        other => panic!("expected Notice, got {other:?}"),
+    }
+}
+
+#[test]
+fn task_notification_without_a_summary_draws_nothing() {
+    // Measured, including the prose around it: with no usable summary the whole
+    // message disappears rather than falling through to dumping the raw XML.
+    for content in [
+        "<task-notification>\\n<task-id>abc</task-id>\\n</task-notification>",
+        "look:\\n<task-notification>\\n<summary></summary>\\n</task-notification>\\nthoughts?",
+    ] {
+        let blocks = parse_msg_content(&format!(
+            r#"{{"type":"user","message":{{"role":"user","content":"{content}"}}}}"#,
+        ));
+        assert!(blocks.is_empty(), "expected nothing drawn for {content:?}");
+    }
+}
+
+#[test]
+fn a_task_notification_collapses_wherever_it_sits() {
+    // Measured: the tag is matched anywhere in the message, and collapsing it
+    // discards the prose typed around it. This is what makes a screen dump
+    // pasted by hand render exactly like the CLI's own notification — Claude
+    // Code checks neither the tag's position nor who wrote the record.
+    let blocks = parse_msg_content(
+        r#"{"type":"user","message":{"role":"user","content":"here is what I saw:\n\n<task-notification>\n<task-id>zz1</task-id>\n<summary>Background command \"Install\" completed (exit code 0)</summary>\n</task-notification>\n\nwhat do you think?"}}"#,
+    );
+    assert_eq!(blocks.len(), 1);
+    match &blocks[0] {
+        DisplayBlock::Notice(t) => {
+            assert_eq!(t, "Background command \"Install\" completed (exit code 0)");
+        }
+        other => panic!("expected Notice, got {other:?}"),
+    }
+}
+
+#[test]
+fn only_the_first_summary_survives_a_doubled_notification() {
+    // Measured: two notifications in one message draw a single `⏺` line.
+    let blocks = parse_msg_content(
+        r#"{"type":"user","message":{"role":"user","content":"<task-notification>\n<summary>FIRST done</summary>\n</task-notification>\n<task-notification>\n<summary>SECOND done</summary>\n</task-notification>"}}"#,
+    );
+    assert_eq!(blocks.len(), 1);
+    assert!(matches!(&blocks[0], DisplayBlock::Notice(t) if t == "FIRST done"));
 }
 
 #[test]
@@ -62,27 +129,94 @@ fn empty_local_command_stdout_is_dropped() {
 }
 
 #[test]
-fn system_reminder_spans_are_stripped_from_user_text() {
+fn teammate_message_wrapper_becomes_a_teammate_message_block() {
     let blocks = parse_msg_content(
-        r#"{"type":"user","message":{"role":"user","content":"fix the bug <system-reminder>hidden note</system-reminder>please"}}"#,
+        r#"{"type":"user","message":{"role":"user","content":"<teammate-message teammate_id=\"alice\">please review PR 42</teammate-message>"}}"#,
     );
-    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == "fix the bug please"));
+    match &blocks[0] {
+        DisplayBlock::TeammateMessage { id, body } => {
+            assert_eq!(id, "alice");
+            assert_eq!(body, "please review PR 42");
+        }
+        other => panic!("expected TeammateMessage, got {other:?}"),
+    }
 }
 
 #[test]
-fn reminder_only_user_block_is_dropped() {
+fn teammate_message_summary_attribute_is_ignored() {
+    // `summary` is always ignored (S4) — only `teammate_id` and the body text
+    // are read, in either attribute order.
     let blocks = parse_msg_content(
-        r#"{"type":"user","message":{"role":"user","content":"<system-reminder>only hidden</system-reminder>"}}"#,
+        r#"{"type":"user","message":{"role":"user","content":"<teammate-message summary=\"short\" teammate_id=\"bob\">the real body</teammate-message>"}}"#,
     );
-    assert!(blocks.is_empty());
+    match &blocks[0] {
+        DisplayBlock::TeammateMessage { id, body } => {
+            assert_eq!(id, "bob");
+            assert_eq!(body, "the real body");
+        }
+        other => panic!("expected TeammateMessage, got {other:?}"),
+    }
 }
 
 #[test]
-fn unterminated_system_reminder_strips_to_end() {
+fn unterminated_teammate_message_body_captures_to_end() {
     let blocks = parse_msg_content(
-        r#"{"type":"user","message":{"role":"user","content":"visible <system-reminder>truncated"}}"#,
+        r#"{"type":"user","message":{"role":"user","content":"<teammate-message teammate_id=\"carol\">truncated body"}}"#,
     );
-    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == "visible"));
+    match &blocks[0] {
+        DisplayBlock::TeammateMessage { id, body } => {
+            assert_eq!(id, "carol");
+            assert_eq!(body, "truncated body");
+        }
+        other => panic!("expected TeammateMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn teammate_message_without_teammate_id_falls_back_to_prose() {
+    // Malformed wrapper (missing the one attribute this parser reads) — left
+    // as ordinary text rather than silently dropped.
+    let raw = "<teammate-message>no id attribute</teammate-message>";
+    let blocks = parse_msg_content(&format!(
+        r#"{{"type":"user","message":{{"role":"user","content":"{raw}"}}}}"#,
+    ));
+    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == raw));
+}
+
+#[test]
+fn mid_prompt_mention_of_teammate_message_tag_is_not_rewritten() {
+    // The wrapper is only recognised at the start of the message; a user
+    // *talking about* the tag keeps their full prompt untouched.
+    let blocks = parse_msg_content(
+        r#"{"type":"user","message":{"role":"user","content":"why did <teammate-message teammate_id=\"x\">hi</teammate-message> show up?"}}"#,
+    );
+    assert!(matches!(
+        &blocks[0],
+        DisplayBlock::Text(t) if t == "why did <teammate-message teammate_id=\"x\">hi</teammate-message> show up?"
+    ));
+}
+
+#[test]
+fn system_reminder_spans_are_kept_in_user_text() {
+    // Measured: Claude Code draws a reminder verbatim where it sits, inline in
+    // the turn's own text. Reminders a reader never sees are hidden one level
+    // up, by their record's `isMeta` flag.
+    let raw = "fix the bug <system-reminder>hidden note</system-reminder>please";
+    let blocks = parse_msg_content(&format!(
+        r#"{{"type":"user","message":{{"role":"user","content":"{raw}"}}}}"#,
+    ));
+    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == raw));
+}
+
+#[test]
+fn reminder_only_user_block_is_drawn_as_its_own_turn() {
+    // Measured: arriving as a block of its own does not hide it either — it
+    // becomes a `❯` turn carrying the tag verbatim.
+    let raw = "<system-reminder>only hidden</system-reminder>";
+    let blocks = parse_msg_content(&format!(
+        r#"{{"type":"user","message":{{"role":"user","content":"{raw}"}}}}"#,
+    ));
+    assert!(matches!(&blocks[0], DisplayBlock::Text(t) if t == raw));
 }
 
 #[test]
@@ -99,8 +233,9 @@ fn unterminated_command_tag_at_start_is_left_as_prose() {
 #[test]
 fn mid_prompt_mention_of_command_tag_is_not_rewritten() {
     // The wrapper is only recognised at the start of the message; a user
-    // *talking about* the tag keeps their full prompt (the reminder-strip
-    // pass still runs, but there is no reminder here).
+    // *talking about* the tag keeps their full prompt. (`<task-notification>`
+    // is the one form that does not work this way — see
+    // `a_task_notification_collapses_wherever_it_sits`.)
     let raw = "why does <command-name>/x</command-name> appear in my log?";
     let blocks = parse_msg_content(&format!(
         r#"{{"type":"user","message":{{"role":"user","content":"{raw}"}}}}"#,
@@ -149,12 +284,13 @@ fn array_content_multiple_block_types() {
     assert!(matches!(blocks[0], DisplayBlock::Text(_)));
     assert!(matches!(blocks[1], DisplayBlock::Thinking { .. }));
     assert!(matches!(blocks[2], DisplayBlock::ToolUse { .. }));
+    // "ls -la" classifies as the List bucket (§2.1); the pairing map (built
+    // from the tool_use two blocks earlier in the same call) resolves the
+    // result's bucket.
     assert!(matches!(
-        blocks[3],
-        DisplayBlock::ToolResult {
-            total_lines: 3,
-            ..
-        }
+        &blocks[3],
+        DisplayBlock::ToolResult { kind: ResultKind::Counted { bucket: CountedBucket::List, from_bash: true }, lines, .. }
+            if lines.len() == 3
     ));
 }
 
@@ -167,23 +303,10 @@ fn sidechain_flag_is_parsed() {
     assert!(r.is_sidechain);
 }
 
-#[test]
-fn tool_use_summary_picks_command_key() {
-    let input = serde_json::json!({"command": "cargo build", "cwd": "/project"});
-    assert_eq!(summarise_tool_input(&input), "cargo build");
-}
-
-#[test]
-fn tool_use_summary_falls_back_to_file_path() {
-    let input = serde_json::json!({"file_path": "/src/main.rs"});
-    assert_eq!(summarise_tool_input(&input), "/src/main.rs");
-}
-
-#[test]
-fn tool_use_summary_falls_back_to_pattern() {
-    let input = serde_json::json!({"pattern": "fn open_reflow"});
-    assert_eq!(summarise_tool_input(&input), "fn open_reflow");
-}
+// Tool-name/argument classification (command key search, Bash dispatch,
+// Counted/Inline/Hidden categorisation) moved to `tool_class.rs` along with
+// its own tests, since `ToolUse` now carries raw `input` instead of a
+// pre-summarised string.
 
 #[test]
 fn tool_result_string_counts_lines() {
@@ -226,9 +349,9 @@ fn tool_result_block_array_counts_lines() {
 }
 
 #[test]
-fn tool_result_preview_caps_and_reports_total() {
-    // 10 output lines → preview capped at TOOL_RESULT_PREVIEW_LINES,
-    // total_lines retains the real count for the "+N lines" summary.
+fn tool_result_keeps_all_lines_no_cap() {
+    // ADR-5: `lines` retains every output line (the old preview cap /
+    // total_lines split is gone) — expansion needs the full output.
     let body: String = (0..10)
         .map(|i| format!("line{i}"))
         .collect::<Vec<_>>()
@@ -238,18 +361,47 @@ fn tool_result_preview_caps_and_reports_total() {
     );
     let blocks = parse_msg_content(&json);
     match &blocks[0] {
-        DisplayBlock::ToolResult {
-            preview,
-            total_lines,
-            is_error,
-        } => {
-            assert_eq!(*total_lines, 10);
-            assert_eq!(preview.len(), TOOL_RESULT_PREVIEW_LINES);
-            assert_eq!(preview[0], "line0");
+        DisplayBlock::ToolResult { lines, is_error, .. } => {
+            assert_eq!(lines.len(), 10);
+            assert_eq!(lines[0], "line0");
+            assert_eq!(lines[9], "line9");
             assert!(!*is_error);
         }
         other => panic!("expected ToolResult, got {other:?}"),
     }
+}
+
+#[test]
+fn tool_result_id_resolves_across_records_in_one_session() {
+    // The pairing map is threaded through `load_session`'s whole scan, not
+    // just one message: a `tool_use` in an assistant record must be found by
+    // a `tool_result` in the very next (user) record.
+    let f = write_jsonl(&[
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Read","input":{"file_path":"/a.txt"}}]}}"#,
+        r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"file contents"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert_eq!(entries.len(), 2);
+    assert!(matches!(
+        &entries[1].blocks[0],
+        DisplayBlock::ToolResult { kind: ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, .. }
+    ));
+}
+
+#[test]
+fn tool_result_with_unknown_tool_use_id_is_hidden() {
+    // A tool_result whose tool_use_id was never seen (truncated log, or a
+    // malformed/dropped tool_use record) resolves to `Hidden` — it draws
+    // nothing rather than guessing a category and emitting a stray block.
+    let blocks = parse_msg_content(
+        r#"{"type":"user","message":{"role":"user","content":[
+            {"type":"tool_result","tool_use_id":"nonexistent","content":"x"}
+        ]}}"#,
+    );
+    assert!(matches!(
+        &blocks[0],
+        DisplayBlock::ToolResult { kind: ResultKind::Hidden, .. }
+    ));
 }
 
 #[test]
@@ -266,6 +418,51 @@ fn tool_result_error_flag_is_captured() {
 }
 
 #[test]
+fn tool_use_errored_flag_resolves_from_later_paired_result() {
+    // The `tool_use`'s `errored` flag must be known by the time its own
+    // record is built, even though the erroring `tool_result` is a later
+    // record in the log — this is the pre-scan pass in `session.rs`.
+    let f = write_jsonl(&[
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"false"}}]}}"#,
+        r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","is_error":true,"content":"boom"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert_eq!(entries.len(), 2);
+    assert!(matches!(
+        &entries[0].blocks[0],
+        DisplayBlock::ToolUse { errored: true, .. }
+    ));
+}
+
+#[test]
+fn tool_use_errored_flag_false_when_result_did_not_error() {
+    let f = write_jsonl(&[
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"true"}}]}}"#,
+        r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"ok"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert!(matches!(
+        &entries[0].blocks[0],
+        DisplayBlock::ToolUse { errored: false, .. }
+    ));
+}
+
+#[test]
+fn tool_use_errored_flag_false_when_no_matching_result() {
+    // A truncated log (or a malformed/dropped tool_result) must not panic or
+    // guess — the call simply resolves to not-errored.
+    let blocks = parse_msg_content(
+        r#"{"type":"assistant","message":{"role":"assistant","content":[
+            {"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"false"}}
+        ]}}"#,
+    );
+    assert!(matches!(
+        &blocks[0],
+        DisplayBlock::ToolUse { errored: false, .. }
+    ));
+}
+
+#[test]
 fn thinking_text_is_captured() {
     let blocks = parse_msg_content(
         r#"{"type":"assistant","message":{"role":"assistant","content":[
@@ -273,7 +470,24 @@ fn thinking_text_is_captured() {
         ]}}"#,
     );
     match &blocks[0] {
-        DisplayBlock::Thinking { text } => assert_eq!(text, "let me reason"),
+        DisplayBlock::Thinking { text, .. } => assert_eq!(text, "let me reason"),
+        other => panic!("expected Thinking, got {other:?}"),
+    }
+}
+
+#[test]
+fn thinking_duration_secs_is_passed_through_from_the_caller() {
+    let r: LogRecord = serde_json::from_str(
+        r#"{"type":"assistant","message":{"role":"assistant","content":[
+            {"type":"thinking","thinking":"let me reason","signature":"x"}
+        ]}}"#,
+    )
+    .expect("valid test json");
+    let msg = r.message.unwrap();
+    let blocks =
+        content_to_display_blocks(msg.content, false, &mut HashMap::new(), &HashSet::new(), 12);
+    match &blocks[0] {
+        DisplayBlock::Thinking { duration_secs, .. } => assert_eq!(*duration_secs, 12),
         other => panic!("expected Thinking, got {other:?}"),
     }
 }
@@ -375,28 +589,210 @@ fn load_session_mixed_records_correct_count() {
 }
 
 #[test]
-fn load_session_includes_enqueued_prompts_skips_removes() {
-    // A prompt typed while Claude is busy is an `enqueue` queue-operation
-    // (top-level content); the dequeue is a contentless `remove`.
+fn load_session_draws_nothing_for_queue_operations() {
+    // Measured: Claude Code ignores the input queue's journal entirely. A
+    // prompt typed while it is busy is re-emitted as an ordinary `user` record
+    // once accepted, so drawing the `enqueue` too would print the turn twice —
+    // and an enqueue that never got re-emitted is not drawn at all.
     let f = write_jsonl(&[
         r#"{"type":"user","message":{"role":"user","content":"first"}}"#,
         r#"{"type":"queue-operation","operation":"enqueue","content":"typed while busy"}"#,
-        r#"{"type":"queue-operation","operation":"remove","content":""}"#,
+        r#"{"type":"queue-operation","operation":"remove","content":"typed while busy"}"#,
+        r#"{"type":"user","message":{"role":"user","content":"typed while busy"},"promptSource":"queued"}"#,
+        r#"{"type":"queue-operation","operation":"enqueue","content":"never re-emitted"}"#,
         r#"{"type":"assistant","message":{"role":"assistant","content":"reply"}}"#,
     ]);
     let entries = load_session(f.path());
-    assert_eq!(entries.len(), 3);
-    assert_eq!(entries[0].role, Role::User);
-    assert_eq!(entries[1].role, Role::User);
-    assert!(
-        matches!(&entries[1].blocks[0], DisplayBlock::Text(t) if t == "typed while busy"),
-        "enqueued prompt text should be surfaced as a user turn"
-    );
+    assert_eq!(entries.len(), 3, "queue-operation records must not draw");
+    assert!(matches!(&entries[0].blocks[0], DisplayBlock::Text(t) if t == "first"));
+    assert!(matches!(&entries[1].blocks[0], DisplayBlock::Text(t) if t == "typed while busy"));
     assert_eq!(entries[2].role, Role::Assistant);
+}
+
+#[test]
+fn load_session_skips_the_session_metadata_journals() {
+    // The other non-conversation record types, none of which Claude Code draws.
+    let f = write_jsonl(&[
+        r#"{"type":"user","message":{"role":"user","content":"first"}}"#,
+        r#"{"type":"mode","mode":"default"}"#,
+        r#"{"type":"permission-mode","permissionMode":"acceptEdits"}"#,
+        r#"{"type":"last-prompt","lastPrompt":"first"}"#,
+        r#"{"type":"ai-title","aiTitle":"Some title"}"#,
+        r#"{"type":"custom-title","customTitle":"Mine"}"#,
+        r#"{"type":"agent-name","agentName":"ivy"}"#,
+        r#"{"type":"pr-link","prNumber":297,"prUrl":"https://example.invalid/pr/297"}"#,
+        r#"{"type":"file-history-snapshot","messageId":"m1","snapshot":{}}"#,
+        r#"{"type":"file-history-delta","messageId":"m1","trackingPath":"src/x.rs"}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":"reply"}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].role, Role::User);
+    assert_eq!(entries[1].role, Role::Assistant);
 }
 
 #[test]
 fn load_session_missing_file_returns_empty() {
     let entries = load_session(std::path::Path::new("/nonexistent/path.jsonl"));
     assert!(entries.is_empty());
+}
+
+#[test]
+fn load_session_computes_thinking_duration_from_timestamps() {
+    let f = write_jsonl(&[
+        r#"{"type":"user","timestamp":"2026-07-31T00:00:00Z","message":{"role":"user","content":"hi"}}"#,
+        r#"{"type":"assistant","timestamp":"2026-07-31T00:00:05Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning","signature":"x"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    match &entries[1].blocks[0] {
+        DisplayBlock::Thinking { duration_secs, .. } => assert_eq!(*duration_secs, 5),
+        other => panic!("expected Thinking, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_session_thinking_duration_falls_back_to_one_when_timestamp_missing() {
+    let f = write_jsonl(&[
+        r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning","signature":"x"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    match &entries[1].blocks[0] {
+        DisplayBlock::Thinking { duration_secs, .. } => assert_eq!(*duration_secs, 1),
+        other => panic!("expected Thinking, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_session_thinking_duration_ignores_skipped_meta_record_as_previous() {
+    // A skipped isMeta record sits between the two displayed turns, carrying a
+    // timestamp that would make the naive "immediately preceding record" diff
+    // go negative. The duration must be computed against the previous
+    // *displayed* record (the first user turn), not this hidden one — 5s, not
+    // the 1s fallback that a negative/skewed diff would otherwise produce.
+    let f = write_jsonl(&[
+        r#"{"type":"user","timestamp":"2026-07-31T00:00:00Z","message":{"role":"user","content":"hi"}}"#,
+        r#"{"type":"user","isMeta":true,"timestamp":"2026-07-31T00:05:00Z","message":{"role":"user","content":"skill dump"}}"#,
+        r#"{"type":"assistant","timestamp":"2026-07-31T00:00:05Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning","signature":"x"}]}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert_eq!(entries.len(), 2, "the isMeta record must not produce an entry");
+    match &entries[1].blocks[0] {
+        DisplayBlock::Thinking { duration_secs, .. } => assert_eq!(*duration_secs, 5),
+        other => panic!("expected Thinking, got {other:?}"),
+    }
+}
+
+// ── Compact boundary and CLI-injected attachments (measured) ─────────────
+
+/// The record sequence a `/compact` writes, in log order. Measured end to end
+/// against a resumed transcript: Claude Code draws
+/// ```text
+/// ✻ Conversation compacted (ctrl+o for history)
+///
+/// ❯ /compact
+///   ⎿  Compacted (ctrl+o to see full summary)
+///   ⎿  Read alpha.rs (42 lines)
+///   ⎿  Referenced file beta.yml
+/// ```
+/// — the summary body itself appears nowhere.
+const COMPACT_SEQUENCE: &[&str] = &[
+    r#"{"type":"system","subtype":"compact_boundary","content":"Conversation compacted"}"#,
+    r#"{"type":"user","isVisibleInTranscriptOnly":true,"isCompactSummary":true,"message":{"role":"user","content":"This session is being continued. SUMMARYBODY"}}"#,
+    r#"{"type":"user","isMeta":true,"message":{"role":"user","content":"<local-command-caveat>Caveat</local-command-caveat>"}}"#,
+    r#"{"type":"user","message":{"role":"user","content":"<command-name>/compact</command-name>\n<command-args></command-args>"}}"#,
+    r#"{"type":"user","message":{"role":"user","content":"<local-command-stdout>Compacted (ctrl+o to see full summary)</local-command-stdout>"}}"#,
+    r#"{"type":"attachment","attachment":{"type":"file","displayPath":"alpha.rs","content":{"type":"text","file":{"numLines":42}}}}"#,
+    r#"{"type":"attachment","attachment":{"type":"compact_file_reference","displayPath":"beta.yml"}}"#,
+];
+
+#[test]
+fn compact_summary_body_is_never_displayed() {
+    let f = write_jsonl(COMPACT_SEQUENCE);
+    let entries = load_session(f.path());
+    let all: String = format!("{:?}", entries);
+    assert!(
+        !all.contains("SUMMARYBODY"),
+        "the compact summary body leaked into the transcript: {all}"
+    );
+}
+
+#[test]
+fn compact_sequence_produces_the_measured_blocks() {
+    let f = write_jsonl(COMPACT_SEQUENCE);
+    let entries = load_session(f.path());
+    let blocks: Vec<&DisplayBlock> = entries.iter().flat_map(|e| &e.blocks).collect();
+    assert_eq!(blocks.len(), 5, "got {blocks:?}");
+    assert!(matches!(blocks[0], DisplayBlock::CompactBoundary));
+    assert!(matches!(blocks[1], DisplayBlock::Text(t) if t == "/compact"));
+    assert!(
+        matches!(blocks[2], DisplayBlock::Annotation { lines }
+            if lines == &["Compacted (ctrl+o to see full summary)".to_string()])
+    );
+    assert!(
+        matches!(blocks[3], DisplayBlock::Annotation { lines }
+            if lines == &["Read alpha.rs (42 lines)".to_string()])
+    );
+    assert!(
+        matches!(blocks[4], DisplayBlock::Annotation { lines }
+            if lines == &["Referenced file beta.yml".to_string()])
+    );
+}
+
+#[test]
+fn file_attachment_without_a_line_count_drops_the_clause() {
+    let f = write_jsonl(&[
+        r#"{"type":"attachment","attachment":{"type":"file","displayPath":"solo.rs"}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert!(
+        matches!(&entries[0].blocks[0], DisplayBlock::Annotation { lines }
+            if lines == &["Read solo.rs".to_string()])
+    );
+}
+
+#[test]
+fn single_line_file_attachment_is_not_pluralised() {
+    let f = write_jsonl(&[
+        r#"{"type":"attachment","attachment":{"type":"file","displayPath":"one.rs","content":{"type":"text","file":{"numLines":1}}}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert!(
+        matches!(&entries[0].blocks[0], DisplayBlock::Annotation { lines }
+            if lines == &["Read one.rs (1 line)".to_string()])
+    );
+}
+
+#[test]
+fn attachment_falls_back_to_filename_when_display_path_is_absent() {
+    let f = write_jsonl(&[
+        r#"{"type":"attachment","attachment":{"type":"compact_file_reference","filename":"/abs/path.yml"}}"#,
+    ]);
+    let entries = load_session(f.path());
+    assert!(
+        matches!(&entries[0].blocks[0], DisplayBlock::Annotation { lines }
+            if lines == &["Referenced file /abs/path.yml".to_string()])
+    );
+}
+
+#[test]
+fn undisplayed_attachment_kinds_draw_nothing() {
+    // The corpus holds 27 other kinds — `hook_success` alone ~47k times.
+    // None was observed to draw, so the renderer works from an allowlist.
+    let f = write_jsonl(&[
+        r#"{"type":"attachment","attachment":{"type":"hook_success","hookName":"PreToolUse:Read","stdout":"{}"}}"#,
+        r#"{"type":"attachment","attachment":{"type":"skill_listing","content":"- daisy: ..."}}"#,
+        r#"{"type":"attachment","attachment":{"type":"diagnostics","displayPath":"x.rs"}}"#,
+    ]);
+    assert!(load_session(f.path()).is_empty());
+}
+
+#[test]
+fn non_compact_system_records_draw_nothing() {
+    let f = write_jsonl(&[
+        r#"{"type":"system","subtype":"something_else","content":"noise"}"#,
+        r#"{"type":"last-prompt","lastPrompt":"/compact"}"#,
+        r#"{"type":"custom-title","customTitle":"a title"}"#,
+    ]);
+    assert!(load_session(f.path()).is_empty());
 }

--- a/src/claude_log/tool_class.rs
+++ b/src/claude_log/tool_class.rs
@@ -1,0 +1,333 @@
+//! Tool-name classification shared by the log parser (which must resolve, at
+//! parse time, which result-side aggregation bucket a `tool_use` belongs to)
+//! and the reflow transcript renderer (which uses [`classify`] directly to
+//! lay out each `tool_use` line).
+//!
+//! The table implemented here is not a guess: it was reconstructed from a
+//! raw-byte capture of Claude Code's own default (non-`ctrl+o`) transcript
+//! output, one tool at a time. See `docs/plans/2026-07-31-native-render-parity.md`
+//! §2.1 for the source table.
+
+use serde_json::Value;
+
+/// How Claude Code's default transcript draws one tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolCategory {
+    /// Folds into a single "{verb} {N} {noun} (ctrl+o to expand)" summary at
+    /// the `tool_result`'s position; the `tool_use` itself draws nothing.
+    Counted(CountedBucket),
+    /// Draws as its own `⏺ {display_name}({arg})` line at the `tool_use`'s
+    /// position; the `tool_result` draws nothing on success. On error it is
+    /// the *only* category that draws a result line at all — `Counted`
+    /// ignores `is_error` completely (measured: a failed `Read` still folds
+    /// into the plain "Read 1 file" summary) — see the reflow renderer.
+    Inline {
+        display_name: String,
+        arg: Option<String>,
+    },
+    /// Draws nothing, in either position (e.g. `TodoWrite`), even on error —
+    /// unmeasured for this category specifically, but Claude Code's own UI
+    /// never surfaces a `TodoWrite` failure as visible transcript text.
+    Hidden,
+}
+
+/// The result-side aggregation bucket a [`ToolCategory::Counted`] call falls
+/// into. Two tool calls resolving to the same bucket within one entry are
+/// summed into a single collapsed line — this is how, per the source table,
+/// a `cat` shell invocation merges with a `Read` tool call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CountedBucket {
+    Read,
+    Search,
+    List,
+}
+
+impl CountedBucket {
+    /// `(verb, noun_singular, noun_plural)` for the collapsed summary line,
+    /// e.g. `("Read", "file", "files")` → "Read 3 files (ctrl+o to expand)".
+    pub fn labels(self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            CountedBucket::Read => ("Read", "file", "files"),
+            CountedBucket::Search => ("Searched for", "pattern", "patterns"),
+            CountedBucket::List => ("Listed", "directory", "directories"),
+        }
+    }
+}
+
+/// The order buckets appear in when one entry produces several clauses.
+/// Measured: `ls`×2 + `Grep` + `Read` renders as
+/// "Searched for 1 pattern, read 1 file, listed 2 directories".
+pub const BUCKET_ORDER: [CountedBucket; 3] = [
+    CountedBucket::Search,
+    CountedBucket::Read,
+    CountedBucket::List,
+];
+
+/// What the *result* side of a tool call draws — the half of [`ToolCategory`]
+/// that survives into [`crate::claude_log::DisplayBlock::ToolResult`].
+///
+/// `Inline` and `Hidden` must stay distinguishable here: a failed `Inline`
+/// call draws an `⎿ Error:` block, while a failed `Hidden` call draws
+/// **nothing** (measured: a `TodoWrite` with `is_error` produced not one line
+/// of output).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultKind {
+    Counted {
+        bucket: CountedBucket,
+        /// True when a shell invocation (`ls`/`cat`) was classified into this
+        /// bucket rather than the bucket's own tool being called. Native only
+        /// counts these as a *fallback* — see [`BUCKET_ORDER`] and the
+        /// renderer's aggregation.
+        from_bash: bool,
+    },
+    Inline,
+    Hidden,
+}
+
+/// The result-side projection of [`classify`].
+pub fn result_kind(name: &str, input: &Value) -> ResultKind {
+    let from_bash = name == "Bash";
+    match classify(name, input) {
+        ToolCategory::Counted(bucket) => ResultKind::Counted { bucket, from_bash },
+        ToolCategory::Inline { .. } => ResultKind::Inline,
+        ToolCategory::Hidden => ResultKind::Hidden,
+    }
+}
+
+/// Classify a `tool_use` call by its raw API name and input JSON.
+///
+/// `Bash` is the only tool whose category depends on its argument: the
+/// command's first whitespace-separated word selects `ls` → [`CountedBucket::List`],
+/// `cat` → [`CountedBucket::Read`] (merging with the `Read` tool's own
+/// bucket), anything else → a plain `Bash(command)` inline line.
+pub fn classify(name: &str, input: &Value) -> ToolCategory {
+    match name {
+        "Read" => ToolCategory::Counted(CountedBucket::Read),
+        "Grep" | "Glob" => ToolCategory::Counted(CountedBucket::Search),
+        "Bash" => classify_bash(input),
+        "Write" => inline("Write", input, "file_path"),
+        "Edit" => inline("Update", input, "file_path"),
+        "Task" => inline("Agent", input, "description"),
+        "WebFetch" => inline("Fetch", input, "url"),
+        "TodoWrite" => ToolCategory::Hidden,
+        other => ToolCategory::Inline {
+            display_name: other.to_string(),
+            arg: unknown_tool_arg(input),
+        },
+    }
+}
+
+fn classify_bash(input: &Value) -> ToolCategory {
+    let command = input.get("command").and_then(Value::as_str).unwrap_or("");
+    match command.split_whitespace().next() {
+        Some("ls") => ToolCategory::Counted(CountedBucket::List),
+        Some("cat") => ToolCategory::Counted(CountedBucket::Read),
+        _ => inline("Bash", input, "command"),
+    }
+}
+
+/// Build an `Inline` category, reading a single named argument key. Empty or
+/// absent values become `arg: None` so the renderer omits the parens
+/// entirely (`⏺ Name` rather than `⏺ Name()`).
+///
+/// The value is sanitized like tool *output* already is: an argument is raw
+/// JSON — a multi-line `Bash` command or a pattern with a tab in it — and a
+/// newline or tab inside a span desyncs the terminal from ratatui's own
+/// column arithmetic, which shows up as an over-wide line.
+fn inline(display_name: &str, input: &Value, key: &str) -> ToolCategory {
+    let arg = input
+        .get(key)
+        .and_then(Value::as_str)
+        .map(super::convert::sanitize_preview_line)
+        .filter(|s| !s.is_empty());
+    ToolCategory::Inline {
+        display_name: display_name.to_string(),
+        arg,
+    }
+}
+
+/// Argument-key search order for a tool name not in the known table, tried
+/// in this fixed priority order (the source table's "未知ツールの引数キー探索順").
+const UNKNOWN_ARG_KEYS: &[&str] = &[
+    "command",
+    "file_path",
+    "path",
+    "pattern",
+    "url",
+    "query",
+    "description",
+];
+
+/// Find the first present, non-empty string argument for an unrecognised
+/// tool, trying [`UNKNOWN_ARG_KEYS`] in order. Also reused by the reflow
+/// renderer's expanded-mode display, where every tool (including `Counted`
+/// ones like `Read`/`Grep`) needs *some* argument shown regardless of its
+/// collapsed-mode category.
+pub fn unknown_tool_arg(input: &Value) -> Option<String> {
+    let obj = input.as_object()?;
+    for key in UNKNOWN_ARG_KEYS {
+        if let Some(s) = obj.get(*key).and_then(Value::as_str) {
+            let cleaned = super::convert::sanitize_preview_line(s);
+            if !cleaned.is_empty() {
+                return Some(cleaned);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn read_is_counted_bucket_read() {
+        let input = json!({"file_path": "/a.txt"});
+        assert_eq!(classify("Read", &input), ToolCategory::Counted(CountedBucket::Read));
+    }
+
+    #[test]
+    fn grep_and_glob_are_counted_bucket_search() {
+        let input = json!({"pattern": "foo"});
+        assert_eq!(classify("Grep", &input), ToolCategory::Counted(CountedBucket::Search));
+        assert_eq!(classify("Glob", &input), ToolCategory::Counted(CountedBucket::Search));
+    }
+
+    #[test]
+    fn bash_ls_is_counted_bucket_list() {
+        let input = json!({"command": "ls -la /tmp"});
+        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::List));
+    }
+
+    #[test]
+    fn bash_cat_merges_into_counted_bucket_read() {
+        // The source table merges a `cat` shell invocation with the `Read`
+        // tool's own bucket — both count toward one "Read N files" line.
+        let input = json!({"command": "cat foo.txt"});
+        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::Read));
+    }
+
+    #[test]
+    fn bash_other_command_is_inline() {
+        let input = json!({"command": "cargo build"});
+        assert_eq!(
+            classify("Bash", &input),
+            ToolCategory::Inline {
+                display_name: "Bash".to_string(),
+                arg: Some("cargo build".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn bash_leading_whitespace_still_dispatches_on_first_word() {
+        let input = json!({"command": "   ls /tmp"});
+        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::List));
+    }
+
+    #[test]
+    fn write_is_inline_with_file_path_arg() {
+        let input = json!({"file_path": "/tmp/out.txt", "content": "..."});
+        assert_eq!(
+            classify("Write", &input),
+            ToolCategory::Inline {
+                display_name: "Write".to_string(),
+                arg: Some("/tmp/out.txt".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn edit_displays_as_update() {
+        let input = json!({"file_path": "/tmp/out.txt"});
+        assert_eq!(
+            classify("Edit", &input),
+            ToolCategory::Inline {
+                display_name: "Update".to_string(),
+                arg: Some("/tmp/out.txt".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn task_displays_as_agent_with_description_arg() {
+        let input = json!({"description": "investigate bug", "prompt": "..."});
+        assert_eq!(
+            classify("Task", &input),
+            ToolCategory::Inline {
+                display_name: "Agent".to_string(),
+                arg: Some("investigate bug".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn webfetch_displays_as_fetch_with_url_arg() {
+        let input = json!({"url": "https://example.com"});
+        assert_eq!(
+            classify("WebFetch", &input),
+            ToolCategory::Inline {
+                display_name: "Fetch".to_string(),
+                arg: Some("https://example.com".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn todowrite_is_hidden() {
+        let input = json!({"todos": []});
+        assert_eq!(classify("TodoWrite", &input), ToolCategory::Hidden);
+    }
+
+    #[test]
+    fn unknown_tool_falls_back_to_generic_arg_key_search() {
+        let input = json!({"query": "some search term"});
+        assert_eq!(
+            classify("WebSearch", &input),
+            ToolCategory::Inline {
+                display_name: "WebSearch".to_string(),
+                arg: Some("some search term".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn inline_arg_absent_key_becomes_none() {
+        let input = json!({"content": "..."}); // no `file_path` key at all
+        assert_eq!(
+            classify("Write", &input),
+            ToolCategory::Inline {
+                display_name: "Write".to_string(),
+                arg: None,
+            }
+        );
+    }
+
+    #[test]
+    fn inline_arg_empty_string_becomes_none() {
+        let input = json!({"file_path": ""});
+        assert_eq!(
+            classify("Write", &input),
+            ToolCategory::Inline {
+                display_name: "Write".to_string(),
+                arg: None,
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_tool_arg_tries_keys_in_priority_order() {
+        // `command` outranks `file_path` in UNKNOWN_ARG_KEYS.
+        let input = json!({"file_path": "/a", "command": "run me"});
+        assert_eq!(unknown_tool_arg(&input), Some("run me".to_string()));
+    }
+
+    #[test]
+    fn unknown_tool_arg_none_when_no_known_key_present() {
+        let input = json!({"unrelated": "x"});
+        assert_eq!(unknown_tool_arg(&input), None);
+    }
+
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -483,7 +483,16 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
                 && !app.reflow.active
             {
                 app.open_reflow();
-                return true;
+                // `open_reflow` bails out (with a status flash) when the panel
+                // has no pinned session or its log is missing on disk. Claiming
+                // the key regardless used to strand the user: `scroll_claude`
+                // stayed 0, so the next press re-entered this branch and failed
+                // identically — scroll-up went permanently dead rather than
+                // degrading to the vt100 buffer. Only claim it if the view
+                // actually opened.
+                if app.reflow.active {
+                    return true;
+                }
             }
             let page = match app.focus {
                 Focus::TerminalClaude => app.terminal.size_claude.0 as usize / 2,
@@ -517,7 +526,10 @@ fn handle_terminal_only_action(app: &mut App, action: Action) -> bool {
                 && !app.reflow.active
             {
                 app.open_reflow();
-                return true;
+                // Same fall-through as ScrollbackUp when the view can't open.
+                if app.reflow.active {
+                    return true;
+                }
             }
             match app.focus {
                 Focus::TerminalClaude => app.terminal.scroll_claude = 1000,

--- a/src/event/mouse/scroll.rs
+++ b/src/event/mouse/scroll.rs
@@ -254,9 +254,18 @@ pub(super) fn handle_mouse_scroll(
                 // look up the grabbed (source) worktree's history, producing a
                 // mismatch.  Keyboard entry is already blocked by the grabbed-
                 // worktree gate in handle_terminal_only_action.
-                if app.terminal.scroll_claude == 0 && !app.is_selected_worktree_grabbed() {
+                // `open_reflow` is a no-op (plus a status flash) when the panel
+                // has no pinned session or its log is missing, so fall back to
+                // the vt100 buffer rather than swallowing the wheel forever.
+                let opened = if app.terminal.scroll_claude == 0
+                    && !app.is_selected_worktree_grabbed()
+                {
                     app.open_reflow();
+                    app.reflow.active
                 } else {
+                    false
+                };
+                if !opened {
                     app.terminal.scroll_claude =
                         app.terminal.scroll_claude.saturating_add(abs_delta);
                 }

--- a/src/event/reflow_key.rs
+++ b/src/event/reflow_key.rs
@@ -73,6 +73,18 @@ pub(super) fn handle_reflow_key(app: &mut App, key: KeyEvent) {
             app.reflow.scroll = total.saturating_sub(inner);
         }
 
+        // ── Expand / collapse ────────────────────────────────────────────────
+        // Claude Code's own transcript folds tool results and thinking blocks
+        // and offers `ctrl+o` to expand; conductor reuses the key but expands
+        // in place rather than switching to a separate full-screen view. It is
+        // a single view-wide toggle: this panel has no per-block cursor to
+        // aim a finer-grained one at.
+        KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.reflow.expanded = !app.reflow.expanded;
+            app.reflow.needs_rebuild = true;
+            return;
+        }
+
         // ── Leave ────────────────────────────────────────────────────────────
         KeyCode::Esc => {
             // Play the exit sweep before returning to the live PTY.

--- a/src/ui/markdown/code_colors.rs
+++ b/src/ui/markdown/code_colors.rs
@@ -1,0 +1,332 @@
+//! Transcript-flavor fenced-code-block rendering: native Claude Code draws
+//! code with no card chrome at all (no background, no inset, no blank
+//! padding rows) and colours tokens with only the terminal's 8 basic ANSI
+//! colours, chosen by classifying syntect's *scope names* rather than by
+//! translating its RGB theme output (see `render.rs::render_code_block` for
+//! the Rich-flavor "card" this deliberately does not touch). Kept as its own
+//! module since the scope-classification logic here is unrelated to the
+//! card-layout code next to it.
+//!
+//! The classification rules below were built by inspecting the scope stacks
+//! `two_face::syntax::extra_newlines()` actually produces for Rust, Python,
+//! Bash and JSON (see the module's tests for the exact fixtures), matched
+//! against a native capture's token-by-token colours. Several of the
+//! required distinctions (`let` vs `str`, `ls` vs `grep`, `Some`/`None` vs
+//! `Option`/`String`) are simply not encoded in these syntaxes' scope names
+//! — the sublime-syntax packages reuse one scope for both — so a handful of
+//! literal-token overrides fill the gap the scopes can't.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use syntect::easy::ScopeRegionIterator;
+use syntect::parsing::{ParseState, ScopeStack, ScopeStackOp, SyntaxSet};
+
+use super::wrap::{spans_to_cells, wrap_cells};
+
+/// Rust primitive type names: the bundled `rust.sublime-syntax` scopes these
+/// identically to the `let`/`const` storage keywords (`storage.type.rust`,
+/// no further suffix), so only the literal text tells them apart. This list
+/// covers every primitive Rust actually has, so it's complete on its own
+/// terms — but it was written to make the acceptance fixtures pass, not
+/// cross-checked token-by-token against a native capture, so treat it as a
+/// best guess rather than a verified table.
+const RUST_PRIMITIVE_TYPES: &[&str] = &[
+    "str", "bool", "char", "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+    "i128", "isize", "f32", "f64",
+];
+
+/// Bash command names the grammar leaves scoped as plain
+/// `variable.function.shell` — indistinguishable from an arbitrary external
+/// command like `grep` — but that native still colours as a builtin.
+///
+/// This is **not** a builtin-command reference list: it only contains the
+/// one word (`ls`) the acceptance fixture happens to exercise. Anything not
+/// listed here (`cd`, `pwd`, `export` is handled separately below, ...)
+/// falls through to `Category::Reset`, which may or may not match native —
+/// unverified. Extend this list only from an actual native capture, not from
+/// guessing at what "should" be a builtin.
+const BASH_COMMANDS_MEASURED_AS_BUILTIN: &[&str] = &["ls"];
+
+/// One native basic-ANSI-colour token category.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Category {
+    Comment,
+    Keyword,
+    FunctionName,
+    Type,
+    Builtin,
+    Number,
+    StringLit,
+    Reset,
+}
+
+impl Category {
+    fn style(self) -> Style {
+        match self {
+            Category::Comment => Style::default().fg(Color::Green),
+            Category::Keyword => Style::default().fg(Color::Blue),
+            Category::FunctionName => Style::default().fg(Color::Yellow),
+            Category::Type => Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            Category::Builtin => Style::default().fg(Color::Cyan),
+            Category::Number => Style::default().fg(Color::Green),
+            Category::StringLit => Style::default().fg(Color::Red),
+            Category::Reset => Style::default().fg(Color::Reset),
+        }
+    }
+}
+
+/// Tracks whether the token stream is currently inside a `string.quoted.*`
+/// run and whether that run has been interrupted by an embedded expression
+/// (f-string interpolation, shell `$VAR` expansion). Native's own quirk,
+/// confirmed against the capture: once a string is interrupted, everything
+/// from that point on — including the closing delimiter — reverts to the
+/// default colour instead of staying string-red.
+#[derive(Default)]
+struct StringState {
+    in_string: bool,
+    interrupted: bool,
+}
+
+impl StringState {
+    /// Update bookkeeping from one token's scope stack. Returns `Some(true)`
+    /// if this token sits on an uninterrupted (red) part of a string,
+    /// `Some(false)` if it's part of an interrupted string (delimiter or
+    /// literal text after the embedded expression), or `None` if the token
+    /// isn't itself scoped as `string.quoted.*` (so the caller should keep
+    /// evaluating other classification rules — this covers embedded
+    /// expression tokens, e.g. Python's `{x}`, which drop the string scope
+    /// entirely while still living inside the string run).
+    fn observe(&mut self, scopes: &[String]) -> Option<bool> {
+        let has_quoted = scopes.iter().any(|s| s.starts_with("string.quoted."));
+        if has_quoted && !self.in_string {
+            self.in_string = true;
+            self.interrupted = false;
+        }
+        let is_interpolation = scopes.iter().any(|s| {
+            s.contains("interpolation.") || s.contains("expansion") || s.contains("embedded")
+                || s.starts_with("variable.")
+        });
+        if self.in_string && is_interpolation {
+            self.interrupted = true;
+        }
+        let result = has_quoted.then_some(!self.interrupted);
+        if has_quoted && scopes.iter().any(|s| s.contains("string.end.")) {
+            self.in_string = false;
+            self.interrupted = false;
+        }
+        result
+    }
+}
+
+fn is_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Classify one token given its full scope stack (outermost first) and the
+/// raw text of the next token on the line (for the call-site fallback).
+fn classify(
+    text: &str,
+    scopes: &[String],
+    next_text: Option<&str>,
+    string_state: &mut StringState,
+) -> Category {
+    // Comments win regardless of what else is nested inside them.
+    if scopes.iter().any(|s| s.starts_with("comment.")) {
+        return Category::Comment;
+    }
+    // JSON object keys: scoped as a string, but native colours them like a
+    // builtin/keyword, not like a string value. Must be checked before the
+    // generic string rule below.
+    if scopes.iter().any(|s| s.starts_with("meta.mapping.key.")) {
+        return Category::Builtin;
+    }
+    // String literal content and delimiters (state machine; see `StringState`).
+    if let Some(uninterrupted) = string_state.observe(scopes) {
+        return if uninterrupted {
+            Category::StringLit
+        } else {
+            Category::Reset
+        };
+    }
+    // A format-string prefix (Python's `f` before the opening quote) reads
+    // as part of the string even though it sits before `string.quoted.*`.
+    if scopes.iter().any(|s| s.starts_with("storage.type.string.")) {
+        return Category::StringLit;
+    }
+    if scopes.iter().any(|s| s.starts_with("constant.numeric.")) {
+        return Category::Number;
+    }
+    // `true`/`false`/`null` and similar (JSON).
+    if scopes.iter().any(|s| s.starts_with("constant.language.")) {
+        return Category::Keyword;
+    }
+    if scopes
+        .iter()
+        .any(|s| s.starts_with("keyword.control.") || s.starts_with("keyword.declaration."))
+    {
+        return Category::Keyword;
+    }
+    // Rust `fn`/`struct`: their own unambiguous `storage.type.*` sub-scopes.
+    if scopes
+        .iter()
+        .any(|s| s.starts_with("storage.type.function.") || s.starts_with("storage.type.struct."))
+    {
+        return Category::Keyword;
+    }
+    // Bare `storage.type.rust`: Rust's grammar reuses this identical scope
+    // for both storage keywords (`let`, `const`) and primitive type names
+    // (`str`, `bool`, `usize`, ...) — only the literal text distinguishes them.
+    if scopes.iter().any(|s| s == "storage.type.rust") {
+        return if RUST_PRIMITIVE_TYPES.contains(&text) {
+            Category::Type
+        } else {
+            Category::Keyword
+        };
+    }
+    if scopes.iter().any(|s| s.starts_with("entity.name.function.")) {
+        return Category::FunctionName;
+    }
+    // Builtin functions the grammar tags explicitly (Python's `range`, Bash's
+    // `echo`). Guarded to word-like text so scopes that reuse the
+    // `support.function.` prefix for punctuation (Bash's `[ ]` test
+    // brackets) don't get swept in.
+    if is_identifier(text) && scopes.iter().any(|s| s.starts_with("support.function.")) {
+        return Category::Builtin;
+    }
+    // Bash's generic command-name scope covers both builtins (`ls`) and
+    // ordinary external commands (`grep`) identically; only a literal
+    // allow-list tells them apart.
+    if scopes.iter().any(|s| s == "variable.function.shell")
+        && BASH_COMMANDS_MEASURED_AS_BUILTIN.contains(&text)
+    {
+        return Category::Builtin;
+    }
+    // Bash builtin keywords like `export`.
+    if scopes.iter().any(|s| s == "storage.modifier.shell") {
+        return Category::Builtin;
+    }
+    // Types — Rust overloads this scope for enum variants too (`Some` is a
+    // call, `None` is a language constant); everything else here really is
+    // a type name (`Option`, `String`, `Vec`, ...).
+    if scopes.iter().any(|s| s.starts_with("support.type.")) {
+        return match text {
+            "None" => Category::Keyword,
+            "Some" => Category::FunctionName,
+            _ => Category::Type,
+        };
+    }
+    // Class/struct names print unstyled, not as a function name — important
+    // since a definition like `class C(object):` immediately follows the
+    // name with a `(`, which would otherwise trip the call-site fallback below.
+    if scopes
+        .iter()
+        .any(|s| s.starts_with("entity.name.class.") || s.starts_with("entity.name.struct."))
+    {
+        return Category::Reset;
+    }
+    // Python base-class position: only recognised builtins (`object`) read
+    // as a language constant; a custom base class stays unstyled. `object`
+    // is the only builtin the acceptance fixture exercises here — this is
+    // not a verified list of every Python builtin that reads this way
+    // (`int`, `Exception`, ...); extend it only from an actual native
+    // capture.
+    if scopes.iter().any(|s| s.starts_with("entity.other.inherited-class.")) {
+        return if text == "object" {
+            Category::Keyword
+        } else {
+            Category::Reset
+        };
+    }
+    // Rust's `as` cast keyword shares its scope with symbol operators (`&`,
+    // `+`, ...) that must stay unstyled, so only the literal token can pick
+    // it out. `as` is the only `keyword.operator.rust` token the fixture
+    // exercises; other word-like operators under this scope (if any exist
+    // in the grammar) aren't verified against native and would currently
+    // fall through to `Category::Reset`.
+    if text == "as" && scopes.iter().any(|s| s.starts_with("keyword.operator.")) {
+        return Category::Keyword;
+    }
+    // Fallback: the grammar didn't tag this as a function name (e.g. Rust's
+    // `String::from(...)`, a path-qualified call it doesn't recognise), but
+    // an identifier directly followed by `(` reads as a call in every
+    // language captured natively.
+    if is_identifier(text) && next_text.is_some_and(|n| n.starts_with('(')) {
+        return Category::FunctionName;
+    }
+    Category::Reset
+}
+
+/// Highlight one already-newline-terminated source line, threading `stack`
+/// and `string_state` across calls so multi-token constructs (and, in
+/// principle, multi-line strings) classify consistently.
+fn classify_line(
+    line: &str,
+    ops: &[(usize, ScopeStackOp)],
+    stack: &mut ScopeStack,
+    string_state: &mut StringState,
+) -> Vec<Span<'static>> {
+    // First pass: apply every op and record each non-empty region's text and
+    // scope stack. A second pass (below) then classifies with one token of
+    // lookahead, needed for the call-site fallback.
+    let mut tokens: Vec<(String, Vec<String>)> = Vec::new();
+    for (text, op) in ScopeRegionIterator::new(ops, line) {
+        let _ = stack.apply(op);
+        let trimmed = text.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+        let scopes = stack.as_slice().iter().map(|s| s.build_string()).collect();
+        tokens.push((trimmed.to_string(), scopes));
+    }
+
+    let mut spans = Vec::with_capacity(tokens.len());
+    for i in 0..tokens.len() {
+        let (text, scopes) = &tokens[i];
+        let next = tokens.get(i + 1).map(|(t, _)| t.as_str());
+        let category = classify(text, scopes, next, string_state);
+        spans.push(Span::styled(text.clone(), category.style()));
+    }
+    spans
+}
+
+/// Render a fenced code block the way native Claude Code does: no card
+/// chrome (background/inset/padding), source indentation preserved, hard
+/// wrap at `width`, tokens coloured with the 8 basic ANSI colours per
+/// [`classify`].
+pub(crate) fn render_code_block_transcript(
+    lang: Option<&str>,
+    lines: &[String],
+    width: usize,
+    syntax_set: &SyntaxSet,
+) -> Vec<Line<'static>> {
+    let syntax = lang
+        .and_then(|l| syntax_set.find_syntax_by_token(l))
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+    let mut parse_state = ParseState::new(syntax);
+    let mut scope_stack = ScopeStack::new();
+    let mut string_state = StringState::default();
+
+    let mut out = Vec::with_capacity(lines.len());
+    for raw in lines {
+        // Expand tabs so display-width math (and thus wrapping) stays correct.
+        let expanded = raw.replace('\t', "    ");
+        let with_nl = format!("{expanded}\n");
+        let spans = match parse_state.parse_line(&with_nl, syntax_set) {
+            Ok(ops) => classify_line(&with_nl, &ops, &mut scope_stack, &mut string_state),
+            Err(_) => vec![Span::raw(expanded.clone())],
+        };
+        let cells = spans_to_cells(&spans);
+        let wrapped = if cells.is_empty() {
+            vec![Line::from("")]
+        } else {
+            wrap_cells(&cells, width.max(1), true)
+        };
+        out.extend(wrapped);
+    }
+    out
+}

--- a/src/ui/markdown/inline.rs
+++ b/src/ui/markdown/inline.rs
@@ -6,15 +6,31 @@ use ratatui::text::Span;
 
 use crate::theme::Theme;
 
+use super::MarkdownFlavor;
+
 /// Parse inline `code`, `**bold**`, `*italic*`, `~~strikethrough~~`, and
 /// `[text](url)` links out of `text`, styling the rest with `base`.
 /// Unmatched/space-flanked delimiters stay literal.
-pub(crate) fn inline_spans(text: &str, base: Style, theme: &Theme) -> Vec<Span<'static>> {
-    // Inline `code`: a pink foreground on a shaded card, with one space of
-    // padding inside the card on each side (`[ code ]`, GitHub-style) so it
-    // reads as a distinct chip and not just tinted text. The padding spaces
-    // carry the card colour too.
-    let code_style = Style::default().fg(theme.code_fg).bg(theme.code_bg);
+///
+/// `flavor` only affects inline code: the Rich UI pads it into a coloured
+/// card (`[ code ]`); the Claude transcript renders it as plain
+/// `theme.info`-coloured text with no padding or background, matching native
+/// Claude Code.
+pub(crate) fn inline_spans(
+    text: &str,
+    base: Style,
+    theme: &Theme,
+    flavor: MarkdownFlavor,
+) -> Vec<Span<'static>> {
+    let code_style = match flavor {
+        // A pink foreground on a shaded card, one space of padding inside the
+        // card on each side (`[ code ]`, GitHub-style) so it reads as a
+        // distinct chip and not just tinted text. The padding spaces carry
+        // the card colour too.
+        MarkdownFlavor::Rich => Style::default().fg(theme.code_fg).bg(theme.code_bg),
+        // Native Claude Code: `theme.info`-coloured text, no card, no padding.
+        MarkdownFlavor::Transcript => Style::default().fg(theme.info),
+    };
     let chars: Vec<char> = text.chars().collect();
     let n = chars.len();
     let mut spans: Vec<Span<'static>> = Vec::new();
@@ -30,12 +46,16 @@ pub(crate) fn inline_spans(text: &str, base: Style, theme: &Theme) -> Vec<Span<'
                 && j > i + 1
             {
                 flush(&mut buf, &mut spans, base);
-                // Pad with NBSP (not a regular space) so the wrapper never
-                // breaks the chip at its padding — it only wraps on 0x20.
-                spans.push(Span::styled(
-                    format!("\u{a0}{}\u{a0}", collect(&chars, i + 1, j)),
-                    code_style,
-                ));
+                let content = collect(&chars, i + 1, j);
+                let styled = match flavor {
+                    // Pad with NBSP (not a regular space) so the wrapper
+                    // never breaks the chip at its padding — it only wraps
+                    // on 0x20.
+                    MarkdownFlavor::Rich => format!("\u{a0}{content}\u{a0}"),
+                    // Native Claude Code has no padding around inline code.
+                    MarkdownFlavor::Transcript => content,
+                };
+                spans.push(Span::styled(styled, code_style));
                 i = j + 1;
                 continue;
             }
@@ -80,7 +100,7 @@ pub(crate) fn inline_spans(text: &str, base: Style, theme: &Theme) -> Vec<Span<'
                 // Link text (which may itself contain inline markup) plus the
                 // URL in a recessive, footnote-like parenthetical so the
                 // destination stays visible/copyable in a non-clickable TUI.
-                spans.extend(inline_spans(&link.text, link_style, theme));
+                spans.extend(inline_spans(&link.text, link_style, theme, flavor));
                 spans.push(Span::styled(
                     format!(" ({})", link.url),
                     Style::default().fg(theme.muted),

--- a/src/ui/markdown/mod.rs
+++ b/src/ui/markdown/mod.rs
@@ -52,10 +52,12 @@
 //! [`render`] (block-to-`Line` rendering), [`table`] (GFM table layout), and
 //! [`wrap`] (display-width-aware span wrapping).
 
+mod code_colors;
 mod inline;
 mod parse;
 mod render;
 mod table;
+mod table_boxed;
 mod wrap;
 
 use parse::{MdBlock, parse_blocks};

--- a/src/ui/markdown/render.rs
+++ b/src/ui/markdown/render.rs
@@ -10,9 +10,11 @@ use syntect::parsing::SyntaxSet;
 use crate::theme::Theme;
 
 use super::MarkdownFlavor;
+use super::code_colors::render_code_block_transcript;
 use super::inline::inline_spans;
 use super::parse::MdBlock;
 use super::table::render_table;
+use super::table_boxed::render_table_boxed;
 use super::wrap::{display_width, spans_to_cells, with_prefix, wrap_cells};
 
 pub(crate) fn render_block(
@@ -30,11 +32,16 @@ pub(crate) fn render_block(
             Style::default().fg(theme.muted),
         ))],
         // Transcript flavor: no colour bar, no underline rule — just bold
-        // body-colour text. The surrounding blank lines are added by
-        // `render_markdown_flavored`.
-        MdBlock::Heading { text, .. } if flavor == MarkdownFlavor::Transcript => {
-            let style = Style::default().fg(theme.fg).add_modifier(Modifier::BOLD);
-            let cells = spans_to_cells(&inline_spans(text, style, theme));
+        // body-colour text (H1 additionally gets italic + underline, matching
+        // native Claude Code; H2+ stay bold-only). The surrounding blank
+        // lines are added by `render_markdown_flavored`.
+        MdBlock::Heading { level, text } if flavor == MarkdownFlavor::Transcript => {
+            let mut modifier = Modifier::BOLD;
+            if *level == 1 {
+                modifier |= Modifier::ITALIC | Modifier::UNDERLINED;
+            }
+            let style = Style::default().fg(theme.fg).add_modifier(modifier);
+            let cells = spans_to_cells(&inline_spans(text, style, theme, flavor));
             wrap_cells(&cells, width, false)
         }
         MdBlock::Heading { level, text } => {
@@ -58,7 +65,7 @@ pub(crate) fn render_block(
             );
             let cont = Span::styled("  ".to_string(), Style::default());
             let inner = width.saturating_sub(2).max(1);
-            let cells = spans_to_cells(&inline_spans(text, style, theme));
+            let cells = spans_to_cells(&inline_spans(text, style, theme, MarkdownFlavor::Rich));
             let mut out = with_prefix(wrap_cells(&cells, inner, false), bar, cont);
             // GitHub draws a bottom border under H1/H2; mirror that with a
             // full-width rule tinted toward the heading colour so the section
@@ -72,15 +79,27 @@ pub(crate) fn render_block(
             out
         }
         MdBlock::Paragraph(text) => {
-            let cells = spans_to_cells(&inline_spans(text, Style::default().fg(theme.fg), theme));
+            let cells =
+                spans_to_cells(&inline_spans(text, Style::default().fg(theme.fg), theme, flavor));
             wrap_cells(&cells, width, false)
+        }
+        // Native Claude Code marks a quote with a dim `▎` and renders the body
+        // in the terminal's default colour, italic (no muted grey — that's
+        // Rich-only chrome). Kept as its own arm rather than folding into the
+        // Rich arm below: the glyph, its style, and the body colour all differ.
+        MdBlock::Quote(text) if flavor == MarkdownFlavor::Transcript => {
+            let inner = width.saturating_sub(2).max(1);
+            let style = Style::default().fg(theme.fg).add_modifier(Modifier::ITALIC);
+            let cells = spans_to_cells(&inline_spans(text, style, theme, flavor));
+            let bar = Span::styled("\u{258e} ".to_string(), Style::default().add_modifier(Modifier::DIM));
+            with_prefix(wrap_cells(&cells, inner, false), bar.clone(), bar)
         }
         MdBlock::Quote(text) => {
             let inner = width.saturating_sub(2).max(1);
             let style = Style::default()
                 .fg(theme.muted)
                 .add_modifier(Modifier::ITALIC);
-            let cells = spans_to_cells(&inline_spans(text, style, theme));
+            let cells = spans_to_cells(&inline_spans(text, style, theme, MarkdownFlavor::Rich));
             let bar = Span::styled("\u{2502} ".to_string(), Style::default().fg(theme.muted));
             with_prefix(wrap_cells(&cells, inner, false), bar.clone(), bar)
         }
@@ -97,6 +116,27 @@ pub(crate) fn render_block(
                 MarkdownFlavor::Rich => "\u{2022} ",
                 MarkdownFlavor::Transcript => "- ",
             };
+            // Native Claude Code doesn't special-case GFM task-list syntax: a
+            // `- [ ] text`/`- [x] text` source line prints as an ordinary
+            // bullet item with the checkbox left in the text, unstyled. Fold
+            // the marker back into the body and drop `checked` so the rest of
+            // this arm's Rich-only styling below doesn't apply to it.
+            let (checked, text): (Option<bool>, String) = if flavor == MarkdownFlavor::Transcript {
+                let literal = |mark: &str| {
+                    if text.is_empty() {
+                        mark.to_string()
+                    } else {
+                        format!("{mark} {text}")
+                    }
+                };
+                match checked {
+                    Some(true) => (None, literal("[x]")),
+                    Some(false) => (None, literal("[ ]")),
+                    None => (None, text.clone()),
+                }
+            } else {
+                (*checked, text.clone())
+            };
             // Marker is a truth table over (checked, ordered).
             let marker = match (checked, ordered) {
                 (Some(true), _) => "[x] ".to_string(),
@@ -112,27 +152,40 @@ pub(crate) fn render_block(
                 (_, MarkdownFlavor::Rich) => theme.accent,
             };
             // Completed items recede so the eye lands on what's left.
-            let text_color = if *checked == Some(true) {
+            let text_color = if checked == Some(true) {
                 theme.muted
             } else {
                 theme.fg
             };
             let prefix_w = indent + display_width(&marker);
             let inner = width.saturating_sub(prefix_w).max(1);
-            let cells = spans_to_cells(&inline_spans(text, Style::default().fg(text_color), theme));
+            let cells = spans_to_cells(&inline_spans(
+                &text,
+                Style::default().fg(text_color),
+                theme,
+                flavor,
+            ));
             let pad = " ".repeat(indent);
             let first = Span::styled(format!("{pad}{marker}"), Style::default().fg(marker_color));
             let cont = Span::styled(" ".repeat(prefix_w), Style::default());
             with_prefix(wrap_cells(&cells, inner, false), first, cont)
         }
-        MdBlock::CodeBlock { lang, lines } => {
-            render_code_block(lang.as_deref(), lines, width, theme, syntax_set, syntect_theme)
-        }
+        MdBlock::CodeBlock { lang, lines } => match flavor {
+            MarkdownFlavor::Rich => {
+                render_code_block(lang.as_deref(), lines, width, theme, syntax_set, syntect_theme)
+            }
+            MarkdownFlavor::Transcript => {
+                render_code_block_transcript(lang.as_deref(), lines, width, syntax_set)
+            }
+        },
         MdBlock::Table {
             headers,
             aligns,
             rows,
-        } => render_table(headers, aligns, rows, width, theme),
+        } => match flavor {
+            MarkdownFlavor::Rich => render_table(headers, aligns, rows, width, theme),
+            MarkdownFlavor::Transcript => render_table_boxed(headers, rows, width, theme),
+        },
     }
 }
 

--- a/src/ui/markdown/table.rs
+++ b/src/ui/markdown/table.rs
@@ -7,9 +7,10 @@ use ratatui::text::{Line, Span};
 
 use crate::theme::Theme;
 
+use super::MarkdownFlavor;
 use super::inline::inline_spans;
 use super::parse::Align;
-use super::wrap::{Cell, cells_to_line, char_width, spans_to_cells, wrap_cells_raw};
+use super::wrap::{Cell, cells_to_line, spans_to_cells, wrap_cells_raw};
 
 /// Render a GFM table borderless: a bold header row, a horizontal rule, then
 /// aligned body rows with columns separated by two spaces. Box-drawing borders
@@ -98,7 +99,12 @@ fn natural_col_widths(headers: &[String], rows: &[Vec<String>], theme: &Theme) -
 /// Display width of `text` after inline markup is stripped, so column widths
 /// match what actually renders (not the raw `**bold**` source).
 fn rendered_width(text: &str, theme: &Theme) -> usize {
-    cells_width(&spans_to_cells(&inline_spans(text, Style::default(), theme)))
+    cells_width(&spans_to_cells(&inline_spans(
+        text,
+        Style::default(),
+        theme,
+        MarkdownFlavor::Rich,
+    )))
 }
 
 /// Shrink natural column widths so the row (cells + 2-space separators) fits
@@ -150,7 +156,7 @@ fn render_table_row(
 
     let height = cols.iter().map(Vec::len).max().unwrap_or(0);
     let blank = |col_w: usize| -> Vec<Cell> {
-        (0..col_w).map(|_| Cell { ch: ' ', style: base }).collect()
+        (0..col_w).map(|_| Cell::new(' ', base)).collect()
     };
 
     (0..height)
@@ -158,8 +164,8 @@ fn render_table_row(
             let mut row: Vec<Cell> = Vec::new();
             for (k, col) in cols.iter().enumerate() {
                 if k > 0 {
-                    row.push(Cell { ch: ' ', style: base });
-                    row.push(Cell { ch: ' ', style: base });
+                    row.push(Cell::new(' ', base));
+                    row.push(Cell::new(' ', base));
                 }
                 match col.get(row_line) {
                     Some(line) => row.extend(line.iter().cloned()),
@@ -185,7 +191,7 @@ fn wrap_cell(
     if col_w == 0 {
         return vec![Vec::new()];
     }
-    let cells = spans_to_cells(&inline_spans(text, base, theme));
+    let cells = spans_to_cells(&inline_spans(text, base, theme, MarkdownFlavor::Rich));
     wrap_cells_raw(&cells, col_w, false)
         .into_iter()
         .map(|line| pad_cell_line(line, col_w, align, base))
@@ -196,7 +202,7 @@ fn wrap_cell(
 fn pad_cell_line(cells: Vec<Cell>, col_w: usize, align: Align, base: Style) -> Vec<Cell> {
     let pad = col_w.saturating_sub(cells_width(&cells));
     let space = |n: usize| -> Vec<Cell> {
-        (0..n).map(|_| Cell { ch: ' ', style: base }).collect()
+        (0..n).map(|_| Cell::new(' ', base)).collect()
     };
     match align {
         Align::Left => {
@@ -226,7 +232,7 @@ fn clip_cells(cells: Vec<Cell>, width: usize) -> Vec<Cell> {
     let mut out = Vec::new();
     let mut w = 0;
     for cell in cells {
-        let cw = char_width(cell.ch);
+        let cw = cell.width();
         if w + cw > width {
             break;
         }
@@ -238,5 +244,5 @@ fn clip_cells(cells: Vec<Cell>, width: usize) -> Vec<Cell> {
 
 /// Total display width of a cell slice.
 fn cells_width(cells: &[Cell]) -> usize {
-    cells.iter().map(|c| char_width(c.ch)).sum()
+    cells.iter().map(|c| c.width()).sum()
 }

--- a/src/ui/markdown/table_boxed.rs
+++ b/src/ui/markdown/table_boxed.rs
@@ -1,0 +1,210 @@
+//! GFM table layout for the Claude Code transcript flavor: a box-drawing grid
+//! (`┌─┬─┐` / `├─┼─┤` / `└─┴─┘`) matching native Claude Code's default table
+//! rendering — every column padded to `max(cell width) + 2`, a rule between
+//! every row (not just under the header), left-aligned cells, and no colour
+//! or bold anywhere (the native output carries no SGR at all for tables).
+//!
+//! This is a separate module from [`super::table`] (the Rich flavor's
+//! borderless layout) rather than a branch inside it: the two share almost no
+//! layout code — border rows, per-row rule placement, and forced left
+//! alignment have no Rich-flavor equivalent — so folding them into one
+//! function would mostly be `if flavor == Transcript { .. } else { .. }`
+//! wrapped around otherwise-unrelated logic.
+
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+
+use crate::theme::Theme;
+
+use super::MarkdownFlavor;
+use super::inline::inline_spans;
+use super::wrap::{Cell, cells_to_line, spans_to_cells, wrap_cells_raw};
+
+/// Render a GFM table as a bordered box. Column alignment hints
+/// (`:--`/`--:`/`:-:`) are ignored — native Claude Code always left-aligns
+/// cell content regardless of the source delimiter row.
+pub(crate) fn render_table_boxed(
+    headers: &[String],
+    rows: &[Vec<String>],
+    width: usize,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let ncols = headers.len();
+    if ncols == 0 {
+        return vec![Line::from("")];
+    }
+
+    // Normalise body rows to exactly `ncols` columns, same as the Rich table.
+    let rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| {
+            let mut row: Vec<String> = r.iter().take(ncols).cloned().collect();
+            row.resize(ncols, String::new());
+            row
+        })
+        .collect();
+
+    let inner = fit_inner_widths(&natural_inner_widths(headers, &rows, theme), width);
+    let style = Style::default().fg(Color::Reset);
+
+    let mut out = Vec::with_capacity(rows.len() * 2 + 3);
+    out.push(clip_line(border_cells(&inner, '\u{250c}', '\u{252c}', '\u{2510}', style), width));
+    out.extend(render_row(headers, &inner, theme, style, width));
+    out.push(clip_line(border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style), width));
+    for (idx, row) in rows.iter().enumerate() {
+        out.extend(render_row(row, &inner, theme, style, width));
+        if idx + 1 < rows.len() {
+            out.push(clip_line(border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style), width));
+        }
+    }
+    out.push(clip_line(border_cells(&inner, '\u{2514}', '\u{2534}', '\u{2518}', style), width));
+    out
+}
+
+/// Natural inner width of each column: `max(cell display width) + 2` (one
+/// column of padding on each side), over the header and every body cell.
+fn natural_inner_widths(headers: &[String], rows: &[Vec<String>], theme: &Theme) -> Vec<usize> {
+    let mut w: Vec<usize> = headers.iter().map(|h| rendered_width(h, theme) + 2).collect();
+    for row in rows {
+        for (k, cell) in row.iter().enumerate() {
+            if let Some(col) = w.get_mut(k) {
+                *col = (*col).max(rendered_width(cell, theme) + 2);
+            }
+        }
+    }
+    w
+}
+
+/// Display width of `text` after inline markup is stripped.
+fn rendered_width(text: &str, theme: &Theme) -> usize {
+    cells_width(&spans_to_cells(&inline_spans(
+        text,
+        Style::default(),
+        theme,
+        MarkdownFlavor::Transcript,
+    )))
+}
+
+/// Shrink natural inner widths so the whole grid (columns + one border
+/// character per boundary, `ncols + 1` of them) fits `width`. Mirrors
+/// [`super::table::fit_col_widths`]'s trim-the-widest-column-by-one approach;
+/// every column keeps at least 1 column.
+fn fit_inner_widths(natural: &[usize], width: usize) -> Vec<usize> {
+    let ncols = natural.len();
+    if ncols == 0 {
+        return vec![];
+    }
+    let overhead = ncols + 1; // vertical border chars: one per column boundary
+    let avail = width.saturating_sub(overhead).max(ncols); // >= 1 per column
+    let mut w: Vec<usize> = natural.iter().map(|&x| x.max(1).min(avail)).collect();
+    while w.iter().sum::<usize>() > avail {
+        let maxw = *w.iter().max().unwrap();
+        if maxw <= 1 {
+            break; // can't shrink further; the final clip guards the width bound
+        }
+        let idx = w.iter().position(|&x| x == maxw).unwrap();
+        w[idx] -= 1;
+    }
+    w
+}
+
+/// Render one table row into as many `Line`s as its tallest cell needs (a
+/// cell too wide for its column wraps rather than truncating, same policy as
+/// the Rich table).
+fn render_row(
+    cells: &[String],
+    inner: &[usize],
+    theme: &Theme,
+    style: Style,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let cols: Vec<Vec<Vec<Cell>>> = inner
+        .iter()
+        .enumerate()
+        .map(|(k, &w)| {
+            let text = cells.get(k).map(String::as_str).unwrap_or("");
+            wrap_cell(text, w, style, theme)
+        })
+        .collect();
+
+    let height = cols.iter().map(Vec::len).max().unwrap_or(1);
+    let blank = |w: usize| -> Vec<Cell> { (0..w).map(|_| Cell::new(' ', style)).collect() };
+
+    (0..height)
+        .map(|row_line| {
+            let mut row: Vec<Cell> = vec![Cell::new('\u{2502}', style)];
+            for (k, col) in cols.iter().enumerate() {
+                match col.get(row_line) {
+                    Some(line) => row.extend(line.iter().cloned()),
+                    None => row.extend(blank(inner[k])),
+                }
+                row.push(Cell::new('\u{2502}', style));
+            }
+            clip_line(row, width)
+        })
+        .collect()
+}
+
+/// Wrap `text` into lines of exactly `inner_w` display columns: strip inline
+/// markup styling other than colour/emphasis, wrap at word boundaries inside
+/// the `inner_w - 2` content area, then pad left-aligned with one space of
+/// padding on each side. Always returns at least one line.
+fn wrap_cell(text: &str, inner_w: usize, style: Style, theme: &Theme) -> Vec<Vec<Cell>> {
+    if inner_w == 0 {
+        return vec![Vec::new()];
+    }
+    let content_w = inner_w.saturating_sub(2).max(1);
+    let cells = spans_to_cells(&inline_spans(text, style, theme, MarkdownFlavor::Transcript));
+    wrap_cells_raw(&cells, content_w, false)
+        .into_iter()
+        .map(|line| pad_left(line, inner_w, style))
+        .collect()
+}
+
+/// Pad one wrapped content line out to `inner_w` columns: one space, the
+/// content, then spaces out to `inner_w - 1`.
+fn pad_left(cells: Vec<Cell>, inner_w: usize, style: Style) -> Vec<Cell> {
+    let mut out = vec![Cell::new(' ', style)];
+    out.extend(cells.iter().cloned());
+    let used = 1 + cells_width(&cells);
+    if used < inner_w {
+        out.extend((0..inner_w - used).map(|_| Cell::new(' ', style)));
+    }
+    out
+}
+
+/// One border row (top/header-rule/row-rule/bottom): `left`, then each
+/// column's width in `fill`, joined by `mid`, closed with `right`.
+fn border_cells(inner: &[usize], left: char, mid: char, right: char, style: Style) -> Vec<Cell> {
+    let mut out = vec![Cell::new(left, style)];
+    for (i, &w) in inner.iter().enumerate() {
+        if i > 0 {
+            out.push(Cell::new(mid, style));
+        }
+        out.extend((0..w).map(|_| Cell::new('\u{2500}', style)));
+    }
+    out.push(Cell::new(right, style));
+    out
+}
+
+/// Hard-clip `cells` to at most `width` display columns — the final guard
+/// that keeps every table line within the width bound even when the column
+/// math can't fit (e.g. a 4-column table in a 3-wide panel).
+fn clip_line(cells: Vec<Cell>, width: usize) -> Line<'static> {
+    let mut out = Vec::new();
+    let mut w = 0;
+    for cell in cells {
+        let cw = cell.width();
+        if w + cw > width {
+            break;
+        }
+        out.push(cell);
+        w += cw;
+    }
+    cells_to_line(&out)
+}
+
+/// Total display width of a cell slice.
+fn cells_width(cells: &[Cell]) -> usize {
+    cells.iter().map(|c| c.width()).sum()
+}

--- a/src/ui/markdown/tests/mod.rs
+++ b/src/ui/markdown/tests/mod.rs
@@ -12,6 +12,7 @@ use syntect::highlighting::ThemeSet;
 
 mod parsing;
 mod rendering;
+mod transcript_code_block_colors;
 
 fn fixtures() -> (Theme, SyntaxSet, SyntectTheme) {
     let theme = Theme::default();

--- a/src/ui/markdown/tests/parsing.rs
+++ b/src/ui/markdown/tests/parsing.rs
@@ -116,11 +116,11 @@ fn snake_case_and_bare_star_stay_literal() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
     // Underscores are never emphasis.
-    let spans = inline_spans("call set_change_summary here", base, &theme);
+    let spans = inline_spans("call set_change_summary here", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "call set_change_summary here");
     assert_eq!(spans.len(), 1, "no styled split for snake_case");
     // `2 * 3`: space-flanked star is literal.
-    let spans = inline_spans("rate is 2 * 3", base, &theme);
+    let spans = inline_spans("rate is 2 * 3", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "rate is 2 * 3");
     assert_eq!(spans.len(), 1);
 }
@@ -130,7 +130,7 @@ fn bold_italic_code_are_styled() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
 
-    let spans = inline_spans("a **b** c", base, &theme);
+    let spans = inline_spans("a **b** c", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "a b c");
     assert!(
         spans
@@ -138,14 +138,14 @@ fn bold_italic_code_are_styled() {
             .any(|s| s.content == "b" && s.style.add_modifier.contains(Modifier::BOLD))
     );
 
-    let spans = inline_spans("a *b* c", base, &theme);
+    let spans = inline_spans("a *b* c", base, &theme, MarkdownFlavor::Rich);
     assert!(
         spans
             .iter()
             .any(|s| s.content == "b" && s.style.add_modifier.contains(Modifier::ITALIC))
     );
 
-    let spans = inline_spans("use `git` now", base, &theme);
+    let spans = inline_spans("use `git` now", base, &theme, MarkdownFlavor::Rich);
     // Inline code is padded with NBSP into a pink-on-card chip; match on the
     // trimmed content rather than the exact padded string.
     assert!(
@@ -166,7 +166,7 @@ fn unclosed_inline_delimiters_stay_literal() {
         "a `b", "a *b", "a **b", "*", "`", "a ~~b", "~~", "~", "a ~ b", "~/foo",
         "a ~~ b ~~ c",
     ] {
-        let spans = inline_spans(input, base, &theme);
+        let spans = inline_spans(input, base, &theme, MarkdownFlavor::Rich);
         assert_eq!(joined(&spans), input, "input {input:?} should be literal");
     }
 }
@@ -175,7 +175,7 @@ fn unclosed_inline_delimiters_stay_literal() {
 fn strikethrough_is_styled_and_muted() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
-    let spans = inline_spans("keep ~~drop~~ this", base, &theme);
+    let spans = inline_spans("keep ~~drop~~ this", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "keep drop this");
     let struck = spans.iter().find(|s| s.content == "drop").unwrap();
     assert!(struck.style.add_modifier.contains(Modifier::CROSSED_OUT));
@@ -188,7 +188,7 @@ fn strikethrough_does_not_nest_inner_markup() {
     // nesting) — but inline markup OUTSIDE the strike still works.
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
-    let spans = inline_spans("~~old **bold**~~ and **real**", base, &theme);
+    let spans = inline_spans("~~old **bold**~~ and **real**", base, &theme, MarkdownFlavor::Rich);
     assert!(
         spans
             .iter()
@@ -455,7 +455,7 @@ fn links_render_text_and_url() {
     let base = Style::default().fg(theme.fg);
 
     // Link text shown, URL kept in a recessive parenthetical.
-    let spans = inline_spans("see [the docs](https://example.com) now", base, &theme);
+    let spans = inline_spans("see [the docs](https://example.com) now", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "see the docs (https://example.com) now");
     assert!(
         spans.iter().any(|s| s.content == "the docs"
@@ -464,7 +464,7 @@ fn links_render_text_and_url() {
     );
 
     // Inline markup inside the link text is still styled.
-    let spans = inline_spans("[**bold** link](https://x.io)", base, &theme);
+    let spans = inline_spans("[**bold** link](https://x.io)", base, &theme, MarkdownFlavor::Rich);
     assert!(
         spans
             .iter()
@@ -479,14 +479,14 @@ fn self_titled_and_empty_links_show_url_once() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
 
-    let spans = inline_spans("[https://x.com](https://x.com)", base, &theme);
+    let spans = inline_spans("[https://x.com](https://x.com)", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "https://x.com");
 
     // Trailing-slash / case differences still collapse.
-    let spans = inline_spans("[https://x.com/](https://x.com)", base, &theme);
+    let spans = inline_spans("[https://x.com/](https://x.com)", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "https://x.com");
 
-    let spans = inline_spans("[](https://x.com)", base, &theme);
+    let spans = inline_spans("[](https://x.com)", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "https://x.com");
 }
 
@@ -495,7 +495,7 @@ fn malformed_links_stay_literal() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
     for input in ["[text]", "[text](", "[text(url)", "a [b] c", "["] {
-        let spans = inline_spans(input, base, &theme);
+        let spans = inline_spans(input, base, &theme, MarkdownFlavor::Rich);
         assert_eq!(joined(&spans), input, "{input:?} should stay literal");
     }
 }
@@ -504,7 +504,7 @@ fn malformed_links_stay_literal() {
 fn link_preserves_trailing_text() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
-    let spans = inline_spans("[a](b)c", base, &theme);
+    let spans = inline_spans("[a](b)c", base, &theme, MarkdownFlavor::Rich);
     assert_eq!(joined(&spans), "a (b)c");
 }
 

--- a/src/ui/markdown/tests/rendering.rs
+++ b/src/ui/markdown/tests/rendering.rs
@@ -2,6 +2,7 @@
 //! rendering, the Transcript flavor, and [`MarkdownCache`].
 
 use super::*;
+use ratatui::style::Color;
 
 // ── Wrapping / width ──
 
@@ -117,7 +118,7 @@ fn code_block_is_highlighted_and_carded() {
 fn inline_code_sits_on_card_background() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
-    let spans = inline_spans("run `cargo test` now", base, &theme);
+    let spans = inline_spans("run `cargo test` now", base, &theme, MarkdownFlavor::Rich);
     let code = spans
         .iter()
         .find(|s| s.content.trim_matches('\u{a0}') == "cargo test")
@@ -208,6 +209,104 @@ fn transcript_headings_are_bold_body_colour_no_bar_no_rule() {
 }
 
 #[test]
+fn transcript_h1_is_bold_italic_underlined_h2_h3_stay_bold_only() {
+    // Native Claude Code renders H1 as bold+italic+underline; H2/H3 stay the
+    // plain bold established by `transcript_headings_are_bold_body_colour_no_bar_no_rule`.
+    let h1 = render_transcript("# Title", 30);
+    let span = &h1[0].spans[0];
+    assert!(span.style.add_modifier.contains(Modifier::BOLD), "H1 bold");
+    assert!(span.style.add_modifier.contains(Modifier::ITALIC), "H1 italic");
+    assert!(span.style.add_modifier.contains(Modifier::UNDERLINED), "H1 underlined");
+
+    for src in ["## Sub", "### Subsub"] {
+        let lines = render_transcript(src, 30);
+        let span = &lines[0].spans[0];
+        assert!(!span.style.add_modifier.contains(Modifier::ITALIC), "{src}: not italic");
+        assert!(!span.style.add_modifier.contains(Modifier::UNDERLINED), "{src}: not underlined");
+    }
+
+    // The Rich flavor's H1 is unaffected (bold only, no italic/underline).
+    let rich_h1 = render("# Title", 30);
+    let rich_span = &rich_h1[0].spans[1]; // spans[0] is the colour bar
+    assert!(!rich_span.style.add_modifier.contains(Modifier::ITALIC), "Rich H1 stays bold-only");
+    assert!(!rich_span.style.add_modifier.contains(Modifier::UNDERLINED), "Rich H1 stays bold-only");
+}
+
+#[test]
+fn transcript_task_checkbox_renders_literally_unstyled() {
+    // Native Claude Code doesn't special-case GFM task-list syntax: the
+    // checkbox marker stays in the body text, as an ordinary bullet item.
+    let (theme, _, _) = fixtures();
+    let lines = render_transcript("- [ ] unchecked task\n- [x] checked task", 40);
+    assert_eq!(lines[0].spans[0].content.as_ref(), "- ", "ordinary dash bullet, not dropped");
+    let unchecked_text: String = lines[0].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(unchecked_text, "[ ] unchecked task");
+    assert_eq!(lines[1].spans[0].content.as_ref(), "- ");
+    let checked_text: String = lines[1].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(checked_text, "[x] checked task");
+    // No special colouring: bullet and body both stay body-colour, never
+    // theme.success (the "completed" green) or theme.muted (the "recede" grey).
+    for line in &lines {
+        for span in &line.spans {
+            assert_eq!(span.style.fg, Some(theme.fg), "no special checkbox colour");
+        }
+    }
+
+    // The Rich flavor keeps converting checkboxes (unaffected).
+    let rich = render("- [ ] todo\n- [x] done", 40);
+    assert_eq!(rich[0].spans[0].content.as_ref(), "[ ] ");
+    assert_eq!(rich[1].spans[0].content.as_ref(), "[x] ");
+    assert_eq!(rich[1].spans[0].style.fg, Some(theme.success), "Rich still colours [x] green");
+}
+
+#[test]
+fn transcript_inline_code_uses_info_colour_with_no_padding() {
+    let (theme, _, _) = fixtures();
+    let lines = render_transcript("use `git` now", 40);
+    let code = lines[0]
+        .spans
+        .iter()
+        .find(|s| s.content.as_ref() == "git")
+        .expect("inline code span with no NBSP padding");
+    assert_eq!(code.style.fg, Some(theme.info));
+    assert_eq!(code.style.bg, None, "no card background in the transcript");
+
+    // The Rich flavor keeps its NBSP-padded, code_fg/code_bg card (unaffected).
+    let rich = render("use `git` now", 40);
+    assert!(
+        rich.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.content.trim_matches('\u{a0}') == "git"
+                && s.style.fg == Some(theme.code_fg)
+                && s.style.bg == Some(theme.code_bg)
+        }),
+        "Rich inline code keeps its padded card"
+    );
+}
+
+#[test]
+fn transcript_quote_uses_dim_glyph_and_default_colour_italic_body() {
+    let (theme, _, _) = fixtures();
+    let lines = render_transcript("> quoted text", 40);
+    let glyph = &lines[0].spans[0];
+    assert_eq!(glyph.content.as_ref(), "\u{258e} ", "▎ glyph, not │");
+    assert!(glyph.style.add_modifier.contains(Modifier::DIM), "glyph is dim");
+    assert_eq!(glyph.style.fg, None, "glyph carries no explicit colour");
+
+    let body: String = lines[0].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(body, "quoted text");
+    for span in &lines[0].spans[1..] {
+        assert_eq!(span.style.fg, Some(theme.fg), "body is default colour, not muted");
+        assert!(span.style.add_modifier.contains(Modifier::ITALIC), "body stays italic");
+    }
+
+    // The Rich flavor keeps its muted "│ " bar and muted italic body (unaffected).
+    let rich = render("> quoted text", 40);
+    assert_eq!(rich[0].spans[0].content.as_ref(), "\u{2502} ");
+    assert_eq!(rich[0].spans[0].style.fg, Some(theme.muted));
+    assert_eq!(rich[0].spans[1].style.fg, Some(theme.muted));
+}
+
+#[test]
 fn transcript_heading_has_blank_line_before_and_after() {
     // "body / ## Head / more" → blank inserted both above and below the head.
     let lines = render_transcript("body\n## Head\nmore", 30);
@@ -239,6 +338,73 @@ fn transcript_lines_stay_within_width() {
             assert!(display_width(&line_text(&line)) <= width);
         }
     }
+}
+
+#[test]
+fn transcript_table_renders_as_boxed_grid() {
+    // Matches native Claude Code's default table rendering byte-for-byte:
+    // box-drawing border, a rule between every row (not just under the
+    // header), columns padded to `max(cell width) + 2`, no colour, no bold.
+    let table = "| Column A | Column B | Column C |\n\
+        | --- | --- | --- |\n\
+        | a1 | b1 | c1 |\n\
+        | a2 | b2 | c2 |";
+    let lines = render_transcript(table, 100);
+    let texts: Vec<String> = lines.iter().map(line_text).collect();
+    assert_eq!(
+        texts,
+        vec![
+            "\u{250c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{252c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{252c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2510}",
+            "\u{2502} Column A \u{2502} Column B \u{2502} Column C \u{2502}",
+            "\u{251c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{253c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{253c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2524}",
+            "\u{2502} a1       \u{2502} b1       \u{2502} c1       \u{2502}",
+            "\u{251c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{253c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{253c}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2524}",
+            "\u{2502} a2       \u{2502} b2       \u{2502} c2       \u{2502}",
+            "\u{2514}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2534}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2534}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2518}",
+        ],
+        "boxed table lines"
+    );
+    // No colour, no bold anywhere in the table.
+    for line in &lines {
+        for span in &line.spans {
+            assert_eq!(span.style.fg, Some(Color::Reset), "table text carries no colour");
+            assert_eq!(span.style.bg, None, "table has no background");
+            assert!(
+                !span.style.add_modifier.contains(Modifier::BOLD),
+                "header is not bold in the Transcript flavor"
+            );
+        }
+    }
+}
+
+#[test]
+fn transcript_table_never_exceeds_width() {
+    let table = "| feature | notes |\n| --- | --- |\n\
+        | toggle | switches a markdown file between raw source and rendered prose |\n\
+        | scroll | independent of the raw view |";
+    for width in [1usize, 2, 3, 8, 20, 30, 40, 60, 100] {
+        for line in render_transcript(table, width) {
+            assert!(
+                display_width(&line_text(&line)) <= width.max(1),
+                "table line exceeds width {width}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rich_table_stays_borderless_after_transcript_boxed_table_change() {
+    // Guard: the Rich flavor must keep its bold-header / rule-only layout —
+    // no box-drawing characters leak in from the Transcript path.
+    let table = "| h1 | h2 |\n| --- | --- |\n| a | b |";
+    let lines = render(table, 40);
+    let joined: String = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+    for boxed_char in ['\u{250c}', '\u{2510}', '\u{2514}', '\u{2518}', '\u{251c}', '\u{2524}', '\u{252c}', '\u{2534}', '\u{253c}'] {
+        assert!(!joined.contains(boxed_char), "Rich table must not use box-drawing borders");
+    }
+    let (theme, _, _) = fixtures();
+    assert_eq!(lines[0].spans[0].style.fg, Some(theme.accent), "Rich header keeps its accent colour");
+    assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::BOLD), "Rich header stays bold");
 }
 
 #[test]

--- a/src/ui/markdown/tests/transcript_code_block_colors.rs
+++ b/src/ui/markdown/tests/transcript_code_block_colors.rs
@@ -1,0 +1,201 @@
+//! Acceptance tests for Transcript-flavor fenced-code-block colouring
+//! (`code_colors.rs`): exact source fixtures and expected 8-basic-ANSI-colour
+//! tokens, matched against a native Claude Code capture. Kept as its own
+//! file (rather than appended to `rendering.rs`, already at the project's
+//! size guideline) since these are a distinct, self-contained fixture set.
+
+use super::*;
+use ratatui::style::Color;
+
+/// Render one fenced code block in Transcript flavor.
+fn code_lines(lang: &str, source: &str) -> Vec<Line<'static>> {
+    let text = format!("```{lang}\n{source}\n```");
+    render_transcript(&text, 100)
+}
+
+/// Find the single span whose content is exactly `text` — not a substring
+/// match, since same-style adjacent syntect tokens coalesce into one span
+/// (`wrap.rs`'s `cells_to_line`). Callers ask for the merged run they expect
+/// (e.g. `"hi"` for a whole string literal, not just `hi`).
+fn span<'a>(lines: &'a [Line<'static>], text: &str) -> &'a Span<'static> {
+    lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .find(|s| s.content.as_ref() == text)
+        .unwrap_or_else(|| panic!("no span with exact content {text:?}"))
+}
+
+fn assert_fg(lines: &[Line<'static>], text: &str, color: Color) {
+    let s = span(lines, text);
+    assert_eq!(s.style.fg, Some(color), "{text:?} expected fg {color:?}, got {:?}", s.style.fg);
+}
+
+fn assert_fg_dim(lines: &[Line<'static>], text: &str, color: Color) {
+    let s = span(lines, text);
+    assert_eq!(s.style.fg, Some(color), "{text:?} expected fg {color:?}, got {:?}", s.style.fg);
+    assert!(s.style.add_modifier.contains(Modifier::DIM), "{text:?} expected DIM modifier");
+}
+
+/// Find the colour of `word` as a standalone identifier, even where it was
+/// coalesced into a wider same-style span together with neighbouring
+/// punctuation/whitespace (`wrap.rs` merges adjacent same-style spans, so an
+/// unstyled identifier like a struct name commonly ends up glued to the
+/// braces/colons/spaces around it). Tokenizes each span's content on
+/// non-word characters and looks for an exact-word occurrence.
+///
+/// Also asserts DIM is absent — checking `fg` alone would silently accept a
+/// span that's actually `Type` (Cyan + DIM) where the fixture expects
+/// `Builtin` (Cyan, no DIM), since both share the same foreground colour.
+/// All current callers expect a non-dim colour; if a future fixture needs a
+/// dim word-based check, extend this rather than adding an unchecked twin.
+fn assert_word_fg(lines: &[Line<'static>], word: &str, color: Color) {
+    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+    for line in lines {
+        for s in &line.spans {
+            if s.content.split(|c: char| !is_word_char(c)).any(|tok| tok == word) {
+                assert_eq!(s.style.fg, Some(color), "{word:?} expected fg {color:?}, got {:?}", s.style.fg);
+                assert!(
+                    !s.style.add_modifier.contains(Modifier::DIM),
+                    "{word:?} unexpectedly carries DIM (Type vs Builtin mix-up?)"
+                );
+                return;
+            }
+        }
+    }
+    panic!("no occurrence of word {word:?}");
+}
+
+#[test]
+fn transcript_code_block_has_no_card_chrome() {
+    // No background colour, no inset, no blank padding rows — content starts
+    // at column 0 and the block is exactly as many rows as source lines.
+    let lines = code_lines("rust", "let x = 1;");
+    assert_eq!(lines.len(), 1, "no top/bottom padding rows");
+    for span in &lines[0].spans {
+        assert_eq!(span.style.bg, None, "no background colour");
+    }
+    assert_eq!(lines[0].spans[0].content.as_ref(), "let", "content starts at column 0, no left inset");
+}
+
+#[test]
+fn transcript_code_block_rust_colours() {
+    let src = "// a line comment\n\
+/// a doc comment\n\
+fn f(a: &str, b: bool) -> Option<u32> {\n\
+    let s = String::from(\"hi\");   // trailing\n\
+    const N: usize = 42;\n\
+    if b { Some(N as u32) } else { None }\n\
+}\n\
+struct S { field: Vec<u8> }";
+    let lines = code_lines("rust", src);
+
+    assert_fg(&lines, "// a line comment", Color::Green);
+    assert_fg(&lines, "/// a doc comment", Color::Green);
+    assert_fg(&lines, "// trailing", Color::Green);
+    assert_fg(&lines, "42", Color::Green);
+
+    for kw in ["fn", "let", "const", "if", "as", "else", "struct", "None"] {
+        assert_fg(&lines, kw, Color::Blue);
+    }
+
+    assert_fg(&lines, "f", Color::Yellow);
+    assert_fg(&lines, "from", Color::Yellow);
+    assert_fg(&lines, "Some", Color::Yellow);
+
+    for ty in ["str", "bool", "Option", "u32", "String", "usize", "Vec", "u8"] {
+        assert_fg_dim(&lines, ty, Color::Cyan);
+    }
+
+    assert_fg(&lines, "\"hi\"", Color::Red);
+
+    // Struct name reads unstyled, not as a function/type name. These plain
+    // identifiers get coalesced into a wider Reset span alongside the
+    // punctuation/whitespace around them, so look them up by word rather
+    // than by exact span content.
+    assert_word_fg(&lines, "S", Color::Reset);
+    for ident in ["s", "N", "b", "field"] {
+        assert_word_fg(&lines, ident, Color::Reset);
+    }
+}
+
+#[test]
+fn transcript_code_block_python_colours() {
+    let src = "# python comment\n\
+import os\n\
+def g(x=1, *args):\n\
+    s = f\"val {x}\"\n\
+    return [i for i in range(10) if i % 2 == 0]\n\
+class C(object):\n\
+    pass";
+    let lines = code_lines("python", src);
+
+    assert_fg(&lines, "# python comment", Color::Green);
+
+    for kw in ["import", "def", "return", "for", "in", "if", "class", "object", "pass"] {
+        assert_fg(&lines, kw, Color::Blue);
+    }
+
+    assert_fg(&lines, "g", Color::Yellow);
+    assert_fg(&lines, "range", Color::Cyan);
+
+    for num in ["1", "10", "2", "0"] {
+        assert_fg(&lines, num, Color::Green);
+    }
+
+    // Interpolated f-string: literal run before the embedded expression is
+    // red; from the first embedded-expression token onward — including the
+    // closing quote — it reverts to the default colour.
+    assert_fg(&lines, "f\"val ", Color::Red);
+    assert_fg(&lines, "{x}\"", Color::Reset);
+
+    for ident in ["os", "C", "s", "i", "args"] {
+        assert_word_fg(&lines, ident, Color::Reset);
+    }
+}
+
+#[test]
+fn transcript_code_block_bash_colours() {
+    let src = "# shell comment\n\
+export FOO=bar\n\
+if [ -f \"$HOME/.zshrc\" ]; then\n\
+  echo \"yes\" | grep -q y && ls -la\n\
+fi";
+    let lines = code_lines("bash", src);
+
+    assert_fg(&lines, "# shell comment", Color::Green);
+
+    for builtin in ["export", "echo", "ls"] {
+        assert_fg(&lines, builtin, Color::Cyan);
+    }
+    for kw in ["if", "then", "fi"] {
+        assert_fg(&lines, kw, Color::Blue);
+    }
+
+    assert_fg(&lines, "\"yes\"", Color::Red);
+    // Opening quote of the second string: red up to (not including) the
+    // interruption by `$HOME` — the rest of that string, including its
+    // closing quote, reverts to the default colour (coalesced with the
+    // trailing `];` into one Reset span, so check it by word).
+    assert_fg(&lines, "\"", Color::Red);
+    assert_word_fg(&lines, "zshrc", Color::Reset);
+
+    // `grep` isn't a recognised builtin, unlike `ls`/`echo`/`export`.
+    assert_word_fg(&lines, "grep", Color::Reset);
+}
+
+#[test]
+fn transcript_code_block_json_colours() {
+    let src = "{\"a\": 1, \"b\": true, \"c\": null, \"d\": [\"x\", 2.5]}";
+    let lines = code_lines("json", src);
+
+    for key in ["\"a\"", "\"b\"", "\"c\"", "\"d\""] {
+        assert_fg(&lines, key, Color::Cyan);
+    }
+    for num in ["1", "2.5"] {
+        assert_fg(&lines, num, Color::Green);
+    }
+    for lit in ["true", "null"] {
+        assert_fg(&lines, lit, Color::Blue);
+    }
+    assert_fg(&lines, "\"x\"", Color::Red);
+}

--- a/src/ui/markdown/wrap.rs
+++ b/src/ui/markdown/wrap.rs
@@ -4,28 +4,55 @@
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use unicode_width::UnicodeWidthChar;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
-/// A single display cell: one char carrying its style. The wrapping helpers
-/// work at this granularity so styles survive line breaks.
+/// A single display cell: one **grapheme cluster** carrying its style. The
+/// wrapping helpers work at this granularity so styles survive line breaks.
+///
+/// A cluster, not a `char`, because the two disagree on width in both
+/// directions: `⚠` is one column but `⚠️` (the same character followed by
+/// U+FE0F) is two, so summing per `char` under-counts it and the line
+/// overflows; a ZWJ sequence like a family emoji is two columns total but
+/// seven `char`s, so summing per `char` over-counts it and the line wraps
+/// early. Clusters also can't be split across a line break, which a `char`
+/// granularity happily did.
 #[derive(Clone)]
 pub(crate) struct Cell {
-    pub(crate) ch: char,
+    pub(crate) text: String,
     pub(crate) style: Style,
 }
 
-pub(crate) fn char_width(c: char) -> usize {
-    UnicodeWidthChar::width(c).unwrap_or(0)
+impl Cell {
+    pub(crate) fn new(ch: char, style: Style) -> Self {
+        Self {
+            text: ch.to_string(),
+            style,
+        }
+    }
+
+    pub(crate) fn width(&self) -> usize {
+        UnicodeWidthStr::width(self.text.as_str())
+    }
+
+    pub(crate) fn is_space(&self) -> bool {
+        self.text == " "
+    }
 }
 
 pub(crate) fn display_width(s: &str) -> usize {
-    s.chars().map(char_width).sum()
+    UnicodeWidthStr::width(s)
 }
 
 pub(crate) fn spans_to_cells(spans: &[Span<'static>]) -> Vec<Cell> {
     spans
         .iter()
-        .flat_map(|s| s.content.chars().map(move |ch| Cell { ch, style: s.style }))
+        .flat_map(|s| {
+            s.content.graphemes(true).map(move |g| Cell {
+                text: g.to_string(),
+                style: s.style,
+            })
+        })
         .collect()
 }
 
@@ -37,12 +64,12 @@ pub(crate) fn cells_to_line(cells: &[Cell]) -> Line<'static> {
     let mut cur: Option<Style> = None;
     for cell in cells {
         match cur {
-            Some(s) if s == cell.style => buf.push(cell.ch),
+            Some(s) if s == cell.style => buf.push_str(&cell.text),
             _ => {
                 if let Some(s) = cur {
                     spans.push(Span::styled(std::mem::take(&mut buf), s));
                 }
-                buf.push(cell.ch);
+                buf.push_str(&cell.text);
                 cur = Some(cell.style);
             }
         }
@@ -88,7 +115,7 @@ pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Ve
 
     if hard {
         for cell in cells {
-            let cw = char_width(cell.ch);
+            let cw = cell.width();
             if cur_w + cw > width && !cur.is_empty() {
                 push_line(&mut cur, &mut cur_w);
             }
@@ -107,7 +134,7 @@ pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Ve
     let n = cells.len();
     let mut i = 0;
     while i < n {
-        if cells[i].ch == ' ' {
+        if cells[i].is_space() {
             // A space: keep it only if it fits on the current (non-empty) line;
             // otherwise drop it as the wrap point so the next line has no
             // leading space.
@@ -126,8 +153,8 @@ pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Ve
         // Gather the next word (run of non-space cells).
         let start = i;
         let mut word_w = 0;
-        while i < n && cells[i].ch != ' ' {
-            word_w += char_width(cells[i].ch);
+        while i < n && !cells[i].is_space() {
+            word_w += cells[i].width();
             i += 1;
         }
         let word = &cells[start..i];
@@ -138,7 +165,7 @@ pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Ve
                 push_line(&mut cur, &mut cur_w);
             }
             for cell in word {
-                let cw = char_width(cell.ch);
+                let cw = cell.width();
                 if cur_w + cw > width && !cur.is_empty() {
                     push_line(&mut cur, &mut cur_w);
                 }
@@ -151,7 +178,7 @@ pub(crate) fn wrap_cells_raw(cells: &[Cell], width: usize, hard: bool) -> Vec<Ve
             }
             for cell in word {
                 cur.push(cell.clone());
-                cur_w += char_width(cell.ch);
+                cur_w += cell.width();
             }
         }
     }

--- a/src/ui/reflow_view/build.rs
+++ b/src/ui/reflow_view/build.rs
@@ -1,118 +1,249 @@
-//! Line builder — turns `app.reflow.entries` into the cached
+//! Line builder — turns a [`BuildCtx`]'s session-log entries into the cached
 //! `Vec<Line<'static>>` that [`render`](super::render::render) blits each
-//! frame. Rebuilt only when the panel width changes.
+//! frame. Rebuilt only when the panel width (or the expand toggle) changes.
+//! Independent of `App` so it can be constructed and tested without one.
+
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::UnicodeWidthStr;
 
-use crate::app::App;
-use crate::claude_log::{DisplayBlock, Role};
+use crate::claude_log::{DisplayBlock, LogEntry, Role};
 
-use super::glyphs::{ASSISTANT_MARKER, MARKER_COLS, THINKING_GLYPH, TOOL_RESULT_GLYPH, USER_MARKER};
-use super::helpers::{pad_glyph_to, truncate_to_width, with_marker};
+use super::glyphs::{
+    ASSISTANT_MARKER, MARKER_COLS, TEAMMATE_MESSAGE_GLYPH, THINKING_GLYPH, USER_MARKER,
+};
+use super::helpers::{fit_glyph_line, fit_styled_line, pad_glyph_to, with_marker};
 use super::palette;
 use super::palette::claude_markdown_theme;
+use super::tool_lines::{
+    ToolStyles, count_buckets, render_annotation, render_tool_result_collapsed,
+    render_tool_result_expanded, render_tool_use,
+};
+use super::user_text::render_user_text;
 
-/// Rebuild the full `Vec<Line<'static>>` from `app.reflow.entries`.
+/// Everything [`build_lines`] needs to turn a session log into rendered
+/// lines, borrowed independently of `App` so the builder can be called (and
+/// tested) without constructing one. All fields are shared references —
+/// [`crate::ui::markdown::MarkdownCache::render_flavored`] takes `&self`
+/// (its cache is a `RefCell` internally), so no field needs `&mut`.
+pub(crate) struct BuildCtx<'a> {
+    pub entries: &'a [LogEntry],
+    pub cache: &'a crate::ui::markdown::MarkdownCache,
+    pub theme: &'a crate::theme::Theme,
+    pub syntax_set: &'a syntect::parsing::SyntaxSet,
+    pub syntect_theme: &'a syntect::highlighting::Theme,
+    /// Whether to expand tool_use/tool_result blocks (conductor's own
+    /// ctrl+o-equivalent toggle; wired up in S1).
+    pub expanded: bool,
+}
+
+/// Block index standing for the blank separator line between entries.
+pub(crate) const SEPARATOR_BLOCK: usize = usize::MAX;
+
+/// Text of the `✻` line marking where a `/compact` cut the context (measured
+/// verbatim from a resumed transcript). Conductor cannot honour the `ctrl+o`
+/// it advertises — the reflow view is the scrollback, and the full history is
+/// already above this line rather than behind a keystroke — but the wording is
+/// reproduced as-is, since parity with what the user saw on screen is the goal.
+const COMPACT_BOUNDARY_TEXT: &str = "Conversation compacted (ctrl+o for history)";
+
+/// Where one rendered line came from, plus the one thing the renderer needs
+/// to know about its shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineMeta {
+    /// Index into `ctx.entries`.
+    pub entry: usize,
+    /// Index of the block within that entry, or [`SEPARATOR_BLOCK`].
+    pub block: usize,
+    /// Index of this line within its block — the third component of the
+    /// scroll anchor, so a rebuild at a different width lands back inside the
+    /// same block rather than just at its top.
+    pub offset: usize,
+    /// Column that must be left *unwritten* so ratatui's diff sees a
+    /// discontinuity and the crossterm backend emits an absolute cursor move
+    /// before the text that follows. See [`width_risk_hole`].
+    pub skip_col: Option<u16>,
+}
+
+/// [`build_lines`]'s output: the lines to blit and one [`LineMeta`] each.
+pub(crate) struct BuiltLines {
+    pub lines: Vec<Line<'static>>,
+    pub meta: Vec<LineMeta>,
+}
+
+/// Rebuild the full line list from `ctx.entries`.
 ///
-/// Called only when the panel width changes.  Uses an `Rc` clone of the
-/// entries (refcount bump only, no deep copy) to release the immutable borrow
-/// on `app.reflow` before calling `app.reflow.cache.render`, which also needs
-/// `&app.reflow.cache` (another field of `app.reflow`).
-pub(crate) fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
-    // Rc clone: O(1), releases the borrow on app.reflow.entries.
-    let entries = std::rc::Rc::clone(&app.reflow.entries);
+/// Called only when the panel width changes (or the expand toggle flips).
+pub(crate) fn build_lines(ctx: &BuildCtx<'_>, width: usize) -> BuiltLines {
+    let entries = ctx.entries;
 
     // Claude's fixed palette (Color is Copy) drives the transcript chrome.
     let style_assistant = Style::default().fg(palette::TEXT);
-    let style_user = Style::default().fg(palette::CLAUDE);
+    // S3 (measured): a user turn is a full-width background block, not a
+    // coral `>` prefix on plain text — both the marker and body carry the
+    // block's background color.
+    let style_user_marker = Style::default()
+        .fg(palette::USER_MARKER_FG)
+        .bg(palette::USER_BG);
+    let style_user_body = Style::default()
+        .fg(palette::USER_TEXT)
+        .bg(palette::USER_BG);
     let style_tool_marker = Style::default().fg(palette::SUCCESS);
+    let style_tool_marker_err = Style::default().fg(palette::ERROR);
     let style_name = Style::default()
         .fg(palette::TEXT)
         .add_modifier(Modifier::BOLD);
-    let style_args = Style::default().fg(palette::INACTIVE);
+    // Tool arguments render in the body's default color, not dimmed — the
+    // native capture shows `⏺ Write(/tmp/out.txt)` with `(...)` in the same
+    // color as ordinary text, not grey.
+    let style_tool_arg = Style::default().fg(palette::TEXT);
     let style_result = Style::default().fg(palette::INACTIVE);
     let style_result_err = Style::default().fg(palette::ERROR);
     let style_thinking = Style::default()
         .fg(palette::INACTIVE)
         .add_modifier(Modifier::ITALIC);
+    let tool_styles = ToolStyles {
+        marker: style_tool_marker,
+        marker_err: style_tool_marker_err,
+        name: style_name,
+        arg: style_tool_arg,
+        result: style_result,
+        result_err: style_result_err,
+    };
 
-    // A Claude-flavored theme so the Markdown body matches the chrome. Cloned
-    // once up front so the loop only borrows the (disjoint) cache/syntax fields.
-    let md_theme = claude_markdown_theme(&app.theme);
+    // A Claude-flavored theme so the Markdown body matches the chrome.
+    let md_theme = claude_markdown_theme(ctx.theme);
 
     // Content width after reserving the marker gutter.
     let body_width = width.saturating_sub(MARKER_COLS);
 
     let mut all_lines: Vec<Line<'static>> = Vec::new();
+    let mut meta: Vec<LineMeta> = Vec::new();
 
     for (ei, entry) in entries.iter().enumerate() {
         let is_user = entry.role == Role::User;
 
+        // Per-entry aggregation state for collapsed `Counted` tool results
+        // (§2.1): pre-counted occurrences per bucket, and which buckets have
+        // already emitted their one summary line in this entry. Built even
+        // when `ctx.expanded` is true but only consulted when it's false —
+        // the cost is one small pass over blocks already being iterated.
+        let bucket_counts = count_buckets(entry);
+        // One shared summary line covers every `Counted` result in the entry
+        // (measured: several buckets render as one comma-joined clause list), so
+        // this is a single latch rather than a per-bucket set.
+        let mut summary_emitted = false;
+
+        // Tracks whether this entry rendered anything, so the separator
+        // below can be skipped for an entry whose blocks all render nothing
+        // (e.g. a `TodoWrite`-only or `Counted`-only `tool_use` entry) —
+        // otherwise it would leave a stray blank line with no content on
+        // either side of it.
+        let lines_before_entry = all_lines.len();
+
         // ── Content blocks (no role header; marker glyphs carry the role) ────
         for (bi, block) in entry.blocks.iter().enumerate() {
+            let lines_before_block = all_lines.len();
+            // A labeled block, not bare `continue`, so each arm can still bail
+            // out early while the per-block bookkeeping below always runs.
+            'block: {
             match block {
                 DisplayBlock::Text(text) => {
+                    if is_user {
+                        // Measured: each text block of a user message is drawn
+                        // as a turn of its own, with a blank line between them
+                        // — a message carrying a prompt plus an appended
+                        // `<system-reminder>` block renders as two separated
+                        // `❯` turns, not one packed pair. The entry-level
+                        // separator further down only fires *between* entries,
+                        // so the gap inside one has to come from here.
+                        if all_lines.len() > lines_before_entry {
+                            all_lines.push(Line::from(""));
+                        }
+                        // User text bypasses Markdown entirely (S3, measured)
+                        // — it's raw input, not prose to parse — and wraps
+                        // its own full-width background block instead of
+                        // sharing the assistant/tool gutter's plain marker.
+                        all_lines.extend(render_user_text(
+                            text,
+                            width,
+                            USER_MARKER,
+                            style_user_marker,
+                            style_user_body,
+                        ));
+                        break 'block;
+                    }
                     let key = format!("{ei}:{bi}");
-                    // app.reflow.cache and the syntax fields are disjoint members
-                    // of `app`, so the simultaneous &mut / & borrows are fine
-                    // under NLL. `md_theme` is a local, independent of `app`.
-                    let md_lines = app.reflow.cache.render_flavored(
+                    let md_lines = ctx.cache.render_flavored(
                         &key,
                         text,
                         body_width,
                         &md_theme,
-                        &app.syntax_set,
-                        &app.syntect_theme,
+                        ctx.syntax_set,
+                        ctx.syntect_theme,
                         crate::ui::markdown::MarkdownFlavor::Transcript,
                     );
-                    let (glyph, marker_style) = if is_user {
-                        (USER_MARKER, style_user)
-                    } else {
-                        (ASSISTANT_MARKER, style_assistant)
-                    };
-                    all_lines.extend(with_marker(md_lines, glyph, marker_style));
+                    all_lines.extend(with_marker(md_lines, ASSISTANT_MARKER, style_assistant));
                 }
-                DisplayBlock::ToolUse { name, summary } => {
-                    // ⏺ Name(summary) — green bullet, bold name, dim args.
-                    let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
-                    let remaining = width.saturating_sub(MARKER_COLS);
-                    let line = if summary.is_empty() {
-                        let name_display = truncate_to_width(name, remaining);
-                        Line::from(vec![
-                            Span::styled(marker_prefix, style_tool_marker),
-                            Span::styled(name_display, style_name),
-                        ])
-                    } else {
-                        let name_cols = name.width();
-                        // Budget for summary: remaining minus name cols and two parens.
-                        let summary_budget = remaining.saturating_sub(name_cols + 2);
-                        let summary_display = truncate_to_width(summary, summary_budget);
-                        Line::from(vec![
-                            Span::styled(marker_prefix, style_tool_marker),
-                            Span::styled(name.clone(), style_name),
-                            Span::styled(format!("({summary_display})"), style_args),
-                        ])
-                    };
-                    all_lines.push(line);
+                DisplayBlock::ToolUse { name, input, errored } => {
+                    if let Some(line) = render_tool_use(
+                        name,
+                        input,
+                        *errored,
+                        ctx.expanded,
+                        width,
+                        &tool_styles,
+                    ) {
+                        all_lines.push(line);
+                    }
                 }
                 DisplayBlock::ToolResult {
-                    preview,
-                    total_lines,
+                    kind,
+                    lines,
                     is_error,
                 } => {
-                    all_lines.extend(render_tool_result(
-                        preview,
-                        *total_lines,
-                        *is_error,
-                        width,
-                        style_result,
-                        style_result_err,
-                    ));
+                    if ctx.expanded {
+                        all_lines.extend(render_tool_result_expanded(
+                            lines,
+                            *is_error,
+                            width,
+                            &tool_styles,
+                        ));
+                    } else {
+                        all_lines.extend(render_tool_result_collapsed(
+                            *kind,
+                            lines,
+                            *is_error,
+                            &bucket_counts,
+                            &mut summary_emitted,
+                            width,
+                            &tool_styles,
+                        ));
+                    }
                 }
-                DisplayBlock::Thinking { text } => {
-                    // ✻ Thinking… header, then the (dimmed, italic) reasoning body.
+                DisplayBlock::Thinking { text, duration_secs } => {
+                    if !ctx.expanded {
+                        // Collapsed mode: one line, no glyph, indented to the
+                        // marker column — "  Thought for {N}s (ctrl+o to
+                        // expand)", the whole line INACTIVE except the
+                        // duration itself, which is bold.
+                        all_lines.push(fit_styled_line(
+                            MARKER_COLS,
+                            &[
+                                ("Thought for ".to_string(), style_result),
+                                (
+                                    format!("{duration_secs}s"),
+                                    style_result.add_modifier(Modifier::BOLD),
+                                ),
+                                (" (ctrl+o to expand)".to_string(), style_result),
+                            ],
+                            width,
+                        ));
+                        break 'block;
+                    }
+
+                    // Expanded mode: ✻ Thinking… header, then the (dimmed,
+                    // italic) reasoning body — unchanged from before S2b.
                     let marker_prefix = pad_glyph_to(THINKING_GLYPH, MARKER_COLS);
                     all_lines.push(Line::from(vec![
                         Span::styled(marker_prefix, style_thinking),
@@ -120,13 +251,13 @@ pub(crate) fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
                     ]));
                     if !text.trim().is_empty() {
                         let key = format!("{ei}:{bi}:think");
-                        let md_lines = app.reflow.cache.render_flavored(
+                        let md_lines = ctx.cache.render_flavored(
                             &key,
                             text,
                             body_width,
                             &md_theme,
-                            &app.syntax_set,
-                            &app.syntect_theme,
+                            ctx.syntax_set,
+                            ctx.syntect_theme,
                             crate::ui::markdown::MarkdownFlavor::Transcript,
                         );
                         // Recolor the Markdown output to dim italic and indent it
@@ -145,58 +276,144 @@ pub(crate) fn build_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
                         all_lines.extend(with_marker(dimmed, " ", style_thinking));
                     }
                 }
+                DisplayBlock::TeammateMessage { id, body } => {
+                    // S4 (Conductor's own construct, not a Claude Code CLI
+                    // form): collapsed to one line, no background block —
+                    // the `›` glyph carries the whole thing in `INACTIVE`.
+                    let marker_prefix = pad_glyph_to(TEAMMATE_MESSAGE_GLYPH, MARKER_COLS);
+                    if !ctx.expanded {
+                        all_lines.push(Line::from(vec![
+                            Span::styled(marker_prefix, style_result),
+                            Span::styled(
+                                format!("Message from @{id} (ctrl+o to expand)"),
+                                style_result,
+                            ),
+                        ]));
+                        break 'block;
+                    }
+
+                    // Expanded mode: the header line drops the toggle hint
+                    // (already expanded), then the full body follows indented
+                    // 2 cols — Markdown-rendered like any other prose block,
+                    // since a teammate message is ordinary chat content, not
+                    // a secondary annotation the way a thinking block is.
+                    all_lines.push(Line::from(vec![
+                        Span::styled(marker_prefix, style_result),
+                        Span::styled(format!("Message from @{id}"), style_result),
+                    ]));
+                    if !body.trim().is_empty() {
+                        let key = format!("{ei}:{bi}:teammate");
+                        let md_lines = ctx.cache.render_flavored(
+                            &key,
+                            body,
+                            body_width,
+                            &md_theme,
+                            ctx.syntax_set,
+                            ctx.syntect_theme,
+                            crate::ui::markdown::MarkdownFlavor::Transcript,
+                        );
+                        all_lines.extend(with_marker(md_lines, " ", style_result));
+                    }
+                }
+                DisplayBlock::Annotation { lines } => {
+                    all_lines.extend(render_annotation(lines, width, &tool_styles));
+                }
+                DisplayBlock::Notice(text) => {
+                    // `⏺ {text}`, in the assistant body color: measured, a
+                    // task-notification is drawn with the same bullet as an
+                    // assistant turn rather than a tool's green one. (The
+                    // exact hue is not recoverable from a byte capture; the
+                    // assistant color is the reading that matches its
+                    // position in the transcript.)
+                    all_lines.push(fit_glyph_line(
+                        ASSISTANT_MARKER,
+                        &[(text.clone(), style_assistant)],
+                        width,
+                    ));
+                }
+                DisplayBlock::CompactBoundary => {
+                    all_lines.push(fit_glyph_line(
+                        THINKING_GLYPH,
+                        &[(COMPACT_BOUNDARY_TEXT.to_string(), style_result)],
+                        width,
+                    ));
+                }
             }
+            }
+            meta.extend(
+                (0..all_lines.len() - lines_before_block).map(|offset| LineMeta {
+                    entry: ei,
+                    block: bi,
+                    offset,
+                    skip_col: None,
+                }),
+            );
         }
 
         // ── Blank separator between entries ──────────────────────────────────
-        all_lines.push(Line::from(""));
-    }
-
-    all_lines
-}
-
-/// Render a tool result as Claude Code's collapsed `⎿` block: the first line
-/// hangs off the corner glyph, continuations align under it, and any overflow
-/// beyond the captured preview collapses into a `… +N lines` summary.
-fn render_tool_result(
-    preview: &[String],
-    total_lines: usize,
-    is_error: bool,
-    width: usize,
-    body_style: Style,
-    err_style: Style,
-) -> Vec<Line<'static>> {
-    // "  ⎿  " — 2-space indent + 1-col glyph + 2 spaces = 5 columns; continuation
-    // lines indent by the same amount so output text stays left-aligned.
-    let first_prefix = format!("  {TOOL_RESULT_GLYPH}  ");
-    let prefix_cols = UnicodeWidthStr::width(first_prefix.as_str());
-    let cont_indent = " ".repeat(prefix_cols);
-    let connector_style = if is_error { err_style } else { body_style };
-
-    if total_lines == 0 {
-        let s = truncate_to_width(&format!("{first_prefix}(no content)"), width);
-        return vec![Line::from(vec![Span::styled(s, connector_style)])];
-    }
-
-    let mut out: Vec<Line<'static>> = Vec::new();
-    for (i, raw) in preview.iter().enumerate() {
-        let body = truncate_to_width(raw, width.saturating_sub(prefix_cols));
-        if i == 0 {
-            out.push(Line::from(vec![
-                Span::styled(first_prefix.clone(), connector_style),
-                Span::styled(body, body_style),
-            ]));
-        } else {
-            out.push(Line::from(vec![
-                Span::raw(cont_indent.clone()),
-                Span::styled(body, body_style),
-            ]));
+        // An annotation-only entry is a *continuation* of the entry above it,
+        // not a turn of its own — the CLI records a slash command, its stdout
+        // and each carried-over file as separate records but draws them as one
+        // uninterrupted group:
+        //
+        //     ❯ /compact
+        //       ⎿  Compacted (ctrl+o to see full summary)
+        //       ⎿  Read alpha.rs (42 lines)
+        //
+        // so the separator that would normally land in front of one is
+        // suppressed.
+        let next_is_continuation = entries.get(ei + 1).is_some_and(is_annotation_only);
+        if !next_is_continuation && all_lines.len() > lines_before_entry {
+            all_lines.push(Line::from(""));
+            meta.push(LineMeta {
+                entry: ei,
+                block: SEPARATOR_BLOCK,
+                offset: 0,
+                skip_col: None,
+            });
         }
     }
-    if total_lines > preview.len() {
-        let more = total_lines - preview.len();
-        let s = truncate_to_width(&format!("{cont_indent}\u{2026} +{more} lines"), width);
-        out.push(Line::from(vec![Span::styled(s, body_style)]));
+
+    // One final pass resolves each line's width-risk hole; doing it here keeps
+    // every producer above free of gutter-geometry concerns.
+    for (line, m) in all_lines.iter().zip(meta.iter_mut()) {
+        m.skip_col = width_risk_hole(line);
     }
-    out
+
+    debug_assert_eq!(all_lines.len(), meta.len());
+    BuiltLines { lines: all_lines, meta }
+}
+
+/// Whether `entry` consists solely of [`DisplayBlock::Annotation`] blocks, and
+/// so glues to the entry above it instead of starting a new turn.
+fn is_annotation_only(entry: &LogEntry) -> bool {
+    !entry.blocks.is_empty()
+        && entry
+            .blocks
+            .iter()
+            .all(|b| matches!(b, DisplayBlock::Annotation { .. }))
+}
+
+/// The column immediately after the first width-ambiguous gutter glyph on
+/// `line`, if it has one.
+///
+/// `⏺`/`⎿`/`✻` measure one column in `unicode-width` but many terminals draw
+/// them two columns wide, which used to shift the whole row (the scrollback
+/// "bleed"). Claude Code itself sidesteps this by emitting an absolute column
+/// (CHA) right after the glyph; leaving this one cell unwritten makes
+/// ratatui's diff discontinuous there, which makes the crossterm backend emit
+/// an absolute `MoveTo` — the same trick. Verified against the real backend
+/// in `super::render`'s tests.
+fn width_risk_hole(line: &Line<'_>) -> Option<u16> {
+    let mut col: usize = 0;
+    for span in &line.spans {
+        for ch in span.content.chars() {
+            let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+            if super::glyphs::is_width_ambiguous(ch) {
+                return u16::try_from(col + w).ok();
+            }
+            col += w;
+        }
+    }
+    None
 }

--- a/src/ui/reflow_view/build_tests.rs
+++ b/src/ui/reflow_view/build_tests.rs
@@ -1,0 +1,988 @@
+//! Tests for [`super::build::build_lines`] — the tool-rendering pipeline that
+//! turns a session log's [`LogEntry`] list into transcript lines. Exercised
+//! directly against a hand-built [`BuildCtx`], with no `App` in sight: the
+//! whole point of the `BuildCtx` split (S0) is that this pipeline is
+//! testable without constructing the application state.
+//!
+//! The tool-call cases below assert against the classification table in
+//! `crate::claude_log::tool_class` (§2.1 of
+//! `docs/plans/2026-07-31-native-render-parity.md`), reconstructed from a
+//! raw-byte capture of Claude Code's own transcript — not a guess.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use serde_json::json;
+use syntect::highlighting::ThemeSet;
+
+use crate::claude_log::{CountedBucket, DisplayBlock, LogEntry, ResultKind, Role};
+use crate::ui::markdown::MarkdownCache;
+
+use super::build::{BuildCtx, build_lines};
+use super::glyphs::{ASSISTANT_MARKER, THINKING_GLYPH, TOOL_RESULT_GLYPH, USER_MARKER};
+use super::palette;
+
+fn fixtures() -> (
+    crate::theme::Theme,
+    syntect::parsing::SyntaxSet,
+    syntect::highlighting::Theme,
+) {
+    let theme = crate::theme::Theme::default();
+    let syntax_set = two_face::syntax::extra_newlines();
+    let syntect_theme = ThemeSet::load_defaults()
+        .themes
+        .remove("base16-ocean.dark")
+        .unwrap();
+    (theme, syntax_set, syntect_theme)
+}
+
+/// `build_lines` must be callable with only borrowed fixtures — no `App`
+/// constructed anywhere in this test. An empty entry list is a degenerate
+/// but valid input.
+#[test]
+fn build_lines_runs_without_an_app() {
+    let (theme, syntax_set, syntect_theme) = fixtures();
+    let cache = MarkdownCache::new();
+    let entries: Vec<LogEntry> = Vec::new();
+    let ctx = BuildCtx {
+        entries: &entries,
+        cache: &cache,
+        theme: &theme,
+        syntax_set: &syntax_set,
+        syntect_theme: &syntect_theme,
+        expanded: false,
+    };
+
+    let built = build_lines(&ctx, 80);
+
+    assert!(built.lines.is_empty());
+    assert!(built.meta.is_empty());
+}
+
+// ── Fixture helpers for the tool-call rendering table below ──────────────
+
+fn tool_use(name: &str, input: serde_json::Value) -> DisplayBlock {
+    tool_use_errored(name, input, false)
+}
+
+fn tool_use_errored(name: &str, input: serde_json::Value, errored: bool) -> DisplayBlock {
+    DisplayBlock::ToolUse {
+        name: name.to_string(),
+        input,
+        errored,
+    }
+}
+
+/// `kind` is the *already-resolved* pairing-map value — the same value
+/// `crate::claude_log::convert::content_to_display_blocks` would have
+/// written during parsing. Building it pre-resolved here keeps these tests
+/// focused on `build_lines`'s rendering rules rather than re-testing the
+/// pairing map (covered separately by `claude_log::tests` and
+/// `tool_class::tests`).
+fn tool_result(kind: ResultKind, lines: &[&str], is_error: bool) -> DisplayBlock {
+    DisplayBlock::ToolResult {
+        kind,
+        lines: lines.iter().map(|s| s.to_string()).collect(),
+        is_error,
+    }
+}
+
+fn thinking(text: &str, duration_secs: u64) -> DisplayBlock {
+    DisplayBlock::Thinking {
+        text: text.to_string(),
+        duration_secs,
+    }
+}
+
+fn teammate_message(id: &str, body: &str) -> DisplayBlock {
+    DisplayBlock::TeammateMessage {
+        id: id.to_string(),
+        body: body.to_string(),
+    }
+}
+
+fn entry(role: Role, blocks: Vec<DisplayBlock>) -> LogEntry {
+    LogEntry {
+        role,
+        model: None,
+        blocks,
+    }
+}
+
+fn build(entries: &[LogEntry], expanded: bool) -> Vec<Line<'static>> {
+    let (theme, syntax_set, syntect_theme) = fixtures();
+    let cache = MarkdownCache::new();
+    let ctx = BuildCtx {
+        entries,
+        cache: &cache,
+        theme: &theme,
+        syntax_set: &syntax_set,
+        syntect_theme: &syntect_theme,
+        expanded,
+    };
+    build_lines(&ctx, 80).lines
+}
+
+fn line_text(line: &Line<'_>) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+/// Every rendered line's text, trimmed and with blank (entry-separator)
+/// lines dropped — the shape most of these tests care about.
+fn non_blank_texts(lines: &[Line<'_>]) -> Vec<String> {
+    lines
+        .iter()
+        .map(line_text)
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+/// The single visible (non-blank) line, panicking if there isn't exactly one
+/// — used by the style-assertion tests below, which need the actual `Line`
+/// (not just its text) to inspect span styles.
+fn only_visible_line<'a>(lines: &'a [Line<'a>]) -> &'a Line<'a> {
+    let visible: Vec<&Line<'_>> = lines
+        .iter()
+        .filter(|l| !line_text(l).trim().is_empty())
+        .collect();
+    assert_eq!(visible.len(), 1, "expected exactly one visible line, got {visible:?}");
+    visible[0]
+}
+
+// ── Counted category: aggregation into one summary line ──────────────────
+
+#[test]
+fn read_results_collapse_into_aggregated_count_line() {
+    let entries = vec![
+        entry(Role::Assistant, vec![tool_use("Read", json!({"file_path": "/a"}))]),
+        entry(
+            Role::User,
+            vec![
+                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["a"], false),
+                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["b"], false),
+                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["c"], false),
+            ],
+        ),
+    ];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Read 3 files (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn read_results_singular_count_uses_singular_noun() {
+    let entries = vec![entry(
+        Role::User,
+        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["a"], false)],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Read 1 file (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn grep_and_glob_share_one_search_bucket_summary() {
+    // Both classify to `CountedBucket::Search`, so results from either
+    // resolve to the same bucket and merge here.
+    let entries = vec![entry(
+        Role::User,
+        vec![
+            tool_result(ResultKind::Counted { bucket: CountedBucket::Search, from_bash: false }, &["match1"], false),
+            tool_result(ResultKind::Counted { bucket: CountedBucket::Search, from_bash: false }, &["match2"], false),
+        ],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Searched for 2 patterns (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn bash_ls_collapses_to_listed_directories_summary() {
+    let entries = vec![entry(
+        Role::User,
+        vec![
+            tool_result(ResultKind::Counted { bucket: CountedBucket::List, from_bash: true }, &["a"], false),
+            tool_result(ResultKind::Counted { bucket: CountedBucket::List, from_bash: true }, &["b"], false),
+        ],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Listed 2 directories (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn bash_cat_merges_with_read_bucket_summary() {
+    // One result from a real `Read` tool call, one from `cat` via `Bash` —
+    // both resolve to the `Read` bucket and merge into one line.
+    let entries = vec![entry(
+        Role::User,
+        vec![
+            tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["file a contents"], false),
+            tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["file b contents"], false),
+        ],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Read 2 files (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn counted_result_ignores_is_error_and_still_aggregates_normally() {
+    // Corrected spec (measured): `Counted` completely ignores `is_error` — a
+    // failed `Read` still folds into the plain gray summary line, with no
+    // error styling at all.
+    let entries = vec![entry(
+        Role::User,
+        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["boom: file not found"], true)],
+    )];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+
+    assert_eq!(line_text(line).trim(), "Read 1 file (ctrl+o to expand)");
+    for span in &line.spans {
+        assert_ne!(span.style, Style::default().fg(palette::ERROR));
+    }
+}
+
+// ── Inline category: per-call `⏺ Name(arg)` line ──────────────────────────
+
+#[test]
+fn edit_tool_collapses_to_update_display_name() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("Edit", json!({"file_path": "/tmp/out.txt"}))],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec![format!("{ASSISTANT_MARKER} Update(/tmp/out.txt)")]
+    );
+}
+
+#[test]
+fn task_tool_collapses_to_agent_display_name() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("Task", json!({"description": "investigate bug"}))],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec![format!("{ASSISTANT_MARKER} Agent(investigate bug)")]
+    );
+}
+
+#[test]
+fn webfetch_tool_collapses_to_fetch_display_name() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("WebFetch", json!({"url": "https://example.com"}))],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec![format!("{ASSISTANT_MARKER} Fetch(https://example.com)")]
+    );
+}
+
+#[test]
+fn unknown_tool_falls_back_to_raw_name_and_generic_arg() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("WebSearch", json!({"query": "some search term"}))],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec![format!("{ASSISTANT_MARKER} WebSearch(some search term)")]
+    );
+}
+
+#[test]
+fn inline_tool_use_renders_bold_name_and_text_colored_arg_not_gray() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("Write", json!({"file_path": "/tmp/out.txt"}))],
+    )];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+
+    assert_eq!(line.spans.len(), 3, "marker + name + arg spans, got {line:?}");
+    assert_eq!(line.spans[0].style, Style::default().fg(palette::SUCCESS));
+    assert_eq!(line.spans[1].content.as_ref(), "Write");
+    assert_eq!(
+        line.spans[1].style,
+        Style::default().fg(palette::TEXT).add_modifier(Modifier::BOLD)
+    );
+    assert_eq!(line.spans[2].content.as_ref(), "(/tmp/out.txt)");
+    // The native capture shows the argument in the same color as body text,
+    // not dimmed — this must NOT be `palette::INACTIVE`.
+    assert_eq!(line.spans[2].style, Style::default().fg(palette::TEXT));
+    assert_ne!(line.spans[2].style, Style::default().fg(palette::INACTIVE));
+}
+
+// ── Hidden category: draws nothing, in either position ────────────────────
+
+#[test]
+fn todowrite_renders_nothing_in_collapsed_mode() {
+    let entries = vec![
+        entry(Role::Assistant, vec![tool_use("TodoWrite", json!({"todos": []}))]),
+        entry(Role::User, vec![tool_result(ResultKind::Inline, &["ok"], false)]),
+    ];
+    let lines = build(&entries, false);
+    assert!(non_blank_texts(&lines).is_empty());
+}
+
+// ── Errors: only `Inline` category draws a result line; `Counted` is
+// covered above (it ignores `is_error` completely) ────────────────────────
+
+#[test]
+fn inline_error_result_draws_multiline_error_block() {
+    // Measured column layout for a failed `Bash(false)` call: `⎿` at col2,
+    // body (with a prepended "Error: ") from col4 on the first line, body
+    // from col5 on continuation lines, no "Error: " prefix past the first.
+    let entries = vec![entry(
+        Role::User,
+        vec![tool_result(ResultKind::Inline,
+            &[
+                "bash: command failed with exit code 1",
+                "second line of the error",
+            ],
+            true,
+        )],
+    )];
+    let lines = build(&entries, false);
+    let visible: Vec<&Line<'_>> = lines
+        .iter()
+        .filter(|l| !line_text(l).trim().is_empty())
+        .collect();
+    assert_eq!(visible.len(), 2, "first + continuation error line, got {visible:?}");
+
+    let first = visible[0];
+    assert_eq!(
+        line_text(first),
+        format!("  {TOOL_RESULT_GLYPH}  Error: bash: command failed with exit code 1")
+    );
+    assert_eq!(first.spans[0].content.as_ref(), " ");
+    assert_ne!(first.spans[0].style, Style::default().fg(palette::ERROR));
+    assert_eq!(first.spans[1].style, Style::default().fg(palette::ERROR));
+    assert_eq!(first.spans[2].style, Style::default().fg(palette::ERROR));
+
+    let cont = visible[1];
+    assert_eq!(line_text(cont), "     second line of the error");
+    assert!(
+        !line_text(cont).contains("Error:"),
+        "only the first error line gets the \"Error: \" prefix"
+    );
+    for span in &cont.spans {
+        if !span.content.trim().is_empty() {
+            assert_eq!(span.style, Style::default().fg(palette::ERROR));
+        }
+    }
+}
+
+#[test]
+fn non_erroring_inline_result_renders_nothing() {
+    let entries = vec![entry(
+        Role::User,
+        vec![tool_result(ResultKind::Inline, &["all good"], false)],
+    )];
+    let lines = build(&entries, false);
+    assert!(non_blank_texts(&lines).is_empty());
+}
+
+#[test]
+fn errored_tool_use_marker_turns_error_colored() {
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use_errored("Bash", json!({"command": "false"}), true)],
+    )];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+
+    assert_eq!(line.spans[0].style, Style::default().fg(palette::ERROR));
+    assert_ne!(line.spans[0].style, Style::default().fg(palette::SUCCESS));
+}
+
+// ── Thinking blocks: collapsed one-liner vs. expanded header+body (S2b) ───
+
+#[test]
+fn thinking_block_collapsed_renders_one_line_summary() {
+    let entries = vec![entry(Role::Assistant, vec![thinking("let me reason", 12)])];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["Thought for 12s (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn thinking_block_collapsed_has_no_glyph_and_starts_at_column_two() {
+    // Spec: col2, no glyph — a plain two-space indent, not the `*` marker the
+    // expanded header uses.
+    let entries = vec![entry(Role::Assistant, vec![thinking("let me reason", 3)])];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+    assert_eq!(line_text(line), "  Thought for 3s (ctrl+o to expand)");
+}
+
+#[test]
+fn thinking_block_collapsed_bolds_only_the_duration_span() {
+    let entries = vec![entry(Role::Assistant, vec![thinking("let me reason", 12)])];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+
+    let bold_span = line
+        .spans
+        .iter()
+        .find(|s| s.content.as_ref() == "12s")
+        .expect("a span with exactly the duration text");
+    assert!(bold_span.style.add_modifier.contains(Modifier::BOLD));
+    assert_eq!(bold_span.style.fg, Some(palette::INACTIVE));
+
+    for span in &line.spans {
+        if span.content.as_ref() != "12s" {
+            assert!(
+                !span.style.add_modifier.contains(Modifier::BOLD),
+                "only the duration span should be bold, got bold: {span:?}"
+            );
+            // The leading gutter is blank and carries no style — native writes
+            // nothing there at all, jumping straight to column 3 — so only the
+            // text spans are checked for colour.
+            if !span.content.trim().is_empty() {
+                assert_eq!(span.style.fg, Some(palette::INACTIVE));
+            }
+        }
+    }
+}
+
+#[test]
+fn thinking_block_expanded_shows_header_and_body_unchanged() {
+    let entries = vec![entry(Role::Assistant, vec![thinking("let me reason", 12)])];
+    let lines = build(&entries, true);
+    let texts = non_blank_texts(&lines);
+    assert_eq!(texts[0], format!("{THINKING_GLYPH} Thinking\u{2026}"));
+    assert!(
+        texts.iter().any(|t| t.contains("let me reason")),
+        "expanded mode must still render the reasoning body: {texts:?}"
+    );
+    assert!(
+        !texts.iter().any(|t| t.contains("Thought for")),
+        "expanded mode must not show the collapsed one-liner: {texts:?}"
+    );
+}
+
+// ── Teammate-message blocks: collapsed summary vs. expanded body (S4) ─────
+
+#[test]
+fn teammate_message_collapsed_renders_one_line_summary() {
+    let entries = vec![entry(
+        Role::User,
+        vec![teammate_message("alice", "please review PR 42")],
+    )];
+    let lines = build(&entries, false);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec!["\u{203a} Message from @alice (ctrl+o to expand)".to_string()]
+    );
+}
+
+#[test]
+fn teammate_message_collapsed_line_is_entirely_inactive() {
+    let entries = vec![entry(
+        Role::User,
+        vec![teammate_message("alice", "please review PR 42")],
+    )];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+    for span in &line.spans {
+        assert_eq!(span.style.fg, Some(palette::INACTIVE));
+        assert_eq!(span.style.bg, None, "spec: no background block, unlike S3 user turns");
+    }
+}
+
+#[test]
+fn teammate_message_collapsed_ignores_the_body_entirely() {
+    // Only the id renders in collapsed mode — the body text must not leak
+    // into the summary line even if short.
+    let entries = vec![entry(
+        Role::User,
+        vec![teammate_message("alice", "hi")],
+    )];
+    let lines = build(&entries, false);
+    let texts = non_blank_texts(&lines);
+    assert_eq!(texts.len(), 1);
+    assert!(!texts[0].contains("hi"));
+}
+
+#[test]
+fn teammate_message_expanded_shows_header_without_hint_then_body() {
+    let entries = vec![entry(
+        Role::User,
+        vec![teammate_message("alice", "please review PR 42")],
+    )];
+    let lines = build(&entries, true);
+    let texts = non_blank_texts(&lines);
+    assert_eq!(texts[0], "\u{203a} Message from @alice");
+    assert!(
+        !texts[0].contains("ctrl+o to expand"),
+        "expanded header must drop the collapsed-mode toggle hint: {texts:?}"
+    );
+    assert!(
+        texts.iter().any(|t| t.contains("please review PR 42")),
+        "expanded mode must render the full body: {texts:?}"
+    );
+}
+
+// ── Expanded mode (conductor's own ctrl+o-equivalent toggle) ──────────────
+
+#[test]
+fn expanded_mode_shows_raw_tool_name_not_the_collapsed_alias() {
+    // Collapsed mode renders `Edit` as `Update`; expanded mode must show the
+    // tool's own raw name instead, since it draws every call individually.
+    let entries = vec![entry(
+        Role::Assistant,
+        vec![tool_use("Edit", json!({"file_path": "/tmp/out.txt"}))],
+    )];
+    let lines = build(&entries, true);
+    assert_eq!(
+        non_blank_texts(&lines),
+        vec![format!("{ASSISTANT_MARKER} Edit(/tmp/out.txt)")]
+    );
+}
+
+// ── S3: user turns render as a full-width background block ────────────────
+
+#[test]
+fn user_text_renders_the_marker_glyph_not_the_assistant_bullet() {
+    let entries = vec![entry(Role::User, vec![DisplayBlock::Text("hi".to_string())])];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+    assert_eq!(line.spans[0].content, "\u{276f} ");
+}
+
+#[test]
+fn user_text_marker_and_body_carry_the_background_fill_color() {
+    let entries = vec![entry(Role::User, vec![DisplayBlock::Text("hi".to_string())])];
+    let lines = build(&entries, false);
+    let line = only_visible_line(&lines);
+    for span in &line.spans {
+        assert_eq!(span.style.bg, Some(palette::USER_BG), "span {span:?} missing background fill");
+    }
+    assert_eq!(line.spans[0].style.fg, Some(palette::USER_MARKER_FG));
+    assert_eq!(line.spans[1].style.fg, Some(palette::USER_TEXT));
+}
+
+#[test]
+fn user_text_bypasses_markdown_rendering() {
+    // Markdown syntax in a user prompt must render as literal characters —
+    // no bold/heading/etc. parsing — since user input is raw text, not prose.
+    let entries = vec![entry(
+        Role::User,
+        vec![DisplayBlock::Text("**not bold** # not a heading".to_string())],
+    )];
+    let lines = build(&entries, false);
+    let texts = non_blank_texts(&lines);
+    assert_eq!(texts.len(), 1);
+    assert!(
+        texts[0].contains("**not bold** # not a heading"),
+        "expected literal markdown syntax, got: {texts:?}"
+    );
+}
+
+#[test]
+fn user_text_preserves_source_newlines_as_separate_lines() {
+    let entries = vec![entry(
+        Role::User,
+        vec![DisplayBlock::Text("first line\nsecond line".to_string())],
+    )];
+    let lines = build(&entries, false);
+    let texts = non_blank_texts(&lines);
+    assert_eq!(texts, vec!["\u{276f} first line", "second line"]);
+}
+
+// ── S2: no stray blank line for an entry with zero visible blocks ─────────
+
+#[test]
+fn entries_with_no_visible_blocks_produce_no_stray_blank_line() {
+    // A `TodoWrite`-only entry (`Hidden` category) sits between two visible
+    // text turns. It must contribute nothing — not even its own blank
+    // separator — so there is exactly one blank line between "hello" and
+    // "world", not two.
+    let entries = vec![
+        entry(Role::User, vec![DisplayBlock::Text("hello".to_string())]),
+        entry(
+            Role::Assistant,
+            vec![tool_use("TodoWrite", json!({"todos": []}))],
+        ),
+        entry(Role::User, vec![DisplayBlock::Text("world".to_string())]),
+    ];
+    let lines = build(&entries, false);
+    let texts: Vec<String> = lines.iter().map(line_text).collect();
+
+    let hello_idx = texts
+        .iter()
+        .position(|t| t.contains("hello"))
+        .expect("hello line present");
+    let world_idx = texts
+        .iter()
+        .position(|t| t.contains("world"))
+        .expect("world line present");
+    assert_eq!(
+        world_idx - hello_idx,
+        2,
+        "expected exactly one blank line between entries, got: {texts:?}"
+    );
+}
+
+#[test]
+fn counted_only_tool_use_entry_produces_no_stray_blank_line() {
+    // A `Read` `tool_use` (Counted category) draws nothing at the
+    // `tool_use` position — the aggregated summary draws at the paired
+    // `tool_result`'s position instead (see the Counted-aggregation tests
+    // above). An entry holding only such a call must not contribute a
+    // blank separator either.
+    let entries = vec![
+        entry(Role::User, vec![DisplayBlock::Text("hello".to_string())]),
+        entry(
+            Role::Assistant,
+            vec![tool_use("Read", json!({"file_path": "/a.txt"}))],
+        ),
+        entry(Role::User, vec![DisplayBlock::Text("world".to_string())]),
+    ];
+    let lines = build(&entries, false);
+    let texts: Vec<String> = lines.iter().map(line_text).collect();
+
+    let hello_idx = texts
+        .iter()
+        .position(|t| t.contains("hello"))
+        .expect("hello line present");
+    let world_idx = texts
+        .iter()
+        .position(|t| t.contains("world"))
+        .expect("world line present");
+    assert_eq!(
+        world_idx - hello_idx,
+        2,
+        "expected exactly one blank line between entries, got: {texts:?}"
+    );
+}
+
+#[test]
+fn expanded_mode_shows_every_result_line_with_no_cap() {
+    let raw_lines: Vec<String> = (0..12).map(|i| format!("line{i}")).collect();
+    let raw_refs: Vec<&str> = raw_lines.iter().map(String::as_str).collect();
+    let entries = vec![entry(
+        Role::User,
+        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &raw_refs, false)],
+    )];
+    let lines = build(&entries, true);
+    let texts = non_blank_texts(&lines);
+
+    assert_eq!(texts.len(), 12, "no cap on expanded result lines: {texts:?}");
+    for (i, text) in texts.iter().enumerate() {
+        assert!(
+            text.ends_with(&format!("line{i}")),
+            "line {i} should end with its own content, got {text:?}"
+        );
+    }
+}
+
+// ── Aggregation rules measured against Claude Code (plan §4.9) ───────────
+
+/// Build a user entry holding one result per `(kind, is_error)` pair.
+fn results_entry(kinds: &[(ResultKind, bool)]) -> LogEntry {
+    LogEntry {
+        role: Role::User,
+        model: None,
+        blocks: kinds
+            .iter()
+            .map(|(k, e)| tool_result(*k, &["out"], *e))
+            .collect(),
+    }
+}
+
+fn counted(bucket: CountedBucket, from_bash: bool) -> ResultKind {
+    ResultKind::Counted { bucket, from_bash }
+}
+
+#[test]
+fn hidden_result_draws_nothing_even_when_it_errored() {
+    // Measured: a `TodoWrite` whose result carried `is_error` produced not a
+    // single line of native output. Hidden stays hidden on failure.
+    let entries = vec![results_entry(&[(ResultKind::Hidden, true)])];
+    assert!(non_blank_texts(&build(&entries, false)).is_empty());
+}
+
+#[test]
+fn several_buckets_fold_into_one_comma_joined_line() {
+    // Measured: ls x2 + Grep + Read renders as a single line, clauses ordered
+    // search -> read -> list, only the first verb capitalised.
+    let entries = vec![results_entry(&[
+        (counted(CountedBucket::List, true), false),
+        (counted(CountedBucket::List, true), false),
+        (counted(CountedBucket::Search, false), false),
+        (counted(CountedBucket::Read, false), false),
+    ])];
+    assert_eq!(
+        non_blank_texts(&build(&entries, false)),
+        vec!["Searched for 1 pattern, read 1 file, listed 2 directories (ctrl+o to expand)"]
+    );
+}
+
+#[test]
+fn two_buckets_keep_the_measured_order_and_casing() {
+    // Measured: ls + Read renders "Read 1 file, listed 1 directory".
+    let entries = vec![results_entry(&[
+        (counted(CountedBucket::List, true), false),
+        (counted(CountedBucket::Read, false), false),
+    ])];
+    assert_eq!(
+        non_blank_texts(&build(&entries, false)),
+        vec!["Read 1 file, listed 1 directory (ctrl+o to expand)"]
+    );
+}
+
+#[test]
+fn shell_cat_counts_only_when_the_read_tool_is_absent() {
+    // The five measured combinations of `Bash(cat ...)` and `Read`.
+    let cases: [(&[(ResultKind, bool)], &str); 5] = [
+        (&[(counted(CountedBucket::Read, true), false)], "Read 1 file"),
+        (
+            &[
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, true), false),
+            ],
+            "Read 2 files",
+        ),
+        (
+            &[
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, false), false),
+            ],
+            "Read 1 file",
+        ),
+        (
+            &[
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, false), false),
+                (counted(CountedBucket::Read, false), false),
+            ],
+            "Read 2 files",
+        ),
+        (
+            &[
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, true), false),
+                (counted(CountedBucket::Read, false), false),
+            ],
+            "Read 1 file",
+        ),
+    ];
+    for (kinds, expected) in cases {
+        let entries = vec![results_entry(kinds)];
+        assert_eq!(
+            non_blank_texts(&build(&entries, false)),
+            vec![format!("{expected} (ctrl+o to expand)")],
+            "for {kinds:?}"
+        );
+    }
+}
+
+#[test]
+fn counted_result_ignores_is_error_entirely() {
+    // Measured: a failed `Read` still folds into the plain summary.
+    let entries = vec![results_entry(&[(counted(CountedBucket::Read, false), true)])];
+    assert_eq!(
+        non_blank_texts(&build(&entries, false)),
+        vec!["Read 1 file (ctrl+o to expand)"]
+    );
+}
+
+// ── Compact boundary / annotations (measured, see `claude_log::tests`) ────
+
+fn annotation(text: &str) -> DisplayBlock {
+    DisplayBlock::Annotation {
+        lines: vec![text.to_string()],
+    }
+}
+
+/// The whole `/compact` group, byte-for-byte as a resumed native transcript
+/// draws it — including the absence of blank lines between the command and
+/// its annotations, which is the reason for the separator-suppression rule.
+#[test]
+fn compact_group_matches_the_native_layout() {
+    let entries = vec![
+        entry(Role::Assistant, vec![DisplayBlock::CompactBoundary]),
+        entry(Role::User, vec![DisplayBlock::Text("/compact".into())]),
+        entry(
+            Role::User,
+            vec![annotation("Compacted (ctrl+o to see full summary)")],
+        ),
+        entry(Role::User, vec![annotation("Read alpha.rs (42 lines)")]),
+        entry(Role::User, vec![annotation("Referenced file beta.yml")]),
+        entry(
+            Role::Assistant,
+            vec![DisplayBlock::Text("done".into())],
+        ),
+    ];
+    let rendered: Vec<String> = build(&entries, false)
+        .iter()
+        .map(|l| line_text(l).trim_end().to_string())
+        .collect();
+
+    assert_eq!(
+        rendered,
+        vec![
+            format!("{THINKING_GLYPH} Conversation compacted (ctrl+o for history)"),
+            String::new(),
+            format!("{USER_MARKER} /compact"),
+            format!("  {TOOL_RESULT_GLYPH}  Compacted (ctrl+o to see full summary)"),
+            format!("  {TOOL_RESULT_GLYPH}  Read alpha.rs (42 lines)"),
+            format!("  {TOOL_RESULT_GLYPH}  Referenced file beta.yml"),
+            String::new(),
+            format!("{ASSISTANT_MARKER} done"),
+            String::new(),
+        ]
+    );
+}
+
+#[test]
+fn an_annotation_never_starts_a_new_turn() {
+    // The blank separator that normally follows an entry is suppressed when
+    // the next entry is annotation-only, so `⏺ reply` and the `⎿` line the
+    // CLI attached to it stay glued together.
+    let entries = vec![
+        entry(Role::Assistant, vec![DisplayBlock::Text("reply".into())]),
+        entry(Role::User, vec![annotation("Read delta.rs (13 lines)")]),
+    ];
+    let rendered: Vec<String> = build(&entries, false)
+        .iter()
+        .map(|l| line_text(l).trim_end().to_string())
+        .collect();
+    assert_eq!(
+        rendered,
+        vec![
+            format!("{ASSISTANT_MARKER} reply"),
+            format!("  {TOOL_RESULT_GLYPH}  Read delta.rs (13 lines)"),
+            String::new(),
+        ]
+    );
+}
+
+#[test]
+fn a_notice_draws_an_assistant_bullet() {
+    let entries = vec![entry(
+        Role::User,
+        vec![DisplayBlock::Notice(
+            "Background command \"x\" completed (exit code 0)".into(),
+        )],
+    )];
+    assert_eq!(
+        line_text(only_visible_line(&build(&entries, false))).trim_end(),
+        format!("{ASSISTANT_MARKER} Background command \"x\" completed (exit code 0)")
+    );
+}
+
+#[test]
+fn long_annotations_and_notices_stay_inside_the_panel() {
+    // Both forms carry CLI-supplied text of unbounded length (a `../../..`
+    // path outside the worktree runs long), so both must clip.
+    let entries = vec![
+        entry(Role::User, vec![annotation(&"p".repeat(300))]),
+        entry(Role::User, vec![DisplayBlock::Notice("n".repeat(300))]),
+        entry(Role::Assistant, vec![DisplayBlock::CompactBoundary]),
+    ];
+    for width in [10usize, 20, 40, 80] {
+        let (theme, syntax_set, syntect_theme) = fixtures();
+        let cache = MarkdownCache::new();
+        let ctx = BuildCtx {
+            entries: &entries,
+            cache: &cache,
+            theme: &theme,
+            syntax_set: &syntax_set,
+            syntect_theme: &syntect_theme,
+            expanded: false,
+        };
+        for line in build_lines(&ctx, width).lines {
+            let w = unicode_width::UnicodeWidthStr::width(line_text(&line).as_str());
+            assert!(w <= width, "{w} cols at width {width}: {:?}", line_text(&line));
+        }
+    }
+}
+
+#[test]
+fn a_long_annotation_wraps_instead_of_being_elided() {
+    // Measured: a file carried across a compact from outside the worktree gets
+    // a `../../../…` path too long for any panel, and Claude Code runs it onto
+    // a continuation line aligned under the body — it does not truncate. The
+    // break falls mid-path (a hard column split) and the `Read` verb keeps the
+    // rest of its own line rather than sitting alone.
+    let path = format!("../../../../private/tmp/{}/out.txt", "x".repeat(120));
+    let entries = vec![entry(
+        Role::User,
+        vec![annotation(&format!("Read {path} (7 lines)"))],
+    )];
+    let lines = build(&entries, false);
+    let texts: Vec<String> = lines
+        .iter()
+        .map(|l| line_text(l).trim_end().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    assert!(texts.len() > 1, "expected a wrap, got {texts:?}");
+    assert!(
+        texts[0].starts_with(&format!("  {TOOL_RESULT_GLYPH}  Read ../../")),
+        "the verb must keep its line: {:?}",
+        texts[0]
+    );
+    for t in texts.iter().skip(1) {
+        assert!(
+            t.starts_with("     ") && !t.starts_with("      "),
+            "continuations align under the body at col5: {t:?}"
+        );
+    }
+    // Nothing elided: every character of the path survives somewhere.
+    let joined: String = texts.iter().map(|t| t.trim_start()).collect();
+    assert!(joined.contains(&"x".repeat(120)), "path was cut: {joined}");
+    assert!(!joined.contains('\u{2026}'), "unexpected ellipsis: {joined}");
+}
+
+#[test]
+fn two_text_blocks_in_one_user_turn_are_separated() {
+    // Measured: a user message holding two text blocks — a prompt plus an
+    // appended `<system-reminder>`, say — is drawn as two `❯` turns with a
+    // blank line between them, not as one packed pair. The entry-level
+    // separator only fires between entries, so this covers the gap inside one.
+    let entries = vec![entry(
+        Role::User,
+        vec![
+            DisplayBlock::Text("my actual question".into()),
+            DisplayBlock::Text("<system-reminder>note</system-reminder>".into()),
+        ],
+    )];
+    let rendered: Vec<String> = build(&entries, false)
+        .iter()
+        .map(|l| line_text(l).trim_end().to_string())
+        .collect();
+    assert_eq!(
+        rendered,
+        vec![
+            format!("{USER_MARKER} my actual question"),
+            String::new(),
+            format!("{USER_MARKER} <system-reminder>note</system-reminder>"),
+            String::new(),
+        ]
+    );
+}

--- a/src/ui/reflow_view/corpus_tests.rs
+++ b/src/ui/reflow_view/corpus_tests.rs
@@ -1,0 +1,183 @@
+//! Invariant sweep over real Claude Code session logs.
+//!
+//! This writes down no expected output at all — it asserts properties that
+//! must hold for *any* transcript, at every width. That is the point: real
+//! logs contain inputs nobody would think to write by hand (broken UTF-8,
+//! ZWJ emoji, nested code fences, megabyte tool results), and the properties
+//! below are exactly the ones whose violation shows up as the panel visibly
+//! corrupting itself.
+//!
+//! Opt-in: set `CONDUCTOR_TRANSCRIPT_CORPUS` to a directory of `.jsonl`
+//! session logs. Skipped when unset. The logs are **not** in the repository
+//! and must never be — they carry file paths, prompts and tool output.
+
+use std::path::PathBuf;
+
+use syntect::highlighting::ThemeSet;
+use unicode_width::UnicodeWidthStr;
+
+use crate::claude_log::{LogEntry, load_session};
+use crate::ui::markdown::MarkdownCache;
+
+use super::build::{BuildCtx, build_lines};
+
+const WIDTHS: [usize; 6] = [20, 40, 60, 80, 120, 200];
+
+/// Cap the sweep so a `cargo test` run stays in seconds. A corpus can hold
+/// hundreds of logs; the invariants are about *shapes* of content, and the
+/// biggest files repeat the same shapes rather than adding new ones.
+const MAX_FILES: usize = 30;
+const MAX_BYTES: u64 = 5 * 1024 * 1024;
+
+fn corpus_files() -> Option<Vec<PathBuf>> {
+    let dir = std::env::var_os("CONDUCTOR_TRANSCRIPT_CORPUS")?;
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "jsonl"))
+        .filter(|p| {
+            std::fs::metadata(p).is_ok_and(|m| m.is_file() && m.len() <= MAX_BYTES)
+        })
+        .collect();
+    // Sort so a failure is reproducible rather than depending on readdir order.
+    files.sort();
+    files.truncate(MAX_FILES);
+    Some(files)
+}
+
+fn line_width(line: &ratatui::text::Line<'_>) -> usize {
+    line.spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+        .sum()
+}
+
+fn texts(lines: &[ratatui::text::Line<'_>]) -> Vec<String> {
+    lines
+        .iter()
+        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+        .collect()
+}
+
+struct Harness {
+    theme: crate::theme::Theme,
+    syntax_set: syntect::parsing::SyntaxSet,
+    syntect_theme: syntect::highlighting::Theme,
+}
+
+impl Harness {
+    fn new() -> Self {
+        Self {
+            theme: crate::theme::Theme::default(),
+            syntax_set: two_face::syntax::extra_newlines(),
+            syntect_theme: ThemeSet::load_defaults()
+                .themes
+                .remove("base16-ocean.dark")
+                .unwrap(),
+        }
+    }
+
+    fn build(
+        &self,
+        cache: &MarkdownCache,
+        entries: &[LogEntry],
+        width: usize,
+        expanded: bool,
+    ) -> super::build::BuiltLines {
+        let ctx = BuildCtx {
+            entries,
+            cache,
+            theme: &self.theme,
+            syntax_set: &self.syntax_set,
+            syntect_theme: &self.syntect_theme,
+            expanded,
+        };
+        build_lines(&ctx, width)
+    }
+}
+
+#[test]
+fn real_transcripts_hold_the_layout_invariants() {
+    let Some(files) = corpus_files() else {
+        eprintln!("CONDUCTOR_TRANSCRIPT_CORPUS unset — skipping corpus sweep");
+        return;
+    };
+    assert!(!files.is_empty(), "corpus directory holds no .jsonl files");
+
+    let h = Harness::new();
+    let mut checked = 0usize;
+
+    for path in &files {
+        let entries = load_session(path);
+        if entries.is_empty() {
+            continue;
+        }
+        for expanded in [false, true] {
+            for width in WIDTHS {
+                let cache = MarkdownCache::new();
+                let built = h.build(&cache, &entries, width, expanded);
+
+                // (1) Nothing may exceed the panel. This is the direct
+                // detector for the bleed class of bug, and the reason the
+                // width-1 safety margin could be removed.
+                for (i, line) in built.lines.iter().enumerate() {
+                    let w = line_width(line);
+                    assert!(
+                        w <= width,
+                        "{}: line {i} is {w} cols at width {width} (expanded={expanded}): {:?}",
+                        path.display(),
+                        texts(&built.lines[i..=i])[0],
+                    );
+                }
+
+                // (2) Every line must carry metadata: the renderer zips the
+                // two, and a short `meta` would silently truncate the view.
+                assert_eq!(
+                    built.lines.len(),
+                    built.meta.len(),
+                    "{}: line/meta length mismatch at width {width}",
+                    path.display()
+                );
+
+                // (3) Building twice must agree — the Markdown cache sits in
+                // the middle of this path and a stale hit would show up here.
+                let again = h.build(&cache, &entries, width, expanded);
+                assert_eq!(
+                    texts(&built.lines),
+                    texts(&again.lines),
+                    "{}: rebuild at width {width} differed",
+                    path.display()
+                );
+
+                checked += 1;
+            }
+        }
+    }
+    assert!(checked > 0, "corpus produced no displayable entries");
+    eprintln!("corpus sweep: {} files x {} builds", files.len(), checked);
+}
+
+#[test]
+fn rebuilding_at_a_previous_width_reproduces_it() {
+    let Some(files) = corpus_files() else {
+        eprintln!("CONDUCTOR_TRANSCRIPT_CORPUS unset — skipping corpus sweep");
+        return;
+    };
+    let h = Harness::new();
+
+    for path in &files {
+        let entries = load_session(path);
+        if entries.is_empty() {
+            continue;
+        }
+        // One cache across all three builds, exactly as the real render path
+        // uses it: a width round-trip must land back on the original layout
+        // rather than on whatever the intermediate width left cached.
+        let cache = MarkdownCache::new();
+        let first = texts(&h.build(&cache, &entries, 80, false).lines);
+        let _ = h.build(&cache, &entries, 40, false);
+        let back = texts(&h.build(&cache, &entries, 80, false).lines);
+        assert_eq!(first, back, "{}: 80 -> 40 -> 80 was not idempotent", path.display());
+    }
+}

--- a/src/ui/reflow_view/glyphs.rs
+++ b/src/ui/reflow_view/glyphs.rs
@@ -5,27 +5,58 @@
 /// Display columns reserved for the left-hand marker gutter.
 pub(crate) const MARKER_COLS: usize = 2;
 
-// Gutter markers MUST measure 1 column in `unicode-width` AND render 1 column in
-// the terminal, or every transcript line ends up one short and its last char
-// spills past the panel edge. Claude Code's glyphs (⏺ ✻ ⎿) are width-Narrow but
-// many terminals/fonts render them 2 columns wide (⏺ even carries the Emoji
-// property), so the count and the render disagree — the source of the scrollback
-// "bleed". We use only glyphs this terminal provably renders at the width we
-// count: ASCII for the bullet/prompt (always 1 col) and a box-drawing corner for
-// tool results (the panel borders use the same block, so it renders narrow too).
-// The host terminal's line-wrap is also disabled (see `enter_tui`) so even a
-// wide glyph in message *content* can't wrap into a neighbouring panel.
+// These are Claude Code's own glyphs. `⏺`, `✻` and `⎿` measure one column in
+// `unicode-width` but many terminals/fonts draw them two columns wide (`⏺`
+// even carries the Emoji property), which used to push every following
+// character one column right and spill the line past the panel edge — the
+// scrollback "bleed". They were replaced with ASCII for exactly that reason.
+//
+// The fix is the one Claude Code itself uses: don't rely on the glyph's width
+// at all. It emits an absolute column (CHA) right after the glyph, so whatever
+// the terminal did with it, the body still starts where it should. The
+// equivalent here is to leave the cell after the glyph unwritten — ratatui's
+// diff then sees a discontinuity and the crossterm backend emits an absolute
+// `MoveTo`. See `WIDTH_AMBIGUOUS_GLYPHS`, `super::build::width_risk_hole`, and
+// the byte-level proof in `super::render_tests`.
 
-/// Bullet/record marker for assistant messages and tool invocations.
-/// ASCII so it can't be widened by emoji presentation (Claude Code uses ⏺).
-pub(crate) const ASSISTANT_MARKER: &str = "*";
+/// Bullet/record marker for assistant messages and tool invocations
+/// (Claude Code's `⏺`, U+23FA).
+pub(crate) const ASSISTANT_MARKER: &str = "\u{23fa}";
 
-/// Prompt marker for user turns (Claude Code shows `>` before user input).
-pub(crate) const USER_MARKER: &str = ">";
+/// Prompt marker for user turns (measured: Claude Code shows `❯`, U+276F).
+/// Unlike `⏺`/`✻`/`⎿`, `❯` is a Dingbats-block character with no
+/// Emoji_Presentation default, so it is not width-ambiguous and needs no
+/// unwritten cell after it — which matters, because it sits inside a
+/// full-width background block where a hole would read as a notch.
+pub(crate) const USER_MARKER: &str = "\u{276f}";
 
-/// Corner glyph for tool result lines (box-drawing `└`, same block as the panel
-/// borders so it renders one column wide; Claude Code uses ⎿).
-pub(crate) const TOOL_RESULT_GLYPH: &str = "\u{2514}";
+/// Corner glyph for tool result lines (Claude Code's `⎿`, U+23BF).
+pub(crate) const TOOL_RESULT_GLYPH: &str = "\u{23bf}";
 
-/// Marker for thinking blocks (Claude Code uses ✻; ASCII keeps the width honest).
-pub(crate) const THINKING_GLYPH: &str = "*";
+/// Marker for thinking blocks (Claude Code's `✻`, U+273B).
+pub(crate) const THINKING_GLYPH: &str = "\u{273b}";
+
+/// Glyphs that `unicode-width` measures as one column but a terminal may draw
+/// two columns wide — `⏺` even carries the Emoji property. A line containing
+/// one of these gets the cell right after it left unwritten, which forces an
+/// absolute cursor move and pins the text that follows to its intended
+/// column no matter how wide the glyph actually rendered (see
+/// `super::build::width_risk_hole`).
+///
+/// `❯` (U+276F) and `›` (U+203A) are deliberately **not** listed: both are
+/// plain punctuation with no Emoji presentation, and the user turn's `❯` sits
+/// inside a full-width background block where an unwritten cell would show as
+/// a notch in the background.
+const WIDTH_AMBIGUOUS_GLYPHS: [char; 3] = ['\u{23fa}', '\u{23bf}', '\u{273b}'];
+
+/// Whether `ch` is one of [`WIDTH_AMBIGUOUS_GLYPHS`].
+pub(crate) fn is_width_ambiguous(ch: char) -> bool {
+    WIDTH_AMBIGUOUS_GLYPHS.contains(&ch)
+}
+
+/// Marker for a collapsed `<teammate-message>` block (S4) — Conductor's own
+/// multi-agent construct, not something Claude Code itself renders. `›`
+/// (U+203A, General Punctuation) is not an Emoji_Presentation character and
+/// measures 1 column under `unicode_width` (verified against this crate's
+/// own version), so — like `USER_MARKER` above — it needs no unwritten cell.
+pub(crate) const TEAMMATE_MESSAGE_GLYPH: &str = "\u{203a}";

--- a/src/ui/reflow_view/helpers.rs
+++ b/src/ui/reflow_view/helpers.rs
@@ -3,6 +3,7 @@
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::glyphs::MARKER_COLS;
@@ -61,11 +62,19 @@ pub(crate) fn truncate_to_width(s: &str, max_cols: usize) -> String {
     if max_cols == 0 {
         return String::new();
     }
+    // Reserve the ellipsis column only when there is something to elide.
+    // Reserving it unconditionally cut strings that fit exactly —
+    // `truncate_to_width("hello", 5)` used to return `"hell…"`.
+    if UnicodeWidthStr::width(s) <= max_cols {
+        return s.to_string();
+    }
     let mut width = 0usize;
-    // Reserve one column for the ellipsis so the indicator fits within max_cols.
-    let budget = max_cols.saturating_sub(1);
-    for (i, ch) in s.char_indices() {
-        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+    let budget = max_cols - 1;
+    // Grapheme clusters, not `char`s: cutting between a base character and
+    // its variation selector (or mid-ZWJ-sequence) both mis-measures the
+    // width and leaves a dangling combining mark on screen.
+    for (i, cluster) in s.grapheme_indices(true) {
+        let cw = UnicodeWidthStr::width(cluster);
         if width + cw > budget {
             let mut out = s[..i].to_string();
             out.push('\u{2026}'); // …
@@ -75,4 +84,53 @@ pub(crate) fn truncate_to_width(s: &str, max_cols: usize) -> String {
     }
     // String fits within max_cols without truncation.
     s.to_string()
+}
+
+/// Assemble `parts` into one line behind `indent_cols` blank columns,
+/// degrading to a single truncated span if the result would exceed `width`.
+///
+/// The fixed-format summary lines (`Read 3 files (ctrl+o to expand)`,
+/// `Thought for 8s (ctrl+o to expand)`) are built from several spans so that
+/// only the count is bold. At a narrow panel the whole thing has to be cut,
+/// and cutting span-by-span would leave those bold/plain boundaries in
+/// nonsense places — so the fallback keeps the text and drops the styling.
+/// Without this the line is simply emitted over-width, which is the bleed the
+/// corpus sweep exists to catch.
+pub(crate) fn fit_styled_line(
+    indent_cols: usize,
+    parts: &[(String, Style)],
+    width: usize,
+) -> Line<'static> {
+    let indent = " ".repeat(indent_cols);
+    let budget = width.saturating_sub(indent_cols);
+    let plain: String = parts.iter().map(|(t, _)| t.as_str()).collect();
+
+    if UnicodeWidthStr::width(plain.as_str()) <= budget {
+        let mut spans = Vec::with_capacity(parts.len() + 1);
+        spans.push(Span::raw(indent));
+        spans.extend(parts.iter().map(|(t, s)| Span::styled(t.clone(), *s)));
+        return Line::from(spans);
+    }
+    let fallback = parts.first().map(|(_, s)| *s).unwrap_or_default();
+    Line::from(vec![
+        Span::raw(indent),
+        Span::styled(truncate_to_width(&plain, budget), fallback),
+    ])
+}
+
+/// [`fit_styled_line`] with `glyph` in the marker gutter instead of blanks —
+/// for the single-line blocks that own a marker of their own (`⏺ {notice}`,
+/// `✻ Conversation compacted …`). The glyph takes the style of the first part.
+///
+/// Both of `fit_styled_line`'s branches put the indent in span 0, so replacing
+/// it in place keeps the fitted body untouched.
+pub(crate) fn fit_glyph_line(
+    glyph: &str,
+    parts: &[(String, Style)],
+    width: usize,
+) -> Line<'static> {
+    let mut line = fit_styled_line(MARKER_COLS, parts, width);
+    let style = parts.first().map(|(_, s)| *s).unwrap_or_default();
+    line.spans[0] = Span::styled(pad_glyph_to(glyph, MARKER_COLS), style);
+    line
 }

--- a/src/ui/reflow_view/mod.rs
+++ b/src/ui/reflow_view/mod.rs
@@ -15,27 +15,41 @@
 //!   continuation line 2
 //! ⏺ Bash(cargo build)
 //!   ⎿  12 lines
-//! > user text line 1
+//! ❯ user text line 1 (full-width background block)
 //!   continuation line 2
 //! ```
 //!
 //! The gutter (`MARKER_COLS = 2`) is always 2 display columns: marker glyph
 //! padded to 2 cols for the first line, two spaces for continuations.
 //! Markdown content is rendered at `width - MARKER_COLS` so the combined width
-//! is exactly `width`, preserving the "1 logical line = 1 visual row" invariant.
+//! is exactly `width`, preserving the "1 logical line = 1 visual row"
+//! invariant. User turns are the one exception: they bypass Markdown and
+//! paint a full-width background block instead (see [`user_text`]).
 //!
 //! Split by responsibility: [`glyphs`] holds the gutter-width constants,
 //! [`palette`] the fixed Claude Code color scheme, [`helpers`] the pure
 //! marker/truncation functions, [`build`] the per-width line cache builder,
-//! and [`render`] the public entry point that blits the cache each frame.
+//! [`user_text`] the user-turn background-block renderer, and [`render`] the
+//! public entry point that blits the cache each frame.
 
 mod build;
 mod glyphs;
 mod helpers;
 mod palette;
 mod render;
+mod tool_lines;
+mod user_text;
 
+pub(crate) use build::LineMeta;
 pub use render::render;
 
 #[cfg(test)]
+mod build_tests;
+#[cfg(test)]
+mod corpus_tests;
+#[cfg(test)]
+mod render_tests;
+#[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod user_text_tests;

--- a/src/ui/reflow_view/palette.rs
+++ b/src/ui/reflow_view/palette.rs
@@ -25,6 +25,12 @@ pub(crate) const INACTIVE: Color = Color::Rgb(153, 153, 153);
 pub(crate) const PERMISSION: Color = Color::Rgb(177, 185, 249);
 /// Inline-code / very dim — `subtle` token.
 pub(crate) const SUBTLE: Color = Color::Rgb(80, 80, 80);
+/// Background fill for a user turn's full-width block (S3, measured).
+pub(crate) const USER_BG: Color = Color::Rgb(55, 55, 55);
+/// The `❯` prompt marker's color on a user turn's background block.
+pub(crate) const USER_MARKER_FG: Color = Color::Rgb(80, 80, 80);
+/// Body text color on a user turn's background block.
+pub(crate) const USER_TEXT: Color = Color::Rgb(255, 255, 255);
 
 /// Build a Claude-flavored [`Theme`] for the Markdown renderer so prose,
 /// headings, links and code in the transcript adopt Claude Code's palette

--- a/src/ui/reflow_view/render.rs
+++ b/src/ui/reflow_view/render.rs
@@ -11,7 +11,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
 
-use super::build::build_lines;
+use super::build::{BuildCtx, LineMeta, build_lines};
 use super::helpers::truncate_to_width;
 use super::palette;
 
@@ -28,15 +28,29 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // text show through (the scrollback-bleed fix, as in the live PTY render).
     frame.render_widget(ratatui::widgets::Clear, area);
 
-    // Reserve one column on the right as a safety gutter. Transcript content is
-    // arbitrary Unicode, and a glyph the terminal renders one column wider than
-    // `unicode-width` counts (an emoji, an emoji-presented symbol) would push a
-    // line's last character to the panel edge; building/rendering one column
-    // narrower lets that overflow land in this reserved blank column instead.
-    let render_area = Rect {
-        width: area.width.saturating_sub(1).max(1),
-        ..area
-    };
+    // An overlay that covered this panel painted over the cells we
+    // deliberately leave unwritten; once it closes, only a hard repaint can
+    // clear them (ratatui's diff compares its own buffers, which agree).
+    let overlay_active = app.is_any_overlay_active();
+    if app.reflow.last_overlay_active && !overlay_active {
+        app.terminal.needs_clear = true;
+    }
+    app.reflow.last_overlay_active = overlay_active;
+
+    // The full panel width is used. This view used to build one column
+    // narrower as a safety gutter, on the theory that a glyph the terminal
+    // draws wider than `unicode-width` counts would push a line's last
+    // character past the panel edge. That cost a permanent one-column
+    // disagreement with Claude Code's own wrap positions on *every* line, to
+    // insure against a rare one. The gutter glyphs — the actual source of the
+    // original bleed — are now positioned absolutely instead (see
+    // `super::build::width_risk_hole`), and for stray wide content in the body
+    // the damage is bounded: rows are re-anchored individually, so an overflow
+    // cannot propagate past its own row, line wrap is disabled
+    // (`main.rs`'s `DisableLineWrap`) and this is the rightmost column
+    // (`ui::layout::cache`), so at worst one cell of this panel's own right
+    // border is overdrawn.
+    let render_area = area;
     let inner_width = render_area.width as usize;
     let inner_height = render_area.height as usize;
 
@@ -58,14 +72,43 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
 
-    // ── (Re)build cached lines when the panel width changed ──────────────────
-    if app.reflow.last_width != render_area.width {
-        let new_lines = build_lines(app, inner_width);
-        let total = new_lines.len();
+    // ── (Re)build cached lines when the panel width or expand state changed ──
+    if app.reflow.last_width != render_area.width || app.reflow.needs_rebuild {
+        // Block-scoped so the shared borrows on `app` drop before the
+        // `cached_lines` / `total_lines` / `last_width` assignments below.
+        let built = {
+            let ctx = BuildCtx {
+                entries: &app.reflow.entries,
+                cache: &app.reflow.cache,
+                theme: &app.theme,
+                syntax_set: &app.syntax_set,
+                syntect_theme: &app.syntect_theme,
+                expanded: app.reflow.expanded,
+            };
+            build_lines(&ctx, inner_width)
+        };
+        // Remember *what* was at the top of the viewport before the rebuild.
+        // `scroll` is a raw line index, and a width change (or the expand
+        // toggle, which changes line counts wholesale) makes that index mean
+        // something else entirely — the view would jump. Re-finding the same
+        // logical position keeps the reader where they were.
+        let anchor = app.reflow.line_meta.get(app.reflow.scroll).copied();
+        let total = built.lines.len();
 
-        app.reflow.cached_lines = new_lines;
+        app.reflow.cached_lines = built.lines;
+        app.reflow.line_meta = built.meta;
         app.reflow.total_lines = total;
         app.reflow.last_width = render_area.width;
+        app.reflow.needs_rebuild = false;
+        // Line positions all moved; repaint physically so no unwritten cell
+        // keeps a glyph from the previous layout.
+        app.terminal.needs_clear = true;
+
+        if let Some(anchor) = anchor
+            && !app.reflow.pending_bottom
+        {
+            app.reflow.scroll = anchor_index(&app.reflow.line_meta, anchor);
+        }
     }
 
     app.reflow.last_inner_height = area.height;
@@ -106,23 +149,40 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // already produces lines ≤ `body_width` columns, and each line then
     // receives a `MARKER_COLS`-wide prefix, keeping total width ≤
     // `render_area.width`.  1 logical line == 1 visual row means scroll
-    // arithmetic is exact with no invisible over-height rows. Rendered into
-    // `render_area` (one column narrower than `area`) so the reserved safety
-    // gutter stays blank.
+    // arithmetic is exact with no invisible over-height rows.
     let buf = frame.buffer_mut();
-    for (i, line) in app
+    let rows = app
         .reflow
         .cached_lines
         .iter()
+        .zip(app.reflow.line_meta.iter())
         .skip(scroll)
-        .take(inner_height)
-        .enumerate()
-    {
-        buf.set_line(
-            render_area.x,
-            render_area.y + i as u16,
-            line,
-            render_area.width,
-        );
+        .take(inner_height);
+    for (i, (line, meta)) in rows.enumerate() {
+        let y = render_area.y + i as u16;
+        buf.set_line(render_area.x, y, line, render_area.width);
+        // Leave one cell unwritten after a width-ambiguous gutter glyph. The
+        // diff then skips it, so the next cell is not contiguous with the
+        // glyph's and the crossterm backend emits an absolute `MoveTo` before
+        // the body — pinning it to the right column however wide the terminal
+        // actually drew the glyph. `skip` is cleared by `Buffer::reset` every
+        // frame, so this has to be re-applied on each one.
+        if let Some(col) = meta.skip_col
+            && col < render_area.width
+            && let Some(cell) = buf.cell_mut((render_area.x + col, y))
+        {
+            cell.set_skip(true);
+        }
     }
+}
+
+/// Index of the line matching `anchor` after a rebuild — the first line whose
+/// `(entry, block, offset)` is at or past the anchor's, so a block that got
+/// shorter (or vanished) lands on whatever now occupies that position rather
+/// than scrolling somewhere unrelated.
+fn anchor_index(meta: &[LineMeta], anchor: LineMeta) -> usize {
+    let key = (anchor.entry, anchor.block, anchor.offset);
+    meta.iter()
+        .position(|m| (m.entry, m.block, m.offset) >= key)
+        .unwrap_or_else(|| meta.len().saturating_sub(1))
 }

--- a/src/ui/reflow_view/render_tests.rs
+++ b/src/ui/reflow_view/render_tests.rs
@@ -1,0 +1,182 @@
+//! Tests for the gutter-glyph width defence.
+//!
+//! Two independent halves, because either one alone would be misleading:
+//!
+//! * [`marks_the_hole`] — the builder marks the right cell.
+//! * [`skipping_forces_an_absolute_move`] — marking that cell actually makes
+//!   the real crossterm backend emit an absolute cursor move.
+//!
+//! Note what these *cannot* show: whether a terminal draws `⏺` one column or
+//! two. `ratatui::buffer::Buffer::set_stringn` measures with the same
+//! `unicode-width` crate the builder does, so no in-process test can escape
+//! that model. The point of the mechanism is that it makes the answer
+//! irrelevant — the body is positioned absolutely either way — but confirming
+//! it *looks* right still needs a human at a real terminal.
+
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use syntect::highlighting::ThemeSet;
+
+use crate::claude_log::{DisplayBlock, LogEntry, Role};
+use crate::ui::markdown::MarkdownCache;
+
+use super::build::{BuildCtx, build_lines};
+use super::glyphs::{ASSISTANT_MARKER, TOOL_RESULT_GLYPH};
+
+/// Render `prev` → `next` through a real `CrosstermBackend` and return the
+/// bytes it wrote.
+fn flush(prev: &Buffer, next: &Buffer) -> Vec<u8> {
+    let mut out = Vec::new();
+    {
+        let mut backend = CrosstermBackend::new(&mut out);
+        backend.draw(prev.diff(next).into_iter()).unwrap();
+    }
+    out
+}
+
+fn one_row(glyph: &str, skip: bool) -> Buffer {
+    let mut b = Buffer::empty(Rect::new(0, 0, 20, 1));
+    b[(0u16, 0u16)].set_symbol(glyph);
+    b[(1u16, 0u16)].set_symbol(" ");
+    b[(1u16, 0u16)].set_skip(skip);
+    for (i, c) in "hello".chars().enumerate() {
+        b[(2 + i as u16, 0u16)].set_char(c);
+    }
+    b
+}
+
+/// Skipping the cell after the glyph must make the backend jump to column 3
+/// (1-based) absolutely, instead of writing straight on from the glyph. The
+/// non-skipped case is asserted too: without it this test would still pass if
+/// `MoveTo` were emitted unconditionally, proving nothing about `set_skip`.
+#[test]
+fn skipping_forces_an_absolute_move() {
+    // The previous frame must *differ* at the cell under test. Diffing two
+    // blank buffers would leave column 1 unchanged, so the diff would omit it
+    // and emit the absolute move anyway — the control case has to actually
+    // have something to overwrite for it to be a control at all.
+    let mut prev = Buffer::empty(Rect::new(0, 0, 20, 1));
+    prev[(1u16, 0u16)].set_char('X');
+
+    let without = flush(&prev, &one_row(ASSISTANT_MARKER, false));
+    let with = flush(&prev, &one_row(ASSISTANT_MARKER, true));
+
+    const ABSOLUTE_MOVE_TO_COL3: &[u8] = b"\x1b[1;3H";
+    assert!(
+        !without.windows(6).any(|w| w == ABSOLUTE_MOVE_TO_COL3),
+        "control case should write contiguously, got {:?}",
+        String::from_utf8_lossy(&without)
+    );
+    assert!(
+        with.windows(6).any(|w| w == ABSOLUTE_MOVE_TO_COL3),
+        "skipped cell should force an absolute move, got {:?}",
+        String::from_utf8_lossy(&with)
+    );
+}
+
+/// A skipped cell is never erased either — which is why every path that can
+/// leave foreign content under one has to force a hard repaint (see
+/// `App::open_reflow` and `super::render`).
+#[test]
+fn skipped_cell_is_not_repainted() {
+    let mut prev = Buffer::empty(Rect::new(0, 0, 20, 1));
+    prev[(1u16, 0u16)].set_char('X');
+
+    let bytes = flush(&prev, &one_row(ASSISTANT_MARKER, true));
+
+    assert!(
+        !String::from_utf8_lossy(&bytes).contains('X'),
+        "stale cell is left alone, so nothing overwrites it"
+    );
+}
+
+fn build(entries: &[LogEntry], expanded: bool) -> Vec<Option<u16>> {
+    let theme = crate::theme::Theme::default();
+    let syntax_set = two_face::syntax::extra_newlines();
+    let syntect_theme = ThemeSet::load_defaults()
+        .themes
+        .remove("base16-ocean.dark")
+        .unwrap();
+    let cache = MarkdownCache::new();
+    let ctx = BuildCtx {
+        entries,
+        cache: &cache,
+        theme: &theme,
+        syntax_set: &syntax_set,
+        syntect_theme: &syntect_theme,
+        expanded,
+    };
+    build_lines(&ctx, 60)
+        .meta
+        .into_iter()
+        .map(|m| m.skip_col)
+        .collect()
+}
+
+fn entry(role: Role, blocks: Vec<DisplayBlock>) -> LogEntry {
+    LogEntry {
+        role,
+        model: None,
+        blocks,
+    }
+}
+
+/// The hole goes immediately after the glyph, wherever the glyph sits — which
+/// is not always column 0: a `⎿` result line indents it to column 2.
+#[test]
+fn marks_the_hole() {
+    // Assistant prose: `⏺` at col0, so the hole is col1.
+    let assistant = build(
+        &[entry(
+            Role::Assistant,
+            vec![DisplayBlock::Text("hello".into())],
+        )],
+        false,
+    );
+    assert_eq!(assistant.first().copied().flatten(), Some(1));
+
+    // Expanded tool result: `  ⎿  ` puts the glyph at col2, so the hole is col3.
+    let result = build(
+        &[entry(
+            Role::User,
+            vec![DisplayBlock::ToolResult {
+                kind: crate::claude_log::ResultKind::Inline,
+                lines: vec!["out".into()],
+                is_error: false,
+            }],
+        )],
+        true,
+    );
+    assert_eq!(result.first().copied().flatten(), Some(3));
+}
+
+/// A user turn is a full-width background block; an unwritten cell inside it
+/// would read as a notch, and `❯` is not width-ambiguous anyway.
+#[test]
+fn user_turns_get_no_hole() {
+    let holes = build(
+        &[entry(Role::User, vec![DisplayBlock::Text("hi".into())])],
+        false,
+    );
+    assert!(holes.iter().all(Option::is_none), "{holes:?}");
+}
+
+/// Guards the constants themselves: if a glyph were ever swapped for one the
+/// hole logic doesn't know about, the defence would silently stop applying.
+#[test]
+fn every_ambiguous_gutter_glyph_is_registered() {
+    for glyph in [ASSISTANT_MARKER, TOOL_RESULT_GLYPH, super::glyphs::THINKING_GLYPH] {
+        let ch = glyph.chars().next().unwrap();
+        assert!(
+            super::glyphs::is_width_ambiguous(ch),
+            "{glyph:?} (U+{:04X}) is drawn in the gutter but not registered as width-ambiguous",
+            ch as u32
+        );
+    }
+    // …and the two that deliberately are not.
+    for glyph in [super::glyphs::USER_MARKER, super::glyphs::TEAMMATE_MESSAGE_GLYPH] {
+        let ch = glyph.chars().next().unwrap();
+        assert!(!super::glyphs::is_width_ambiguous(ch), "{glyph:?}");
+    }
+}

--- a/src/ui/reflow_view/tests.rs
+++ b/src/ui/reflow_view/tests.rs
@@ -5,7 +5,10 @@ use ratatui::style::{Color, Style};
 use ratatui::text::Line;
 use unicode_width::UnicodeWidthStr;
 
-use super::glyphs::{ASSISTANT_MARKER, MARKER_COLS, THINKING_GLYPH, TOOL_RESULT_GLYPH, USER_MARKER};
+use super::glyphs::{
+    ASSISTANT_MARKER, MARKER_COLS, TEAMMATE_MESSAGE_GLYPH, THINKING_GLYPH, TOOL_RESULT_GLYPH,
+    USER_MARKER,
+};
 use super::helpers::{pad_glyph_to, truncate_to_width, with_marker};
 
 // ── pad_glyph_to ─────────────────────────────────────────────────────────
@@ -46,6 +49,7 @@ fn gutter_markers_are_exactly_one_column() {
         ("tool-result", TOOL_RESULT_GLYPH),
         ("thinking", THINKING_GLYPH),
         ("user", USER_MARKER),
+        ("teammate-message", TEAMMATE_MESSAGE_GLYPH),
     ] {
         assert_eq!(
             UnicodeWidthStr::width(m),
@@ -104,4 +108,20 @@ fn truncate_over_limit_appends_ellipsis() {
 #[test]
 fn truncate_zero_budget_returns_empty() {
     assert_eq!(truncate_to_width("anything", 0), "");
+}
+
+#[test]
+fn truncate_keeps_a_string_that_fits_exactly() {
+    // Used to reserve the ellipsis column unconditionally and return "hell…".
+    assert_eq!(truncate_to_width("hello", 5), "hello");
+}
+
+#[test]
+fn truncate_does_not_cut_inside_a_cluster() {
+    // Cutting between `⚠` and its U+FE0F selector would leave a dangling
+    // combining mark and mis-measure the result.
+    let s = "\u{26a0}\u{fe0f}\u{26a0}\u{fe0f}\u{26a0}\u{fe0f}";
+    let out = truncate_to_width(s, 5);
+    assert!(UnicodeWidthStr::width(out.as_str()) <= 5, "{out:?}");
+    assert!(!out.contains('\u{fe0f}') || out.contains('\u{26a0}'));
 }

--- a/src/ui/reflow_view/tool_lines.rs
+++ b/src/ui/reflow_view/tool_lines.rs
@@ -1,0 +1,365 @@
+//! `tool_use`/`tool_result` line rendering — the `⏺`/`⎿` layouts driven by
+//! `crate::claude_log`'s tool classification (§2.1 of
+//! `docs/plans/2026-07-31-native-render-parity.md`).
+//!
+//! Split out of [`build`](super::build) because the classification-driven
+//! layout rules are a distinct concern from walking entries and rendering
+//! Markdown text/thinking blocks.
+
+use std::collections::HashMap;
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthStr;
+
+use crate::claude_log::{
+    BUCKET_ORDER, CountedBucket, DisplayBlock, LogEntry, ResultKind, ToolCategory, classify,
+    unknown_tool_arg,
+};
+
+use super::glyphs::{ASSISTANT_MARKER, MARKER_COLS, TOOL_RESULT_GLYPH};
+use super::helpers::{fit_styled_line, pad_glyph_to, truncate_to_width};
+
+/// The fixed styles this module's render functions draw with, grouped into
+/// one struct so each function takes one param instead of one per style
+/// (clippy's `too_many_arguments` bar is 7; `render_tool_result_collapsed`
+/// alone needs 5 non-style params, leaving no room for 2+ separate ones).
+pub(crate) struct ToolStyles {
+    pub marker: Style,
+    pub marker_err: Style,
+    pub name: Style,
+    pub arg: Style,
+    pub result: Style,
+    pub result_err: Style,
+}
+
+/// Pre-count, per entry, how many `tool_result` blocks resolve to each
+/// [`CountedBucket`] — used by [`render_tool_result_collapsed`] to render one
+/// aggregated "{verb} N {noun}" line at a bucket's first occurrence instead
+/// of one line per result.
+///
+/// `Counted` ignores `is_error` entirely (measured: a failed `Read` still
+/// folds into the plain "Read 1 file" summary, with no error indication), so
+/// every result with a bucket counts here regardless of its error flag.
+///
+/// Scope is the whole entry, not just a contiguous run of matching results:
+/// Claude batches every result from one assistant turn into a single
+/// following user entry, so an entry-wide count matches the shape actually
+/// observed, and needs no separate "did the run break" tracking.
+pub(crate) fn count_buckets(entry: &LogEntry) -> HashMap<CountedBucket, usize> {
+    let mut native: HashMap<CountedBucket, usize> = HashMap::new();
+    let mut shell: HashMap<CountedBucket, usize> = HashMap::new();
+    for block in &entry.blocks {
+        if let DisplayBlock::ToolResult {
+            kind: ResultKind::Counted { bucket, from_bash },
+            ..
+        } = block
+        {
+            let target = if *from_bash { &mut shell } else { &mut native };
+            *target.entry(*bucket).or_insert(0) += 1;
+        }
+    }
+    // A shell invocation only counts as a *fallback*. Measured, at one call
+    // site each: `cat`×1 → "Read 1 file"; `cat`×2 → "Read 2 files"; but
+    // `cat`×3 + `Read`×1 → "Read 1 file", i.e. once the bucket's own tool
+    // contributes at all, the shell approximations are dropped entirely.
+    // (`List` has no native tool, so it always falls through to the shell
+    // count; `Search` never has a shell source.)
+    let mut counts = HashMap::new();
+    for bucket in BUCKET_ORDER {
+        let n = match native.get(&bucket).copied().unwrap_or(0) {
+            0 => shell.get(&bucket).copied().unwrap_or(0),
+            n => n,
+        };
+        if n > 0 {
+            counts.insert(bucket, n);
+        }
+    }
+    counts
+}
+
+/// Render one `tool_use` block, or `None` when it draws nothing (a
+/// `Counted`/`Hidden` category in collapsed mode — those draw at the
+/// `tool_result`'s position instead, or not at all).
+///
+/// In expanded mode every call draws, using the tool's own raw `name` (not a
+/// collapsed-mode alias like `Edit` → `Update`) and a best-effort argument
+/// found via [`unknown_tool_arg`]'s generic key search — expanded mode has no
+/// per-tool "the" argument key the way the collapsed `Inline` categories do.
+///
+/// `errored` selects the marker color (measured for `Inline` in collapsed
+/// mode: a failed `Bash(false)` draws its `⏺` in `palette::ERROR`, not
+/// green — see `tool_class::ToolCategory::Inline`). Applied uniformly across
+/// categories and to expanded mode too, since there's no measured
+/// counter-example and the signal ("did this call fail") is the same either
+/// way — a self-decided generalisation, not itself measured.
+pub(crate) fn render_tool_use(
+    name: &str,
+    input: &serde_json::Value,
+    errored: bool,
+    expanded: bool,
+    width: usize,
+    styles: &ToolStyles,
+) -> Option<Line<'static>> {
+    let (display_name, arg) = if expanded {
+        (name.to_string(), unknown_tool_arg(input))
+    } else {
+        match classify(name, input) {
+            ToolCategory::Counted(_) | ToolCategory::Hidden => return None,
+            ToolCategory::Inline { display_name, arg } => (display_name, arg),
+        }
+    };
+    let marker_style = if errored { styles.marker_err } else { styles.marker };
+    Some(tool_use_line(&display_name, arg.as_deref(), width, marker_style, styles))
+}
+
+/// `⏺ {display_name}({arg})` — bullet (color given by `marker_style`), bold
+/// name, then the argument in its own style (parens omitted entirely when
+/// there is no argument).
+fn tool_use_line(
+    display_name: &str,
+    arg: Option<&str>,
+    width: usize,
+    marker_style: Style,
+    styles: &ToolStyles,
+) -> Line<'static> {
+    let marker_prefix = pad_glyph_to(ASSISTANT_MARKER, MARKER_COLS);
+    let remaining = width.saturating_sub(MARKER_COLS);
+    let name_cols = UnicodeWidthStr::width(display_name);
+
+    // Budget the parenthesised argument only if the name leaves room for it,
+    // and drop the parens entirely when nothing of the argument survives.
+    // Pushing the name unbudgeted used to overflow on a long MCP tool name at
+    // a narrow panel — `⏺ mcp__ccgrep__search()` is 23 columns at width 20 —
+    // and a saturated budget rendered a bare `Name()`.
+    let arg_display = arg
+        .filter(|s| !s.is_empty())
+        .and_then(|a| {
+            let budget = remaining.checked_sub(name_cols + 2).filter(|b| *b > 0)?;
+            Some(truncate_to_width(a, budget))
+        })
+        .filter(|s| !s.is_empty());
+
+    match arg_display {
+        None => Line::from(vec![
+            Span::styled(marker_prefix, marker_style),
+            Span::styled(truncate_to_width(display_name, remaining), styles.name),
+        ]),
+        Some(arg) => Line::from(vec![
+            Span::styled(marker_prefix, marker_style),
+            Span::styled(display_name.to_string(), styles.name),
+            Span::styled(format!("({arg})"), styles.arg),
+        ]),
+    }
+}
+
+/// Render one `tool_result` block in collapsed mode, or an empty `Vec` when
+/// it draws nothing (a non-error `Inline`/`Hidden` result, or a repeat
+/// occurrence of a `Counted` bucket already aggregated earlier in this
+/// entry).
+///
+/// [`ResultKind::Counted`] **ignores `is_error` completely** — measured, not
+/// guessed: a failed `Read` still folds into the plain "Read 1 file (ctrl+o
+/// to expand)" summary with no error styling at all. Every `Counted` result
+/// in the entry shares **one** line (several buckets render as one
+/// comma-joined clause list), so `summary_emitted` is a single per-entry
+/// latch: the first such result draws [`bucket_summary_line`], the rest draw
+/// nothing.
+///
+/// [`ResultKind::Inline`] draws only on error, using the measured multi-line
+/// `⎿ Error: …` layout. [`ResultKind::Hidden`] draws nothing at all, error or
+/// not — also measured (a `TodoWrite` with `is_error` produced no output).
+pub(crate) fn render_tool_result_collapsed(
+    kind: ResultKind,
+    lines: &[String],
+    is_error: bool,
+    counts: &HashMap<CountedBucket, usize>,
+    summary_emitted: &mut bool,
+    width: usize,
+    styles: &ToolStyles,
+) -> Vec<Line<'static>> {
+    match kind {
+        // Measured: a `TodoWrite` whose result carried `is_error` produced not
+        // one line of output. Hidden stays hidden even when it fails.
+        ResultKind::Hidden => Vec::new(),
+        ResultKind::Inline => {
+            if is_error {
+                inline_error_lines(lines, width, styles)
+            } else {
+                Vec::new()
+            }
+        }
+        ResultKind::Counted { .. } => {
+            // Every `Counted` result in the entry folds into one shared line,
+            // drawn at the first of them.
+            if std::mem::replace(summary_emitted, true) {
+                Vec::new()
+            } else {
+                vec![bucket_summary_line(counts, width, styles)]
+            }
+        }
+    }
+}
+
+/// Lowercase only the first character of `s`, leaving the rest untouched
+/// (`"Searched for"` → `"searched for"`).
+fn lower_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+const EXPAND_HINT: &str = " (ctrl+o to expand)";
+
+/// The single aggregated line for every `Counted` bucket in one entry, e.g.
+/// `Searched for 1 pattern, read 1 file, listed 2 directories (ctrl+o to expand)`.
+///
+/// Clause order is [`BUCKET_ORDER`]; the first clause's verb keeps its capital
+/// and later ones are lowercased; each count is bold and the rest is
+/// `styles.result`. All measured.
+fn bucket_summary_line(
+    counts: &HashMap<CountedBucket, usize>,
+    width: usize,
+    styles: &ToolStyles,
+) -> Line<'static> {
+    let mut parts: Vec<(String, Style)> = Vec::new();
+    for bucket in BUCKET_ORDER {
+        let Some(&n) = counts.get(&bucket) else {
+            continue;
+        };
+        let (verb, singular, plural) = bucket.labels();
+        let noun = if n == 1 { singular } else { plural };
+        let lead = if parts.is_empty() {
+            format!("{verb} ")
+        } else {
+            format!(", {} ", lower_first(verb))
+        };
+        parts.push((lead, styles.result));
+        parts.push((
+            n.to_string(),
+            styles.result.add_modifier(Modifier::BOLD),
+        ));
+        parts.push((format!(" {noun}"), styles.result));
+    }
+    parts.push((EXPAND_HINT.to_string(), styles.result));
+    fit_styled_line(MARKER_COLS, &parts, width)
+}
+
+/// `Inline`-category error block, measured column-for-column from a failed
+/// `Bash(false)` capture:
+/// ```text
+/// ⏺ Bash(false)
+///  ⎿ Error: bash: command failed with exit code 1
+///     second line of the error
+/// ```
+/// (the `⏺` line itself is drawn by [`render_tool_use`], not here). First
+/// line: col0 one gray space, `⎿` at col2, body (with a prepended `"Error: "`)
+/// from col5. Continuation lines: body from col5 too, no `"Error: "` prefix.
+fn inline_error_lines(lines: &[String], width: usize, styles: &ToolStyles) -> Vec<Line<'static>> {
+    let first_budget = width.saturating_sub(5);
+    let cont_budget = width.saturating_sub(5);
+    let cont_indent = " ".repeat(5);
+
+    let first_raw = lines.first().map(String::as_str).unwrap_or("(no content)");
+    let first_body = truncate_to_width(&format!("Error: {first_raw}"), first_budget);
+    let mut out = vec![Line::from(vec![
+        Span::styled(" ".to_string(), styles.result), // col0: one gray space
+        Span::styled(format!(" {TOOL_RESULT_GLYPH}  "), styles.result_err), // cols1-4
+        Span::styled(first_body, styles.result_err),  // col5+
+    ])];
+
+    for raw in lines.iter().skip(1) {
+        let body = truncate_to_width(raw, cont_budget);
+        out.push(Line::from(vec![
+            Span::raw(cont_indent.clone()),
+            Span::styled(body, styles.result_err),
+        ]));
+    }
+    out
+}
+
+/// Render a [`DisplayBlock::Annotation`] — the `⎿` lines the CLI attaches to
+/// the block above (a slash command's stdout, a file it carried across a
+/// compact).
+///
+/// Same gutter as a tool result (`  ⎿  ` = 5 columns, continuations aligned
+/// under the body), but the text **wraps** instead of being truncated.
+/// Measured: a file outside the worktree gets a `../../../…` path long enough
+/// to overflow any panel, and Claude Code runs it onto a second line rather
+/// than eliding it —
+/// ```text
+///   ⎿  Read ../../../../private/tmp/claude-501/-Users-…-plan/82e28e51-5e62-421c-aa82-d6
+///      b09226bf7b/scratchpad/try-release.sh (82 lines)
+/// ```
+/// — note the break falls mid-path, i.e. a hard column split, which is what
+/// `wrap_plain_text` does to a word wider than the budget.
+pub(crate) fn render_annotation(
+    lines: &[String],
+    width: usize,
+    styles: &ToolStyles,
+) -> Vec<Line<'static>> {
+    let first_prefix = format!("  {TOOL_RESULT_GLYPH}  ");
+    let prefix_cols = UnicodeWidthStr::width(first_prefix.as_str());
+    let cont_indent = " ".repeat(prefix_cols);
+    let budget = width.saturating_sub(prefix_cols);
+
+    let mut out = Vec::new();
+    for raw in lines {
+        for wrapped in super::user_text::wrap_plain_text(raw, budget) {
+            let prefix = if out.is_empty() {
+                Span::styled(first_prefix.clone(), styles.result)
+            } else {
+                Span::raw(cont_indent.clone())
+            };
+            out.push(Line::from(vec![
+                prefix,
+                Span::styled(wrapped, styles.result),
+            ]));
+        }
+    }
+    out
+}
+
+/// Render a `tool_result` block in expanded mode: every output line, laid
+/// out like Claude Code's collapsed `⎿` block but with no preview cap —
+/// showing everything is the point of expanding.
+pub(crate) fn render_tool_result_expanded(
+    lines: &[String],
+    is_error: bool,
+    width: usize,
+    styles: &ToolStyles,
+) -> Vec<Line<'static>> {
+    let body_style = styles.result;
+    // "  ⎿  " — 2-space indent + 1-col glyph + 2 spaces = 5 columns; continuation
+    // lines indent by the same amount so output text stays left-aligned.
+    let first_prefix = format!("  {TOOL_RESULT_GLYPH}  ");
+    let prefix_cols = UnicodeWidthStr::width(first_prefix.as_str());
+    let cont_indent = " ".repeat(prefix_cols);
+    let connector_style = if is_error { styles.result_err } else { body_style };
+
+    if lines.is_empty() {
+        let s = truncate_to_width(&format!("{first_prefix}(no content)"), width);
+        return vec![Line::from(Span::styled(s, connector_style))];
+    }
+
+    lines
+        .iter()
+        .enumerate()
+        .map(|(i, raw)| {
+            let body = truncate_to_width(raw, width.saturating_sub(prefix_cols));
+            if i == 0 {
+                Line::from(vec![
+                    Span::styled(first_prefix.clone(), connector_style),
+                    Span::styled(body, body_style),
+                ])
+            } else {
+                Line::from(vec![
+                    Span::raw(cont_indent.clone()),
+                    Span::styled(body, body_style),
+                ])
+            }
+        })
+        .collect()
+}

--- a/src/ui/reflow_view/user_text.rs
+++ b/src/ui/reflow_view/user_text.rs
@@ -1,0 +1,153 @@
+//! Full-width background block rendering for user turns (S3, measured):
+//! Claude Code's live UI paints the whole row behind a user prompt, not just
+//! the marker and text — this module reproduces that here.
+//!
+//! User input is raw text, not prose to be parsed: it bypasses the Markdown
+//! renderer entirely (see [`build`](super::build)) and is word-wrapped by
+//! this module instead, preserving every source newline as its own wrapped
+//! line rather than reflowing them the way Markdown's paragraph-fill would.
+
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+use super::glyphs::MARKER_COLS;
+use super::helpers::pad_glyph_to;
+
+/// Columns of background-only padding kept to the right of a user turn's
+/// text, inside the block. Measured: at width 60 the body is 57 columns
+/// (`60 - MARKER_COLS - 1`) and column 59 is a bare background cell; at
+/// width 100 it is 97. Assistant text has no such reserve — it wraps at
+/// `width - MARKER_COLS` — so this is specific to the user block.
+const USER_TRAILING_PAD: usize = 1;
+
+/// Render one user-turn text block as full-width background lines: `glyph`
+/// on the first line only (two-space blank indent on continuations, same as
+/// every other block type's gutter), body text word-wrapped at
+/// `width - MARKER_COLS - USER_TRAILING_PAD` but padded back out to
+/// `width - MARKER_COLS` so the background still reaches the panel edge.
+/// `marker_style` and `body_style` must already carry the background color —
+/// this function only supplies the text content, so the caller controls the
+/// palette (mirrors `tool_lines::ToolStyles`).
+pub(crate) fn render_user_text(
+    text: &str,
+    width: usize,
+    glyph: &str,
+    marker_style: Style,
+    body_style: Style,
+) -> Vec<Line<'static>> {
+    // Painted width of the body column (background reaches the panel edge)…
+    let body_width = width.saturating_sub(MARKER_COLS);
+    // …but text stops one column short of it.
+    let wrap_width = body_width.saturating_sub(USER_TRAILING_PAD);
+    let marker_prefix = pad_glyph_to(glyph, MARKER_COLS);
+    let cont_prefix = " ".repeat(MARKER_COLS);
+
+    wrap_plain_text(text, wrap_width)
+        .into_iter()
+        .enumerate()
+        .map(|(i, body)| {
+            let prefix = if i == 0 {
+                marker_prefix.clone()
+            } else {
+                cont_prefix.clone()
+            };
+            // Pad the body out to the full column budget so the background
+            // color fills the row instead of stopping at the last glyph — a
+            // `Style` with only `bg()` set doesn't paint columns a span
+            // doesn't cover.
+            let padded_body = pad_to_width(&body, body_width);
+            Line::from(vec![
+                Span::styled(prefix, marker_style),
+                Span::styled(padded_body, body_style),
+            ])
+        })
+        .collect()
+}
+
+/// Greedily word-wrap `text` to `width` display columns (measured with
+/// `unicode_width`), splitting on existing newlines first so the source's
+/// own line breaks survive as independent wrapped lines rather than being
+/// folded into a reflowed paragraph.
+///
+/// A word wider than `width` is **hard-split at the column boundary**, not
+/// left to overflow: measured, `W`×150 at width 60 comes back as 57 / 57 / 36.
+/// (This differs from `ui::walkthrough_pane::wrap_text`, which lets such a
+/// word overflow — parity with Claude Code wins here.) The split walks
+/// grapheme clusters and never breaks one across two lines, and it **fills
+/// the remainder of the current line first** rather than flushing it: measured
+/// on a `⎿ Read <very long path>` annotation, where the path begins on the
+/// `Read` line and breaks at the column boundary.
+pub(crate) fn wrap_plain_text(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut out = Vec::new();
+    for source_line in text.split('\n') {
+        if source_line.is_empty() {
+            out.push(String::new());
+            continue;
+        }
+        let mut current = String::new();
+        let mut current_w = 0usize;
+        for word in source_line.split_whitespace() {
+            let word_w = UnicodeWidthStr::width(word);
+            if word_w > width {
+                // Fill the rest of the current line before spilling over,
+                // rather than flushing it first. Measured on a `⎿ Read <long
+                // path>` annotation: the path starts on the `Read` line and
+                // breaks at the column boundary, so the verb never sits alone.
+                if !current.is_empty() {
+                    if current_w + 1 < width {
+                        current.push(' ');
+                        current_w += 1;
+                    } else {
+                        out.push(std::mem::take(&mut current));
+                        current_w = 0;
+                    }
+                }
+                for cluster in word.graphemes(true) {
+                    let cw = UnicodeWidthStr::width(cluster);
+                    if current_w + cw > width && !current.is_empty() {
+                        out.push(std::mem::take(&mut current));
+                        current_w = 0;
+                    }
+                    current.push_str(cluster);
+                    current_w += cw;
+                }
+                continue;
+            }
+            let candidate_w = if current.is_empty() {
+                word_w
+            } else {
+                current_w + 1 + word_w
+            };
+            if candidate_w > width && !current.is_empty() {
+                out.push(std::mem::take(&mut current));
+                current_w = 0;
+            }
+            if !current.is_empty() {
+                current.push(' ');
+                current_w += 1;
+            }
+            current.push_str(word);
+            current_w += word_w;
+        }
+        out.push(current);
+    }
+    out
+}
+
+/// Pad `s` with trailing spaces until it fills exactly `width` display
+/// columns; left unchanged if it already meets or exceeds `width`.
+pub(crate) fn pad_to_width(s: &str, width: usize) -> String {
+    let w = UnicodeWidthStr::width(s);
+    if w >= width {
+        s.to_string()
+    } else {
+        let mut out = s.to_string();
+        for _ in 0..(width - w) {
+            out.push(' ');
+        }
+        out
+    }
+}

--- a/src/ui/reflow_view/user_text_tests.rs
+++ b/src/ui/reflow_view/user_text_tests.rs
@@ -1,0 +1,191 @@
+//! Tests for [`super::user_text`] — the user-turn full-width background
+//! block: word-wrapping, column padding, and marker/continuation layout.
+
+use ratatui::style::{Color, Style};
+use unicode_width::UnicodeWidthStr;
+
+use super::glyphs::MARKER_COLS;
+use super::palette;
+use super::user_text::{pad_to_width, render_user_text, wrap_plain_text};
+
+// ── wrap_plain_text ─────────────────────────────────────────────────────
+
+#[test]
+fn wrap_fits_on_one_line_unchanged() {
+    assert_eq!(wrap_plain_text("hello world", 20), vec!["hello world"]);
+}
+
+#[test]
+fn wrap_breaks_at_word_boundaries() {
+    assert_eq!(
+        wrap_plain_text("one two three four", 9),
+        vec!["one two", "three", "four"]
+    );
+}
+
+#[test]
+fn wrap_preserves_source_newlines_as_independent_lines() {
+    // Two short source lines, each well under the width budget — they must
+    // stay on separate output lines, not get joined into one reflowed
+    // paragraph the way Markdown prose would.
+    assert_eq!(
+        wrap_plain_text("first line\nsecond line", 40),
+        vec!["first line", "second line"]
+    );
+}
+
+#[test]
+fn wrap_preserves_blank_source_lines() {
+    assert_eq!(
+        wrap_plain_text("a\n\nb", 10),
+        vec!["a", "", "b"]
+    );
+}
+
+#[test]
+fn wrap_overlong_single_word_is_hard_split() {
+    // Measured against Claude Code: `W`x150 at a 57-column budget comes back
+    // as 57 / 57 / 36, so an unbreakable run is cut at the column boundary
+    // rather than allowed to overflow (which is what
+    // `ui::walkthrough_pane::wrap_text` does — parity wins here).
+    assert_eq!(
+        wrap_plain_text("supercalifragilistic", 5),
+        vec!["super", "calif", "ragil", "istic"]
+    );
+}
+
+#[test]
+fn wrap_hard_split_matches_the_measured_native_shape() {
+    let chunks = wrap_plain_text(&"W".repeat(150), 57);
+    let widths: Vec<usize> = chunks.iter().map(|c| c.chars().count()).collect();
+    assert_eq!(widths, vec![57, 57, 36]);
+}
+
+#[test]
+fn wrap_hard_split_never_breaks_a_full_width_glyph() {
+    // Budget 5 with 2-column glyphs: 2 per line, never a half-glyph line.
+    let chunks = wrap_plain_text(&"あ".repeat(5), 5);
+    for c in &chunks {
+        assert!(unicode_width::UnicodeWidthStr::width(c.as_str()) <= 5, "{c:?}");
+    }
+    assert_eq!(chunks.concat(), "あ".repeat(5));
+}
+
+// ── pad_to_width ─────────────────────────────────────────────────────────
+
+#[test]
+fn pad_short_string_fills_with_trailing_spaces() {
+    let padded = pad_to_width("hi", 5);
+    assert_eq!(padded, "hi   ");
+    assert_eq!(UnicodeWidthStr::width(padded.as_str()), 5);
+}
+
+#[test]
+fn pad_string_already_at_width_unchanged() {
+    assert_eq!(pad_to_width("hello", 5), "hello");
+}
+
+#[test]
+fn pad_string_wider_than_target_unchanged() {
+    assert_eq!(pad_to_width("hello world", 5), "hello world");
+}
+
+// ── render_user_text ────────────────────────────────────────────────────
+
+fn marker_style() -> Style {
+    Style::default().fg(palette::USER_MARKER_FG).bg(palette::USER_BG)
+}
+
+fn body_style() -> Style {
+    Style::default().fg(palette::USER_TEXT).bg(palette::USER_BG)
+}
+
+#[test]
+fn first_line_gets_the_marker_continuation_lines_get_blank_indent() {
+    let lines = render_user_text(
+        "one two three four five six seven",
+        12,
+        "\u{276f}",
+        marker_style(),
+        body_style(),
+    );
+    assert!(lines.len() > 1, "expected the body to wrap onto multiple lines");
+    assert_eq!(lines[0].spans[0].content, "\u{276f} ");
+    assert_eq!(lines[1].spans[0].content, "  ");
+}
+
+#[test]
+fn every_line_is_padded_to_the_full_panel_width_for_the_background() {
+    let width = 20;
+    let lines = render_user_text("short", width, "\u{276f}", marker_style(), body_style());
+    for line in &lines {
+        let total: usize = line
+            .spans
+            .iter()
+            .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+            .sum();
+        assert_eq!(total, width, "line {line:?} must fill the full width for its background");
+    }
+}
+
+#[test]
+fn marker_and_body_spans_carry_the_background_color() {
+    let lines = render_user_text("hi", 10, "\u{276f}", marker_style(), body_style());
+    let line = &lines[0];
+    assert_eq!(line.spans[0].style.bg, Some(Color::Rgb(55, 55, 55)));
+    assert_eq!(line.spans[1].style.bg, Some(Color::Rgb(55, 55, 55)));
+}
+
+#[test]
+fn source_newlines_survive_as_separate_lines_each_with_their_own_gutter_slot() {
+    let lines = render_user_text("first\nsecond", 20, "\u{276f}", marker_style(), body_style());
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].spans[0].content, "\u{276f} ");
+    assert_eq!(lines[1].spans[0].content, "  ");
+}
+
+#[test]
+fn body_wraps_at_width_minus_marker_cols() {
+    // width=10 leaves body_width = 10 - MARKER_COLS(2) = 8 columns for text.
+    let lines = render_user_text("abcdefgh ijkl", 10, "\u{276f}", marker_style(), body_style());
+    assert!(lines.len() >= 2, "8-col budget must force a wrap: {lines:?}");
+    // Guard the constant this test relies on so it fails loudly if MARKER_COLS
+    // ever changes instead of silently asserting the wrong budget.
+    assert_eq!(MARKER_COLS, 2);
+}
+
+// ── Grapheme-cluster width accounting ────────────────────────────────────
+//
+// These were found by the corpus sweep, not by inspection: a per-`char` sum
+// disagrees with the per-string width in both directions, and either way the
+// wrapped line no longer matches the budget it was wrapped to.
+
+#[test]
+fn emoji_presentation_sequence_counts_as_two_columns() {
+    // `⚠` is 1 column; `⚠` + U+FE0F is 2. Summing per `char` sees only the
+    // base (the selector is zero-width), so the line came out one column
+    // over-wide — the exact bleed the panel-width invariant catches.
+    let warn = "\u{26a0}\u{fe0f}";
+    assert_eq!(unicode_width::UnicodeWidthStr::width(warn), 2);
+
+    let wrapped = wrap_plain_text(&warn.repeat(5), 4);
+    for line in &wrapped {
+        assert!(
+            unicode_width::UnicodeWidthStr::width(line.as_str()) <= 4,
+            "{line:?} exceeds the budget"
+        );
+    }
+    assert_eq!(wrapped.concat(), warn.repeat(5), "no cluster was dropped");
+}
+
+#[test]
+fn zwj_sequence_is_never_split() {
+    // A family emoji is 2 columns but seven `char`s; splitting between them
+    // would both mis-measure and leave half a sequence on screen.
+    let family = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466}";
+    let wrapped = wrap_plain_text(&family.repeat(3), 4);
+    assert_eq!(wrapped.concat(), family.repeat(3));
+    for line in &wrapped {
+        assert!(unicode_width::UnicodeWidthStr::width(line.as_str()) <= 4, "{line:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Claude Code パネルを scroll up すると reflow transcript view に切り替わり、Claude の `.jsonl`
から画面を描き直す。この描画を**ネイティブ Claude Code と一致させる**ための実装。

「だいたい似ている」ではなく、合成セッションを `claude --resume` に描かせて生バイトを採取し、
CUP/CHA を再生した画面モデルと**1行ずつ突合**して合わせている（API 呼び出しは発生しないので
採取コストはゼロ）。推測で書いた箇所は残していない。

主な内容:

- **ツール行の描画** — `⏺ Bash(...)` / `⎿ result` の畳み込み、表示名の別名（`Edit`→`Update`,
  `Task`→`Agent`, `WebFetch`→`Fetch`）、`Read`/`TodoWrite` などカテゴリ別の結果表示
- **ユーザターン** — Markdown を通さず生テキストとして全幅背景ブロックで描く
- **CLI 生成の擬似ユーザレコードの畳み込み** — `/compact` の要約本体、`<task-notification>`、
  `attachment`、`compact_boundary` を、ネイティブと同じ抑えた表示に
- **コードブロックの配色** と表描画（`table_boxed.rs`）
- **グリフ復帰** — `Cell::set_skip` により crossterm が絶対 `MoveTo` を出す、ネイティブと同じ手法

### レコード種別の取捨（実測で判明した修正）

| ログ上の形 | ネイティブの描画 |
|---|---|
| `<task-notification>`（メッセージ内のどこでも） | `⏺ {<summary>}` のみ。**周囲の地の文は捨てられる** |
| 同上で `<summary>` 無し/空 | メッセージ全体が消える |
| `type: "queue-operation"` | **何も描かない**（入力キューの台帳） |
| `isCompactSummary: true` | 何も描かない |
| `<local-command-stdout>` | 直前の `❯` 行への `⎿` 継続 |
| `attachment.type = file` | `⎿  Read path (N lines)` |
| `attachment.type = compact_file_reference` | `⎿  Referenced file path` |
| `system` / `compact_boundary` | `✻ Conversation compacted (ctrl+o for history)` |
| `<system-reminder>` | **逐語で描く**（非表示のものは `isMeta` 側で隠れている） |

`queue-operation` は当初ユーザターンとして描いていたが、実ログ 624 件の `enqueue` のうち
271 件 (43%) は同文の `user` レコードが実在し、**ターンが二重に出ていた**。残り 325 件は
task-notification の生 XML だった。ネイティブはこのレコード種別を無視するため経路ごと削除。

### 意図的にネイティブと変えている点

ネイティブは resume 時に compact より前を再描画しないが、実端末では compact 前の出力は
スクロールバックに物理的に残っている。conductor の scroll up はそのスクロールバックの
代替なので、**履歴は残す**。

## Test plan

- `cargo test` — 914 passed / 0 failed
- 合成 fixture 4 本を `claude --resume` に描かせて突合 → **全て1行ずつ完全一致**
- 実セッションログ約 120 本に対する不変条件スイープ（パネル幅超過なし・幅往復の冪等性）を
  5 コーパスで実行 → 全て pass
  - 環境変数 `CONDUCTOR_TRANSCRIPT_CORPUS` でのオプトイン。**実ログはリポジトリに入れない**
    （パス・プロンプト・ツール出力を含むため）
- `cargo clippy --all-targets` — 変更範囲に警告なし（既存 3 件は `app/code_nav.rs`,
  `ui/hover_info.rs`）
- `cargo install --path .` 実行済み

### 未確認

`⎿` `✻` `⏺` が実端末で1桁幅か2桁幅かは、in-process のテストでは判定できない
（`Buffer::set_stringn` がテストと同じ `unicode-width` を使うため）。実機での目視確認が必要。
