### PR TITLE
fix: confine explorer hover underline to the row's name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.96.0"
+version = "0.96.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.96.0"
+version = "0.96.1"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/common/list_row.rs
+++ b/src/ui/common/list_row.rs
@@ -152,6 +152,20 @@ pub fn row_style(
     }
 }
 
+/// The same row style, minus the hover underline: for the parts of a row that
+/// are not its name — leading indent, expand arrow, icon, origin marker, line
+/// counts.
+///
+/// The underline is a "this is the thing you're pointing at" mark, and the
+/// thing is the file, not the tree scaffolding in front of it. Running it under
+/// the indent made a nested row's rule start far to the left of anything
+/// clickable, which read as a text-input underline spanning the row rather than
+/// as a pointer affordance. Colour still applies to the whole row, so the row
+/// as a whole is still visibly hovered.
+pub fn decoration_style(style: Style) -> Style {
+    style.remove_modifier(Modifier::UNDERLINED)
+}
+
 /// How far a hovered row's colour has to sit from its resting colour, in the
 /// units of [`Theme::perceptual_distance`] (`0` identical, ~`765` black vs
 /// white).
@@ -484,6 +498,34 @@ mod tests {
             "the underline marks where the pointer *is*, so it must not linger \
              into the fade-out"
         );
+    }
+
+    /// The underline marks the name, not the row: the indent/arrow/icon prefix
+    /// keeps the hover *colour* (so the whole row still lights up) but drops
+    /// the rule, which is what kept it from starting at the left edge of a
+    /// deeply nested row.
+    #[test]
+    fn decoration_keeps_the_hover_colour_but_not_the_underline() {
+        let theme = test_theme();
+        let hovered = row_style(&theme, theme.fg, false, true, Some(HoverPhase::On));
+        let decoration = decoration_style(hovered);
+
+        assert_eq!(decoration.fg, hovered.fg);
+        assert!(hovered.add_modifier.contains(Modifier::UNDERLINED));
+        assert!(!decoration.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    /// A selected row's BOLD is not the hover affordance and must survive the
+    /// split, or the prefix would render lighter than the name it belongs to.
+    #[test]
+    fn decoration_preserves_selection_styling() {
+        let theme = test_theme();
+        let selected = row_style(&theme, theme.fg, true, true, None);
+        let decoration = decoration_style(selected);
+
+        assert_eq!(decoration.fg, selected.fg);
+        assert_eq!(decoration.bg, selected.bg);
+        assert!(decoration.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]

--- a/src/ui/explorer_panel/diff_list.rs
+++ b/src/ui/explorer_panel/diff_list.rs
@@ -135,7 +135,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
             } => {
                 let indent = "  ".repeat(*depth);
                 let arrow = if *collapsed { "\u{25b6}" } else { "\u{25bc}" };
-                let label = format!("  {indent}{arrow} \u{1f4c1} {name}");
+                let prefix = format!("  {indent}{arrow} \u{1f4c1} ");
 
                 let style = crate::ui::common::list_row::row_style(
                     theme,
@@ -145,7 +145,15 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                     app.diff_list_hover.phase(idx),
                 );
 
-                Some(ListItem::new(Span::styled(label, style)))
+                // Prefix split off so the hover underline stops at the name
+                // (see `list_row::decoration_style`).
+                Some(ListItem::new(Line::from(vec![
+                    Span::styled(
+                        prefix,
+                        crate::ui::common::list_row::decoration_style(style),
+                    ),
+                    Span::styled(name.clone(), style),
+                ])))
             }
             DiffListEntry::File {
                 section,
@@ -173,7 +181,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                     DiffSection::Committed => "C",
                     DiffSection::Uncommitted => "U",
                 };
-                let label = format!("  {indent}{marker} {icon} {filename}");
+                let prefix = format!("  {indent}{marker} {icon} ");
 
                 // D6: the filename color reports the file's git stage state
                 // (untracked / unstaged / staged / committed), not the
@@ -190,19 +198,24 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                     diff_focused,
                     app.diff_list_hover.phase(idx),
                 );
+                // Everything that isn't the filename — indent, origin marker,
+                // icon, line counts — drops the hover underline so the rule
+                // sits under the name alone.
+                let decoration = crate::ui::common::list_row::decoration_style(style);
                 // The row's background/selection styling comes from `style`
                 // (via `row_style`), but +added/-deleted keep their own
                 // foreground regardless of stage state, so they're split into
-                // separate spans rather than baked into `label`.
+                // separate spans rather than baked into the label.
                 let counts_style = |fg| Style {
                     fg: Some(fg),
-                    ..style
+                    ..decoration
                 };
 
                 // GitHub-style comment badge: 💬N for files with review comments,
                 // coloured by whether any are still unresolved.
                 let mut spans = vec![
-                    Span::styled(label, style),
+                    Span::styled(prefix, decoration),
+                    Span::styled(filename.to_string(), style),
                     Span::styled(
                         format!(" +{}", file_diff.added_lines),
                         counts_style(theme.diff_add),
@@ -237,7 +250,13 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                 if !selected {
                     style = style.add_modifier(Modifier::BOLD);
                 }
-                Some(ListItem::new(Span::styled("  \u{25A3} SUMMARY", style)))
+                Some(ListItem::new(Line::from(vec![
+                    Span::styled(
+                        "  \u{25A3} ",
+                        crate::ui::common::list_row::decoration_style(style),
+                    ),
+                    Span::styled("SUMMARY", style),
+                ])))
             }
         });
     let items: Vec<ListItem> = error_banner.into_iter().chain(entry_items).collect();

--- a/src/ui/explorer_panel/file_tree.rs
+++ b/src/ui/explorer_panel/file_tree.rs
@@ -120,15 +120,17 @@ pub(super) fn render_file_tree(frame: &mut Frame, area: Rect, app: &mut App, pan
             let entry = app.viewer_state.tree.file_tree.get(tree_idx)?;
             let indent = indent_for_depth(entry.depth);
 
-            let label = if entry.is_dir {
+            // Split from the name so the hover underline can be confined to
+            // the name itself (see `list_row::decoration_style`).
+            let prefix = if entry.is_dir {
                 let arrow = if entry.is_expanded {
                     "\u{25bc}" // ▼
                 } else {
                     "\u{25b6}" // ▶
                 };
-                format!("{indent}{arrow} {} {}", entry.icon, entry.name)
+                format!("{indent}{arrow} {} ", entry.icon)
             } else {
-                format!("{indent}  {} {}", entry.icon, entry.name)
+                format!("{indent}  {} ", entry.icon)
             };
 
             // Untracked/ignored entries dim regardless of file-vs-directory,
@@ -157,7 +159,13 @@ pub(super) fn render_file_tree(frame: &mut Frame, area: Rect, app: &mut App, pan
                 hover,
             );
 
-            Some(ListItem::new(Span::styled(label, style)))
+            Some(ListItem::new(Line::from(vec![
+                Span::styled(
+                    prefix,
+                    crate::ui::common::list_row::decoration_style(style),
+                ),
+                Span::styled(entry.name.clone(), style),
+            ])))
         })
         .collect();
 


### PR DESCRIPTION
## Summary

Explorer のファイルツリーと Changed files で行をホバーしたとき、下線が行頭（インデントの左端）から引かれていた。ネストの深い行ほど、クリック対象より遥か左から線が始まり、ポインタのアフォーダンスではなくテキスト入力欄の下線のように見えていた。

下線を**名前の部分だけ**に限定する。行全体は1つの span で描かれていたので、装飾部（インデント / ▼▶ / アイコン、Changed files では C/U マーカーと `+N/-M` カウント）と名前を別 span に分割し、装飾部からは `UNDERLINED` だけを落とす。

ホバーの**色**は行全体に残るので、「その行がホバーされている」という情報は失われない。落とすのは下線だけで、fg/bg/BOLD は保持する（選択行のプレフィックスが名前より薄く描かれないように）。

- `src/ui/common/list_row.rs` — `decoration_style()` を追加。行スタイルから下線のみを除去する単一の場所。
- `src/ui/explorer_panel/file_tree.rs` — ラベルを prefix と `entry.name` に分割。
- `src/ui/explorer_panel/diff_list.rs` — ディレクトリ行・ファイル行・SUMMARY 行を同様に分割。ファイル行の `+N/-M` は `..style` 経由で下線を継承していたので、こちらも装飾扱いに変更。

## Test plan

- [x] `cargo test` — 918 passed / 0 failed
- [x] `cargo clippy --all-targets` — 新規警告なし（既存の3件は `code_nav.rs` / `hover_info.rs` 由来）
- [x] 追加テスト2件（`list_row`）
  - 装飾部はホバー色を保ちつつ下線だけ落とす
  - 選択行の fg/bg/BOLD が分割後も装飾部に残る
- [ ] 実機でのホバー確認（マウス操作のため要目視）
