### PR TITLE
fix: keep the reflow gutter-glyph hole out of body text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.96.0"
+version = "0.96.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.96.0"
+version = "0.96.1"
 edition = "2024"
 
 [dependencies]

--- a/src/ui/reflow_view/build.rs
+++ b/src/ui/reflow_view/build.rs
@@ -6,6 +6,8 @@
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use crate::claude_log::{DisplayBlock, LogEntry, Role};
 
@@ -39,6 +41,14 @@ pub(crate) struct BuildCtx<'a> {
 
 /// Block index standing for the blank separator line between entries.
 pub(crate) const SEPARATOR_BLOCK: usize = usize::MAX;
+
+/// Rightmost column a gutter marker can start at, and so the last column
+/// [`width_risk_hole`] scans. Markers are emitted at column 0 by
+/// [`helpers::with_marker`](super::helpers::with_marker) and
+/// [`fit_glyph_line`](super::helpers::fit_glyph_line), and at column 2 by
+/// [`tool_lines`](super::tool_lines)' `"  ⎿  "` / `" ⎿  "` prefixes. Anything
+/// past this is body text, where the same characters are content.
+pub(crate) const MAX_GUTTER_GLYPH_COL: usize = 2;
 
 /// Text of the `✻` line marking where a `/compact` cut the context (measured
 /// verbatim from a resumed transcript). Conductor cannot honour the `ctrl+o`
@@ -404,12 +414,40 @@ fn is_annotation_only(entry: &LogEntry) -> bool {
 /// ratatui's diff discontinuous there, which makes the crossterm backend emit
 /// an absolute `MoveTo` — the same trick. Verified against the real backend
 /// in `super::render`'s tests.
+///
+/// Two things this must get right, both of which a naive scan gets wrong:
+///
+/// * **Only the gutter counts.** `⏺`/`⎿`/`✻` are also ordinary characters that
+///   appear in body text — this app's own transcripts are full of pasted Claude
+///   Code output. A hole is an *unwritten cell*, so punching one into body text
+///   both drops a character and leaves whatever the previous frame had there.
+///   A marker only ever sits at column 0 (`helpers::with_marker`,
+///   `helpers::fit_glyph_line`) or column 2 (`tool_lines`' `"  ⎿  "` and
+///   `" ⎿  "` prefixes), so the scan stops after [`MAX_GUTTER_GLYPH_COL`].
+/// * **Columns advance by grapheme cluster, not by `char`.** Summing per `char`
+///   over-counts a ZWJ sequence (a family emoji is 2 columns but 7 `char`s) and
+///   under-counts an emoji-presentation sequence, which would put the hole on
+///   the wrong cell. Same reasoning as `helpers::truncate_to_width` and
+///   `user_text::wrap_plain_text`.
 fn width_risk_hole(line: &Line<'_>) -> Option<u16> {
     let mut col: usize = 0;
     for span in &line.spans {
-        for ch in span.content.chars() {
-            let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-            if super::glyphs::is_width_ambiguous(ch) {
+        for cluster in span.content.graphemes(true) {
+            if col > MAX_GUTTER_GLYPH_COL {
+                return None; // past the gutter — everything here is content
+            }
+            let w = UnicodeWidthStr::width(cluster);
+            // `w == 1` *is* the ambiguity: the defence exists for glyphs
+            // `unicode-width` calls one column while the terminal may draw two.
+            // A marker carrying a variation selector already measures two, so
+            // measurement and terminal agree and no hole is wanted — punching
+            // one there would blank the body's first cell instead.
+            if w == 1
+                && cluster
+                    .chars()
+                    .next()
+                    .is_some_and(super::glyphs::is_width_ambiguous)
+            {
                 return u16::try_from(col + w).ok();
             }
             col += w;

--- a/src/ui/reflow_view/render_tests.rs
+++ b/src/ui/reflow_view/render_tests.rs
@@ -21,7 +21,7 @@ use syntect::highlighting::ThemeSet;
 use crate::claude_log::{DisplayBlock, LogEntry, Role};
 use crate::ui::markdown::MarkdownCache;
 
-use super::build::{BuildCtx, build_lines};
+use super::build::{BuildCtx, MAX_GUTTER_GLYPH_COL, build_lines};
 use super::glyphs::{ASSISTANT_MARKER, TOOL_RESULT_GLYPH};
 
 /// Render `prev` → `next` through a real `CrosstermBackend` and return the
@@ -178,5 +178,124 @@ fn every_ambiguous_gutter_glyph_is_registered() {
     for glyph in [super::glyphs::USER_MARKER, super::glyphs::TEAMMATE_MESSAGE_GLYPH] {
         let ch = glyph.chars().next().unwrap();
         assert!(!super::glyphs::is_width_ambiguous(ch), "{glyph:?}");
+    }
+}
+
+/// A `⏺`/`⎿`/`✻` in **body text** is content, not a gutter marker. The scan
+/// used to run the whole line, so a transcript quoting Claude Code output —
+/// which this app's own transcripts do constantly — had a cell blanked in the
+/// middle of a sentence: an unwritten cell is never painted, so the character
+/// vanished and whatever the previous frame drew there stayed put.
+#[test]
+fn a_glyph_in_body_text_gets_no_hole() {
+    // Long enough that the `⏺` lands on a continuation line, which carries a
+    // blank indent instead of a marker — so nothing else on it wants a hole.
+    let text = format!("{} \u{23fa} tail", "word ".repeat(20));
+    let holes = build(
+        &[entry(Role::Assistant, vec![DisplayBlock::Text(text)])],
+        false,
+    );
+    // The first line legitimately has one (its own `⏺` marker at column 0);
+    // no other line may.
+    assert_eq!(holes.first().copied().flatten(), Some(1), "{holes:?}");
+    assert!(
+        holes.iter().skip(1).all(Option::is_none),
+        "a glyph in body text punched a hole into content: {holes:?}"
+    );
+}
+
+/// The hole belongs to the gutter glyph and must not move when the body holds
+/// characters whose width is not 1 — full-width CJK, ZWJ sequences, variation
+/// selectors, skin-tone modifiers, combining marks.
+///
+/// Note what this does *not* prove: the scan now stops at the gutter, so the
+/// per-`char` → per-grapheme change in `width_risk_hole` is not independently
+/// observable here (the gutter is ASCII spaces plus the marker, where the two
+/// agree). It is kept for consistency with `helpers::truncate_to_width` and
+/// `user_text::wrap_plain_text`; this test pins the invariant those two
+/// together are meant to preserve.
+#[test]
+fn wide_and_multi_char_clusters_do_not_shift_the_hole() {
+    // `⎿` sits at column 2 of a `  ⎿  ` prefix regardless of what follows it,
+    // so the hole is at column 3 for every one of these bodies.
+    for body in [
+        "plain",
+        "日本語の全角テキスト",                            // width-2 CJK
+        "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466} family", // ZWJ, 7 chars / 2 cols
+        "\u{26a0}\u{fe0f} warn",                          // emoji-presentation selector
+        "\u{1f44b}\u{1f3fd} wave",                        // skin-tone modifier
+        "e\u{0301}\u{0301} combining",                    // combining marks
+    ] {
+        let holes = build(
+            &[entry(
+                Role::User,
+                vec![DisplayBlock::ToolResult {
+                    kind: crate::claude_log::ResultKind::Inline,
+                    lines: vec![body.to_string()],
+                    is_error: false,
+                }],
+            )],
+            true,
+        );
+        assert_eq!(
+            holes.first().copied().flatten(),
+            Some(3),
+            "hole moved off the gutter glyph for body {body:?}: {holes:?}"
+        );
+    }
+}
+
+/// The hole must land on a cell the row does not otherwise use, and every
+/// built line must still fit the panel — the two invariants the mechanism
+/// exists to protect, checked together on wide-character content.
+#[test]
+fn holes_stay_inside_the_line_for_wide_content() {
+    use unicode_width::UnicodeWidthStr;
+
+    let theme = crate::theme::Theme::default();
+    let syntax_set = two_face::syntax::extra_newlines();
+    let syntect_theme = ThemeSet::load_defaults()
+        .themes
+        .remove("base16-ocean.dark")
+        .unwrap();
+    let cache = MarkdownCache::new();
+    let entries = vec![
+        entry(
+            Role::User,
+            vec![DisplayBlock::Text(
+                "日本語の全角テキストと絵文字 \u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466} と \u{26a0}\u{fe0f}".into(),
+            )],
+        ),
+        entry(
+            Role::Assistant,
+            vec![DisplayBlock::Text(
+                "全角 日本語日本語日本語日本語日本語 and \u{1f600} tail".into(),
+            )],
+        ),
+    ];
+    for width in [20usize, 40, 60, 80] {
+        let ctx = BuildCtx {
+            entries: &entries,
+            cache: &cache,
+            theme: &theme,
+            syntax_set: &syntax_set,
+            syntect_theme: &syntect_theme,
+            expanded: true,
+        };
+        let built = build_lines(&ctx, width);
+        for (line, meta) in built.lines.iter().zip(built.meta.iter()) {
+            let w: usize = line
+                .spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
+            assert!(w <= width, "line overflows at width {width}: {w} cols");
+            if let Some(col) = meta.skip_col {
+                assert!(
+                    (col as usize) <= MAX_GUTTER_GLYPH_COL + 1,
+                    "hole at column {col} is past the gutter (width {width})"
+                );
+            }
+        }
     }
 }

--- a/src/ui/reflow_view/tests.rs
+++ b/src/ui/reflow_view/tests.rs
@@ -38,12 +38,18 @@ fn pad_glyph_assistant_marker_produces_two_cols() {
 
 #[test]
 fn gutter_markers_are_exactly_one_column() {
-    // The gutter markers MUST measure as a single column. They render with
-    // emoji presentation (2 cols) in many fonts; the VS15 text-presentation
-    // selector forces narrow rendering to match this width. If a marker ever
-    // measures >1 here, every transcript line will be one column short and
-    // its last char will bleed past the panel edge (the regression that the
-    // VS15 suffix fixes).
+    // The gutter markers MUST measure as a single column, because every line's
+    // body budget is computed as `width - MARKER_COLS`. If a marker measured
+    // >1 here, each transcript line would be one column short and its last
+    // char would bleed past the panel edge.
+    //
+    // Measuring 1 is not the same as *rendering* as 1: `⏺`/`⎿`/`✻` are drawn
+    // two columns wide by many terminals and fonts. That gap is not closed
+    // here (an earlier comment claimed a U+FE0E text-presentation suffix did
+    // it — no such suffix exists on these constants). It is handled instead by
+    // leaving the cell after the glyph unwritten so the body is positioned
+    // absolutely; see `glyphs::WIDTH_AMBIGUOUS_GLYPHS` and
+    // `build::width_risk_hole`.
     for (name, m) in [
         ("assistant", ASSISTANT_MARKER),
         ("tool-result", TOOL_RESULT_GLYPH),


### PR DESCRIPTION
## Summary

Reflow ビューのガターグリフ (`⏺`/`⎿`/`✻`) は、unicode-width では 1 桁だが端末が 2 桁で描くことがある。そのため `build.rs` はグリフ直後のセルを**未書き込み (`skip_col`)** にして、ratatui の diff を不連続にし crossterm に絶対カーソル移動を吐かせることで本文の開始桁を固定している。

その穴の位置を決める `width_risk_hole()` に 2 つの欠陥があった。

**1. 行全体を走査していたため、本文中のグリフにも誤爆する**

`⏺`/`⎿`/`✻` はマーカーであると同時にただの文字でもあり、Conductor のトランスクリプトは Claude Code の出力そのものなので本文に日常的に出現する。穴は「未書き込みセル」なので、本文に開けるとその文字が描画されず、前フレームの残骸がそのまま残る。

実測（幅 60、`⏺` が継続行に来るケース）:

```
holes per line = [Some(1), Some(49), None]
                            ^^^^^^^ 本文カラム49への誤爆
```

**2. 桁送りが `char` 単位だった**

周囲のヘルパ (`helpers::truncate_to_width`, `user_text::wrap_plain_text`, `markdown::wrap::spans_to_cells`) はすべて grapheme cluster 単位なのに、ここだけ `UnicodeWidthChar` で char 単位に積算していた。ZWJ 家族絵文字は 7 char / 2 桁だが、char 単位だと 2+0+2+0+2+0+2 = 8 桁と数える。

```
column of the glyph: per-char sum = 9, true (grapheme) = 3
```

### 修正

`width_risk_hole()` のみを変更（折り返しロジックは未変更 — この関数は `skip_col` にしか影響しない）:

- **ガター境界で走査を打ち切る** — `MAX_GUTTER_GLYPH_COL = 2`。マーカーは col 0 (`with_marker` / `fit_glyph_line`) か col 2 (`"  ⎿  "` / `" ⎿  "`) にしか出ない。それ以降は本文なので content として扱う
- **grapheme cluster 単位で桁送り** — 周囲のヘルパと統一
- **`w == 1` を条件に追加** — 異体字セレクタ付きで既に 2 桁なら測定と端末が一致するので穴は不要。ここで開けると本文先頭を潰す

あわせて `tests.rs` の誤ったコメントを実装に合わせた。「VS15 (U+FE0E) text-presentation selector で narrow 化している」と書かれていたが、定数に U+FE0E は存在しない（実際の対策は上記の未書き込みセル方式）。

## Test plan

- 回帰テスト 3 本追加 (`render_tests.rs`)
  - `a_glyph_in_body_text_gets_no_hole` — 本文グリフに穴を開けない
  - `wide_and_multi_char_clusters_do_not_shift_the_hole` — 全角 / ZWJ / VS16 / 肌色修飾子 / 結合文字を含む本文でも穴がガターに留まる
  - `holes_stay_inside_the_line_for_wide_content` — 幅 20/40/60/80 で全行が幅内、穴はガター内
- **テストが空振りでないことを確認**: 旧実装に差し戻すと `a_glyph_in_body_text_gets_no_hole` が FAILED になることを実行確認
- `cargo test` → 917 passed / 0 failed
- `cargo clippy --all-targets` → 変更ファイルに警告 0（既存 3 件は `app/code_nav.rs` / `ui/hover_info.rs`、未変更）
- 実描画ダンプ（幅 44、修正後）:

```
 cols  hole    |0        1         2         3         4   |
   44  None    |❯ 全角と絵文字 👨‍👩‍👧‍👦 と ⚠️ の行                |
   44  Some(1) |⏺ quoting Claude output: pad pad pad pad pad|
   44  None    |  pad pad pad  ⏺ and ⎿ inside the body text |  ← 本文グリフ、穴なし
   15  Some(3) |  ⎿  結果 ⚠️ ok|
```

ZWJ 家族絵文字・⚠️ は 1 バッファセル (幅 2) として保持され、全行きっかり 44 桁。

### 未検証

端末が `⏺` を実際に何桁で描くかは in-process テストでは検証できない（ratatui も同じ unicode-width で測るため）。この防御機構は「どちらでも本文位置が正しくなる」設計だが、見た目の最終確認は実端末での目視が必要。
