### PR TITLE
feat: add a menu bar under the title bar exposing every command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,18 @@ Single-struct state model: `App` in `app/` (`app/mod.rs`, with logic split acros
 
 ```
 Title bar
+Menu bar (full width)
 Worktree monitor strip (full width)
 Explorer | Viewer | Terminal (Claude Code / Shell)
 Status bar
 ```
+
+- The **menu bar** (`ui/menu_bar.rs`, `menu/`) is a permanent one-row strip of
+  dropdown menus directly under the title bar — the browsable route to the same
+  commands the palette and the keybindings run. `f10` focuses it. Unlike the
+  worktree strip it stays visible while a panel is maximized. Menu rows carry a
+  `CommandId` and go through `App::execute_palette_command`, so the menu holds
+  no command logic of its own; `menu/model.rs` is taxonomy and labels only.
 
 - The worktree list is **not** a column: it lives in a full-width monitor strip
   along the top (`ui/worktree_bar.rs`), showing every worktree's branch, dirty
@@ -72,6 +80,7 @@ Status bar
 |--------|------|
 | `app/` | All application state and business logic methods (`mod.rs` + `review.rs`, `terminal.rs`, `worktree.rs`, `review_publish.rs`, `walkthrough_view.rs`) |
 | `event/` | Keyboard/mouse event dispatch based on Focus and overlay state (per-context submodules) |
+| `menu/` | Menu bar model (`model.rs` — which command sits under which menu), interaction state (`state.rs`), and availability predicates for the greyed-out rows (`enabled.rs`) |
 | `git_engine.rs` | All git operations via `git2` (no shell-out) — worktrees, diffs, branches, cherry-pick, merge |
 | `diff_state.rs` | Diff data model (file diffs, hunks, lines) using `similar` crate |
 | `viewer/` | File tree model (`file_tree.rs`) and file content buffer (`file_view.rs`) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.96.1"
+version = "0.97.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.96.1"
+version = "0.97.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -167,6 +167,7 @@ impl App {
             wtbar_scroll: 0,
             wtbar_reveal_selected: false,
             wtbar_hover: None,
+            menu: Default::default(),
             symbol_index: SymbolIndex::new(PathBuf::new()),
             jump_history: JumpHistory::new(),
             references_overlay: ReferencesOverlay::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -292,6 +292,10 @@ pub struct App {
     /// on chips and the `[x]` delete button.
     pub wtbar_hover: Option<crate::ui::worktree_bar::WtbarAction>,
 
+    /// Menu bar interaction state: which menu is focused or open, and the
+    /// click regions recorded by the last bar/dropdown render.
+    pub menu: crate::menu::MenuState,
+
     // ── Code navigation (symbol index + jump history) ───────────
     pub symbol_index: SymbolIndex,
     pub jump_history: JumpHistory,

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -25,6 +25,10 @@
 # ':' is bound per non-terminal layer so it passes through to the PTY in
 # terminal panels. Ctrl+P stays global for command-palette access anywhere.
 "ctrl+p" = "command_palette"
+# F10 opens the menu bar, as it does in GTK and Windows apps. The function keys
+# are otherwise unused here, so this steals nothing; Alt+<letter> mnemonics were
+# rejected because that space is already dense (alt+h/l, alt+t, alt+w).
+"f10" = "focus_menu_bar"
 # Alt+h / Alt+l — panel cycle that works everywhere, including terminals.
 "alt+h" = "cycle_focus_backward"
 "alt+l" = "cycle_focus_forward"

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -23,6 +23,15 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             app.overlays.command_palette.selected = 0;
             true
         }
+        Action::FocusMenuBar => {
+            // Focus the bar without dropping a list open; Down/Enter does that.
+            // Gated on no overlay being up, which is the invariant the key
+            // dispatcher relies on when it checks the menu ahead of overlays.
+            if app.overlays.active == ActiveOverlay::None {
+                app.menu.focus_bar(0);
+            }
+            true
+        }
         Action::OpenCommentList => {
             app.viewer_state.explorer.comment_list_selected = 0;
             app.viewer_state.explorer.comment_list_scroll = 0;

--- a/src/event/menu.rs
+++ b/src/event/menu.rs
@@ -1,0 +1,150 @@
+//! Keyboard handling while the menu bar has focus.
+//!
+//! Once the menu is active it consumes every key, so the letter-jump shortcuts
+//! here can use bare characters without colliding with any panel binding.
+//!
+//! `Esc` unwinds one level at a time (dropdown → bar → app) rather than
+//! dismissing everything at once, matching how the app's other nested modals
+//! behave and giving a mistyped `Down` an obvious way back.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::app::App;
+use crate::menu::model::{MENUS, MenuItem};
+use crate::menu::state::{
+    MenuFocus, find_by_initial, first_selectable, last_selectable, step_menu, step_selection,
+};
+
+/// Items of the menu at `index`, or an empty slice if the index is stale.
+fn items_of(index: usize) -> &'static [MenuItem] {
+    MENUS.get(index).map(|m| m.items).unwrap_or(&[])
+}
+
+/// Index of the first menu whose title starts with `ch`, case-insensitively.
+fn menu_by_initial(ch: char) -> Option<usize> {
+    let target = ch.to_ascii_lowercase();
+    MENUS.iter().position(|m| {
+        m.title
+            .chars()
+            .next()
+            .is_some_and(|c| c.to_ascii_lowercase() == target)
+    })
+}
+
+/// Run the command on `item_idx` of menu `menu_idx`, if it has one and it is
+/// currently available.
+fn activate(app: &mut App, menu_idx: usize, item_idx: usize) {
+    let Some(id) = items_of(menu_idx).get(item_idx).and_then(MenuItem::command) else {
+        return;
+    };
+    // A greyed-out row stays selectable so its existence is visible, but
+    // activating it does nothing — the same as clicking a disabled GUI item.
+    if !crate::menu::command_enabled(id, app) {
+        return;
+    }
+    // Close first: commands like `OpenRepo` push an overlay, and closing
+    // afterwards would clear the state they just set up.
+    app.menu.close();
+    app.execute_palette_command(id);
+}
+
+/// Keep the highlighted row inside the visible window of the dropdown.
+fn rescroll(app: &mut App) {
+    let visible = crate::ui::menu_bar::visible_rows(app, app.layout_cache.frame_area.height);
+    app.menu.scroll_selection_into_view(visible);
+}
+
+/// Handle a key while [`MenuFocus`] is active. The caller has already
+/// established that the menu owns input.
+pub(super) fn handle_menu_key(app: &mut App, key: KeyEvent) {
+    match app.menu.focus {
+        MenuFocus::Closed => {}
+
+        // ── Bar focused, nothing dropped down ────────────────────────────
+        MenuFocus::Bar { index } => match key.code {
+            KeyCode::Esc => app.menu.close(),
+            KeyCode::Left => app.menu.focus_bar(step_menu(MENUS.len(), index, -1)),
+            KeyCode::Right => app.menu.focus_bar(step_menu(MENUS.len(), index, 1)),
+            KeyCode::Home => app.menu.focus_bar(0),
+            KeyCode::End => app.menu.focus_bar(MENUS.len().saturating_sub(1)),
+            KeyCode::Down | KeyCode::Enter | KeyCode::Char(' ') => {
+                app.menu.open(index, items_of(index));
+            }
+            // A letter jumps straight to that menu and opens it — the fastest
+            // route for someone who knows where they are going.
+            KeyCode::Char(c) => {
+                if let Some(idx) = menu_by_initial(c) {
+                    app.menu.open(idx, items_of(idx));
+                }
+            }
+            _ => {}
+        },
+
+        // ── Dropdown open ────────────────────────────────────────────────
+        MenuFocus::Open {
+            index,
+            selected,
+            scroll,
+        } => match key.code {
+            KeyCode::Esc => app.menu.focus_bar(index),
+            KeyCode::Left => {
+                let idx = step_menu(MENUS.len(), index, -1);
+                app.menu.open(idx, items_of(idx));
+            }
+            KeyCode::Right => {
+                let idx = step_menu(MENUS.len(), index, 1);
+                app.menu.open(idx, items_of(idx));
+            }
+            KeyCode::Up => {
+                app.menu.focus = MenuFocus::Open {
+                    index,
+                    selected: step_selection(items_of(index), selected, -1),
+                    scroll,
+                };
+                rescroll(app);
+            }
+            KeyCode::Down => {
+                app.menu.focus = MenuFocus::Open {
+                    index,
+                    selected: step_selection(items_of(index), selected, 1),
+                    scroll,
+                };
+                rescroll(app);
+            }
+            KeyCode::Home => {
+                app.menu.focus = MenuFocus::Open {
+                    index,
+                    selected: first_selectable(items_of(index)),
+                    scroll,
+                };
+                rescroll(app);
+            }
+            KeyCode::End => {
+                app.menu.focus = MenuFocus::Open {
+                    index,
+                    selected: last_selectable(items_of(index)),
+                    scroll,
+                };
+                rescroll(app);
+            }
+            KeyCode::Enter => activate(app, index, selected),
+            KeyCode::Char(c) => {
+                if let Some(idx) = find_by_initial(items_of(index), selected, c) {
+                    app.menu.focus = MenuFocus::Open {
+                        index,
+                        selected: idx,
+                        scroll,
+                    };
+                    rescroll(app);
+                }
+            }
+            _ => {}
+        },
+    }
+}
+
+/// Mouse-side activation, shared with the click handler so a clicked row and an
+/// `Enter`-ed row go through exactly the same path.
+pub(in crate::event) fn activate_item(app: &mut App, menu_idx: usize, item_idx: usize) {
+    activate(app, menu_idx, item_idx);
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -10,6 +10,7 @@ mod dialogs;
 mod explorer;
 mod explorer_walkthrough;
 mod global;
+mod menu;
 mod mouse;
 mod overlay;
 mod overlay_helpers;
@@ -32,6 +33,7 @@ use self::dialogs::{handle_publish_confirm_key, handle_update_key};
 use self::explorer::handle_explorer_comment_list_key;
 use self::explorer::handle_explorer_key;
 use self::global::dispatch_global_action;
+use self::menu::handle_menu_key;
 use self::overlay::*;
 use self::overlay_helpers::dismiss_overlays;
 use self::reflow_key::handle_reflow_key;
@@ -191,6 +193,16 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
+    }
+
+    // ── 0.5. Menu bar — consumes ALL keys while focused ───────────────
+    //
+    // Ahead of the overlay dispatch because the menu is only ever active when
+    // no overlay is (opening it is gated on that below), so reaching this first
+    // costs nothing and keeps the menu's own Esc/arrow handling in one place.
+    if app.menu.focus.is_active() {
+        handle_menu_key(app, key);
+        return;
     }
 
     // ── 1. Overlay / modal dispatch — consume ALL keys when active ────

--- a/src/event/mouse/menu.rs
+++ b/src/event/mouse/menu.rs
@@ -1,0 +1,152 @@
+//! Mouse handling for the menu bar and its dropdown.
+//!
+//! Both entry points run *before* the other bar handlers in
+//! [`handle_mouse_event`](super::handle_mouse_event). That order is load
+//! bearing: `handle_title_bar_click` treats every row above `main_area` as its
+//! own and returns `true` unconditionally, so a menu-bar click placed after it
+//! would never be seen.
+//!
+//! The decision of *what* a click means is [`classify_menu_click`], a pure
+//! function over the recorded hit regions — same shape as
+//! [`classify_margin_click`](super::viewer_panel::classify_margin_click), and
+//! for the same reason: the interesting rules (toggle, dismiss, inert row) are
+//! then testable without standing up an `App` or a terminal.
+
+use crate::app::App;
+use crate::menu::MenuFocus;
+use crate::menu::model::MENUS;
+use crate::menu::state::MenuState;
+
+/// What a left click at a given point should do to the menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MenuClick {
+    /// Run `item` of `menu`.
+    Activate { menu: usize, item: usize },
+    /// Open `menu`'s dropdown.
+    Open(usize),
+    /// Leave the menu entirely.
+    Close,
+    /// Consumed, but nothing happens — a disabled row, a separator, or the
+    /// dropdown's own border. Keeps the menu open under a near-miss instead of
+    /// blinking it shut.
+    Inert,
+    /// Not the menu's click; let the rest of the dispatcher have it.
+    Pass,
+}
+
+/// Items of the menu at `index`, or an empty slice if the index is stale.
+fn items_of(index: usize) -> &'static [crate::menu::MenuItem] {
+    MENUS.get(index).map(|m| m.items).unwrap_or(&[])
+}
+
+/// Decide what a click at `(col, row)` means. `bar_row` is the menu bar's
+/// screen row, or `None` when the bar isn't drawn.
+pub(super) fn classify_menu_click(
+    state: &MenuState,
+    bar_row: Option<u16>,
+    col: u16,
+    row: u16,
+) -> MenuClick {
+    // Inside the open dropdown.
+    if state.in_dropdown(col, row) {
+        return match (state.focus.open_index(), state.item_hit_at(row)) {
+            (Some(menu), Some(hit)) if hit.enabled => MenuClick::Activate {
+                menu,
+                item: hit.item,
+            },
+            _ => MenuClick::Inert,
+        };
+    }
+
+    // On the bar row itself.
+    if bar_row == Some(row) {
+        return match state.bar_hit_at(col) {
+            // Clicking the open menu closes it, so one target toggles rather
+            // than re-opening what is already there.
+            Some(idx) if state.focus.open_index() == Some(idx) => MenuClick::Close,
+            Some(idx) => MenuClick::Open(idx),
+            // Blank stretch of the bar: nothing to open, and any open menu goes
+            // away.
+            None => MenuClick::Close,
+        };
+    }
+
+    // Anywhere else: dismiss if a menu is up, otherwise not our event. The
+    // dismissing click is swallowed on purpose — closing a menu should not also
+    // press whatever sat underneath it.
+    if state.focus.is_active() {
+        MenuClick::Close
+    } else {
+        MenuClick::Pass
+    }
+}
+
+/// Handle a left click against the menu bar and any open dropdown. Returns
+/// `true` when the click was consumed.
+pub(super) fn handle_menu_click(app: &mut App, col: u16, row: u16) -> bool {
+    let bar = app.layout_cache.menubar_area;
+    let bar_row = (bar.height > 0).then_some(bar.y);
+
+    match classify_menu_click(&app.menu, bar_row, col, row) {
+        MenuClick::Activate { menu, item } => {
+            super::super::menu::activate_item(app, menu, item);
+            true
+        }
+        MenuClick::Open(idx) => {
+            app.menu.open(idx, items_of(idx));
+            true
+        }
+        MenuClick::Close => {
+            app.menu.close();
+            true
+        }
+        MenuClick::Inert => true,
+        MenuClick::Pass => false,
+    }
+}
+
+/// Track hover for the menu bar. Returns `true` when the menu owns this
+/// movement, so the caller skips the other panels' hover bookkeeping (whatever
+/// is under the dropdown shouldn't light up).
+pub(super) fn handle_menu_hover(app: &mut App, col: u16, row: u16) -> bool {
+    let bar = app.layout_cache.menubar_area;
+    let on_bar = bar.height > 0 && row == bar.y;
+
+    // Highlight the title under the cursor; resolving to `None` off the row
+    // doubles as the "mouse left the bar" clear.
+    app.menu.hover = if on_bar { app.menu.bar_hit_at(col) } else { None };
+
+    match app.menu.focus {
+        MenuFocus::Closed => false,
+
+        // With a menu open, sliding along the bar switches which one is shown —
+        // the behaviour that makes a menu bar browsable rather than a series of
+        // click-open-click-close trips.
+        MenuFocus::Open { index, .. } => {
+            if on_bar {
+                if let Some(idx) = app.menu.bar_hit_at(col)
+                    && idx != index
+                {
+                    app.menu.open(idx, items_of(idx));
+                }
+            } else if app.menu.in_dropdown(col, row) {
+                // Hovering a row moves the selection, so the keyboard and the
+                // pointer share one notion of "current item".
+                if let Some(hit) = app.menu.item_hit_at(row)
+                    && let MenuFocus::Open {
+                        ref mut selected, ..
+                    } = app.menu.focus
+                {
+                    *selected = hit.item;
+                }
+            }
+            true
+        }
+
+        // Bar focused via F10 but nothing dropped down. Hover only highlights;
+        // opening still takes a click or Down/Enter, so drifting the mouse
+        // across the top of the screen can't pop a menu the user never asked
+        // for.
+        MenuFocus::Bar { .. } => on_bar,
+    }
+}

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -16,6 +16,7 @@ use super::explorer::open_viewer_comment;
 
 mod bars;
 mod explorer_panel;
+mod menu;
 mod scroll;
 mod terminal_panel;
 mod viewer_panel;
@@ -436,6 +437,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 app.viewer_state.scroll_right(4);
             }
         MouseEventKind::Down(MouseButton::Left) => {
+            // The menu bar goes first, for the same reason the worktree strip
+            // beats the title bar below: `handle_title_bar_click` claims every
+            // row above `main_area`. It also owns the dismiss-on-outside-click,
+            // which has to see the click before any panel does.
+            if menu::handle_menu_click(app, col, row) {
+                return;
+            }
             // Notification / worktree / title bar clicks are consumed first.
             // The worktree bar must be checked before the title bar: the latter
             // treats every row above `main_area` as "title" and would otherwise
@@ -540,6 +548,13 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             }
         }
         MouseEventKind::Moved => {
+            // Menu hover first, and it takes the whole event when a menu is up
+            // — panels under an open dropdown must not light up as if they were
+            // reachable.
+            if menu::handle_menu_hover(app, col, row) {
+                return;
+            }
+
             // Light up the divider under the cursor as a resize affordance — the
             // terminal stand-in for a col-/row-resize mouse cursor (a plain hover
             // never mutates a ratio; only a drag does).

--- a/src/event/mouse/tests.rs
+++ b/src/event/mouse/tests.rs
@@ -364,3 +364,164 @@ fn indexed_double_click_resets_on_different_idx() {
     assert_eq!(last_idx, 7);
     assert_eq!(last, t0 + Duration::from_millis(10));
 }
+
+// ── Menu bar clicks ──────────────────────────────────────────────────────
+
+mod menu_clicks {
+    use super::super::menu::{MenuClick, classify_menu_click};
+    use crate::menu::state::{BarHit, ItemHit, MenuFocus, MenuState};
+    use ratatui::layout::Rect;
+
+    const BAR_ROW: u16 = 1;
+
+    /// A state with two titles on row 1 and, optionally, menu 1's dropdown open
+    /// at rows 2..6 with one enabled row (3) and one disabled row (4).
+    fn state(open: bool) -> MenuState {
+        let mut s = MenuState {
+            bar_hits: vec![
+                BarHit {
+                    x0: 0,
+                    x1: 6,
+                    menu: 0,
+                },
+                BarHit {
+                    x0: 6,
+                    x1: 16,
+                    menu: 1,
+                },
+            ],
+            ..Default::default()
+        };
+        if open {
+            s.focus = MenuFocus::Open {
+                index: 1,
+                selected: 0,
+                scroll: 0,
+            };
+            s.dropdown_area = Rect::new(6, 2, 20, 4);
+            s.item_hits = vec![
+                ItemHit {
+                    y: 3,
+                    item: 0,
+                    enabled: true,
+                },
+                ItemHit {
+                    y: 4,
+                    item: 1,
+                    enabled: false,
+                },
+            ];
+        }
+        s
+    }
+
+    #[test]
+    fn clicking_a_title_opens_that_menu() {
+        let s = state(false);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 8, BAR_ROW),
+            MenuClick::Open(1)
+        );
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 2, BAR_ROW),
+            MenuClick::Open(0)
+        );
+    }
+
+    #[test]
+    fn clicking_the_open_title_again_closes_it() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 8, BAR_ROW),
+            MenuClick::Close,
+            "the same title toggles rather than re-opening"
+        );
+    }
+
+    #[test]
+    fn clicking_a_different_title_switches_menus() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 2, BAR_ROW),
+            MenuClick::Open(0)
+        );
+    }
+
+    #[test]
+    fn clicking_blank_bar_space_closes() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 40, BAR_ROW),
+            MenuClick::Close
+        );
+    }
+
+    #[test]
+    fn clicking_an_enabled_row_activates_it() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 10, 3),
+            MenuClick::Activate { menu: 1, item: 0 }
+        );
+    }
+
+    #[test]
+    fn clicking_a_disabled_row_does_nothing_but_keeps_the_menu_open() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 10, 4),
+            MenuClick::Inert
+        );
+    }
+
+    #[test]
+    fn clicking_the_dropdown_border_is_inert() {
+        // Row 2 and 5 are the popup's own border rows: inside the rect but
+        // carrying no item hit.
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 10, 2),
+            MenuClick::Inert
+        );
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 10, 5),
+            MenuClick::Inert
+        );
+    }
+
+    #[test]
+    fn clicking_outside_an_open_menu_closes_and_swallows_the_click() {
+        let s = state(true);
+        assert_eq!(
+            classify_menu_click(&s, Some(BAR_ROW), 60, 30),
+            MenuClick::Close,
+            "the dismissing click must not also reach the panel underneath"
+        );
+    }
+
+    #[test]
+    fn clicks_elsewhere_pass_through_when_no_menu_is_open() {
+        let s = state(false);
+        assert_eq!(classify_menu_click(&s, Some(BAR_ROW), 60, 30), MenuClick::Pass);
+    }
+
+    #[test]
+    fn a_stale_dropdown_rect_cannot_swallow_clicks_after_closing() {
+        // Regression guard: `close()` clears the recorded regions, so the rect
+        // from the last render can't keep eating clicks.
+        let mut s = state(true);
+        s.close();
+        assert_eq!(classify_menu_click(&s, Some(BAR_ROW), 10, 3), MenuClick::Pass);
+    }
+
+    #[test]
+    fn the_bar_row_is_claimed_even_with_no_menu_open() {
+        // Otherwise the click falls through to `handle_title_bar_click`, which
+        // consumes every row above the main area.
+        let s = state(false);
+        assert!(matches!(
+            classify_menu_click(&s, Some(BAR_ROW), 8, BAR_ROW),
+            MenuClick::Open(_)
+        ));
+    }
+}

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -23,6 +23,13 @@ keymap_suite::actions! {
         Quit => "quit",
         ShowHelp => "show_help",
         CommandPalette => "command_palette",
+        /// Give the menu bar keyboard focus. Arrow keys then browse the titles
+        /// and Down/Enter drops the list open — the GTK/Windows convention,
+        /// which is why the default chord is `f10`. No Alt+letter mnemonics:
+        /// alt+<letter> is already dense here (alt+h/l focus cycling, alt+t
+        /// theme picker, alt+w walkthrough), and a mnemonic set would have to
+        /// steal from it.
+        FocusMenuBar => "focus_menu_bar",
         CycleFocusForward => "cycle_focus_forward",
         CycleFocusBackward => "cycle_focus_backward",
         /// Switch the selected worktree to the next/previous one, from any panel
@@ -190,6 +197,7 @@ impl Action {
             Action::Quit => "Quit application",
             Action::ShowHelp => "Toggle this cheatsheet",
             Action::CommandPalette => "Command palette",
+            Action::FocusMenuBar => "Focus the menu bar",
             Action::CycleFocusForward => "Focus next panel",
             Action::CycleFocusBackward => "Focus previous panel",
             Action::NextWorktree => "Next worktree",
@@ -318,6 +326,10 @@ impl Action {
                 | Action::FocusTerminalClaude
                 | Action::FocusTerminalShell
                 | Action::CommandPalette
+                // The menu bar must be reachable from a terminal panel too —
+                // that's where most time is spent, and a menu you can only open
+                // after focusing something else is a menu you stop using.
+                | Action::FocusMenuBar
                 | Action::CycleFocusForward
                 | Action::CycleFocusBackward
                 | Action::NextWorktree

--- a/src/keymap/tests/resolution.rs
+++ b/src/keymap/tests/resolution.rs
@@ -406,3 +406,29 @@ fn viewer_c_is_add_comment() {
         Some(Action::AddComment)
     );
 }
+
+#[test]
+fn f10_opens_the_menu_bar_from_every_context() {
+    // The menu bar is only discoverable if its chord actually resolves. It is
+    // also the one place a function key is used, so a parser that silently
+    // dropped `f10` would leave the bar keyboard-unreachable while every other
+    // binding kept working.
+    let km = default_keymap();
+    let f10 = KeyEvent::new(KeyCode::F(10), KeyModifiers::NONE);
+
+    assert_eq!(km.resolve(&f10, KeyContext::Global), Some(Action::FocusMenuBar));
+    // Including over a PTY, where most time is spent.
+    assert_eq!(
+        km.resolve(&f10, KeyContext::Terminal),
+        Some(Action::FocusMenuBar),
+        "must fire while a terminal panel is focused"
+    );
+    assert_eq!(km.resolve(&f10, KeyContext::Explorer), Some(Action::FocusMenuBar));
+
+    // And it must be advertised in the generated cheatsheet.
+    assert_eq!(
+        km.keys_in_layer(KeyContext::Global, Action::FocusMenuBar),
+        vec!["f10".to_string()],
+        "the cheatsheet reads this; an empty result means the binding is invisible"
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod jump_history;
 mod keymap;
 mod mcp_serve;
 mod media_state;
+mod menu;
 mod overlay;
 mod pr_intake;
 mod pty_manager;

--- a/src/menu/enabled.rs
+++ b/src/menu/enabled.rs
@@ -1,0 +1,100 @@
+//! Whether a command can run right now — what drives the greyed-out rows.
+//!
+//! **The default is enabled.** A case is written here only where the command
+//! already refuses itself somewhere concrete, and each one names that place.
+//! The asymmetry is deliberate: a wrong `false` silently removes a working
+//! operation from the one UI that lists everything, while a wrong `true` costs
+//! nothing beyond today's behaviour — the command runs and reports its own
+//! outcome in the status bar, exactly as it does from the palette.
+//!
+//! So the rule for adding a case is: point at the existing check being
+//! mirrored. Do not invent a precondition from what a command's name suggests.
+//!
+//! Where a command's real precondition needs I/O — a SQLite read, a `git`
+//! call — only the cheap part is mirrored. This runs for every visible row of
+//! an open dropdown on every frame, and the app redraws at 60fps, so a
+//! predicate that queried the review DB would put a database round trip in the
+//! render loop. Erring toward "enabled" is the safe side of that trade: the
+//! command still explains itself when it can't proceed.
+
+use crate::app::App;
+use crate::command_palette::CommandId;
+
+/// Whether `id` can run against the current app state.
+///
+/// Must stay allocation-light and side-effect free — see the module note on
+/// where this is called from.
+pub fn command_enabled(id: CommandId, app: &App) -> bool {
+    let selected_worktree = app.worktrees.get(app.selected_worktree);
+
+    match id {
+        // ── App ──────────────────────────────────────────────────────────
+        // `Action::UpdateAndRestart` is a no-op unless a release was found
+        // (`event/global.rs`, `if app.update_info.is_some()`).
+        CommandId::UpdateAndRestart => app.update_info.is_some(),
+
+        // ── Repository ───────────────────────────────────────────────────
+        // The repo selector only opens with somewhere to switch to
+        // (`event/global.rs`, `if app.repo_list.len() > 1`).
+        CommandId::SwitchRepo => app.repo_list.len() > 1,
+
+        // ── Worktree ─────────────────────────────────────────────────────
+        // The strip's delete button refuses the main worktree and one already
+        // being torn down (`event/mouse/bars.rs`).
+        CommandId::DeleteWorktree => selected_worktree
+            .is_some_and(|w| !w.is_main && !app.is_worktree_pending_delete(&w.path)),
+
+        // "Cannot merge main into itself." (`app/worktree_commands.rs`).
+        CommandId::MergeToMain => selected_worktree.is_some_and(|w| !w.is_main),
+
+        // "Already grabbing a branch. Ungrab first (G)."
+        // (`app/worktree_commands.rs`). The follow-up "no non-main worktrees to
+        // grab" check is not mirrored: it needs `load_grab_branches()`, which
+        // mutates overlay state.
+        CommandId::GrabBranch => app.worktree_mgr.grabbed_branch.is_none(),
+
+        // "Not grabbing — nothing to ungrab." (`app/commands.rs`).
+        CommandId::UngrabBranch => app.worktree_mgr.grabbed_branch.is_some(),
+
+        // "No worktree selected." (`app/worktree_pr.rs`). Whether the branch
+        // actually has a PR takes a `git` call, so it is left to the command.
+        CommandId::OpenPullRequest => selected_worktree.is_some(),
+
+        // ── Viewer ───────────────────────────────────────────────────────
+        // "Raw/Rendered applies to a markdown file in the Viewer"
+        // (`app/view_state.rs`) — the same helper the command consults.
+        CommandId::ToggleMarkdownRender => app.viewer_state.markdown_toggle_available(),
+
+        // ── Review ───────────────────────────────────────────────────────
+        // A comment is anchored to the file open in the Viewer
+        // (`app/review_commands.rs`, `if let Some(file_path) = …current_file`).
+        CommandId::AddReviewComment => app.viewer_state.content.current_file.is_some(),
+
+        // Both guard on the comment list being the focused sub-panel and
+        // non-empty (`app/review_commands.rs`).
+        CommandId::DeleteComment | CommandId::ToggleCommentResolve => comment_list_focused(app),
+
+        // Both resolve a selected comment first and bail with "No comment
+        // selected." (`app/review_commands.rs`).
+        CommandId::EditComment | CommandId::ReplyToComment => app
+            .review_state
+            .selected_comment_idx(app.viewer_state.explorer.comment_list_selected)
+            .is_some(),
+
+        // Needs the review DB and a worktree (`app/review_publish.rs`). Whether
+        // the branch has an associated PR is a `get_pr_review_meta` query, so
+        // that part is left to the command.
+        CommandId::PublishReview => app.review_store.is_some() && selected_worktree.is_some(),
+
+        _ => true,
+    }
+}
+
+/// Whether the Explorer's bottom pane is showing the comment list, has focus,
+/// and has rows — the precondition `cmd_delete_comment` and
+/// `cmd_toggle_comment_resolve` both spell out.
+fn comment_list_focused(app: &App) -> bool {
+    app.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
+        && app.viewer_state.explorer.explorer_focus_on_diff_list
+        && !app.review_state.comment_list_rows.is_empty()
+}

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,0 +1,34 @@
+//! Menu bar — the pointer-and-arrow-key route to every command.
+//!
+//! Conductor already had two ways to run a command: a chord from
+//! `default_keybinds.toml`, and the fuzzy command palette. Both require knowing
+//! what you are looking for. The menu bar is the browsable third route: a
+//! permanent strip under the title bar whose dropdowns list the operations
+//! grouped by what they act on.
+//!
+//! It adds no behaviour of its own. Every row carries a
+//! [`CommandId`](crate::command_palette::CommandId) and activating it calls
+//! [`App::execute_palette_command`](crate::app::App::execute_palette_command) —
+//! the same entry point the palette uses and the same methods the keyboard
+//! actions in `event::global` call. The shortcut shown at the right of a row is
+//! read live from the keymap, so a rebind in the user's config is reflected
+//! without touching this module.
+//!
+//! - [`model`] — the static table: which command sits under which menu.
+//! - [`state`] — interaction state ([`MenuFocus`]) and the pure navigation
+//!   helpers shared by the keyboard and mouse handlers.
+//! - [`enabled`] — whether a command can run right now, for the greyed-out rows.
+//!
+//! Rendering lives in [`crate::ui::menu_bar`]; input handling in
+//! [`crate::event::menu`] (keys) and `crate::event::mouse` (clicks and hover).
+
+pub mod enabled;
+pub mod model;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+pub use enabled::command_enabled;
+pub use model::MenuItem;
+pub use state::{MenuFocus, MenuState};

--- a/src/menu/model.rs
+++ b/src/menu/model.rs
@@ -1,0 +1,207 @@
+//! The static menu table — which commands appear under which top-level menu,
+//! in which order, with which separators.
+//!
+//! This table holds *taxonomy and presentation only*. Every actionable entry is
+//! a [`CommandId`], and running it goes through
+//! [`App::execute_palette_command`](crate::app::App::execute_palette_command) —
+//! the same funnel the command palette and the keyboard shortcuts use. There is
+//! no second copy of any command's behaviour here, and adding a menu entry can
+//! never change what a command does.
+//!
+//! The short `label` on each item is menu-local on purpose. The palette labels
+//! are self-describing because the palette is a flat list ("Worktree: Create
+//! New"); inside a menu the top-level title already supplies that context, so
+//! repeating it would read as "Worktree ▸ Worktree: Create New". Only the
+//! display string is local — the `id` is what actually runs.
+//!
+//! `tests::every_command_is_reachable` holds the completeness promise: every
+//! `CommandId` must appear in exactly one menu or be listed in
+//! [`INTENTIONALLY_UNLISTED`] with a reason.
+
+use crate::command_palette::CommandId;
+
+/// One row of a dropdown: either an invocable command or a horizontal rule.
+pub enum MenuItem {
+    /// An invocable command. `label` is the text shown in the dropdown; `id` is
+    /// what gets executed.
+    Command {
+        id: CommandId,
+        label: &'static str,
+    },
+    /// A non-selectable divider between groups of related commands.
+    Separator,
+}
+
+impl MenuItem {
+    /// The command this row runs, or `None` for a [`MenuItem::Separator`].
+    pub fn command(&self) -> Option<CommandId> {
+        match self {
+            MenuItem::Command { id, .. } => Some(*id),
+            MenuItem::Separator => None,
+        }
+    }
+
+    /// Whether this row can hold the selection. Separators are skipped by
+    /// keyboard navigation and are not clickable.
+    pub fn is_selectable(&self) -> bool {
+        matches!(self, MenuItem::Command { .. })
+    }
+}
+
+/// One top-level menu and the dropdown it opens.
+pub struct Menu {
+    /// The word shown on the menu bar itself.
+    pub title: &'static str,
+    pub items: &'static [MenuItem],
+}
+
+/// Shorthand for a command row.
+const fn cmd(id: CommandId, label: &'static str) -> MenuItem {
+    MenuItem::Command { id, label }
+}
+
+/// A divider row.
+const SEP: MenuItem = MenuItem::Separator;
+
+/// Commands deliberately absent from the menu bar, each with the reason. The
+/// completeness test reads this list, so removing an entry here without adding
+/// the command to a menu fails the build.
+///
+/// Note this covers only [`CommandId`]s. The keymap also has per-panel cursor
+/// motions (`NavigateUp`, `GoToTop`, `NextHunk`, …) which are `Action`s without
+/// a `CommandId` — they are modal cursor movement, not operations, and are
+/// meaningless as a menu row. They are absent from the palette for the same
+/// reason.
+// Read by `tests::every_command_is_reachable`, which is the point of it: this
+// list is the written record of what the menu deliberately omits, and the test
+// is what stops the record from silently going stale.
+#[allow(dead_code)]
+pub const INTENTIONALLY_UNLISTED: &[(CommandId, &str)] = &[(
+    CommandId::TogglePartyMode,
+    "Labelled '(secret)' in the palette — listing it on the menu bar would \
+     defeat the point. Still reachable from the command palette.",
+)];
+
+/// The menu bar, left to right.
+pub const MENUS: &[Menu] = &[
+    Menu {
+        title: "Repo",
+        items: &[
+            cmd(CommandId::OpenRepo, "Open Repository…"),
+            cmd(CommandId::SwitchRepo, "Switch Repository…"),
+            SEP,
+            cmd(CommandId::RefreshDiff, "Refresh Diff"),
+            SEP,
+            cmd(CommandId::Quit, "Quit Conductor"),
+        ],
+    },
+    Menu {
+        title: "Worktree",
+        items: &[
+            cmd(CommandId::CreateWorktree, "New Worktree…"),
+            cmd(CommandId::DeleteWorktree, "Delete Worktree…"),
+            SEP,
+            cmd(CommandId::NextWorktree, "Next Worktree"),
+            cmd(CommandId::PrevWorktree, "Previous Worktree"),
+            SEP,
+            cmd(CommandId::SwitchBranch, "Switch Branch (Remote)…"),
+            cmd(CommandId::GrabBranch, "Grab Branch…"),
+            cmd(CommandId::UngrabBranch, "Ungrab Branch"),
+            SEP,
+            cmd(CommandId::PullWorktree, "Pull (fast-forward)"),
+            cmd(CommandId::MergeToMain, "Merge into Main"),
+            cmd(CommandId::CherryPick, "Cherry-pick…"),
+            cmd(CommandId::ResetMainToOrigin, "Reset Main to Origin"),
+            SEP,
+            cmd(CommandId::PruneWorktrees, "Prune Stale Worktrees"),
+            cmd(CommandId::RefreshWorktrees, "Refresh Worktree List"),
+            SEP,
+            cmd(CommandId::OpenPullRequest, "Open Pull Request in Browser"),
+        ],
+    },
+    Menu {
+        title: "Review",
+        items: &[
+            cmd(CommandId::AddReviewComment, "Add Comment"),
+            cmd(CommandId::EditComment, "Edit Comment"),
+            cmd(CommandId::ReplyToComment, "Reply to Comment"),
+            cmd(CommandId::DeleteComment, "Delete Comment"),
+            cmd(CommandId::ToggleCommentResolve, "Toggle Resolved"),
+            cmd(CommandId::ViewCommentDetail, "View Comment Detail"),
+            SEP,
+            cmd(CommandId::ShowReviewComments, "Show Comments"),
+            cmd(CommandId::ShowReviewTemplates, "Show Templates"),
+            SEP,
+            cmd(CommandId::ReviewPullRequest, "Review Pull Request…"),
+            // The walkthrough rows sit together under Review rather than with
+            // the other Explorer bottom-pane switches under View: reading a
+            // walkthrough is a review activity, and having "show" next to
+            // "generate" is what you want when there isn't one yet.
+            cmd(CommandId::ShowWalkthrough, "Show Walkthrough"),
+            cmd(CommandId::GenerateWalkthrough, "Generate Walkthrough"),
+            cmd(
+                CommandId::ForceGenerateWalkthrough,
+                "Regenerate Walkthrough (force)",
+            ),
+            SEP,
+            cmd(CommandId::PublishReview, "Publish Comments to GitHub…"),
+            SEP,
+            cmd(CommandId::SessionHistory, "Session History"),
+            cmd(CommandId::SaveSessionHistory, "Save Session History"),
+        ],
+    },
+    Menu {
+        title: "View",
+        items: &[
+            cmd(CommandId::ShowDiffList, "Changed Files"),
+            cmd(CommandId::ShowCommentList, "Comment List"),
+            SEP,
+            cmd(CommandId::ToggleMarkdownRender, "Markdown: Raw / Rendered"),
+            SEP,
+            cmd(CommandId::SwitchTheme, "Switch Theme…"),
+            cmd(CommandId::ToggleHighContrast, "Toggle High Contrast"),
+            cmd(CommandId::ToggleRichMode, "Toggle Rich Mode"),
+        ],
+    },
+    Menu {
+        title: "Panel",
+        items: &[
+            cmd(CommandId::FocusWorktree, "Focus Worktree"),
+            cmd(CommandId::FocusExplorer, "Focus Explorer"),
+            cmd(CommandId::FocusViewer, "Focus Viewer"),
+            cmd(CommandId::FocusTerminalClaude, "Focus Claude Code"),
+            cmd(CommandId::FocusTerminalShell, "Focus Shell"),
+            SEP,
+            cmd(CommandId::TogglePanelExpand, "Maximize / Restore Panel"),
+            SEP,
+            cmd(CommandId::ResizePaneLeft, "Resize Pane Left"),
+            cmd(CommandId::ResizePaneRight, "Resize Pane Right"),
+            cmd(CommandId::ResizePaneUp, "Resize Pane Up"),
+            cmd(CommandId::ResizePaneDown, "Resize Pane Down"),
+        ],
+    },
+    Menu {
+        title: "Search",
+        items: &[
+            cmd(CommandId::SearchInFile, "Search in File…"),
+            cmd(CommandId::SearchFullText, "Full-text Search (Grep)…"),
+        ],
+    },
+    Menu {
+        title: "Terminal",
+        items: &[
+            cmd(CommandId::NewClaudeCode, "New Claude Code Session"),
+            cmd(CommandId::NewShell, "New Shell Session"),
+            cmd(CommandId::ResumeClaudeSession, "Resume Claude Session…"),
+        ],
+    },
+    Menu {
+        title: "Help",
+        items: &[
+            cmd(CommandId::ToggleHelp, "Keyboard Shortcuts"),
+            SEP,
+            cmd(CommandId::CheckForUpdate, "Check for Updates"),
+            cmd(CommandId::UpdateAndRestart, "Update and Restart"),
+        ],
+    },
+];

--- a/src/menu/state.rs
+++ b/src/menu/state.rs
@@ -1,0 +1,251 @@
+//! Menu bar interaction state, plus the pure navigation helpers the keyboard
+//! and mouse handlers share.
+//!
+//! The navigation helpers are free functions over `&[MenuItem]` rather than
+//! methods on `App`, so the separator-skipping and wrap-around rules can be
+//! unit-tested without standing up a terminal or an `App`.
+
+use ratatui::layout::Rect;
+
+use super::model::MenuItem;
+
+/// Where menu-bar interaction currently sits.
+///
+/// Three states rather than two because `F10` focuses the bar *without*
+/// committing to a menu — matching the GTK/Windows convention where the arrow
+/// keys then browse the titles and `Down`/`Enter` drops the list open. Merging
+/// `Bar` into `Open` would force `F10` to pop a dropdown the user never asked
+/// for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MenuFocus {
+    /// The menu bar is drawn but inert; keys go to the app as usual.
+    #[default]
+    Closed,
+    /// The bar has keyboard focus and `index` is highlighted, no dropdown yet.
+    Bar { index: usize },
+    /// `index`'s dropdown is open with `selected` highlighted.
+    Open {
+        index: usize,
+        selected: usize,
+        scroll: usize,
+    },
+}
+
+impl MenuFocus {
+    /// Whether the menu is consuming input. When true the event dispatcher
+    /// routes every key to the menu handler and nothing reaches the panels.
+    pub fn is_active(self) -> bool {
+        !matches!(self, MenuFocus::Closed)
+    }
+
+    /// The highlighted top-level menu, in either active state.
+    pub fn active_index(self) -> Option<usize> {
+        match self {
+            MenuFocus::Closed => None,
+            MenuFocus::Bar { index } => Some(index),
+            MenuFocus::Open { index, .. } => Some(index),
+        }
+    }
+
+    /// The menu whose dropdown is open, if any.
+    pub fn open_index(self) -> Option<usize> {
+        match self {
+            MenuFocus::Open { index, .. } => Some(index),
+            _ => None,
+        }
+    }
+}
+
+/// A clickable top-level title on the menu bar row: `x0` inclusive, `x1`
+/// exclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BarHit {
+    pub x0: u16,
+    pub x1: u16,
+    /// Index into [`MENUS`](super::model::MENUS).
+    pub menu: usize,
+}
+
+/// A clickable row inside the open dropdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ItemHit {
+    /// Absolute screen row.
+    pub y: u16,
+    /// Index into the open menu's `items`.
+    pub item: usize,
+    /// False for a row whose command is currently unavailable — it is drawn
+    /// greyed out and clicking it does nothing.
+    pub enabled: bool,
+}
+
+/// Menu bar state carried on `App`.
+#[derive(Default)]
+pub struct MenuState {
+    pub focus: MenuFocus,
+    /// Top-level title hit regions, recorded by the last bar render.
+    pub bar_hits: Vec<BarHit>,
+    /// Dropdown row hit regions, recorded by the last dropdown render. Empty
+    /// while no dropdown is open.
+    pub item_hits: Vec<ItemHit>,
+    /// The open dropdown's rect (including its border), for outside-click
+    /// detection. Zero-sized while closed.
+    pub dropdown_area: Rect,
+    /// Top-level title under the mouse, for the hover highlight.
+    pub hover: Option<usize>,
+}
+
+impl MenuState {
+    /// Drop every recorded dropdown region. Called whenever the dropdown
+    /// closes so a stale rect can't keep swallowing clicks.
+    pub fn clear_dropdown_regions(&mut self) {
+        self.item_hits.clear();
+        self.dropdown_area = Rect::default();
+    }
+
+    /// Give the bar keyboard focus without opening anything.
+    pub fn focus_bar(&mut self, index: usize) {
+        self.focus = MenuFocus::Bar { index };
+        self.clear_dropdown_regions();
+    }
+
+    /// Open `index`'s dropdown with the first selectable row highlighted.
+    pub fn open(&mut self, index: usize, items: &[MenuItem]) {
+        self.focus = MenuFocus::Open {
+            index,
+            selected: first_selectable(items),
+            scroll: 0,
+        };
+        self.clear_dropdown_regions();
+    }
+
+    /// Leave the menu entirely and hand input back to the app.
+    ///
+    /// Always call this *before* running a command: several commands open an
+    /// overlay of their own, and closing afterwards would tear that overlay's
+    /// state back down.
+    pub fn close(&mut self) {
+        self.focus = MenuFocus::Closed;
+        self.clear_dropdown_regions();
+    }
+
+    /// Nudge `scroll` so `selected` stays inside a window of `visible` rows.
+    pub fn scroll_selection_into_view(&mut self, visible: usize) {
+        let MenuFocus::Open {
+            selected, scroll, ..
+        } = &mut self.focus
+        else {
+            return;
+        };
+        if visible == 0 {
+            return;
+        }
+        if *selected < *scroll {
+            *scroll = *selected;
+        } else if *selected >= *scroll + visible {
+            *scroll = *selected + 1 - visible;
+        }
+    }
+
+    /// Which top-level title (if any) sits under `col` on the bar row.
+    pub fn bar_hit_at(&self, col: u16) -> Option<usize> {
+        self.bar_hits
+            .iter()
+            .find(|h| col >= h.x0 && col < h.x1)
+            .map(|h| h.menu)
+    }
+
+    /// Which dropdown row (if any) sits at absolute screen row `row`, and
+    /// whether it is enabled.
+    pub fn item_hit_at(&self, row: u16) -> Option<ItemHit> {
+        self.item_hits.iter().find(|h| h.y == row).copied()
+    }
+
+    /// Whether `(col, row)` lands inside the open dropdown's rect.
+    pub fn in_dropdown(&self, col: u16, row: u16) -> bool {
+        let a = self.dropdown_area;
+        a.width > 0
+            && a.height > 0
+            && col >= a.x
+            && col < a.x + a.width
+            && row >= a.y
+            && row < a.y + a.height
+    }
+}
+
+// ── Pure navigation helpers ────────────────────────────────────────────────
+
+/// The first selectable row in `items`, or 0 if there is none.
+///
+/// A menu whose rows are all separators is a table authoring mistake rather
+/// than a runtime condition, so this degrades to 0 instead of returning an
+/// `Option` the callers would all have to unwrap.
+pub fn first_selectable(items: &[MenuItem]) -> usize {
+    items.iter().position(MenuItem::is_selectable).unwrap_or(0)
+}
+
+/// The last selectable row in `items`, or 0 if there is none.
+pub fn last_selectable(items: &[MenuItem]) -> usize {
+    items
+        .iter()
+        .rposition(MenuItem::is_selectable)
+        .unwrap_or(0)
+}
+
+/// Step the selection from `from` by one row in `dir` (`+1` down, `-1` up),
+/// skipping separators and wrapping around the ends.
+///
+/// Disabled rows are deliberately still selectable: greying a row out signals
+/// "not available right now" and skipping it would hide the row's existence,
+/// which is the opposite of what the disabled state is for.
+pub fn step_selection(items: &[MenuItem], from: usize, dir: i32) -> usize {
+    let n = items.len();
+    if n == 0 {
+        return 0;
+    }
+    let mut idx = from.min(n - 1);
+    // At most `n` steps: enough to land on any row, and to give up (returning
+    // `from`) when the menu holds no selectable row at all.
+    for _ in 0..n {
+        idx = if dir >= 0 {
+            (idx + 1) % n
+        } else {
+            (idx + n - 1) % n
+        };
+        if items[idx].is_selectable() {
+            return idx;
+        }
+    }
+    from
+}
+
+/// The next row whose label starts with `ch` (case-insensitive), searching
+/// forward from `from` and wrapping — the type-ahead that lets `n` jump between
+/// the "New …" entries of a menu.
+pub fn find_by_initial(items: &[MenuItem], from: usize, ch: char) -> Option<usize> {
+    let n = items.len();
+    if n == 0 {
+        return None;
+    }
+    let target = ch.to_ascii_lowercase();
+    (1..=n)
+        .map(|off| (from + off) % n)
+        .find(|&idx| match &items[idx] {
+            MenuItem::Command { label, .. } => label
+                .chars()
+                .next()
+                .is_some_and(|c| c.to_ascii_lowercase() == target),
+            MenuItem::Separator => false,
+        })
+}
+
+/// Step the highlighted top-level menu by one, wrapping.
+pub fn step_menu(menu_count: usize, from: usize, dir: i32) -> usize {
+    if menu_count == 0 {
+        return 0;
+    }
+    if dir >= 0 {
+        (from + 1) % menu_count
+    } else {
+        (from + menu_count - 1) % menu_count
+    }
+}

--- a/src/menu/tests.rs
+++ b/src/menu/tests.rs
@@ -1,0 +1,210 @@
+//! Menu table invariants and the pure navigation rules.
+//!
+//! `every_command_is_reachable` is the load-bearing one: it is what makes
+//! "every operation is reachable from the menu" a checked property rather than
+//! a claim that rots the next time a command is added.
+
+use super::model::{INTENTIONALLY_UNLISTED, MENUS, MenuItem};
+use super::state::{find_by_initial, first_selectable, last_selectable, step_menu, step_selection};
+use crate::command_palette::{COMMANDS, CommandId};
+
+/// Every command in a menu, flattened.
+fn menu_command_ids() -> Vec<CommandId> {
+    MENUS
+        .iter()
+        .flat_map(|m| m.items.iter())
+        .filter_map(MenuItem::command)
+        .collect()
+}
+
+#[test]
+fn every_command_is_reachable() {
+    let listed = menu_command_ids();
+    let excused: Vec<CommandId> = INTENTIONALLY_UNLISTED.iter().map(|(id, _)| *id).collect();
+
+    let missing: Vec<_> = COMMANDS
+        .iter()
+        .filter(|c| !listed.contains(&c.id) && !excused.contains(&c.id))
+        .map(|c| c.label)
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these palette commands are on no menu and are not in INTENTIONALLY_UNLISTED: {missing:?}\n\
+         Add each one to a menu in model.rs, or list it in INTENTIONALLY_UNLISTED with a reason."
+    );
+}
+
+#[test]
+fn unlisted_commands_are_actually_unlisted() {
+    let listed = menu_command_ids();
+    for (id, reason) in INTENTIONALLY_UNLISTED {
+        assert!(
+            !listed.contains(id),
+            "{id:?} is on a menu but is also excused in INTENTIONALLY_UNLISTED ({reason})"
+        );
+    }
+}
+
+#[test]
+fn no_command_appears_on_two_menus() {
+    let listed = menu_command_ids();
+    for (i, id) in listed.iter().enumerate() {
+        assert!(
+            !listed[i + 1..].contains(id),
+            "{id:?} appears on more than one menu — a duplicated row makes the \
+             menu bar ambiguous about where an operation lives"
+        );
+    }
+}
+
+#[test]
+fn every_menu_command_exists_in_the_palette_table() {
+    // The menu runs commands through `execute_palette_command`, so a menu entry
+    // for an id absent from COMMANDS would be a row with no shortcut hint and
+    // no palette twin — a sign the two tables drifted.
+    for id in menu_command_ids() {
+        assert!(
+            COMMANDS.iter().any(|c| c.id == id),
+            "{id:?} is on a menu but missing from the palette COMMANDS table"
+        );
+    }
+}
+
+#[test]
+fn menus_are_non_empty_and_have_selectable_rows() {
+    for menu in MENUS {
+        assert!(!menu.items.is_empty(), "menu {:?} is empty", menu.title);
+        assert!(
+            menu.items.iter().any(MenuItem::is_selectable),
+            "menu {:?} has no selectable row",
+            menu.title
+        );
+    }
+}
+
+#[test]
+fn menus_have_no_leading_trailing_or_doubled_separators() {
+    for menu in MENUS {
+        let sel: Vec<bool> = menu.items.iter().map(MenuItem::is_selectable).collect();
+        assert!(
+            sel.first() == Some(&true),
+            "menu {:?} starts with a separator",
+            menu.title
+        );
+        assert!(
+            sel.last() == Some(&true),
+            "menu {:?} ends with a separator",
+            menu.title
+        );
+        assert!(
+            !sel.windows(2).any(|w| !w[0] && !w[1]),
+            "menu {:?} has two separators in a row",
+            menu.title
+        );
+    }
+}
+
+// ── Navigation ─────────────────────────────────────────────────────────────
+
+fn sample() -> Vec<MenuItem> {
+    vec![
+        MenuItem::Command {
+            id: CommandId::Quit,
+            label: "Alpha",
+        },
+        MenuItem::Separator,
+        MenuItem::Command {
+            id: CommandId::OpenRepo,
+            label: "Beta",
+        },
+        MenuItem::Command {
+            id: CommandId::SwitchRepo,
+            label: "Alto",
+        },
+    ]
+}
+
+#[test]
+fn step_selection_skips_separators() {
+    let items = sample();
+    // 0 → (skip the separator at 1) → 2
+    assert_eq!(step_selection(&items, 0, 1), 2);
+    // and back up again
+    assert_eq!(step_selection(&items, 2, -1), 0);
+}
+
+#[test]
+fn step_selection_wraps_at_both_ends() {
+    let items = sample();
+    assert_eq!(step_selection(&items, 3, 1), 0, "past the end wraps to first");
+    assert_eq!(
+        step_selection(&items, 0, -1),
+        3,
+        "before the start wraps to last"
+    );
+}
+
+#[test]
+fn step_selection_is_a_no_op_without_selectable_rows() {
+    let items = vec![MenuItem::Separator, MenuItem::Separator];
+    assert_eq!(step_selection(&items, 0, 1), 0);
+    assert_eq!(step_selection(&items, 1, -1), 1);
+}
+
+#[test]
+fn step_selection_handles_an_empty_menu() {
+    assert_eq!(step_selection(&[], 0, 1), 0);
+}
+
+#[test]
+fn step_selection_clamps_an_out_of_range_start() {
+    // A stale index (menu table changed under a live selection) must not panic.
+    let items = sample();
+    assert!(step_selection(&items, 99, 1) < items.len());
+}
+
+#[test]
+fn first_and_last_selectable_find_the_edges() {
+    let items = sample();
+    assert_eq!(first_selectable(&items), 0);
+    assert_eq!(last_selectable(&items), 3);
+
+    let leading_sep = vec![
+        MenuItem::Separator,
+        MenuItem::Command {
+            id: CommandId::Quit,
+            label: "Only",
+        },
+    ];
+    assert_eq!(first_selectable(&leading_sep), 1);
+    assert_eq!(last_selectable(&leading_sep), 1);
+}
+
+#[test]
+fn find_by_initial_matches_case_insensitively_and_wraps() {
+    let items = sample();
+    // From "Alpha" (0), the next 'a' is "Alto" (3) — not itself.
+    assert_eq!(find_by_initial(&items, 0, 'a'), Some(3));
+    // From "Alto" (3) it wraps back around to "Alpha" (0).
+    assert_eq!(find_by_initial(&items, 3, 'A'), Some(0));
+    assert_eq!(find_by_initial(&items, 0, 'b'), Some(2));
+    assert_eq!(find_by_initial(&items, 0, 'z'), None);
+}
+
+#[test]
+fn find_by_initial_never_lands_on_a_separator() {
+    let items = sample();
+    for ch in ['a', 'b', 'z'] {
+        if let Some(idx) = find_by_initial(&items, 0, ch) {
+            assert!(items[idx].is_selectable());
+        }
+    }
+}
+
+#[test]
+fn step_menu_wraps_both_ways() {
+    assert_eq!(step_menu(3, 2, 1), 0);
+    assert_eq!(step_menu(3, 0, -1), 2);
+    assert_eq!(step_menu(0, 0, 1), 0, "no menus must not divide by zero");
+}

--- a/src/ui/layout/cache.rs
+++ b/src/ui/layout/cache.rs
@@ -3,6 +3,10 @@
 
 use ratatui::layout::{Constraint, Layout, Rect};
 
+/// Rows the menu bar occupies. Constant — the bar is always drawn, so it is not
+/// a cache key (nothing about the app state can change it).
+const MENUBAR_HEIGHT: u16 = 1;
+
 /// Cached layout rectangles computed once per frame.
 /// Shared between render_ui, mouse event handler, PTY sizing, and decoration.
 #[derive(Default, Clone)]
@@ -23,6 +27,12 @@ pub struct LayoutCache {
     pub explorer_split_pct: u16,
     /// Title bar area.
     pub title_area: Rect,
+    /// Menu bar area — one row directly under the title bar. Unlike the
+    /// worktree strip this is *not* hidden while a panel is maximized: a menu
+    /// you can only reach by un-maximizing is a menu you stop reaching for, and
+    /// the maximized panel is exactly where you are most likely to want a
+    /// command you don't have memorised.
+    pub menubar_area: Rect,
     /// Notification bar area.
     pub notif_area: Rect,
     /// Worktree monitor strip area (full-width, between notif and main).
@@ -79,6 +89,7 @@ impl LayoutCache {
 
         let outer = Layout::vertical([
             Constraint::Length(1),
+            Constraint::Length(MENUBAR_HEIGHT),
             Constraint::Length(notif_height),
             Constraint::Length(wtbar_height),
             Constraint::Min(0),
@@ -87,10 +98,11 @@ impl LayoutCache {
         .split(frame_area);
 
         self.title_area = outer[0];
-        self.notif_area = outer[1];
-        self.wtbar_area = outer[2];
-        self.main_area = outer[3];
-        self.status_area = outer[4];
+        self.menubar_area = outer[1];
+        self.notif_area = outer[2];
+        self.wtbar_area = outer[3];
+        self.main_area = outer[4];
+        self.status_area = outer[5];
 
         let (left_w, explorer_w, viewer_w) = accordion_widths(
             expanded_panel,

--- a/src/ui/layout/render.rs
+++ b/src/ui/layout/render.rs
@@ -25,12 +25,16 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     );
 
     let title_area = app.layout_cache.title_area;
+    let menubar_area = app.layout_cache.menubar_area;
     let wtbar_area = app.layout_cache.wtbar_area;
     let main_area = app.layout_cache.main_area;
     let status_area = app.layout_cache.status_area;
 
     // ── Title bar ───────────────────────────────────────────────────
     super::super::common::render_title_bar(frame, title_area, app);
+
+    // ── Menu bar (always present, directly under the title) ─────────
+    super::super::menu_bar::render(frame, menubar_area, app);
 
     // ── Worktree monitor strip (replaces the old left column and the
     //    former CC-waiting notification bar) ─────────────────────────
@@ -99,6 +103,12 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
     }
 
     render_overlays(frame, main_area, app);
+
+    // ── Menu dropdown ────────────────────────────────────────────────
+    // Drawn last among content so it sits over the panels. It hangs off the
+    // menu bar row, which is above `main_area`, so it is clamped to the whole
+    // frame rather than to the main area.
+    super::super::menu_bar::render_dropdown(frame, area, app);
 
     // ── Status bar ──────────────────────────────────────────────────
     // Show worktree branch + repo on the right of status bar.

--- a/src/ui/layout/tests.rs
+++ b/src/ui/layout/tests.rs
@@ -130,3 +130,75 @@ fn custom_percentages_are_respected() {
     assert_eq!(explorer, 30);
     assert_eq!(viewer, 30);
 }
+
+// ── Menu bar row ─────────────────────────────────────────────────
+
+#[test]
+fn menu_bar_sits_directly_under_the_title_bar() {
+    let mut cache = LayoutCache::default();
+    cache.update(rect(200, 50), None, false, &layout(24, 38, 80), 80);
+    assert_eq!(cache.title_area.y, 0);
+    assert_eq!(cache.title_area.height, 1);
+    assert_eq!(
+        cache.menubar_area.y,
+        cache.title_area.y + cache.title_area.height,
+        "the menu bar must be the row immediately below the title bar"
+    );
+    assert_eq!(cache.menubar_area.height, 1);
+    assert_eq!(
+        cache.menubar_area.width, 200,
+        "the bar spans the full width so its blank stretch is still clickable"
+    );
+}
+
+#[test]
+fn menu_bar_stays_visible_while_a_panel_is_maximized() {
+    // Unlike the worktree strip, which collapses to give the expanded panel
+    // its rows back. A menu reachable only after un-maximizing is a menu that
+    // stops being used.
+    let mut cache = LayoutCache::default();
+    cache.update(
+        rect(200, 50),
+        Some(Focus::Explorer),
+        false,
+        &layout(24, 38, 80),
+        80,
+    );
+    assert_eq!(cache.menubar_area.height, 1);
+    assert_eq!(cache.wtbar_area.height, 0, "worktree strip still collapses");
+}
+
+#[test]
+fn menu_bar_row_comes_out_of_the_main_area() {
+    // The bar takes its row from the content region, not from the status bar
+    // or by overdrawing the worktree strip.
+    let mut cache = LayoutCache::default();
+    let cfg = layout(24, 38, 80);
+    cache.update(rect(200, 50), None, false, &cfg, 80);
+
+    assert_eq!(cache.main_area.y, cache.wtbar_area.y + cache.wtbar_area.height);
+    assert_eq!(
+        cache.main_area.y + cache.main_area.height,
+        cache.status_area.y,
+        "main area must still butt up against the status bar"
+    );
+    // title(1) + menubar(1) + wtbar(1) + status(1) = 4 rows of chrome.
+    assert_eq!(cache.main_area.height, 50 - 4);
+}
+
+#[test]
+fn every_vertical_row_is_accounted_for() {
+    // No gaps and no overlaps between the stacked regions, at a couple of
+    // heights including one short enough to squeeze the main area.
+    for h in [50_u16, 10, 6] {
+        let mut cache = LayoutCache::default();
+        cache.update(rect(120, h), None, false, &layout(24, 38, 80), 80);
+        let total = cache.title_area.height
+            + cache.menubar_area.height
+            + cache.notif_area.height
+            + cache.wtbar_area.height
+            + cache.main_area.height
+            + cache.status_area.height;
+        assert_eq!(total, h, "regions must tile the frame exactly at height {h}");
+    }
+}

--- a/src/ui/menu_bar.rs
+++ b/src/ui/menu_bar.rs
@@ -1,0 +1,304 @@
+//! Menu bar rendering: the always-present strip of titles under the title bar,
+//! and the dropdown of the open menu.
+//!
+//! Both passes record their hit regions onto `app.menu` so the mouse handler
+//! resolves clicks against exactly what was drawn, the same contract
+//! [`crate::ui::worktree_bar`] uses for the worktree strip.
+//!
+//! Styling follows the existing popups (`Clear` + `Borders::ALL` + an accent
+//! border, `selected_bg`/`selected_fg` for the highlight) so the dropdown reads
+//! as part of the same app rather than a bolted-on widget.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::App;
+use crate::menu::model::{MENUS, MenuItem};
+use crate::menu::state::{BarHit, ItemHit};
+
+/// Blank columns on each side of a top-level title, giving the highlight a bit
+/// of breathing room and widening the click target.
+const TITLE_PAD: u16 = 1;
+
+/// Columns between the end of a row's label and the start of its shortcut.
+const LABEL_CHORD_GAP: u16 = 4;
+
+fn width(s: &str) -> u16 {
+    UnicodeWidthStr::width(s) as u16
+}
+
+/// Draw the menu bar row and record the click regions of each title.
+pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    if area.height == 0 || area.width == 0 {
+        app.menu.bar_hits.clear();
+        return;
+    }
+
+    let theme = &app.theme;
+    let active = app.menu.focus.active_index();
+    let hover = app.menu.hover;
+
+    // Color::Reset so the terminal's own background (including a background
+    // image) shows through, matching the title bar above it.
+    let bar_bg = ratatui::style::Color::Reset;
+
+    let mut spans: Vec<Span> = Vec::new();
+    let mut hits: Vec<BarHit> = Vec::new();
+    let mut x = area.x;
+
+    for (i, menu) in MENUS.iter().enumerate() {
+        let text = format!(
+            "{pad}{title}{pad}",
+            pad = " ".repeat(TITLE_PAD as usize),
+            title = menu.title
+        );
+        let w = width(&text);
+
+        // Stop before overflowing the row; a clipped, half-drawn title would
+        // record a hit region that doesn't match what's on screen.
+        if x + w > area.x + area.width {
+            break;
+        }
+
+        let style = if active == Some(i) {
+            // The open/focused menu is a *selection*, so it gets the same
+            // background treatment as any other selected row in the app.
+            Style::default()
+                .fg(theme.selected_fg)
+                .bg(theme.selected_bg)
+                .add_modifier(Modifier::BOLD)
+        } else if hover == Some(i) {
+            // Hover is expressed in the foreground only: several themes have a
+            // background-image-friendly transparent bar, and painting a hover
+            // background there fights the title bar's `Color::Reset`.
+            Style::default()
+                .fg(theme.accent)
+                .bg(bar_bg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg).bg(bar_bg)
+        };
+
+        spans.push(Span::styled(text, style));
+        hits.push(BarHit {
+            x0: x,
+            x1: x + w,
+            menu: i,
+        });
+        x += w;
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(bar_bg)),
+        area,
+    );
+    app.menu.bar_hits = hits;
+}
+
+/// Draw the open menu's dropdown, if any, and record its row hit regions.
+///
+/// Called after the panels so the popup lands on top of them. `frame_area` is
+/// the whole screen: the dropdown is clamped to it rather than to the main
+/// area, since it hangs off the menu bar which sits above the main area.
+pub fn render_dropdown(frame: &mut Frame, frame_area: Rect, app: &mut App) {
+    let (menu_idx, selected, scroll) = match app.menu.focus {
+        crate::menu::MenuFocus::Open {
+            index,
+            selected,
+            scroll,
+        } => (index, selected, scroll),
+        _ => {
+            app.menu.clear_dropdown_regions();
+            return;
+        }
+    };
+    let Some(menu) = MENUS.get(menu_idx) else {
+        app.menu.clear_dropdown_regions();
+        return;
+    };
+
+    // Shortcut hints are resolved for the focused panel's layer, so a row shows
+    // the chord that would actually fire right now — the same rule the command
+    // palette uses.
+    let context = app.focus.key_context();
+    let rows: Vec<Row> = menu
+        .items
+        .iter()
+        .map(|item| match item {
+            MenuItem::Separator => Row::Separator,
+            MenuItem::Command { id, label } => {
+                let chord = crate::command_palette::COMMANDS
+                    .iter()
+                    .find(|c| c.id == *id)
+                    .and_then(|c| c.action)
+                    .and_then(|a| {
+                        crate::ui::common::representative_chord(&app.keymap, context, a)
+                    })
+                    .unwrap_or_default();
+                Row::Command {
+                    label,
+                    chord,
+                    enabled: crate::menu::command_enabled(*id, app),
+                }
+            }
+        })
+        .collect();
+
+    // ── Geometry ──────────────────────────────────────────────────────────
+    let label_w = rows
+        .iter()
+        .map(|r| match r {
+            Row::Command { label, .. } => width(label),
+            Row::Separator => 0,
+        })
+        .max()
+        .unwrap_or(0);
+    let chord_w = rows
+        .iter()
+        .map(|r| match r {
+            Row::Command { chord, .. } => width(chord),
+            Row::Separator => 0,
+        })
+        .max()
+        .unwrap_or(0);
+
+    // 2 border columns + a leading and trailing pad column.
+    let content_w = label_w + LABEL_CHORD_GAP + chord_w;
+    let popup_w = (content_w + 4).min(frame_area.width);
+
+    let anchor_x = app
+        .menu
+        .bar_hits
+        .iter()
+        .find(|h| h.menu == menu_idx)
+        .map(|h| h.x0)
+        .unwrap_or(frame_area.x);
+    // Keep the popup on screen when a right-hand menu would overhang.
+    let max_x = (frame_area.x + frame_area.width).saturating_sub(popup_w);
+    let popup_x = anchor_x.min(max_x);
+
+    let popup_y = app.layout_cache.menubar_area.y + app.layout_cache.menubar_area.height;
+    let avail_h = (frame_area.y + frame_area.height).saturating_sub(popup_y);
+    // 2 rows of border; at least one content row or there is nothing to show.
+    let popup_h = ((rows.len() as u16) + 2).min(avail_h);
+    if popup_h < 3 || popup_w < 4 {
+        app.menu.clear_dropdown_regions();
+        return;
+    }
+    let popup_area = Rect::new(popup_x, popup_y, popup_w, popup_h);
+
+    frame.render_widget(Clear, popup_area);
+    let block = Block::default()
+        .title(format!(" {} ", menu.title))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    // ── Rows ──────────────────────────────────────────────────────────────
+    let visible = inner.height as usize;
+    let start = scroll.min(rows.len().saturating_sub(visible.max(1)));
+    let theme = &app.theme;
+    let mut lines: Vec<Line> = Vec::new();
+    let mut hits: Vec<ItemHit> = Vec::new();
+
+    for (offset, row) in rows.iter().skip(start).take(visible).enumerate() {
+        let y = inner.y + offset as u16;
+        let idx = start + offset;
+        match row {
+            Row::Separator => {
+                lines.push(Line::from(Span::styled(
+                    "─".repeat(inner.width as usize),
+                    Style::default().fg(theme.border_unfocused),
+                )));
+            }
+            Row::Command {
+                label,
+                chord,
+                enabled,
+            } => {
+                let is_selected = idx == selected;
+                let pad = (inner.width as usize)
+                    .saturating_sub(width(label) as usize + width(chord) as usize + 2);
+                // A disabled row keeps its place and its label but loses the
+                // shortcut hint: showing a chord that currently does nothing
+                // would be a lie about what the key does.
+                let shown_chord = if *enabled { chord.as_str() } else { "" };
+                let pad = if *enabled {
+                    pad
+                } else {
+                    pad + width(chord) as usize
+                };
+
+                let (label_style, chord_style) = match (is_selected, *enabled) {
+                    (true, true) => (
+                        Style::default()
+                            .fg(theme.selected_fg)
+                            .bg(theme.selected_bg)
+                            .add_modifier(Modifier::BOLD),
+                        Style::default().fg(theme.selected_fg).bg(theme.selected_bg),
+                    ),
+                    // A selected-but-disabled row still shows where the cursor
+                    // is, so arrowing through the menu never appears to stall.
+                    (true, false) => (
+                        Style::default()
+                            .fg(theme.selected_fg)
+                            .bg(theme.selected_bg)
+                            .add_modifier(Modifier::DIM),
+                        Style::default().fg(theme.selected_fg).bg(theme.selected_bg),
+                    ),
+                    (false, true) => (
+                        Style::default().fg(theme.fg),
+                        Style::default().fg(theme.hint),
+                    ),
+                    // DIM over the normal foreground rather than `theme.muted`:
+                    // muted is at or near the background in several of the
+                    // bundled themes, which would make the row vanish instead
+                    // of reading as unavailable.
+                    (false, false) => (
+                        Style::default().fg(theme.fg).add_modifier(Modifier::DIM),
+                        Style::default().fg(theme.fg).add_modifier(Modifier::DIM),
+                    ),
+                };
+
+                lines.push(Line::from(vec![
+                    Span::styled(format!(" {label}"), label_style),
+                    Span::styled(" ".repeat(pad), label_style),
+                    Span::styled(format!("{shown_chord} "), chord_style),
+                ]));
+                hits.push(ItemHit {
+                    y,
+                    item: idx,
+                    enabled: *enabled,
+                });
+            }
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+    app.menu.item_hits = hits;
+    app.menu.dropdown_area = popup_area;
+}
+
+/// A dropdown row resolved for rendering: label, live shortcut, availability.
+enum Row {
+    Command {
+        label: &'static str,
+        chord: String,
+        enabled: bool,
+    },
+    Separator,
+}
+
+/// How many content rows the dropdown can show at `frame_height`, used by the
+/// key handler to keep the selection scrolled into view. Mirrors the clamp in
+/// [`render_dropdown`].
+pub fn visible_rows(app: &App, frame_height: u16) -> usize {
+    let popup_y = app.layout_cache.menubar_area.y + app.layout_cache.menubar_area.height;
+    let avail_h = frame_height.saturating_sub(popup_y);
+    avail_h.saturating_sub(2) as usize
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,7 @@ pub mod decoration;
 pub mod editor_panel;
 pub mod explorer_panel;
 pub mod markdown;
+pub mod menu_bar;
 pub mod party;
 pub mod reflow_view;
 pub mod rich;


### PR DESCRIPTION
## Summary

タイトルバー直下に常時1行のメニューバーを追加し、アプリの基本操作をメニューからも実行できるようにする。既存のショートカット・ボタン・コマンドパレットは従来どおり動作する（置き換えではなく追加）。

```
 Repo  Worktree  Review  View  Panel  Search  Terminal  Help
```

**ロジックの二重化はゼロ。** コマンド実行の単一入口 `App::execute_palette_command(CommandId)` が既にあったため、メニューは分類と表示ラベルだけを持ち、行が運ぶ `CommandId` をその関数に渡す。ショートカット表示も既存の `representative_chord` を流用する。

| 追加 | 役割 |
|---|---|
| `src/menu/model.rs` | どのコマンドがどのメニューに載るか（分類とラベルのみ） |
| `src/menu/state.rs` | 開閉状態と、キーボード/マウスが共有する純粋なナビゲーション関数 |
| `src/menu/enabled.rs` | disabled 判定 |
| `src/ui/menu_bar.rs` | バーとドロップダウンの描画 |
| `src/event/menu.rs`, `src/event/mouse/menu.rs` | キー操作 / クリック・ホバー |

### 操作

- **キーボード**: `F10` で入る → `←/→` でメニュー移動 → `↓`/`Enter` で展開 → `↑/↓` で項目（区切り線はスキップ）→ `Enter` で実行。`Esc` は1段ずつ戻る。英字キーで頭文字ジャンプ。
- **マウス**: クリックで開く／開いているタイトルを再クリックで閉じる、開いた状態で他のトップレベルにホバーすると切り替わる、項目クリックで実行、外側クリックで閉じる。
- 実行できない操作は**非表示にせず** DIM で淡色表示する。`theme.muted` は7テーマで背景と同化して不可視のため使わず、`theme.fg` + `Modifier::DIM` を使う。
- パネル最大化中も隠さない（worktree ストリップとは異なる扱い）。到達できないメニューは使われなくなるため。

### 設計上の判断

- **`f10` を新設**。`Alt+英字` のニーモニックは既に密（alt+h/l, alt+t, alt+w, alt+数字）で既存を奪うため不採用。F キーはこのアプリで未使用だった。ターミナルパネルにフォーカスがあっても届くよう `fires_in_terminal()` に追加。
- **disabled 述語は既定 true**。既存コードが実際に拒否している箇所だけを file 参照付きで写し、DB や git を叩く条件は写さない（ドロップダウンは60fpsのレンダループ内で行ごとに評価されるため）。誤って false にすると唯一の一覧UIから機能が消えるので保守側に倒す。
- **メニュークリックのハンドラは `handle_mouse_event` の先頭に置く**。`handle_title_bar_click` が `row < main_area.y` を無条件で消費するため、後ろに置くと一切届かない。

### 到達性の担保

`menu/tests.rs::every_command_is_reachable` が、全 `CommandId` はどれかのメニューに載るか `INTENTIONALLY_UNLISTED` に理由付きで載るかを強制する。「全操作がメニューにある」は主張ではなく検査対象。

**意図的な除外は Party Mode のみ**（パレット上のラベルが "(secret)" であり、メニューに出すと secret でなくなる。パレットからは従来どおり到達可能）。`NavigateUp` / `GoToTop` / `NextHunk` 等のパネル内カーソル移動は `CommandId` を持たない（操作ではなくモーダルな移動）ため対象外。

### 既知の仕様

ショートカット表示は「今この文脈で実際に発火するキー」だけを出すため、他パネル層でしか効かないコマンドは空欄になる（例: Explorer にフォーカスがある状態での Worktree メニュー）。既存のコマンドパレットと同じ規則で、押しても効かないキーを広告しないための意図的な挙動。

## Test plan

- `cargo test` — 950 passed / 0 failed（メニュー関連の新規テスト16件を含む）
  - `menu/tests.rs`: 到達性・重複掲載・区切り線の健全性・キーボードナビゲーションの純粋関数
  - `ui/layout/tests.rs`: メニューバーがタイトルバー直下に来ること、最大化中も残ること、垂直方向の行が過不足なく敷き詰められること
  - `event/mouse/tests.rs`: クリック分類11件（disabled 行クリック、外側クリック、閉じた後の stale rect が誤ってクリックを飲まないこと 等）
  - `keymap/tests/resolution.rs`: `f10` が全コンテキストで解決すること
- `cargo clippy` — 本 PR で追加した箇所の警告なし
- **実バイナリを PTY 経由で駆動した E2E 21/21・回帰 11/11 通過**: ドロップダウン開閉、ホバー切替、外側クリック、disabled のグレー表示、テーマ追従（ダーク/ライト両方）、既存の `ctrl+p` パレット・`?` ヘルプ・worktree チップクリック、行が1本減ったあとも Shell の PTY が正常動作すること

## Note

依頼は Web/Electron 前提の記述（`role="menubar"`、`aria-expanded`、角丸・影）を含んでいたが、本アプリは ratatui のターミナル TUI のため ARIA に対応物がない。TUI でのアクセシビリティ相当として「全操作がキーボードだけで完結する」を実装し、disabled は色だけに頼らず DIM 属性で表現した。ダークモードは既存の11テーマ（うちライト3種）で確認済み。
