### PR TITLE
feat: preserve the reading position when a reflow resizes the Claude transcript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.96.1"
+version = "0.97.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.96.1"
+version = "0.97.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/pty-reflow-design.md
+++ b/docs/pty-reflow-design.md
@@ -52,6 +52,33 @@ vt100 パーサを再構築する:
 4. **コスト**（shell）: 幅変更のたびに最大 2MB の再パース（同期、`screen` ロック
    保持）。頻度はパネル最大化・エディタ開閉・ウィンドウリサイズ時のみだが、
    リサイズドラッグ中は連発し得る。
+5. **スクロール位置は近似でしか保てない**: リビルドは全行を振り直すので、
+   `scroll_shell` / `scroll_claude` の数値が指す行は前後にずれる。以前は
+   これを「0 に戻す（＝ライブ末尾へスナップ）」で処理していたが、読んでいた
+   位置を捨てる方が実害が大きいため、現在はオフセットを**そのまま維持**する
+   （`app/terminal_resize.rs`）。transcript view のような厳密なアンカー復元は
+   下記の vt100 の制約により**この層では実装できない**。
+
+### vt100 0.15.2 の scrollback 制約（要注意）
+
+`Grid::visible_rows()` が `self.rows.len() - self.scrollback_offset` を計算するため、
+**scrollback オフセットが 1 画面分（＝ビューポート行数）を超えると減算がアンダー
+フローする**。release ビルドは overflow-check が無効なのでラップして偶然正しく
+動くが、**dev ビルド（`cargo run`）では 1 画面以上スクロールバックした時点で panic
+する**。再現:
+
+```rust
+let mut p = vt100::Parser::new(10, 20, 1000);
+for i in 0..100 { p.process(format!("line-{i:03}\r\n").as_bytes()); }
+p.set_scrollback(50);          // 受理される（scrollback.len() までクランプ）
+let _ = p.screen().cell(0, 0); // ← attempt to subtract with overflow
+```
+
+`ui/common/pty.rs` の `snapshot_screen` が毎フレーム通る経路なので、これは
+新規のバグではなく既存の潜在的な地雷。**候補オフセットを走査してアンカー行を
+探す**方式（transcript view の `LineMeta` 相当をこの層でやる方式）は、この API を
+ループで叩くことになるため採用していない。やるなら先に vt100 の置換（§3-B）か
+クランプラッパの導入が要る。
 
 ## 3. 選択肢の評価
 

--- a/src/app/reflow.rs
+++ b/src/app/reflow.rs
@@ -41,8 +41,25 @@ pub struct ReflowView {
     pub total_lines: usize,
     /// Panel inner width at the last render — used to detect size changes for reflow.
     pub last_width: u16,
-    /// When `true`, the next render pins scroll to the bottom (most recent turn).
-    pub pending_bottom: bool,
+    /// Stick-to-bottom state: `true` while the view is riding the newest turn,
+    /// `false` once the reader has scrolled up and away from it.
+    ///
+    /// This is the flag that decides what a reflow does to the viewport. A
+    /// follower is re-pinned to the bottom on every frame, so a resize keeps
+    /// showing the newest output; a detached reader is put back on the same
+    /// *logical* line instead (see
+    /// [`crate::event::reflow::scroll_after_reflow`]). Without the distinction
+    /// one of the two always broke: pinning unconditionally lost the reader's
+    /// place, anchoring unconditionally left the newest lines below the
+    /// viewport whenever a narrower panel wrapped the text into more of them.
+    ///
+    /// It doubles as the "pin on open" flag — the view opens following, so the
+    /// first render lands on the newest turn with no separate one-shot state.
+    pub follow: bool,
+    /// Screen rect of the "jump to the newest turn" badge drawn while detached,
+    /// or `None` when it isn't on screen. Recorded by the renderer each frame
+    /// and consulted by the click handler; see [`super::App::reflow_jump_to_latest`].
+    pub jump_hit: Option<ratatui::layout::Rect>,
     /// Pre-rendered, width-reflowed lines; rebuilt only when `last_width`
     /// changes or `needs_rebuild` is set.
     pub cached_lines: Vec<ratatui::text::Line<'static>>,
@@ -156,7 +173,10 @@ impl App {
             scroll: 0,
             total_lines: 0,
             last_width: 0, // Forces a full line rebuild on first render.
-            pending_bottom: true,
+            // Opens on the newest turn, and stays there until the reader
+            // scrolls up — which is also what pins the first render.
+            follow: true,
+            jump_hit: None,
             cached_lines: Vec::new(),
             line_meta: Vec::new(),
             needs_rebuild: false,
@@ -198,10 +218,30 @@ impl App {
         self.reflow.entries = std::rc::Rc::new(entries);
         self.reflow.loading = false;
         self.reflow.last_width = 0; // Force a full line rebuild on next render.
-        self.reflow.pending_bottom = true;
+        // The placeholder had nothing to scroll, so the reader cannot have
+        // detached yet — the transcript arrives pinned to its newest turn.
+        self.reflow.follow = true;
         // The entry sweep may already have finished on a slow load; redraw so
         // the transcript replaces the "Loading…" placeholder immediately.
         self.dirty.mark(super::DirtyPanels::TERMINAL);
+    }
+
+    /// Jump the transcript to its newest turn and resume following it.
+    ///
+    /// The single "back to the latest" entry point, shared by `G`/`End` and by
+    /// a click on the detached badge, so both leave the view in the same state
+    /// — at the bottom *and* following, which is what makes the next resize
+    /// keep it there.
+    pub fn reflow_jump_to_latest(&mut self) {
+        self.reflow.scroll = crate::event::reflow::bottom_scroll(
+            self.reflow.total_lines,
+            self.reflow.last_inner_height as usize,
+        );
+        self.reflow.follow = true;
+        // Same rationale as the per-step clear in the key handler: every row
+        // moves, and a glyph the terminal draws wider than counted would leave
+        // residue that ratatui's own diff cannot see.
+        self.terminal.needs_clear = true;
     }
 
     /// Leave the reflow transcript view and return to the live PTY display.

--- a/src/app/terminal_resize.rs
+++ b/src/app/terminal_resize.rs
@@ -65,9 +65,25 @@ impl App {
     pub fn update_claude_terminal_size(&mut self, rows: u16, cols: u16) {
         self.terminal.size_claude = (rows, cols);
         if self.resize_sessions_of_kind(pty_manager::SessionKind::ClaudeCode, rows, cols) {
-            // The grid was rebuilt at a new width, so any scrollback offset is
-            // stale. Snap back to the live view and force a re-render.
-            self.terminal.scroll_claude = 0;
+            // The grid was rebuilt at a new width, so the cached render is stale.
+            //
+            // The *scroll offset* is deliberately left alone. This used to
+            // reset it to 0, which snapped a reader who had scrolled back to
+            // the live tail on every width change — and width changes are not
+            // rare events here: a window resize, a panel maximize, a divider
+            // drag, even moving focus between panels (column widths are
+            // focus-driven) all reach this path. Losing your place because you
+            // glanced at another window was the whole complaint.
+            //
+            // Keeping the number is approximate — re-wrapping renumbers the
+            // rows above the viewport, so the view can shift by a few lines —
+            // but it lands near where the reader was instead of at the far end
+            // of the history. Anchoring it exactly, the way the transcript view
+            // does with `LineMeta`, would mean probing `vt100::Parser::
+            // set_scrollback` across candidate offsets, and that API underflows
+            // (`Grid::visible_rows`, vt100 0.15.2) for any offset past one
+            // screenful — it only survives today because release builds wrap on
+            // overflow. See the note in `docs/pty-reflow-design.md`.
             self.terminal.cache_claude = Default::default();
             self.terminal.dirty_claude = true;
         }
@@ -77,9 +93,10 @@ impl App {
     pub fn update_shell_terminal_size(&mut self, rows: u16, cols: u16) {
         self.terminal.size_shell = (rows, cols);
         if self.resize_sessions_of_kind(pty_manager::SessionKind::Shell, rows, cols) {
-            // The grid was rebuilt at a new width, so any scrollback offset is
-            // stale. Snap back to the live view and force a re-render.
-            self.terminal.scroll_shell = 0;
+            // Same as the Claude panel above: invalidate the render cache, keep
+            // the reader's scroll offset. The shell is where this actually
+            // fires today — only shell sessions record the `raw_history` that
+            // makes `resize_session` report a reflow at all.
             self.terminal.cache_shell = Default::default();
             self.terminal.dirty_shell = true;
         }

--- a/src/event/mouse/scroll.rs
+++ b/src/event/mouse/scroll.rs
@@ -240,8 +240,16 @@ pub(super) fn handle_mouse_scroll(
                     app.reflow.scroll = app.reflow.scroll.saturating_add(abs_delta);
                 }
                 let inner = app.reflow.last_inner_height as usize;
-                let max_scroll = app.reflow.total_lines.saturating_sub(inner);
-                app.reflow.scroll = app.reflow.scroll.min(max_scroll);
+                app.reflow.scroll = crate::event::reflow::clamp_scroll(
+                    app.reflow.scroll,
+                    app.reflow.total_lines,
+                    inner,
+                );
+                // Wheel-up detaches the view from the tail, wheel-down re-attaches
+                // once the newest line is back on screen. Without this a resize
+                // after a wheel-up would re-pin to the bottom and undo the scroll.
+                app.reflow.follow =
+                    crate::event::reflow::at_bottom(app.reflow.scroll, app.reflow.total_lines, inner);
             } else if up {
                 // Enter the reflow transcript view on the first upward scroll
                 // from the live tail (scroll_claude == 0) instead of the

--- a/src/event/mouse/terminal_panel.rs
+++ b/src/event/mouse/terminal_panel.rs
@@ -80,6 +80,18 @@ pub(super) fn handle_terminal_column_click(
 
     if row < terminal_split_y {
         app.set_focus(Focus::TerminalClaude);
+        // The transcript's "jump to latest" chip, drawn only while the reader
+        // has scrolled away from the newest turn. Checked before the tab strip
+        // and the blank-area double-click so a click on the chip is never also
+        // read as one of those; `jump_hit` is `None` whenever the chip is not
+        // on screen, so this costs nothing the rest of the time.
+        if app.reflow.active
+            && let Some(hit) = app.reflow.jump_hit
+            && hit.contains(ratatui::layout::Position::new(col, row))
+        {
+            app.reflow_jump_to_latest();
+            return;
+        }
         // Click on tab bar (first row of Claude panel).
         if row == terminal_claude_y {
             handle_terminal_tab_click(app, col, true);

--- a/src/event/reflow.rs
+++ b/src/event/reflow.rs
@@ -23,6 +23,46 @@ pub fn at_bottom(scroll: usize, total: usize, inner: usize) -> bool {
     scroll >= total.saturating_sub(inner)
 }
 
+/// Scroll offset for the newest line — the position [`at_bottom`] reports as
+/// the bottom, and the one a follower is pinned to.
+pub fn bottom_scroll(total: usize, inner: usize) -> usize {
+    total.saturating_sub(inner)
+}
+
+/// Where the viewport should sit once the geometry underneath it has changed.
+///
+/// Called on every frame with `anchored` set only when the line list was just
+/// rebuilt (a width change or the expand toggle). The two branches encode the
+/// whole "preserve the reading position" rule:
+///
+/// * `following` — the reader is riding the newest turn, so re-pin to the
+///   bottom. This is what keeps a resize from stranding the newest output
+///   below the viewport: a narrower panel wraps the same text into *more*
+///   lines, so the old offset (and even a correctly re-anchored one) no
+///   longer reaches the end.
+/// * otherwise — the reader is parked somewhere in the history, so honour
+///   `anchored`: the index of the same logical line (entry / block / offset)
+///   after the rebuild. Falling back to `previous` covers the frames where
+///   nothing was rebuilt and the offset is still meaningful.
+///
+/// Never a raw line offset carried across a rebuild: line *indices* mean
+/// something different at every width, which is exactly how a reflow used to
+/// throw the reader somewhere unrelated.
+pub fn scroll_after_reflow(
+    following: bool,
+    anchored: Option<usize>,
+    previous: usize,
+    total: usize,
+    inner: usize,
+) -> usize {
+    let target = if following {
+        bottom_scroll(total, inner)
+    } else {
+        anchored.unwrap_or(previous)
+    };
+    clamp_scroll(target, total, inner)
+}
+
 // ── Transition animation ──────────────────────────────────────────────────────
 
 /// Total duration of the entry/exit transition animation in milliseconds.
@@ -125,6 +165,75 @@ mod tests {
     fn at_bottom_when_log_fits_in_panel() {
         // total(10) <= inner(20): max_scroll = 0, any scroll >= 0 is at bottom
         assert!(at_bottom(0, 10, 20));
+    }
+
+    // ── scroll_after_reflow ──────────────────────────────────────────────────
+
+    #[test]
+    fn follower_repins_to_bottom_when_a_narrower_width_adds_lines() {
+        // The regression this whole flag exists for: the reader was riding the
+        // newest turn at 100 lines / 20 rows (scroll 80). The panel narrows, the
+        // same text now wraps into 140 lines, and the anchor would put the old
+        // top line back on top — leaving the newest 40 lines below the viewport.
+        let anchored = Some(80); // whatever the anchor resolved to
+        assert_eq!(scroll_after_reflow(true, anchored, 80, 140, 20), 120);
+    }
+
+    #[test]
+    fn follower_repins_to_bottom_when_the_panel_gets_shorter() {
+        // Height-only change: no rebuild, so `anchored` is None. Clamping alone
+        // would leave scroll at 80 with the last 10 lines cut off below.
+        assert_eq!(scroll_after_reflow(true, None, 80, 100, 10), 90);
+    }
+
+    #[test]
+    fn detached_reader_lands_on_the_anchored_line() {
+        // Parked mid-history: the anchor wins over both the old raw offset and
+        // the bottom.
+        assert_eq!(scroll_after_reflow(false, Some(57), 40, 200, 20), 57);
+    }
+
+    #[test]
+    fn detached_reader_keeps_its_offset_when_nothing_was_rebuilt() {
+        assert_eq!(scroll_after_reflow(false, None, 40, 200, 20), 40);
+    }
+
+    #[test]
+    fn detached_reader_never_gets_dragged_to_the_bottom() {
+        // The property that matters more than any single number: for a reader
+        // who is *not* following, no combination of anchor / geometry may
+        // resolve to the bottom unless the anchor genuinely points there.
+        let total = 300;
+        let inner = 25;
+        let bottom = bottom_scroll(total, inner);
+        for anchored in [Some(0), Some(11), Some(120), None] {
+            let got = scroll_after_reflow(false, anchored, 33, total, inner);
+            assert!(
+                got < bottom,
+                "anchored={anchored:?} resolved to {got}, i.e. the live tail"
+            );
+        }
+    }
+
+    #[test]
+    fn anchored_index_past_the_end_is_clamped_not_wrapped() {
+        // A block that shrank can resolve past the last valid offset; that must
+        // clamp to the bottom rather than index out of range downstream.
+        assert_eq!(scroll_after_reflow(false, Some(9_999), 40, 200, 20), 180);
+    }
+
+    #[test]
+    fn short_log_collapses_to_top_for_follower_and_reader_alike() {
+        assert_eq!(scroll_after_reflow(true, None, 0, 10, 40), 0);
+        assert_eq!(scroll_after_reflow(false, Some(5), 3, 10, 40), 0);
+    }
+
+    #[test]
+    fn following_result_always_reports_at_bottom() {
+        for (total, inner) in [(100usize, 20usize), (10, 40), (0, 5), (41, 7)] {
+            let s = scroll_after_reflow(true, None, 0, total, inner);
+            assert!(at_bottom(s, total, inner), "total={total} inner={inner}");
+        }
     }
 
     // ── sweep_progress ───────────────────────────────────────────────────────

--- a/src/event/reflow_key.rs
+++ b/src/event/reflow_key.rs
@@ -15,9 +15,15 @@ use crate::app::App;
 /// * `Ctrl-d` / PageDown — scroll down half a page.
 /// * `Ctrl-u` / PageUp — scroll up half a page.
 /// * `g` / Home — jump to the oldest turn (top).
-/// * `G` / End — jump to the newest turn (bottom) without leaving.
+/// * `G` / End — jump to the newest turn (bottom) and resume following it.
 /// * `Esc` — close reflow view and return to live PTY.
 /// * `j` / Down / PageDown at the bottom — close reflow (live return).
+///
+/// Every arm also maintains [`ReflowView::follow`](crate::app::ReflowView::follow):
+/// moving up detaches, and landing on the bottom re-attaches. That flag is what
+/// a later reflow consults to decide between re-pinning to the newest turn and
+/// restoring the reader's logical position, so leaving it stale here would
+/// resurrect the snap-to-bottom this view exists to avoid.
 pub(super) fn handle_reflow_key(app: &mut App, key: KeyEvent) {
     use crossterm::event::KeyModifiers;
     use crate::event::reflow::{at_bottom, clamp_scroll};
@@ -69,8 +75,10 @@ pub(super) fn handle_reflow_key(app: &mut App, key: KeyEvent) {
             app.reflow.scroll = 0;
         }
         KeyCode::Char('G') | KeyCode::End => {
-            // Snap to the newest turn (logical bottom) without leaving the view.
-            app.reflow.scroll = total.saturating_sub(inner);
+            // Snap to the newest turn (logical bottom) without leaving the view,
+            // and resume following so the next resize keeps it there.
+            app.reflow_jump_to_latest();
+            return;
         }
 
         // ── Expand / collapse ────────────────────────────────────────────────
@@ -98,6 +106,13 @@ pub(super) fn handle_reflow_key(app: &mut App, key: KeyEvent) {
     // Clamp scroll after any adjustment.  Upper bound is total - inner, not
     // total - 1: aligns with the render path and at_bottom logic.
     app.reflow.scroll = clamp_scroll(app.reflow.scroll, total, inner);
+
+    // Re-derive the follow state from where the scroll actually landed, rather
+    // than per-arm: the reader is following exactly when the newest line is on
+    // screen, whichever key put it there. (`G`/`End` returned early above —
+    // that one sets the flag itself, because a bottom that is only *reachable*
+    // once the panel is re-measured still has to count as following.)
+    app.reflow.follow = at_bottom(app.reflow.scroll, total, inner);
 
     // On each scroll step, force a hard clear (presented atomically thanks to
     // synchronized output). The transcript is arbitrary Unicode; a glyph the

--- a/src/ui/dashboard/help.rs
+++ b/src/ui/dashboard/help.rs
@@ -140,10 +140,33 @@ fn help_lines_for(app: &App, focus: crate::app::Focus, theme: &Theme) -> Vec<Lin
     for (title, ctx) in panel_ctxs {
         section(&mut lines, title, *ctx);
     }
+    if matches!(focus, Focus::TerminalClaude | Focus::TerminalShell) {
+        help_transcript_section(&mut lines, theme);
+    }
     help_review_commands_section(&mut lines, theme);
     section(&mut lines, "Global — works anywhere", KeyContext::Global);
 
     lines
+}
+
+/// Keys for the Claude transcript, reached by scrolling up from the live tail.
+///
+/// Hand-written for the same reason as the section below: `handle_reflow_key`
+/// owns these directly instead of going through `app.keymap`, so `section()` —
+/// which walks the keymap — cannot see any of them. They were invisible in the
+/// help until this existed, `G` included.
+fn help_transcript_section(lines: &mut Vec<Line<'static>>, theme: &Theme) {
+    help_section(lines, "Claude transcript (scroll up to enter)", theme);
+    for (keys, desc) in [
+        ("j / k", "Scroll one line"),
+        ("ctrl+d / ctrl+u", "Scroll half a page"),
+        ("g / Home", "Oldest turn"),
+        ("G / End", "Newest turn, and resume following it"),
+        ("ctrl+o", "Expand / collapse tool results and thinking"),
+        ("Esc", "Back to the live prompt"),
+    ] {
+        help_key_dyn(lines, keys.to_string(), desc, theme);
+    }
 }
 
 /// The PR-intake, walkthrough-generation, and publish commands have no

--- a/src/ui/reflow_view/render.rs
+++ b/src/ui/reflow_view/render.rs
@@ -20,6 +20,9 @@ use super::palette;
 /// `app` is taken as `&mut` so the render can write updated scroll / cache state
 /// back to `app.reflow` after building or scrolling the line list.
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    // Any path that returns before the badge is drawn must retract its hit
+    // region, or a click would keep landing on a chip that is no longer there.
+    app.reflow.jump_hit = None;
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -73,6 +76,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 
     // ── (Re)build cached lines when the panel width or expand state changed ──
+    // `anchored` carries the rebuild's answer to "where did the top line go?"
+    // down to the single scroll decision below; it stays `None` on the frames
+    // where nothing was rebuilt.
+    let mut anchored: Option<usize> = None;
     if app.reflow.last_width != render_area.width || app.reflow.needs_rebuild {
         // Block-scoped so the shared borrows on `app` drop before the
         // `cached_lines` / `total_lines` / `last_width` assignments below.
@@ -104,31 +111,26 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         // keeps a glyph from the previous layout.
         app.terminal.needs_clear = true;
 
-        if let Some(anchor) = anchor
-            && !app.reflow.pending_bottom
-        {
-            app.reflow.scroll = anchor_index(&app.reflow.line_meta, anchor);
-        }
+        anchored = anchor.map(|a| anchor_index(&app.reflow.line_meta, a));
     }
 
     app.reflow.last_inner_height = area.height;
 
-    // ── Pin to bottom on first open ───────────────────────────────────────────
-    if app.reflow.pending_bottom {
-        app.reflow.scroll = app
-            .reflow
-            .total_lines
-            .saturating_sub(inner_height);
-        app.reflow.pending_bottom = false;
-    }
-
-    // ── Clamp scroll to valid range ───────────────────────────────────────────
-    // Upper bound is total - inner_height, not total - 1: when pinned to the
-    // logical bottom, the last content line sits at the last visual row, not
-    // one row above.  total < inner_height (short log) collapses to 0 via
-    // saturating_sub so the view stays at the top and shows no blank rows.
-    app.reflow.scroll =
-        crate::event::reflow::clamp_scroll(app.reflow.scroll, app.reflow.total_lines, inner_height);
+    // ── Place the viewport ────────────────────────────────────────────────────
+    // One decision for every way the geometry can move under the reader —
+    // width (rebuild above), height, and the expand toggle. A follower is
+    // re-pinned to the newest line; anyone parked in the history is put back on
+    // the line the anchor resolved to, never dragged to the tail. The result is
+    // clamped, so the upper bound is total - inner_height rather than total - 1:
+    // at the logical bottom the last content line sits on the last visual row,
+    // and a log shorter than the panel collapses to 0 with no blank rows.
+    app.reflow.scroll = crate::event::reflow::scroll_after_reflow(
+        app.reflow.follow,
+        anchored,
+        app.reflow.scroll,
+        app.reflow.total_lines,
+        inner_height,
+    );
 
     let scroll = app.reflow.scroll;
 
@@ -174,13 +176,63 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             cell.set_skip(true);
         }
     }
+
+    app.reflow.jump_hit = render_jump_badge(frame, render_area, app.reflow.follow);
+}
+
+/// Text of the detached badge at each width tier, longest first. Deliberately
+/// ASCII: the badge is positioned against the panel's right edge, so a glyph
+/// the terminal draws wider than `unicode-width` counts (the `⏺`/`⎿` problem
+/// the gutter solves with an unwritten cell) would push its tail onto the
+/// border. There is no arrow here for that reason.
+pub(super) const JUMP_BADGE_LABELS: [&str; 3] = [" Jump to latest (G) ", " Latest (G) ", " (G) "];
+
+/// Draw the "you are not at the newest turn" badge, returning its screen rect
+/// so a click can be routed back to it.
+///
+/// Only visible while detached — that *is* the feedback. Following, the badge
+/// is absent and the function reports no hit region, so a stale rect can never
+/// keep swallowing clicks after the reader returns to the tail.
+///
+/// It is deliberately the quietest thing on screen that is still a target:
+/// one right-aligned chip on the last row, in the transcript's own dim grey on
+/// the user-turn block's background. Anything louder would compete with the
+/// transcript for attention on every scroll-up, which is the common case.
+pub(super) fn render_jump_badge(frame: &mut Frame, area: Rect, following: bool) -> Option<Rect> {
+    if following || area.height == 0 {
+        return None;
+    }
+    // Widest label that fits, leaving one column of slack against the panel
+    // edge; if even the shortest needs more room than the panel has, the badge
+    // is dropped rather than truncated into something unreadable.
+    let label = JUMP_BADGE_LABELS
+        .iter()
+        .find(|l| UnicodeWidthStr::width(**l) < area.width as usize)?;
+    let w = UnicodeWidthStr::width(*label) as u16;
+
+    let rect = Rect::new(
+        area.x + area.width - w,
+        area.y + area.height - 1,
+        w,
+        1,
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            *label,
+            Style::default()
+                .fg(palette::INACTIVE)
+                .bg(palette::USER_BG),
+        ))),
+        rect,
+    );
+    Some(rect)
 }
 
 /// Index of the line matching `anchor` after a rebuild — the first line whose
 /// `(entry, block, offset)` is at or past the anchor's, so a block that got
 /// shorter (or vanished) lands on whatever now occupies that position rather
 /// than scrolling somewhere unrelated.
-fn anchor_index(meta: &[LineMeta], anchor: LineMeta) -> usize {
+pub(super) fn anchor_index(meta: &[LineMeta], anchor: LineMeta) -> usize {
     let key = (anchor.entry, anchor.block, anchor.offset);
     meta.iter()
         .position(|m| (m.entry, m.block, m.offset) >= key)

--- a/src/ui/reflow_view/render_tests.rs
+++ b/src/ui/reflow_view/render_tests.rs
@@ -299,3 +299,272 @@ fn holes_stay_inside_the_line_for_wide_content() {
         }
     }
 }
+// ── Detached badge ──────────────────────────────────────────────────────────
+//
+// The badge is the only signal that the view is not showing the newest turn,
+// and the only pointer route back to it, so both its presence rule and its
+// reported hit region are asserted rather than eyeballed.
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use unicode_width::UnicodeWidthStr;
+
+use super::render::{JUMP_BADGE_LABELS, render_jump_badge};
+
+/// Draw the badge into a `width x height` frame and return what it reported
+/// plus the rendered screen.
+fn draw_badge(width: u16, height: u16, following: bool) -> (Option<Rect>, Buffer) {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    let mut hit = None;
+    terminal
+        .draw(|f| {
+            hit = render_jump_badge(f, Rect::new(0, 0, width, height), following);
+        })
+        .unwrap();
+    (hit, terminal.backend().buffer().clone())
+}
+
+fn screen_text(buf: &Buffer) -> String {
+    (0..buf.area.height)
+        .map(|y| {
+            (0..buf.area.width)
+                .map(|x| buf[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Following the newest turn is the quiet state: no badge, and — just as
+/// importantly — no hit region, or a click on that spot would keep firing.
+#[test]
+fn no_badge_while_following() {
+    let (hit, buf) = draw_badge(40, 6, true);
+    assert_eq!(hit, None);
+    assert!(
+        !screen_text(&buf).contains("(G)"),
+        "{}",
+        screen_text(&buf)
+    );
+}
+
+#[test]
+fn detached_draws_the_badge_bottom_right_and_reports_its_rect() {
+    let (hit, buf) = draw_badge(40, 6, false);
+    let rect = hit.expect("detached view must offer a way back");
+
+    // Bottom-right corner, flush with the right edge.
+    assert_eq!(rect.y, 5, "badge belongs on the last row");
+    assert_eq!(rect.x + rect.width, 40, "badge is right-aligned");
+    assert_eq!(rect.height, 1);
+
+    // The reported rect is where the text actually is — this is the contract
+    // the click handler relies on.
+    let text = screen_text(&buf);
+    let last_row = text.lines().last().unwrap();
+    assert!(last_row.contains("Jump to latest (G)"), "{last_row:?}");
+    assert_eq!(
+        rect.width as usize,
+        UnicodeWidthStr::width(JUMP_BADGE_LABELS[0])
+    );
+}
+
+/// The badge steps down through shorter labels rather than being truncated
+/// into something unreadable, and disappears entirely when even the shortest
+/// would not fit — the Claude column can be narrow.
+#[test]
+fn badge_shrinks_with_the_panel_and_eventually_gives_up() {
+    // Wide enough for the full label (20 cols + 1 of slack).
+    assert_eq!(draw_badge(21, 3, false).0.map(|r| r.width), Some(20));
+    // One column short of it: falls back to " Latest (G) " (12).
+    assert_eq!(draw_badge(20, 3, false).0.map(|r| r.width), Some(12));
+    // Only room for " (G) " (5).
+    assert_eq!(draw_badge(12, 3, false).0.map(|r| r.width), Some(5));
+    // Not even that.
+    assert_eq!(draw_badge(5, 3, false).0, None);
+}
+
+/// Every label must measure exactly what `unicode-width` says, because the
+/// badge is positioned against the panel's right edge — a glyph the terminal
+/// draws wider would push its tail onto the border.
+#[test]
+fn badge_labels_are_plain_ascii() {
+    for label in JUMP_BADGE_LABELS {
+        assert!(
+            label.is_ascii(),
+            "{label:?} is not ASCII; see the note on JUMP_BADGE_LABELS"
+        );
+        assert_eq!(UnicodeWidthStr::width(label), label.len());
+    }
+}
+
+/// Labels are ordered longest-first; `render_jump_badge` picks the first that
+/// fits, so a mis-ordered list would silently prefer a shorter one.
+#[test]
+fn badge_labels_are_ordered_longest_first() {
+    let widths: Vec<usize> = JUMP_BADGE_LABELS
+        .iter()
+        .map(|l| UnicodeWidthStr::width(*l))
+        .collect();
+    assert!(
+        widths.windows(2).all(|w| w[0] > w[1]),
+        "labels must strictly shrink, got {widths:?}"
+    );
+}
+
+// ── Scroll placement across a reflow ────────────────────────────────────────
+//
+// The pure arithmetic is covered in `event::reflow`; these run the real line
+// builder at two widths and check the two outcomes that matter to a reader:
+// a detached one stays on their line, a following one stays on the newest.
+
+use crate::event::reflow::{at_bottom, scroll_after_reflow};
+
+use super::build::BuiltLines;
+use super::render::anchor_index;
+
+/// Prose long enough that the wrap positions genuinely differ between the two
+/// widths under test — the fixture's whole job.
+fn reflow_fixture() -> Vec<LogEntry> {
+    // Long enough that a 20-row viewport is a small slice of it — with a short
+    // log, "three quarters down" is already the bottom and the clamp, not the
+    // anchor, would decide where the reader lands.
+    (0..40)
+        .map(|i| {
+            entry(
+                if i % 2 == 0 { Role::Assistant } else { Role::User },
+                vec![DisplayBlock::Text(format!(
+                    "Turn {i}: {}",
+                    "the quick brown fox jumps over the lazy dog ".repeat(4)
+                ))],
+            )
+        })
+        .collect()
+}
+
+fn build_at(entries: &[LogEntry], width: usize) -> BuiltLines {
+    let theme = crate::theme::Theme::default();
+    let syntax_set = two_face::syntax::extra_newlines();
+    let syntect_theme = ThemeSet::load_defaults()
+        .themes
+        .remove("base16-ocean.dark")
+        .unwrap();
+    let cache = MarkdownCache::new();
+    let ctx = BuildCtx {
+        entries,
+        cache: &cache,
+        theme: &theme,
+        syntax_set: &syntax_set,
+        syntect_theme: &syntect_theme,
+        expanded: false,
+    };
+    build_lines(&ctx, width)
+}
+
+/// The reported bug, end to end: a reader parked in the history must come out
+/// of a width change looking at the same turn — not at the newest one, and not
+/// at whatever unrelated text inherited their old line number.
+#[test]
+fn narrowing_keeps_a_detached_reader_on_the_same_turn() {
+    const INNER: usize = 20;
+    let entries = reflow_fixture();
+
+    let before = build_at(&entries, 80);
+    // Three quarters in: far enough down that the extra wrapped lines the
+    // narrower width introduces have accumulated into real drift.
+    let scroll = before.meta.len() * 3 / 4;
+    let anchor = before.meta[scroll];
+
+    let after = build_at(&entries, 50);
+    assert!(
+        after.lines.len() > before.lines.len(),
+        "fixture must wrap into more lines at the narrower width"
+    );
+
+    // Carrying the raw line number across is the behaviour being replaced —
+    // assert it would actually have been wrong, or this test proves nothing.
+    let naive = after.meta[scroll];
+    assert_ne!(
+        (naive.entry, naive.block, naive.offset),
+        (anchor.entry, anchor.block, anchor.offset),
+        "fixture no longer renumbers lines; the test would pass vacuously"
+    );
+
+    let placed = scroll_after_reflow(
+        false,
+        Some(anchor_index(&after.meta, anchor)),
+        scroll,
+        after.lines.len(),
+        INNER,
+    );
+    let landed = after.meta[placed];
+    assert_eq!(
+        (landed.entry, landed.block),
+        (anchor.entry, anchor.block),
+        "reader was moved off their turn: {anchor:?} -> {landed:?}"
+    );
+    assert!(
+        !at_bottom(placed, after.lines.len(), INNER),
+        "a reader in the middle of the log must not end up at the live tail"
+    );
+}
+
+/// The other half: someone riding the newest turn must still be riding it, or
+/// the fix would have traded one broken case for another.
+#[test]
+fn narrowing_keeps_a_follower_on_the_newest_turn() {
+    const INNER: usize = 20;
+    let entries = reflow_fixture();
+
+    let before = build_at(&entries, 80);
+    let scroll = before.lines.len().saturating_sub(INNER);
+    assert!(at_bottom(scroll, before.lines.len(), INNER));
+    let anchor = before.meta[scroll];
+
+    let after = build_at(&entries, 50);
+    let placed = scroll_after_reflow(
+        true,
+        Some(anchor_index(&after.meta, anchor)),
+        scroll,
+        after.lines.len(),
+        INNER,
+    );
+
+    assert!(at_bottom(placed, after.lines.len(), INNER));
+    assert_eq!(
+        placed + INNER,
+        after.lines.len(),
+        "the last built line must sit on the last visual row"
+    );
+    // And the anchor alone would have left the newest lines off-screen — which
+    // is exactly why `follow` overrides it.
+    let anchored_only = anchor_index(&after.meta, anchor);
+    assert!(
+        anchored_only < placed,
+        "fixture does not exercise the follow override"
+    );
+}
+
+/// Growing the panel is the mirror case: fewer wrapped lines, and the follower
+/// must not be left short of the end.
+#[test]
+fn widening_keeps_a_follower_on_the_newest_turn() {
+    const INNER: usize = 20;
+    let entries = reflow_fixture();
+
+    let before = build_at(&entries, 50);
+    let scroll = before.lines.len().saturating_sub(INNER);
+    let anchor = before.meta[scroll];
+
+    let after = build_at(&entries, 100);
+    assert!(after.lines.len() < before.lines.len());
+
+    let placed = scroll_after_reflow(
+        true,
+        Some(anchor_index(&after.meta, anchor)),
+        scroll,
+        after.lines.len(),
+        INNER,
+    );
+    assert_eq!(placed + INNER, after.lines.len());
+}


### PR DESCRIPTION
## Summary

パネル幅・高さが変わったときに、**読んでいたスクロール位置を失わない**ようにする。対象は 2 レイヤ。

1. **Claude transcript view（reflow view）** — 追従中(`follow`)なら最新行へ再ピン、離脱中なら同じ*論理行*（entry/block/offset アンカー）へ復元。配置判断を `scroll_after_reflow()` の 1 関数に集約した。
2. **ライブ PTY パネル（Claude / Shell）** — 幅変更時に `scroll_claude` / `scroll_shell` を 0 にリセットしていたのをやめ、オフセットをそのまま維持する。

あわせて、離脱中であることの唯一の視覚的シグナル兼ポインタ導線として **「Jump to latest (G)」バッジ**を右下に追加した。

### なぜこの問題が起きていたか

Conductor では**幅変更が日常的に起きる**。ウィンドウリサイズ、パネル最大化(`Ctrl+Alt+Z`)、分割線ドラッグ、そして**フォーカス移動（列幅が focus 駆動なので Tab を押すだけで幅が変わる）**がすべて同じ経路を通る。「別ウィンドウを見て戻ったら読んでいた場所を失っていた」が元の不満。

transcript view 側は `pending_bottom: bool`（初回オープン時に一度だけ末尾へピンする使い捨てフラグ）しか持っておらず、「最新を追っている読者」と「履歴を読んでいる読者」を区別できなかった。どちらか一方に倒すと必ずもう一方が壊れる:

- 常に末尾ピン → 履歴を読んでいた人が最新へ飛ばされる
- 常にアンカー復元 → 幅が狭まると同じ本文がより多くの行に折り返されるため、追従していた人の視界の下に最新行が取り残される

### なぜこれらのファイルを触るのか

| ファイル | 役割 |
|---|---|
| `src/app/reflow.rs` | 状態: `pending_bottom` → `follow`、`jump_hit` 追加、`reflow_jump_to_latest()` |
| `src/event/reflow.rs` | 配置ロジック本体 `scroll_after_reflow()` / `bottom_scroll()` + 純粋テスト |
| `src/ui/reflow_view/render.rs` | 3 箇所に散っていたスクロール決定を 1 呼び出しに統合、バッジ描画 |
| `src/app/terminal_resize.rs` | ライブ PTY のスクロールリセット撤去 |
| `src/event/reflow_key.rs` / `mouse/scroll.rs` / `mouse/terminal_panel.rs` | `follow` の維持と、バッジクリックの経路 |
| `src/ui/dashboard/help.rs` | transcript のキーがヘルプに一切出ていなかった（`G` 含む）ので手書きセクション追加 |
| `docs/pty-reflow-design.md` | 設計判断と vt100 0.15.2 の地雷を記録 |

### レビュー時に前提として知っておくこと

- **意図的にスコープ外**: ライブ PTY 側の**厳密な**アンカー復元。transcript view と同じことをやるには `vt100::Parser::set_scrollback` を候補オフセットで走査する必要があるが、vt100 0.15.2 の `Grid::visible_rows()` は **1 画面分を超える scrollback オフセットで減算アンダーフローする**（release ビルドがラップして偶然動いているだけで、dev ビルドでは panic する）。この既存の地雷をループで叩く実装は採らず、「近似でよいのでオフセットを維持する」に留めた。詳細は `docs/pty-reflow-design.md` の新設節。
- バッジは**離脱中のみ**表示され、`jump_hit` も同時に `None` になる。「見えないのにクリックが吸われる」状態が構造的に発生しない作りになっている。

## Test plan

### 自動テスト

- `cargo test` — **935 passed / 0 failed**（新規 15 本）
  - `event::reflow` — `scroll_after_reflow` の純粋テスト。追従時の再ピン、離脱時のアンカー優先、範囲外アンカーのクランプ、「離脱中の読者はどう転んでも末尾に落ちない」性質テスト
  - `ui::reflow_view::render_tests` — 実 line builder を 2 つの幅で走らせ、離脱中は同じ論理行に着地すること／追従中は最終行が最終視覚行に来ることを検証（幅拡大・縮小の両方向）。バッジは `TestBackend` で表示規則・右下配置・幅段階縮退・報告 Rect の一致を検証
- `cargo clippy --all-targets` — 変更ファイルに新規警告なし（残 3 件は `code_nav.rs` / `hover_info.rs` の既存分）

### 実機検証（PTY ハーネス）

実バイナリを PTY 上で起動しキー注入・`TIOCSWINSZ` でリサイズし、`pyte` で画面を再構成して検証。合成トランスクリプトの各ターンに `QUESTION-047` / `ANSWER-047` のような ID を振り、幅非依存の「今どこを見ているか」として突き合わせた（PATH に置いたスタブ `claude` が自分の `--session-id` 宛にログを書くので API 呼び出しはゼロ）。

**変更前のバイナリ（`origin/main` から `git worktree` でビルド）と同じ検証を流して対照**した結果:

| シナリオ | 変更前 | 変更後 |
|---|---|---|
| transcript を**離脱中**にターミナルをリサイズ | 保持されていた（アンカー復元は元からあった） | 保持 |
| transcript を離脱中に pane resize / `Ctrl+Alt+Z` 最大化・復元 | 保持 | 保持 |
| transcript で**最下部に張り付き中**にリサイズ | ❌ 最新ターン `ANSWER-059` が画面外へ | ✅ 最新ターンを維持 |
| 離脱中のバッジ表示 / 追従復帰で非表示 | ❌ 存在しない | ✅ 期待通り |
| `G` で最新へジャンプ + 追従復帰 | 最新へは飛ぶが追従に戻らない | ✅ 追従復帰 |
| **Shell のライブスクロールバック**をリサイズ | ❌ ライブ末尾へ強制ジャンプ（top: `0391` → `0399`） | ✅ 位置維持（`0391` → `0395`） |
| 全リサイズ後もプロセス生存 | ✅ | ✅ |

### 未検証（要手動確認）

**マウスクリックでの他パネルへのフォーカス移動**。transcript 表示中は `dispatch_pty_key` が pane resize / maximize / panel-overlay 以外の全キーを消費するため、キーボードでは他パネルへ移動できず、クリックだけが到達経路になる。実装上は `set_focus` が意図的に reflow を閉じないので維持されるはず。
