### PR TITLE
fix: scope walkthrough generation exclusion to the branch, not the whole app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.97.0"
+version = "0.97.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.97.0"
+version = "0.97.1"
 edition = "2024"
 
 [dependencies]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -103,7 +103,7 @@ impl App {
             main_repo_name,
             should_quit: false,
             editor: None,
-            walkthrough_gen: None,
+            walkthrough_gens: Default::default(),
             current_walkthrough: None,
             publish_confirm: None,
             publish_op: BackgroundOp::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -99,10 +99,11 @@ pub struct App {
     /// [`App::exit_editor`] (the only two methods that pair this field with
     /// `Focus::Editor`, keeping the invariant local).
     pub editor: Option<EditorPanel>,
-    /// In-flight headless walkthrough generation, if any. Polled by
+    /// In-flight headless walkthrough generations, at most one per branch so
+    /// worktrees don't block each other. Polled by
     /// [`App::poll_walkthrough_generation`]; the DB row is the source of
-    /// truth for completion, this handle only catches process failures.
-    pub walkthrough_gen: Option<crate::walkthrough::WalkthroughGeneration>,
+    /// truth for completion, these handles only catch process failures.
+    pub walkthrough_gens: crate::walkthrough::WalkthroughGenerations,
     /// The selected worktree's walkthrough (header + steps), reloaded by
     /// [`App::refresh_reviews`] alongside the comment list.
     pub current_walkthrough: Option<(

--- a/src/app/review_walkthrough.rs
+++ b/src/app/review_walkthrough.rs
@@ -12,7 +12,9 @@ impl App {
     /// Re-running regenerates from scratch — except when a `ready` walkthrough
     /// already exists for the current branch tip, which is a no-op that just
     /// re-shows it (the diff, and so the walkthrough, hasn't changed). While a
-    /// generation is already in flight it's a no-op with a status hint.
+    /// generation for *this* branch is already in flight it's a no-op with a
+    /// status hint; other branches' generations are unaffected and keep
+    /// running, so several worktrees can be generating at once.
     pub fn cmd_generate_walkthrough(&mut self, force: bool) {
         if self.review_store.is_none() {
             self.set_status(
@@ -29,19 +31,17 @@ impl App {
             );
             return;
         }
-        // Only one generation may be in flight per app instance: replacing
-        // the handle would silently drop (and orphan) the running `claude`
-        // child and strand its branch's row in `generating` forever.
-        if let Some(g) = &self.walkthrough_gen {
-            let msg = if g.branch == branch {
-                "A walkthrough is already being generated for this branch.".to_string()
-            } else {
-                format!(
-                    "A walkthrough is already being generated for '{}' — wait for it to finish.",
-                    g.branch
-                )
-            };
-            self.set_status(msg, StatusLevel::Warning);
+        // Only one generation may be in flight *per branch*: replacing the
+        // handle would silently drop (and orphan) the running `claude` child
+        // and strand its branch's row in `generating` forever. Generations
+        // for other branches are none of this branch's business — they write
+        // disjoint rows, so they run concurrently (see
+        // `walkthrough::WalkthroughGenerations`).
+        if self.walkthrough_gens.is_generating(&branch) {
+            self.set_status(
+                "A walkthrough is already being generated for this branch.".to_string(),
+                StatusLevel::Warning,
+            );
             return;
         }
         let Some((wt_path, head_oid)) = self
@@ -111,7 +111,7 @@ impl App {
             language.as_deref(),
         ) {
             Ok(generation) => {
-                self.walkthrough_gen = Some(generation);
+                self.walkthrough_gens.insert(generation);
                 // Display-only switch — no `set_focus`, so kicking off a
                 // generation from the palette never steals focus from an
                 // active terminal input; it just makes the in-progress state
@@ -138,35 +138,61 @@ impl App {
         self.refresh_reviews();
     }
 
-    /// Kill an in-flight walkthrough generation, if any, so it doesn't
-    /// outlive the app as an orphaned headless `claude` process. Called once
-    /// on shutdown (see `main.rs`'s main loop, right before it returns on
-    /// `should_quit`) — a generation still running at that point would
-    /// otherwise keep making API calls with no one polling its outcome.
+    /// Kill every in-flight walkthrough generation so none outlives the app as
+    /// an orphaned headless `claude` process. Called once on shutdown (see
+    /// `main.rs`'s main loop, right before it returns on `should_quit`) — a
+    /// generation still running at that point would otherwise keep making API
+    /// calls with no one polling its outcome.
     pub fn shutdown_walkthrough_generation(&mut self) {
-        if let Some(mut generation) = self.walkthrough_gen.take() {
-            generation.abort();
-        }
+        self.walkthrough_gens.abort_all();
     }
 
-    /// Poll the in-flight walkthrough generation (if any) and reconcile the
-    /// database row with what the process actually did. Called from
+    /// Poll the in-flight walkthrough generations and reconcile each one's
+    /// database row with what its process actually did. Called from
     /// [`App::poll_all_background_ops`](Self::poll_all_background_ops).
     pub fn poll_walkthrough_generation(&mut self) {
-        let Some(generation) = &mut self.walkthrough_gen else {
-            return;
-        };
-        use crate::walkthrough::{GenerationPoll, WalkthroughStatus};
-        let outcome = generation.poll();
-        if matches!(outcome, GenerationPoll::Running) {
+        if self.walkthrough_gens.is_empty() {
             return;
         }
-        let branch = generation.branch.clone();
-        let log_path = generation.log_path.clone();
-        self.walkthrough_gen = None;
+        let finished = self.walkthrough_gens.take_finished();
+        if finished.is_empty() {
+            return;
+        }
+        for outcome in finished {
+            let (message, level) = self.reconcile_finished_generation(outcome);
+            self.set_status(message, level);
+        }
+        self.refresh_reviews();
+    }
 
-        let (message, level) = match outcome {
-            GenerationPoll::Running => unreachable!("handled above"),
+    /// Turn one finished generation into the status message to flash, writing
+    /// a `failed` row when the session didn't leave a good one behind.
+    ///
+    /// Messages name the branch: with several worktrees generating at once,
+    /// the one that finishes is often not the one the reviewer is looking at.
+    fn reconcile_finished_generation(
+        &self,
+        finished: crate::walkthrough::FinishedGeneration,
+    ) -> (String, StatusLevel) {
+        use crate::walkthrough::{GenerationPoll, WalkthroughStatus};
+        let crate::walkthrough::FinishedGeneration {
+            branch,
+            log_path,
+            outcome,
+        } = finished;
+        let fail = |msg: &str| {
+            if let Some(store) = &self.review_store {
+                let _ = store.fail_walkthrough(&branch, msg);
+            }
+            (
+                format!("Walkthrough failed for '{branch}': {msg}"),
+                StatusLevel::Error,
+            )
+        };
+        match outcome {
+            GenerationPoll::Running => {
+                unreachable!("take_finished only yields generations that stopped")
+            }
             GenerationPoll::Exited => {
                 // Success is decided by the row the MCP tool wrote, not the
                 // exit code: a session that ended without saving is a failure.
@@ -176,36 +202,22 @@ impl App {
                     .and_then(|s| s.get_walkthrough(&branch).ok().flatten())
                     .is_some_and(|(w, _)| w.status == WalkthroughStatus::Ready);
                 if saved {
-                    ("Walkthrough ready.".to_string(), StatusLevel::Success)
+                    (
+                        format!("Walkthrough ready for '{branch}'."),
+                        StatusLevel::Success,
+                    )
                 } else {
-                    let msg = format!(
+                    fail(&format!(
                         "Claude session ended without saving a walkthrough (log: {})",
                         log_path.display()
-                    );
-                    if let Some(store) = &self.review_store {
-                        let _ = store.fail_walkthrough(&branch, &msg);
-                    }
-                    (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
+                    ))
                 }
             }
-            GenerationPoll::Failed(msg) => {
-                if let Some(store) = &self.review_store {
-                    let _ = store.fail_walkthrough(&branch, &msg);
-                }
-                (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
-            }
-            GenerationPoll::TimedOut => {
-                let msg = format!(
-                    "Timed out after {} minutes.",
-                    crate::walkthrough::GENERATION_TIMEOUT.as_secs() / 60
-                );
-                if let Some(store) = &self.review_store {
-                    let _ = store.fail_walkthrough(&branch, &msg);
-                }
-                (format!("Walkthrough failed: {msg}"), StatusLevel::Error)
-            }
-        };
-        self.set_status(message, level);
-        self.refresh_reviews();
+            GenerationPoll::Failed(msg) => fail(&msg),
+            GenerationPoll::TimedOut => fail(&format!(
+                "Timed out after {} minutes.",
+                crate::walkthrough::GENERATION_TIMEOUT.as_secs() / 60
+            )),
+        }
     }
 }

--- a/src/walkthrough.rs
+++ b/src/walkthrough.rs
@@ -10,6 +10,7 @@
 //! of truth for completion; the process handle here only detects failures
 //! (spawn error, non-zero exit, exit without saving, timeout).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -249,6 +250,107 @@ impl WalkthroughGeneration {
     }
 }
 
+#[cfg(test)]
+impl WalkthroughGeneration {
+    /// Wrap an arbitrary child process in a generation handle. Lets the
+    /// registry tests below drive real process lifecycles (exit, kill,
+    /// timeout) without launching a `claude` session.
+    fn for_test(branch: &str, child: Child, started: Instant) -> Self {
+        Self {
+            branch: branch.to_string(),
+            child,
+            started,
+            log_path: PathBuf::from("/dev/null"),
+        }
+    }
+}
+
+/// A generation that stopped running, as handed back by
+/// [`WalkthroughGenerations::take_finished`]. Carries the context the caller
+/// needs to reconcile the database row it left behind — which branch it was
+/// for, and where its log is — because the handle itself is gone by then.
+pub struct FinishedGeneration {
+    pub branch: String,
+    pub log_path: PathBuf,
+    pub outcome: GenerationPoll,
+}
+
+/// Every walkthrough generation in flight in this Conductor instance, at most
+/// one per branch.
+///
+/// Keyed by branch, not by "one at a time", because the branch is the only
+/// thing a generation actually contends for: `begin_walkthrough` deletes and
+/// re-inserts the `walkthroughs` row for its branch and `save_walkthrough`
+/// replaces it, so two sessions on one branch would race for a single row and
+/// the loser's steps would vanish. Sessions on *different* branches — which
+/// means different worktrees, since git won't check one branch out twice —
+/// touch disjoint rows, disjoint log files, and a database that is already
+/// WAL + `busy_timeout` (see `review_store::schema`), so they can run side by
+/// side. Serializing them was over-broad: it made a reviewer touring one
+/// worktree unable to start a walkthrough in another.
+#[derive(Default)]
+pub struct WalkthroughGenerations {
+    by_branch: HashMap<String, WalkthroughGeneration>,
+}
+
+impl WalkthroughGenerations {
+    /// Whether a generation for `branch` is currently in flight.
+    pub fn is_generating(&self, branch: &str) -> bool {
+        self.by_branch.contains_key(branch)
+    }
+
+    /// Register a freshly spawned generation. The caller is expected to have
+    /// checked [`Self::is_generating`] first: inserting over a live handle
+    /// would drop (and orphan) the running `claude` child and strand its
+    /// branch's row in `generating` forever.
+    pub fn insert(&mut self, generation: WalkthroughGeneration) {
+        debug_assert!(
+            !self.is_generating(&generation.branch),
+            "would orphan the in-flight generation for {}",
+            generation.branch
+        );
+        self.by_branch
+            .insert(generation.branch.clone(), generation);
+    }
+
+    /// Poll every in-flight generation, removing the ones that are no longer
+    /// running and returning what each one did.
+    ///
+    /// Removal is what makes a wedged or externally-killed session
+    /// self-healing: whatever the child did — saved and exited, crashed, was
+    /// `kill`ed from outside, or ran past [`GENERATION_TIMEOUT`] — its slot is
+    /// released here, so the next request for that branch starts a fresh
+    /// session instead of being told one is already running.
+    pub fn take_finished(&mut self) -> Vec<FinishedGeneration> {
+        let mut finished = Vec::new();
+        self.by_branch.retain(|branch, generation| {
+            let outcome = generation.poll();
+            if matches!(outcome, GenerationPoll::Running) {
+                return true;
+            }
+            finished.push(FinishedGeneration {
+                branch: branch.clone(),
+                log_path: generation.log_path.clone(),
+                outcome,
+            });
+            false
+        });
+        finished
+    }
+
+    /// Whether nothing is in flight (lets the caller skip polling entirely).
+    pub fn is_empty(&self) -> bool {
+        self.by_branch.is_empty()
+    }
+
+    /// Kill every in-flight generation (used when the app shuts down).
+    pub fn abort_all(&mut self) {
+        for (_, mut generation) in self.by_branch.drain() {
+            generation.abort();
+        }
+    }
+}
+
 /// Build the `--mcp-config` JSON that registers conductor's own `mcp-serve`
 /// subcommand as the headless generation session's MCP server.
 ///
@@ -476,6 +578,142 @@ mod tests {
         // create_comment, high-signal and low-frequency.
         assert!(prompt.contains("create_comment"));
         assert!(prompt.contains("hard to understand"));
+    }
+
+    // ── WalkthroughGenerations: per-branch, not per-app, exclusion ──
+
+    /// A child that stays alive well past the end of the test.
+    fn long_running_child() -> Child {
+        test_child("sleep 30")
+    }
+
+    fn test_child(script: &str) -> Child {
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn test child")
+    }
+
+    /// Poll until something finishes. `take_finished` is non-blocking, so a
+    /// child that has only just been spawned is legitimately still `Running`
+    /// on the first call.
+    fn wait_for_finished(generations: &mut WalkthroughGenerations) -> Vec<FinishedGeneration> {
+        for _ in 0..400 {
+            let finished = generations.take_finished();
+            if !finished.is_empty() {
+                return finished;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("no generation finished within 10 seconds");
+    }
+
+    #[test]
+    fn different_branches_generate_side_by_side() {
+        // The bug this replaced: one in-flight generation blocked every other
+        // worktree's branch, not just its own.
+        let mut generations = WalkthroughGenerations::default();
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            long_running_child(),
+            Instant::now(),
+        ));
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/b",
+            long_running_child(),
+            Instant::now(),
+        ));
+
+        assert!(generations.is_generating("feature/a"));
+        assert!(generations.is_generating("feature/b"));
+        // Neither displaced nor finished the other.
+        assert!(generations.take_finished().is_empty());
+
+        generations.abort_all();
+        assert!(generations.is_empty());
+    }
+
+    #[test]
+    fn only_the_same_branch_is_refused() {
+        let mut generations = WalkthroughGenerations::default();
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            long_running_child(),
+            Instant::now(),
+        ));
+
+        // This predicate is the guard `cmd_generate_walkthrough` consults.
+        assert!(generations.is_generating("feature/a"));
+        assert!(!generations.is_generating("feature/b"));
+
+        generations.abort_all();
+    }
+
+    #[test]
+    fn a_finished_generation_frees_its_branch() {
+        let mut generations = WalkthroughGenerations::default();
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            test_child("exit 0"),
+            Instant::now(),
+        ));
+
+        let finished = wait_for_finished(&mut generations);
+        assert_eq!(finished.len(), 1);
+        assert_eq!(finished[0].branch, "feature/a");
+        assert!(matches!(finished[0].outcome, GenerationPoll::Exited));
+        assert!(!generations.is_generating("feature/a"));
+    }
+
+    #[test]
+    fn an_externally_killed_generation_frees_its_branch() {
+        // Stale-lock recovery: if the session dies without Conductor asking it
+        // to, its slot must be released so the next request can regenerate
+        // rather than being told one is already running.
+        let mut generations = WalkthroughGenerations::default();
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            test_child("kill -9 $$"),
+            Instant::now(),
+        ));
+
+        let finished = wait_for_finished(&mut generations);
+        assert!(matches!(finished[0].outcome, GenerationPoll::Failed(_)));
+        assert!(!generations.is_generating("feature/a"));
+
+        // And the branch accepts a fresh generation immediately.
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            long_running_child(),
+            Instant::now(),
+        ));
+        assert!(generations.is_generating("feature/a"));
+        generations.abort_all();
+    }
+
+    #[test]
+    fn a_wedged_generation_times_out_and_frees_its_branch() {
+        let Some(started) = Instant::now().checked_sub(GENERATION_TIMEOUT + Duration::from_secs(1))
+        else {
+            // Machine booted less than GENERATION_TIMEOUT ago; no instant far
+            // enough in the past exists to backdate against.
+            return;
+        };
+        let mut generations = WalkthroughGenerations::default();
+        generations.insert(WalkthroughGeneration::for_test(
+            "feature/a",
+            long_running_child(),
+            started,
+        ));
+
+        let finished = generations.take_finished();
+        assert_eq!(finished.len(), 1);
+        assert!(matches!(finished[0].outcome, GenerationPoll::TimedOut));
+        assert!(!generations.is_generating("feature/a"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

別の worktree で walkthrough を生成中だと、他の worktree で生成を開始できなかったバグの修正。

原因はグローバルなロックファイルやポートではなく、**アプリ内の生成中ハンドルが1枠しかなかったこと**:

- `App::walkthrough_gen: Option<WalkthroughGeneration>` — conductor プロセス全体で1つ
- `cmd_generate_walkthrough` はその枠が埋まっていれば **branch を問わず**拒否し、`"A walkthrough is already being generated for '<別branch>' — wait for it to finish."` を返していた

実際に競合するのは `walkthroughs` テーブルの行(branch キーで DELETE→INSERT される)だけで、別 branch = 別 worktree の生成は行もログファイルも DB 接続も干渉しない(DB は既に WAL + `busy_timeout`)。つまり排他が必要より1段広かった。

新設した `WalkthroughGenerations` が生成中ハンドルを **branch キーの HashMap** で保持し、同一 branch のみ直列化、別 branch は並行実行する。`take_finished()` が終了したハンドルを必ず枠から外すので、正常終了・クラッシュ・外部 kill・タイムアウトのいずれでも in-flight 状態が残らない(PID 生存チェックは `Child::try_wait` が兼ねる)。完了時のステータスメッセージには branch 名を含めた — 複数生成中は、完了したものが今見ている worktree とは限らないため。

スコープ外: ロック/一時ファイルのパス設計は変更していない。ログは既に branch 単位、MCP server は stdio 起動でポートを持たず、DB は共有のままで問題ない(下記で実証)。

## Test plan

ユニットテスト5件を追加(実プロセスで exit / kill -9 / timeout を再現):

- 別 branch 2本が同時に in-flight でいられる
- 同一 branch のみ `is_generating` が true
- 正常終了したハンドルが枠から外れる
- 外部から kill されたハンドルが枠から外れ、同じ branch を即再実行できる
- タイムアウトしたハンドルが kill され枠から外れる

実バイナリでの実走検証(`claude` をスリープするスタブに差し替え、1本目を飛行中のまま2本目を要求):

| 確認項目 | 結果 |
|---|---|
| 2 worktree 同時生成 | 両方受理。`walkthroughs` に `generating` 2行 + ログ2本 |
| 同一 worktree の二重実行 | 2回目を `"already being generated for this branch"` で拒否、行・ログとも1本 |
| 生成プロセスを外部 kill | `Walkthrough failed` を検知 → 同 branch で再実行が受理される |
| 1 DB に mcp-serve 2プロセス同時書き込み | 両方 `status=ready` で保存成功 |

`cargo test` 971 passed / `cargo clippy` 新規警告なし(既存3件は `code_nav.rs` / `hover_info.rs`、未変更)。