### PR TITLE
fix: resolve walkthrough step paths by one canonical spelling and generate through the [api] seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ MCP tools together, which is the point: they used to be two artifacts on two
 release channels and drifted apart.
 
 - **Run by hand:** `conductor mcp-serve --db <path>` (speaks JSON-RPC on stdout)
-- **Who starts it:** `walkthrough.rs` for headless generation (passes `--db`), and
-  `plugins/conductor/.mcp.json` for sessions inside the TUI (resolves the DB from
-  `$CONDUCTOR_DB_PATH`, injected by `pty_manager/spawn.rs`)
+- **Who starts it:** `plugins/conductor/.mcp.json`, for the interactive Claude Code
+  sessions inside the TUI (it resolves the DB from `$CONDUCTOR_DB_PATH`, injected by
+  `pty_manager/spawn.rs`). Conductor's own walkthrough generation does *not* go
+  through MCP — it parses the model's JSON reply and writes the rows itself
 - **Tool contract:** the 8 `#[tool]` handlers in `src/mcp_serve/tools.rs`. Their doc
   comments become the JSON Schema descriptions the model reads, so changing one
   changes the tool's public contract — treat them as API, not commentary.
@@ -91,7 +92,7 @@ Status bar
 | `theme.rs` | Color themes (catppuccin-mocha default, dracula, nord, solarized-dark) |
 | `term_caps.rs` | Rich-mode terminal capability detection (truecolor / graphics protocol tiers) |
 | `pr_intake.rs` | Fetches a PR via `gh` and prepares its worktree for review (re-entrant: reuses an existing valid worktree) |
-| `walkthrough.rs` | AI walkthrough data model and generation trigger — spawns a headless `claude -p` session that saves its result via the MCP server |
+| `walkthrough.rs` | AI walkthrough data model, generation prompt, and reply parser — generation runs through the `[api]` seam (`ai_caller.rs`) on a background thread, never by spawning a CLI |
 | `app/walkthrough_view.rs` | Explorer walkthrough-view methods for `App` — step selection, jumping to a step's diff location, and the "viewed" file/step toggle |
 | `app/review_publish.rs` | Publishes review comments to GitHub via `gh`, tracking which comments are already posted |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.97.1"
+version = "0.98.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.97.1"
+version = "0.98.0"
 edition = "2024"
 
 [dependencies]

--- a/src/ai_caller.rs
+++ b/src/ai_caller.rs
@@ -5,34 +5,50 @@
 //! return raw text. That is what keeps the user-facing extension point trivial: the
 //! output format never crosses the provider boundary.
 //!
-//! Built-in providers ([`GeminiCaller`], [`ClaudeCliCaller`]) ship inside the binary.
-//! The user-extensible path is [`CommandCaller`]: the user names a command in their
-//! config and Conductor speaks a minimal, stable protocol to it.
+//! The one built-in provider ([`GeminiCaller`]) ships inside the binary. The
+//! user-extensible path is [`CommandCaller`]: the user names a command in their config
+//! and Conductor speaks a minimal, stable protocol to it. Conductor never hard-codes
+//! any CLI of its own — every other provider is whatever the config names.
 //!
-//! ## External LLM Command Protocol (v1)
+//! ## External LLM Command Protocol (v2)
+//!
+//! `[api] command` names the **AI tool itself**: any CLI that takes a prompt and
+//! prints a completion. It is not a place for per-task behaviour — which output
+//! format a task needs, whether the model may use tools, and which directory it
+//! should look at are all decided by the *feature* asking for the completion, so
+//! no wrapper script is needed to adapt one to the other.
 //!
 //! - **Invocation:** Conductor runs the configured argv directly (no shell).
-//! - **Input:** the assembled prompt (system prompt + two newlines + user message) is
-//!   written to the command's **stdin** as UTF-8, then stdin is closed (EOF).
-//! - **Output:** the command writes the model's completion to **stdout** and Conductor
-//!   parses it on its own side. The command does no formatting itself — it only relays
-//!   the model's answer (see the output requirement below).
+//! - **Placeholders:** any argument may contain `{prompt}` (the assembled
+//!   prompt) or `{workdir}` (the task's directory). A tool that takes its prompt
+//!   as a positional argument puts `{prompt}` where that argument goes; one that
+//!   reads stdin needs no placeholder at all.
+//! - **Input:** with `{prompt}` present the prompt goes in that argument and
+//!   stdin is closed immediately. Without it, the prompt (system prompt + two
+//!   newlines + user message) is written to **stdin** as UTF-8, then closed.
+//! - **Working directory:** the child runs in the task's directory, so a tool
+//!   that resolves paths relatively (`-w .`) lands in the right place even
+//!   without `{workdir}`.
+//! - **Output:** the command writes the model's completion to **stdout** and
+//!   Conductor parses it on its own side. The command does no formatting and no
+//!   JSON extraction — the feature's own parser tolerates fences and prose.
 //! - **Exit code:** `0` = success. Non-zero = failure; stderr is surfaced in the error.
 //! - **stderr:** diagnostics only, never parsed.
-//! - **Timeout / cancel:** Conductor enforces a wall-clock timeout and kills the child if
-//!   the user cancels. The command is simply killed; it is not notified.
+//! - **Timeout / cancel:** Conductor enforces a per-task wall-clock timeout (see
+//!   [`TaskEnv`]) and kills the child if the user cancels. The command is simply
+//!   killed; it is not notified.
 //!
-//! ### Output requirement (current task)
+//! ### What belongs to the feature, not to the command
 //!
-//! Today Conductor's only LLM task is smart-worktree generation, which parses the
-//! returned text into `{ branch, prompt, session_name }`. So the relayed text must
-//! ultimately *contain* that JSON object. The command author does no JSON work — the
-//! model produces it, because Conductor's system prompt instructs it to, and the parser
-//! tolerates surrounding prose / code fences. A weak model that ignores the prompt and
-//! returns prose will make smart-worktree fail with a parse error; pair `command` with a
-//! model capable of following a "reply with only this JSON" instruction.
+//! Each task writes its own system prompt, and that is where its constraints
+//! live: smart-worktree naming tells the model not to use tools and to answer
+//! with one JSON object, while walkthrough generation tells it the opposite —
+//! go read the diff. Retrying an off-format reply is likewise the feature's
+//! call, because only it knows what a retry costs (seconds for a branch name,
+//! minutes for a walkthrough).
 
 use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -88,75 +104,59 @@ impl AiCaller for GeminiCaller {
     }
 }
 
-/// Built-in: the `claude -p` CLI.
-///
-/// `json_schema` is *injected* by the caller (the task owns its schema), so this
-/// provider stays generic. When present, structured output is requested.
-pub struct ClaudeCliCaller {
-    pub json_schema: Option<String>,
-}
+// There is deliberately no built-in Claude provider — Conductor does not spawn a
+// `claude` process for completions. Wanting one is fine; it is just config, and
+// needs no wrapper script:
+//
+//     [api]
+//     provider = "command"
+//     command = ["claude", "-p", "{prompt}"]
+//
+// Any other prompt-in/completion-out CLI is configured the same way.
 
-impl AiCaller for ClaudeCliCaller {
-    fn complete(
-        &self,
-        system_prompt: &str,
-        user_message: &str,
-        cancel: &Arc<AtomicBool>,
-    ) -> Result<String, String> {
-        if cancel.load(Ordering::Relaxed) {
-            return Err("Cancelled".to_string());
-        }
-        log::info!("AI caller: using claude -p CLI");
+/// Placeholder replaced with the assembled prompt. Its presence also switches
+/// prompt delivery from stdin to argv.
+const PROMPT_PLACEHOLDER: &str = "{prompt}";
 
-        let mut cmd = Command::new("claude");
-        cmd.args(["-p", "--output-format", "json"]);
-        if let Some(schema) = &self.json_schema {
-            cmd.arg("--json-schema").arg(schema);
-        }
-        cmd.arg("--system-prompt").arg(system_prompt).arg(user_message);
+/// Placeholder replaced with the task's working directory.
+const WORKDIR_PLACEHOLDER: &str = "{workdir}";
 
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Failed to run claude CLI: {e}"))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("claude CLI failed ({}): {stderr}", output.status));
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        if stdout.trim().is_empty() {
-            return Err("claude CLI returned empty output".to_string());
-        }
-        extract_claude_payload(&stdout)
-    }
-}
-
-/// Pull the model's payload out of `claude -p --output-format json` output.
-///
-/// `structured_output` (with `--json-schema`) or `result` (plain) carries the text;
-/// a string field is returned as-is, an object is re-serialized for the caller's parser.
-fn extract_claude_payload(stdout: &str) -> Result<String, String> {
-    let wrapper: serde_json::Value = serde_json::from_str(stdout)
-        .map_err(|e| format!("Failed to parse claude CLI JSON wrapper: {e}"))?;
-    let payload = wrapper
-        .get("structured_output")
-        .or_else(|| wrapper.get("result"))
-        .ok_or_else(|| {
-            format!("claude CLI response missing structured_output/result\nRaw: {stdout}")
-        })?;
-    Ok(match payload.as_str() {
-        Some(s) => s.to_string(),
-        None => payload.to_string(),
-    })
-}
-
-/// User-extensible: an external command speaking the v1 protocol (see module docs).
+/// User-extensible: an external command speaking the protocol in the module docs.
 pub struct CommandCaller {
-    /// argv: `cmd[0]` is the executable, the rest are fixed arguments.
+    /// argv: `cmd[0]` is the executable, the rest are fixed arguments, any of
+    /// which may contain `{prompt}` / `{workdir}`.
     pub cmd: Vec<String>,
     /// Wall-clock timeout in seconds. `0` disables the timeout.
     pub timeout_secs: u64,
+    /// Directory to run the command in — the repository or worktree the task is
+    /// about, and what `{workdir}` expands to. `None` inherits Conductor's cwd.
+    pub working_dir: Option<PathBuf>,
+}
+
+/// Expand the placeholders in a configured argv.
+///
+/// Returns the expanded argv and whether `{prompt}` was found — the caller
+/// needs that to decide between argv and stdin delivery, and "no placeholder
+/// anywhere" has to mean stdin rather than a command that silently receives no
+/// prompt at all.
+fn expand_argv(cmd: &[String], prompt: &str, workdir: Option<&Path>) -> (Vec<String>, bool) {
+    let workdir = workdir.map(|d| d.to_string_lossy().into_owned());
+    let mut saw_prompt = false;
+    let expanded = cmd
+        .iter()
+        .map(|arg| {
+            let mut out = arg.clone();
+            if out.contains(PROMPT_PLACEHOLDER) {
+                saw_prompt = true;
+                out = out.replace(PROMPT_PLACEHOLDER, prompt);
+            }
+            if let Some(dir) = &workdir {
+                out = out.replace(WORKDIR_PLACEHOLDER, dir);
+            }
+            out
+        })
+        .collect();
+    (expanded, saw_prompt)
 }
 
 impl AiCaller for CommandCaller {
@@ -166,14 +166,24 @@ impl AiCaller for CommandCaller {
         user_message: &str,
         cancel: &Arc<AtomicBool>,
     ) -> Result<String, String> {
-        let program = self
-            .cmd
+        let payload = format!("{system_prompt}\n\n{user_message}");
+        let (argv, prompt_in_argv) =
+            expand_argv(&self.cmd, &payload, self.working_dir.as_deref());
+        let program = argv
             .first()
-            .ok_or_else(|| "AI command is empty".to_string())?;
-        log::info!("AI caller: using external command '{program}'");
+            .ok_or_else(|| "AI command is empty".to_string())?
+            .clone();
+        log::info!(
+            "AI caller: using external command '{program}' (prompt via {})",
+            if prompt_in_argv { "argv" } else { "stdin" }
+        );
 
-        let mut child = Command::new(program)
-            .args(&self.cmd[1..])
+        let mut command = Command::new(&program);
+        command.args(&argv[1..]);
+        if let Some(dir) = &self.working_dir {
+            command.current_dir(dir);
+        }
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -185,9 +195,13 @@ impl AiCaller for CommandCaller {
         let stdout_reader = child.stdout.take().map(spawn_pipe_reader);
         let stderr_reader = child.stderr.take().map(spawn_pipe_reader);
 
-        // Write the assembled prompt and close stdin (EOF) so the command can proceed.
-        if let Some(mut stdin) = child.stdin.take() {
-            let payload = format!("{system_prompt}\n\n{user_message}");
+        // Deliver the prompt. When it already went out as an argument, stdin is
+        // still closed immediately (dropping the handle) — a tool that reads
+        // stdin anyway must see EOF rather than block forever, and sending the
+        // prompt twice would be worse than not sending it at all.
+        if let Some(mut stdin) = child.stdin.take()
+            && !prompt_in_argv
+        {
             stdin
                 .write_all(payload.as_bytes())
                 .map_err(|e| format!("Failed to write to AI command stdin: {e}"))?;
@@ -259,25 +273,42 @@ fn tail_chars(s: &str, n: usize) -> &str {
     }
 }
 
-/// Build the configured AI caller.
+/// What a task needs from the AI beyond its prompt: how long it may take and
+/// which directory it is about.
 ///
-/// `json_schema` is the task's optional output schema, handed to the `claude` provider.
+/// Both are per-task, not per-provider. Smart-worktree naming is a few seconds of
+/// pure text generation; a walkthrough is minutes of an agent reading a diff. One
+/// `[api] command_timeout_secs` cannot serve both, and only the second needs a
+/// working directory at all.
+#[derive(Debug, Clone, Default)]
+pub struct TaskEnv {
+    /// Overrides `[api] command_timeout_secs` when set. `0` disables the timeout.
+    pub timeout_secs: Option<u64>,
+    /// Directory to run an external command in — the worktree the task concerns.
+    pub working_dir: Option<PathBuf>,
+}
+
+/// Build the configured AI caller for a task.
 ///
 /// Providers (`[api] provider`). Each provider stands alone — a failure surfaces to the
 /// user rather than silently falling back to another provider.
 /// - `"gemini"` (default): Gemini HTTP API.
-/// - `"claude"`: `claude -p` CLI.
 /// - `"command"`: the user's external command (`[api] command`).
-pub fn build_caller(
-    api: &ApiConfig,
-    json_schema: Option<String>,
-) -> Result<Box<dyn AiCaller>, String> {
+///
+/// There is deliberately **no built-in `claude` provider**: spawning the `claude` CLI
+/// from inside Conductor is not allowed anywhere in this codebase. Driving Claude is
+/// exactly what `provider = "command"` is for — the user names the CLI directly and
+/// Conductor never needs to know which model is behind it.
+///
+/// Note that `"gemini"` is a plain HTTP completion: it cannot read the repository, so
+/// a task that needs the code (walkthrough generation) only works behind `"command"`
+/// pointed at an agentic CLI.
+pub fn build_caller(api: &ApiConfig, env: &TaskEnv) -> Result<Box<dyn AiCaller>, String> {
     match api.provider.trim().to_lowercase().as_str() {
         "gemini" => Ok(Box::new(GeminiCaller {
             model: api.model.clone(),
             max_tokens: GEMINI_MAX_TOKENS,
         })),
-        "claude" => Ok(Box::new(ClaudeCliCaller { json_schema })),
         "command" => {
             if api.command.is_empty() {
                 return Err(
@@ -287,11 +318,12 @@ pub fn build_caller(
             }
             Ok(Box::new(CommandCaller {
                 cmd: api.command.clone(),
-                timeout_secs: api.command_timeout_secs,
+                timeout_secs: env.timeout_secs.unwrap_or(api.command_timeout_secs),
+                working_dir: env.working_dir.clone(),
             }))
         }
         other => Err(format!(
-            "unknown AI provider '{other}' (expected: gemini, claude, command)"
+            "unknown AI provider '{other}' (expected: gemini, command)"
         )),
     }
 }
@@ -311,21 +343,30 @@ mod tests {
 
     #[test]
     fn build_caller_accepts_known_providers() {
-        assert!(build_caller(&api("gemini"), None).is_ok());
-        assert!(build_caller(&api("claude"), None).is_ok());
-        assert!(build_caller(&ApiConfig::default(), None).is_ok());
+        assert!(build_caller(&api("gemini"), &TaskEnv::default()).is_ok());
+        assert!(build_caller(&ApiConfig::default(), &TaskEnv::default()).is_ok());
     }
 
     #[test]
     fn build_caller_is_case_and_whitespace_insensitive() {
-        assert!(build_caller(&api("GEMINI"), None).is_ok());
-        assert!(build_caller(&api("Claude"), None).is_ok());
-        assert!(build_caller(&api("  gemini  "), None).is_ok());
+        assert!(build_caller(&api("GEMINI"), &TaskEnv::default()).is_ok());
+        assert!(build_caller(&api("  gemini  "), &TaskEnv::default()).is_ok());
+    }
+
+    /// Conductor must never spawn the `claude` CLI itself, so the provider name
+    /// that used to do exactly that is now an ordinary unknown value — and the
+    /// error has to point at `command`, which is how a Claude-backed setup is
+    /// wired instead.
+    #[test]
+    fn build_caller_rejects_the_removed_claude_provider() {
+        let err = build_caller(&api("claude"), &TaskEnv::default()).err().unwrap();
+        assert!(err.contains("claude"), "should echo the bad value: {err}");
+        assert!(err.contains("command"), "should point at the way in: {err}");
     }
 
     #[test]
     fn build_caller_rejects_unknown_provider() {
-        let err = build_caller(&api("ollama"), None).err().unwrap();
+        let err = build_caller(&api("ollama"), &TaskEnv::default()).err().unwrap();
         assert!(err.contains("ollama"), "should echo the bad value: {err}");
         assert!(err.contains("gemini"), "should list valid values: {err}");
     }
@@ -337,7 +378,7 @@ mod tests {
             command: Vec::new(),
             ..Default::default()
         };
-        let err = build_caller(&cfg, None).err().unwrap();
+        let err = build_caller(&cfg, &TaskEnv::default()).err().unwrap();
         assert!(err.contains("command"), "actionable message: {err}");
     }
 
@@ -348,7 +389,7 @@ mod tests {
             command: vec!["cat".to_string()],
             ..Default::default()
         };
-        assert!(build_caller(&cfg, None).is_ok());
+        assert!(build_caller(&cfg, &TaskEnv::default()).is_ok());
     }
 
     // ── tail_chars ───────────────────────────────────────────────────
@@ -362,29 +403,6 @@ mod tests {
         assert_eq!(tail_chars("あいうえお", 2), "えお");
     }
 
-    // ── extract_claude_payload ───────────────────────────────────────
-
-    #[test]
-    fn extract_claude_payload_reads_structured_object() {
-        let out = r#"{"structured_output":{"branch":"x","prompt":"p"}}"#;
-        let payload = extract_claude_payload(out).unwrap();
-        // Re-serialized object the caller's parser can consume.
-        assert!(payload.contains("\"branch\""));
-        assert!(payload.contains("\"x\""));
-    }
-
-    #[test]
-    fn extract_claude_payload_reads_result_string() {
-        let out = r#"{"result":"hello world"}"#;
-        assert_eq!(extract_claude_payload(out).unwrap(), "hello world");
-    }
-
-    #[test]
-    fn extract_claude_payload_errors_on_missing_field() {
-        let out = r#"{"other":1}"#;
-        assert!(extract_claude_payload(out).is_err());
-    }
-
     // ── CommandCaller (real subprocess, Unix only) ───────────────────
 
     #[cfg(unix)]
@@ -395,6 +413,7 @@ mod tests {
             CommandCaller {
                 cmd: vec!["sh".to_string(), "-c".to_string(), script.to_string()],
                 timeout_secs,
+                working_dir: None,
             }
         }
 
@@ -404,6 +423,135 @@ mod tests {
             let cancel = Arc::new(AtomicBool::new(false));
             let out = caller.complete("SYS", "USER", &cancel).unwrap();
             assert!(out.contains("SYS") && out.contains("USER"), "got: {out}");
+        }
+
+        /// The command runs in the directory the task is about. This is the only
+        /// way an agentic command can reach the code it is being asked about, so
+        /// it is part of the protocol, not a detail.
+        #[test]
+        fn runs_in_the_task_working_directory() {
+            let dir = tempfile::tempdir().unwrap();
+            let caller = CommandCaller {
+                cmd: vec!["sh".to_string(), "-c".to_string(), "pwd".to_string()],
+                timeout_secs: 5,
+                working_dir: Some(dir.path().to_path_buf()),
+            };
+            let cancel = Arc::new(AtomicBool::new(false));
+            let out = caller.complete("s", "u", &cancel).unwrap();
+            // macOS reports /private/var… for a /var… tempdir, so compare the
+            // resolved forms rather than the strings we started with.
+            let reported = std::fs::canonicalize(out.trim()).unwrap();
+            assert_eq!(reported, std::fs::canonicalize(dir.path()).unwrap());
+        }
+
+        /// A task that names a timeout gets that one; the config value only fills in
+        /// when it doesn't. Walkthrough generation depends on this — it runs for
+        /// minutes under a `command_timeout_secs` meant for a few seconds of naming.
+        ///
+        /// Asserted by behaviour rather than by inspecting the built caller: the
+        /// config disables the timeout entirely, so the command can only be killed
+        /// if the task's own value is what reached it.
+        #[test]
+        fn task_timeout_overrides_the_configured_one() {
+            let cfg = ApiConfig {
+                provider: "command".to_string(),
+                command: vec!["sh".to_string(), "-c".to_string(), "sleep 30".to_string()],
+                command_timeout_secs: 0,
+                ..Default::default()
+            };
+            let caller = build_caller(
+                &cfg,
+                &TaskEnv {
+                    timeout_secs: Some(1),
+                    working_dir: None,
+                },
+            )
+            .unwrap();
+
+            let start = Instant::now();
+            let err = caller
+                .complete("s", "u", &Arc::new(AtomicBool::new(false)))
+                .unwrap_err();
+            assert!(err.contains("timed out after 1s"), "got: {err}");
+            assert!(start.elapsed() < Duration::from_secs(10));
+        }
+
+        /// A tool that takes its prompt as a positional argument (`claude -p`,
+        /// and most agentic CLIs) is named directly in the config; `{prompt}` is
+        /// what makes that possible without a wrapper script.
+        #[test]
+        fn prompt_placeholder_delivers_via_argv() {
+            let caller = CommandCaller {
+                // `printf %s` echoes its argument, so stdout is exactly what
+                // landed in argv.
+                cmd: vec![
+                    "printf".to_string(),
+                    "%s".to_string(),
+                    "PRE[{prompt}]POST".to_string(),
+                ],
+                timeout_secs: 5,
+                working_dir: None,
+            };
+            let out = caller
+                .complete("SYS", "USER", &Arc::new(AtomicBool::new(false)))
+                .unwrap();
+            assert_eq!(out, "PRE[SYS\n\nUSER]POST");
+        }
+
+        /// …and the prompt must not also arrive on stdin, or the model sees it
+        /// twice. `cat` would append whatever stdin carried.
+        #[test]
+        fn prompt_placeholder_leaves_stdin_empty() {
+            let caller = CommandCaller {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "printf 'argv=%s;' \"$1\"; printf 'stdin='; cat".to_string(),
+                    "sh".to_string(),
+                    "{prompt}".to_string(),
+                ],
+                timeout_secs: 5,
+                working_dir: None,
+            };
+            let out = caller
+                .complete("SYS", "USER", &Arc::new(AtomicBool::new(false)))
+                .unwrap();
+            assert_eq!(out, "argv=SYS\n\nUSER;stdin=");
+        }
+
+        /// No placeholder anywhere keeps the stdin delivery that stdin-shaped
+        /// tools (`ollama run …`) rely on.
+        #[test]
+        fn without_a_placeholder_the_prompt_still_goes_to_stdin() {
+            let caller = sh("cat", 5);
+            let out = caller
+                .complete("SYS", "USER", &Arc::new(AtomicBool::new(false)))
+                .unwrap();
+            assert_eq!(out, "SYS\n\nUSER");
+        }
+
+        /// `{workdir}` expands to the task's directory, so a tool that wants it
+        /// as an explicit flag rather than as its cwd gets it without the user
+        /// hard-coding any one worktree in their config.
+        #[test]
+        fn workdir_placeholder_expands_to_the_task_directory() {
+            let dir = tempfile::tempdir().unwrap();
+            let caller = CommandCaller {
+                cmd: vec![
+                    "printf".to_string(),
+                    "%s".to_string(),
+                    "{workdir}".to_string(),
+                ],
+                timeout_secs: 5,
+                working_dir: Some(dir.path().to_path_buf()),
+            };
+            let out = caller
+                .complete("s", "u", &Arc::new(AtomicBool::new(false)))
+                .unwrap();
+            assert_eq!(
+                std::fs::canonicalize(out.trim()).unwrap(),
+                std::fs::canonicalize(dir.path()).unwrap()
+            );
         }
 
         #[test]
@@ -448,6 +596,7 @@ mod tests {
             let caller = CommandCaller {
                 cmd: vec!["definitely_not_a_real_binary_xyzzy".to_string()],
                 timeout_secs: 5,
+                working_dir: None,
             };
             let cancel = Arc::new(AtomicBool::new(false));
             let err = caller.complete("s", "u", &cancel).unwrap_err();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,6 +19,7 @@ mod review_edit;
 mod review_history;
 mod review_publish;
 mod review_walkthrough;
+pub use review_walkthrough::WalkthroughGenerations;
 mod terminal;
 mod terminal_cc_state;
 mod terminal_resize;
@@ -99,11 +100,11 @@ pub struct App {
     /// [`App::exit_editor`] (the only two methods that pair this field with
     /// `Focus::Editor`, keeping the invariant local).
     pub editor: Option<EditorPanel>,
-    /// In-flight headless walkthrough generations, at most one per branch so
-    /// worktrees don't block each other. Polled by
-    /// [`App::poll_walkthrough_generation`]; the DB row is the source of
-    /// truth for completion, these handles only catch process failures.
-    pub walkthrough_gens: crate::walkthrough::WalkthroughGenerations,
+    /// In-flight walkthrough generations, at most one per branch so worktrees
+    /// don't block each other: each is a background thread's result channel
+    /// plus enough context to report against the right branch. Drained by
+    /// [`App::poll_walkthrough_generation`].
+    pub walkthrough_gens: WalkthroughGenerations,
     /// The selected worktree's walkthrough (header + steps), reloaded by
     /// [`App::refresh_reviews`] alongside the comment list.
     pub current_walkthrough: Option<(

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -19,6 +19,23 @@ impl App {
             self.review_state.load_comments(store, &wt);
             // Walkthrough (if any) rides along with the same branch scope.
             self.current_walkthrough = store.get_walkthrough(&wt).ok().flatten();
+            // Re-anchor each step onto the diff's own spelling of its file
+            // while we have both in hand. The Viewer's step banner and its
+            // line-range underline compare `current_file` against
+            // `step.file_path` directly, so a step whose stored path only
+            // *resolves* to a diff file (a `git diff` `b/` prefix, a path
+            // written relative to a subdirectory) would jump correctly and
+            // then render neither. Steps that already match, and steps whose
+            // file isn't in the diff at all, are left exactly as they are.
+            if let Some((_, steps)) = self.current_walkthrough.as_mut() {
+                for step in steps.iter_mut() {
+                    if let Some(resolved) = self.diff_state.resolve_changed_path(&step.file_path)
+                        && resolved != step.file_path
+                    {
+                        step.file_path = resolved;
+                    }
+                }
+            }
             // Rebuild per-file cache for the currently viewed file.
             if let Some(file_path) = self.viewer_state.content.current_file.clone() {
                 self.review_state.build_file_comment_cache(&file_path);

--- a/src/app/review_walkthrough.rs
+++ b/src/app/review_walkthrough.rs
@@ -1,14 +1,127 @@
 //! AI walkthrough generation orchestration for [`App`].
 //!
-//! Starts a headless `claude -p` session via [`crate::walkthrough`], polls it
-//! to completion, and reflects success/failure back into the review database
-//! via [`crate::review_store::ReviewStore`].
+//! Runs [`crate::walkthrough::generate`] on a background thread — which asks
+//! whichever model `[api]` names, never a `claude` process Conductor spawns
+//! itself — and reflects the result into the review database via
+//! [`crate::review_store::ReviewStore`].
+//!
+//! One generation may be in flight per branch ([`WalkthroughGenerations`]), so
+//! a reviewer touring one worktree can still start a walkthrough in another.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, TryRecvError, channel};
 
 use super::*;
 
+/// An in-flight generation: where its result will arrive, which branch it is
+/// for, and the flag that stops it.
+pub struct WalkthroughGeneration {
+    pub branch: String,
+    result: Receiver<Result<crate::walkthrough::Generated, String>>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl WalkthroughGeneration {
+    /// Signal the worker to stop. The AI caller checks this between polls of
+    /// its child, so an external command is killed rather than left running.
+    fn abort(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+/// A generation that stopped running, as handed back by
+/// [`WalkthroughGenerations::take_finished`]. Carries the branch it was for,
+/// because the handle itself is gone by the time the caller reconciles the
+/// database row it left behind.
+pub struct FinishedGeneration {
+    pub branch: String,
+    pub outcome: Result<crate::walkthrough::Generated, String>,
+}
+
+/// Every walkthrough generation in flight in this Conductor instance, at most
+/// one per branch.
+///
+/// Keyed by branch, not by "one at a time", because the branch is the only
+/// thing a generation actually contends for: `begin_walkthrough` deletes and
+/// re-inserts the `walkthroughs` row for its branch and `save_walkthrough`
+/// replaces it, so two generations on one branch would race for a single row
+/// and the loser's steps would vanish. Generations for *different* branches —
+/// which means different worktrees, since git won't check one branch out
+/// twice — touch disjoint rows and a database that is already WAL +
+/// `busy_timeout` (see `review_store::schema`), so they can run side by side.
+/// Serializing them was over-broad: it made a reviewer touring one worktree
+/// unable to start a walkthrough in another.
+#[derive(Default)]
+pub struct WalkthroughGenerations {
+    by_branch: HashMap<String, WalkthroughGeneration>,
+}
+
+impl WalkthroughGenerations {
+    /// Whether a generation for `branch` is currently in flight.
+    pub fn is_generating(&self, branch: &str) -> bool {
+        self.by_branch.contains_key(branch)
+    }
+
+    /// Register a freshly spawned generation. The caller is expected to have
+    /// checked [`Self::is_generating`] first: inserting over a live handle
+    /// would drop its receiver, so the worker's result would go nowhere and
+    /// strand that branch's row in `generating` forever.
+    pub fn insert(&mut self, generation: WalkthroughGeneration) {
+        debug_assert!(
+            !self.is_generating(&generation.branch),
+            "would orphan the in-flight generation for {}",
+            generation.branch
+        );
+        self.by_branch
+            .insert(generation.branch.clone(), generation);
+    }
+
+    /// Drain every in-flight generation's result channel, removing the ones
+    /// that are no longer running and returning what each one produced.
+    ///
+    /// Removal is what makes a dead worker self-healing: a thread that panicked
+    /// or dropped its sender without a result releases its slot here, so the
+    /// next request for that branch starts a fresh generation instead of being
+    /// told one is already running.
+    pub fn take_finished(&mut self) -> Vec<FinishedGeneration> {
+        let mut finished = Vec::new();
+        self.by_branch.retain(|branch, generation| {
+            let outcome = match generation.result.try_recv() {
+                Ok(outcome) => outcome,
+                Err(TryRecvError::Empty) => return true,
+                // The worker died without sending: treat it as a failure rather
+                // than leaving the row in `generating` forever.
+                Err(TryRecvError::Disconnected) => {
+                    Err("walkthrough generation ended without a result".to_string())
+                }
+            };
+            finished.push(FinishedGeneration {
+                branch: branch.clone(),
+                outcome,
+            });
+            false
+        });
+        finished
+    }
+
+    /// Whether nothing is in flight (lets the caller skip polling entirely).
+    pub fn is_empty(&self) -> bool {
+        self.by_branch.is_empty()
+    }
+
+    /// Stop every in-flight generation (used when the app shuts down).
+    pub fn abort_all(&mut self) {
+        for (_, generation) in self.by_branch.drain() {
+            generation.abort();
+        }
+    }
+}
+
 impl App {
     /// Kick off walkthrough generation for the selected worktree's branch:
-    /// insert the `generating` row, then spawn the headless Claude session.
+    /// insert the `generating` row, then start the background worker.
     /// Re-running regenerates from scratch — except when a `ready` walkthrough
     /// already exists for the current branch tip, which is a no-op that just
     /// re-shows it (the diff, and so the walkthrough, hasn't changed). While a
@@ -32,11 +145,10 @@ impl App {
             return;
         }
         // Only one generation may be in flight *per branch*: replacing the
-        // handle would silently drop (and orphan) the running `claude` child
-        // and strand its branch's row in `generating` forever. Generations
-        // for other branches are none of this branch's business — they write
-        // disjoint rows, so they run concurrently (see
-        // `walkthrough::WalkthroughGenerations`).
+        // handle would drop the running worker's receiver, stranding its
+        // branch's row in `generating` forever. Generations for other branches
+        // are none of this branch's business — they write disjoint rows, so
+        // they run concurrently (see [`WalkthroughGenerations`]).
         if self.walkthrough_gens.is_generating(&branch) {
             self.set_status(
                 "A walkthrough is already being generated for this branch.".to_string(),
@@ -99,57 +211,67 @@ impl App {
             .ok()
             .flatten()
             .and_then(|m| m.base_ref);
-        let db = crate::review_store::db_path(&self.repo_path);
-        let model = self.config.review.walkthrough_model.clone();
+        let api = self.config.api.clone();
         let language = self.config.review.walkthrough_language.clone();
-        match crate::walkthrough::spawn_generation(
-            &wt_path,
-            &db,
-            &branch,
-            base_ref.as_deref(),
-            model.as_deref(),
-            language.as_deref(),
-        ) {
-            Ok(generation) => {
-                self.walkthrough_gens.insert(generation);
-                // Display-only switch — no `set_focus`, so kicking off a
-                // generation from the palette never steals focus from an
-                // active terminal input; it just makes the in-progress state
-                // visible once the reviewer does look at the Explorer.
-                self.viewer_state.explorer.explorer_bottom_view =
-                    crate::viewer::ExplorerBottomView::Walkthrough;
-                self.set_status(
-                    "Generating walkthrough in the background — this takes a few minutes."
-                        .to_string(),
-                    StatusLevel::Info,
-                );
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                if let Some(store) = &self.review_store {
-                    let _ = store.fail_walkthrough(&branch, &msg);
-                }
-                self.set_status(
-                    format!("Failed to launch walkthrough generation: {msg}"),
-                    StatusLevel::Error,
-                );
-            }
-        }
+        // `[review] walkthrough_model` is not passed on: which model answers is
+        // the configured command's business now, not Conductor's. A user who
+        // wants a specific model puts it in `[api] command`.
+        let worktree = wt_path.clone();
+        let branch_for_thread = branch.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = channel();
+        let worker_cancel = cancel.clone();
+        std::thread::spawn(move || {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                crate::walkthrough::generate(
+                    &api,
+                    &worktree,
+                    &branch_for_thread,
+                    base_ref.as_deref(),
+                    language.as_deref(),
+                    &worker_cancel,
+                )
+            }))
+            .unwrap_or_else(|_| Err("walkthrough generation thread panicked".to_string()));
+            // A closed receiver means the app moved on (or shut down); nothing
+            // to report to, and nothing to clean up.
+            let _ = tx.send(outcome);
+        });
+
+        self.walkthrough_gens.insert(WalkthroughGeneration {
+            branch: branch.clone(),
+            result: rx,
+            cancel,
+        });
+        // Display-only switch — no `set_focus`, so kicking off a generation
+        // from the palette never steals focus from an active terminal input;
+        // it just makes the in-progress state visible once the reviewer does
+        // look at the Explorer.
+        self.viewer_state.explorer.explorer_bottom_view =
+            crate::viewer::ExplorerBottomView::Walkthrough;
+        self.set_status(
+            "Generating walkthrough in the background — this takes a few minutes.".to_string(),
+            StatusLevel::Info,
+        );
         self.refresh_reviews();
     }
 
-    /// Kill every in-flight walkthrough generation so none outlives the app as
-    /// an orphaned headless `claude` process. Called once on shutdown (see
-    /// `main.rs`'s main loop, right before it returns on `should_quit`) — a
-    /// generation still running at that point would otherwise keep making API
-    /// calls with no one polling its outcome.
+    /// Stop every in-flight generation so none outlives the app as an orphaned
+    /// subprocess. Called once on shutdown (see `event_loop.rs`, right before
+    /// it returns on `should_quit`) — a generation still running at that point
+    /// would otherwise keep burning tokens with no one left to read its result.
     pub fn shutdown_walkthrough_generation(&mut self) {
         self.walkthrough_gens.abort_all();
     }
 
-    /// Poll the in-flight walkthrough generations and reconcile each one's
-    /// database row with what its process actually did. Called from
+    /// Drain the in-flight generations' result channels and reconcile each
+    /// one's database row with it. Called from
     /// [`App::poll_all_background_ops`](Self::poll_all_background_ops).
+    ///
+    /// Unlike the old headless-session path, the row's `ready` state is written
+    /// *here*, from the parsed reply — the model has no way to write it itself
+    /// over the plain text seam, which is also why a malformed reply can no
+    /// longer leave a row stuck in `generating`.
     pub fn poll_walkthrough_generation(&mut self) {
         if self.walkthrough_gens.is_empty() {
             return;
@@ -158,66 +280,213 @@ impl App {
         if finished.is_empty() {
             return;
         }
-        for outcome in finished {
-            let (message, level) = self.reconcile_finished_generation(outcome);
+        for generation in finished {
+            let (message, level) = self.reconcile_finished_generation(generation);
             self.set_status(message, level);
         }
         self.refresh_reviews();
     }
 
     /// Turn one finished generation into the status message to flash, writing
-    /// a `failed` row when the session didn't leave a good one behind.
+    /// a `failed` row when it did not produce a usable walkthrough.
     ///
     /// Messages name the branch: with several worktrees generating at once,
     /// the one that finishes is often not the one the reviewer is looking at.
     fn reconcile_finished_generation(
-        &self,
-        finished: crate::walkthrough::FinishedGeneration,
+        &mut self,
+        finished: FinishedGeneration,
     ) -> (String, StatusLevel) {
-        use crate::walkthrough::{GenerationPoll, WalkthroughStatus};
-        let crate::walkthrough::FinishedGeneration {
-            branch,
-            log_path,
-            outcome,
-        } = finished;
-        let fail = |msg: &str| {
-            if let Some(store) = &self.review_store {
-                let _ = store.fail_walkthrough(&branch, msg);
-            }
-            (
-                format!("Walkthrough failed for '{branch}': {msg}"),
-                StatusLevel::Error,
-            )
-        };
+        let FinishedGeneration { branch, outcome } = finished;
         match outcome {
-            GenerationPoll::Running => {
-                unreachable!("take_finished only yields generations that stopped")
-            }
-            GenerationPoll::Exited => {
-                // Success is decided by the row the MCP tool wrote, not the
-                // exit code: a session that ended without saving is a failure.
-                let saved = self
-                    .review_store
-                    .as_ref()
-                    .and_then(|s| s.get_walkthrough(&branch).ok().flatten())
-                    .is_some_and(|(w, _)| w.status == WalkthroughStatus::Ready);
-                if saved {
-                    (
-                        format!("Walkthrough ready for '{branch}'."),
-                        StatusLevel::Success,
-                    )
-                } else {
-                    fail(&format!(
-                        "Claude session ended without saving a walkthrough (log: {})",
-                        log_path.display()
-                    ))
+            Ok(generated) => self.save_generated_walkthrough(&branch, generated),
+            Err(error) => {
+                if let Some(store) = &self.review_store {
+                    let _ = store.fail_walkthrough(&branch, &error);
                 }
+                (
+                    format!("Walkthrough failed for '{branch}': {error}"),
+                    StatusLevel::Error,
+                )
             }
-            GenerationPoll::Failed(msg) => fail(&msg),
-            GenerationPoll::TimedOut => fail(&format!(
-                "Timed out after {} minutes.",
-                crate::walkthrough::GENERATION_TIMEOUT.as_secs() / 60
-            )),
         }
+    }
+
+    /// Write a parsed generation into the review database, returning the status
+    /// line to show for it.
+    ///
+    /// The inline comments are best-effort on purpose: they are the optional
+    /// extra on top of the tour, so a comment that fails to insert must not
+    /// turn a perfectly good walkthrough into a failed one.
+    fn save_generated_walkthrough(
+        &mut self,
+        branch: &str,
+        generated: crate::walkthrough::Generated,
+    ) -> (String, StatusLevel) {
+        let Some(store) = &self.review_store else {
+            return (
+                "Walkthrough generated but the review database is unavailable.".to_string(),
+                StatusLevel::Error,
+            );
+        };
+        let step_count = generated.steps.len();
+        if let Err(e) = store.save_walkthrough(
+            branch,
+            &generated.title,
+            &generated.summary,
+            &generated.steps,
+        ) {
+            let msg = format!("Failed to save walkthrough: {e}");
+            let _ = store.fail_walkthrough(branch, &msg);
+            return (msg, StatusLevel::Error);
+        }
+
+        let mut saved_comments = 0usize;
+        for comment in &generated.comments {
+            let Some(line_start) = comment.line_start else {
+                continue;
+            };
+            let result = store.add_review(
+                branch,
+                &comment.file_path,
+                line_start,
+                comment.line_end,
+                crate::review_store::CommentKind::Question,
+                &comment.body,
+                "HEAD",
+                crate::review_store::Author::Claude,
+                Some(branch),
+            );
+            match result {
+                Ok(_) => saved_comments += 1,
+                Err(e) => log::warn!("failed to save generated inline comment: {e}"),
+            }
+        }
+
+        let comments = if saved_comments > 0 {
+            format!(", {saved_comments} inline comment(s)")
+        } else {
+            String::new()
+        };
+        (
+            format!("Walkthrough ready for '{branch}' ({step_count} step(s){comments})."),
+            StatusLevel::Success,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc::Sender;
+
+    type Outcome = Result<crate::walkthrough::Generated, String>;
+
+    /// A registered generation plus the sender its worker thread would hold.
+    /// Keeping the sender alive is what "still running" means to
+    /// [`WalkthroughGenerations::take_finished`]; dropping it is how a worker
+    /// that died without a result looks from here.
+    fn generation(branch: &str) -> (WalkthroughGeneration, Sender<Outcome>, Arc<AtomicBool>) {
+        let (tx, rx) = channel();
+        let cancel = Arc::new(AtomicBool::new(false));
+        (
+            WalkthroughGeneration {
+                branch: branch.to_string(),
+                result: rx,
+                cancel: cancel.clone(),
+            },
+            tx,
+            cancel,
+        )
+    }
+
+    fn sample_generated() -> crate::walkthrough::Generated {
+        crate::walkthrough::Generated {
+            title: "t".to_string(),
+            summary: "s".to_string(),
+            steps: Vec::new(),
+            comments: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn different_branches_generate_side_by_side() {
+        // The bug this replaced: one in-flight generation blocked every other
+        // worktree's branch, not just its own.
+        let mut generations = WalkthroughGenerations::default();
+        let (a, _tx_a, _) = generation("feature/a");
+        let (b, _tx_b, _) = generation("feature/b");
+        generations.insert(a);
+        generations.insert(b);
+
+        assert!(generations.is_generating("feature/a"));
+        assert!(generations.is_generating("feature/b"));
+        // Neither displaced nor finished the other.
+        assert!(generations.take_finished().is_empty());
+
+        generations.abort_all();
+        assert!(generations.is_empty());
+    }
+
+    #[test]
+    fn only_the_same_branch_is_refused() {
+        let mut generations = WalkthroughGenerations::default();
+        let (a, _tx_a, _) = generation("feature/a");
+        generations.insert(a);
+
+        // This predicate is the guard `cmd_generate_walkthrough` consults.
+        assert!(generations.is_generating("feature/a"));
+        assert!(!generations.is_generating("feature/b"));
+    }
+
+    #[test]
+    fn a_finished_generation_frees_its_branch() {
+        let mut generations = WalkthroughGenerations::default();
+        let (a, tx, _) = generation("feature/a");
+        generations.insert(a);
+        tx.send(Ok(sample_generated())).expect("receiver is alive");
+
+        let finished = generations.take_finished();
+        assert_eq!(finished.len(), 1);
+        assert_eq!(finished[0].branch, "feature/a");
+        assert!(finished[0].outcome.is_ok());
+        assert!(!generations.is_generating("feature/a"));
+    }
+
+    #[test]
+    fn a_dead_worker_frees_its_branch() {
+        // Stale-lock recovery: a thread that panicked (or otherwise dropped its
+        // sender without a result) must release its slot, so the next request
+        // regenerates rather than being told one is already running.
+        let mut generations = WalkthroughGenerations::default();
+        let (a, tx, _) = generation("feature/a");
+        generations.insert(a);
+        drop(tx);
+
+        let finished = generations.take_finished();
+        assert_eq!(finished.len(), 1);
+        let err = finished[0].outcome.as_ref().unwrap_err();
+        assert!(err.contains("without a result"), "got: {err}");
+        assert!(!generations.is_generating("feature/a"));
+
+        // And the branch accepts a fresh generation immediately.
+        let (again, _tx, _) = generation("feature/a");
+        generations.insert(again);
+        assert!(generations.is_generating("feature/a"));
+    }
+
+    #[test]
+    fn abort_all_signals_every_worker_to_stop() {
+        let mut generations = WalkthroughGenerations::default();
+        let (a, _tx_a, cancel_a) = generation("feature/a");
+        let (b, _tx_b, cancel_b) = generation("feature/b");
+        generations.insert(a);
+        generations.insert(b);
+
+        generations.abort_all();
+
+        // The flag each worker (and, through it, the AI caller's child) polls.
+        assert!(cancel_a.load(Ordering::Relaxed));
+        assert!(cancel_b.load(Ordering::Relaxed));
+        assert!(generations.is_empty());
     }
 }

--- a/src/app/walkthrough_view.rs
+++ b/src/app/walkthrough_view.rs
@@ -53,14 +53,25 @@ impl App {
         }
         let cur = self.viewer_state.explorer.walkthrough_selected as isize;
         let next = (cur + delta).clamp(0, len as isize - 1) as usize;
+        // The cursor moves whether or not the jump lands. A step whose file
+        // can't be resolved would otherwise pin `n`/`N` in place — every press
+        // retries the same unresolvable step and the reviewer can never reach
+        // the rest of the tour.
+        self.viewer_state.explorer.walkthrough_selected = next;
         self.jump_to_walkthrough_step(next);
     }
 
-    /// Shared implementation for jumping to walkthrough step `idx`: opens its
-    /// file in the diff pane, scrolls to its starting line, and marks it
-    /// viewed. Returns `false` (a no-op otherwise) if there's no walkthrough,
-    /// the index is out of range, or the step's file isn't part of the
-    /// current diff.
+    /// Shared implementation for jumping to walkthrough step `idx`: resolves
+    /// its file against the diff, opens it in the diff pane, scrolls to its
+    /// starting line, and marks it viewed. Returns `false` (a no-op otherwise)
+    /// if there's no walkthrough, the index is out of range, or the step's
+    /// file genuinely isn't part of the current diff.
+    ///
+    /// The step's path is matched *tolerantly* (see
+    /// [`crate::diff_state::DiffState::resolve_changed_path`]) because it was
+    /// written by a language model and the diff list matches by string
+    /// equality: a step spelled `./src/a.rs` names a file that is right there
+    /// in the list, and used to report itself as missing.
     fn jump_to_walkthrough_step(&mut self, idx: usize) -> bool {
         let Some((_, steps)) = &self.current_walkthrough else {
             return false;
@@ -68,26 +79,64 @@ impl App {
         let Some(step) = steps.get(idx) else {
             return false;
         };
-        let file_path = step.file_path.clone();
+        let step_path = step.file_path.clone();
         let line_start = step.line_start;
         let step_id = step.id.clone();
+        let Some(wt) = self.worktrees.get(self.selected_worktree) else {
+            return false;
+        };
+        let wt_path = wt.path.clone();
 
+        // The step's spelling of the path and the diff's may differ (an older
+        // row saved before paths were normalised, a `git diff` `a/`/`b/`
+        // prefix); `resolve_changed_path` returns the diff's own spelling.
+        let Some(file_path) = self.diff_state.resolve_changed_path(&step_path) else {
+            // Ordered so the status bar's truncation eats the least useful part
+            // last: what was searched for first, the (potentially very long)
+            // base directory at the end. The full text always reaches the log.
+            let normalized = crate::repo_path::normalize(&step_path);
+            let searched = if normalized == step_path {
+                String::new()
+            } else {
+                format!(" (searched as {normalized})")
+            };
+            let msg = format!(
+                "Walkthrough step's file isn't in this diff: {step_path}{searched} — \
+                 {} changed file(s) vs {}, under {}",
+                self.diff_state.changed_paths().len(),
+                self.diff_state.base_branch,
+                wt_path.display(),
+            );
+            log::warn!("{msg}");
+            self.set_status(msg, StatusLevel::Warning);
+            return false;
+        };
+        // Adopt that spelling for the rest of the session: the Viewer's step
+        // banner and its line-range underline both test
+        // `current_file == step.file_path`, so leaving the step on its own
+        // spelling would jump correctly and then render neither.
+        if file_path != step_path
+            && let Some((_, steps)) = self.current_walkthrough.as_mut()
+            && let Some(step) = steps.get_mut(idx)
+        {
+            log::debug!("walkthrough step {idx}: resolved '{step_path}' to '{file_path}'");
+            step.file_path = file_path.clone();
+        }
+
+        // A file inside a collapsed directory has no display row until the
+        // directory is expanded, so reveal before looking the row up.
         let Some((file_diff, _)) = self
             .diff_state
-            .display_index_for_path(&file_path)
+            .reveal_path(&file_path)
             .and_then(|i| self.diff_state.resolve_file(i))
         else {
             self.set_status(
-                format!("Walkthrough step references a file not in this diff: {file_path}"),
+                format!("Walkthrough step's file is in the diff but has no row: {file_path}"),
                 StatusLevel::Warning,
             );
             return false;
         };
         let file_diff_clone = file_diff.clone();
-        let Some(wt) = self.worktrees.get(self.selected_worktree) else {
-            return false;
-        };
-        let wt_path = wt.path.clone();
         let tab_width = self.config.viewer.tab_width;
         self.viewer_state.open_file(&wt_path, &file_path, tab_width);
         self.viewer_state.reveal_file_in_tree(&file_path, &wt_path);

--- a/src/app/worktree_smart.rs
+++ b/src/app/worktree_smart.rs
@@ -11,14 +11,23 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::*;
 
+/// Everything this task needs the model to do differently from other tasks
+/// lives here, not in the configured command.
+///
+/// The "no tools, no commands" line matters when `[api] command` is an *agentic*
+/// CLI (`claude -p` and the like): left to itself such a tool reaches for Bash
+/// and answers conversationally, which fails the parse. A pure completion API
+/// ignores the line harmlessly, so it is safe to state unconditionally rather
+/// than having the user encode it in a wrapper.
 const SMART_WORKTREE_SYSTEM_PROMPT: &str = r#"You are a helper that generates a git branch name, a Claude Code prompt, and a session name from a task description.
+
+IMPORTANT: Do not use any tools. Do not run any commands. Do not explain. Answer immediately from the description alone.
+
 Output ONLY a JSON object with three fields:
 - "branch": a kebab-case branch name in English, 3-5 words, prefixed with "feature/", "fix/", or "refactor/" as appropriate.
 - "prompt": a detailed, actionable prompt for Claude Code to implement the task. Write the prompt in the same language as the input description.
 - "session_name": a short, descriptive session name (max 50 chars) for display in session lists. Write in the same language as the input description.
 No markdown fences, no explanation, just the JSON object."#;
-
-const SMART_WORKTREE_JSON_SCHEMA: &str = r#"{"type":"object","properties":{"branch":{"type":"string"},"prompt":{"type":"string"},"session_name":{"type":"string"}},"required":["branch","prompt","session_name"]}"#;
 
 /// Parse LLM raw output into `SmartGenResult`, extracting JSON even if surrounded by text.
 fn parse_smart_gen_result(raw: &str) -> Result<SmartGenResult, String> {
@@ -51,29 +60,54 @@ fn parse_smart_gen_result(raw: &str) -> Result<SmartGenResult, String> {
     ))
 }
 
+/// How many times to ask again when the reply contains no usable JSON.
+///
+/// An agentic CLI occasionally answers conversationally however firmly the
+/// prompt is worded, and one off-format turn should not sink the whole
+/// smart-worktree flow. Cheap to retry here — this task is seconds of pure text
+/// generation, which is exactly why walkthrough generation does *not* retry.
+const SMART_WORKTREE_ATTEMPTS: usize = 3;
+
 /// Run the LLM generation for smart worktree (branch name + prompt).
 ///
 /// The provider is selected from `[api]` config and built via [`crate::ai_caller`];
-/// this function owns the prompt, the output schema, and the parsing — the provider
-/// only returns raw text. Checks `cancel_token` before and after the (blocking) call.
+/// this function owns the prompt, the retry policy, and the parsing — the
+/// configured command is just the model. Checks `cancel_token` before and after
+/// each (blocking) call.
+///
+/// The task keeps `[api] command_timeout_secs` as-is: naming a branch is a few
+/// seconds of text generation, unlike walkthrough generation, which asks for its own
+/// far larger budget.
 fn run_smart_generation(
     desc: &str,
     cancel_token: &Arc<AtomicBool>,
     api: &crate::config::ApiConfig,
+    repo_path: &std::path::Path,
 ) -> Result<SmartGenResult, String> {
-    if cancel_token.load(Ordering::Relaxed) {
-        return Err("Cancelled".to_string());
+    let env = crate::ai_caller::TaskEnv {
+        timeout_secs: None,
+        working_dir: Some(repo_path.to_path_buf()),
+    };
+    let caller = crate::ai_caller::build_caller(api, &env)?;
+
+    let mut last_err = String::new();
+    for attempt in 1..=SMART_WORKTREE_ATTEMPTS {
+        if cancel_token.load(Ordering::Relaxed) {
+            return Err("Cancelled".to_string());
+        }
+        let raw = caller.complete(SMART_WORKTREE_SYSTEM_PROMPT, desc, cancel_token)?;
+        if cancel_token.load(Ordering::Relaxed) {
+            return Err("Cancelled".to_string());
+        }
+        match parse_smart_gen_result(&raw) {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                log::warn!("smart worktree: unusable reply on attempt {attempt}: {e}");
+                last_err = e;
+            }
+        }
     }
-
-    let caller =
-        crate::ai_caller::build_caller(api, Some(SMART_WORKTREE_JSON_SCHEMA.to_string()))?;
-    let raw = caller.complete(SMART_WORKTREE_SYSTEM_PROMPT, desc, cancel_token)?;
-
-    if cancel_token.load(Ordering::Relaxed) {
-        return Err("Cancelled".to_string());
-    }
-
-    parse_smart_gen_result(&raw)
+    Err(last_err)
 }
 
 impl App {
@@ -124,7 +158,7 @@ impl App {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 // Phase 1: LLM generation.
                 let gen_result =
-                    match run_smart_generation(&desc, &cancel, &api) {
+                    match run_smart_generation(&desc, &cancel, &api, &repo_path) {
                         Ok(r) => r,
                         Err(e) => {
                             let _ = tx.send(WorktreeOpResult::SmartFailed {
@@ -236,6 +270,17 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// This task's constraints belong to the task, not to whatever `[api]
+    /// command` happens to be: an agentic CLI reaches for tools and chats
+    /// unless told not to, and that instruction used to live in a wrapper
+    /// script the user had to maintain.
+    #[test]
+    fn system_prompt_forbids_tools_and_demands_json() {
+        assert!(SMART_WORKTREE_SYSTEM_PROMPT.contains("Do not use any tools"));
+        assert!(SMART_WORKTREE_SYSTEM_PROMPT.contains("Do not run any commands"));
+        assert!(SMART_WORKTREE_SYSTEM_PROMPT.contains("Output ONLY a JSON object"));
+    }
 
     #[test]
     fn test_parse_plain_json() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,14 +29,14 @@ pub use persist::{
     config_file_path, generate_default_config, persist_layout_proportions,
     persist_ui_high_contrast, persist_ui_theme,
 };
-// PromptAction and AppearanceSnapshot are not referenced by name anywhere else
-// in the crate yet (call sites use type inference / field access instead),
-// but they are part of this module's public surface, so keep re-exporting
-// them under `crate::config::*` rather than letting the split hide them.
+// AppearanceSnapshot is not referenced by name anywhere else in the crate yet
+// (call sites use type inference / field access instead), but it is part of
+// this module's public surface, so keep re-exporting it under
+// `crate::config::*` rather than letting the split hide it.
 #[allow(unused_imports)]
 pub use sections::{
-    ApiConfig, CcusageConfig, DiffConfig, DiffView, GeneralConfig, LayoutConfig, PromptAction,
-    ReviewConfig, RichConfig, TerminalConfig, UiConfig, UpdatesConfig, ViewerConfig,
+    ApiConfig, CcusageConfig, DiffConfig, DiffView, GeneralConfig, LayoutConfig, ReviewConfig,
+    RichConfig, TerminalConfig, UiConfig, UpdatesConfig, ViewerConfig,
 };
 #[allow(unused_imports)]
 pub use snapshot::{AppearanceSnapshot, has_restart_changes};

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -62,15 +62,11 @@ pub fn generate_default_config() -> String {
 # word_diff = true                      # highlight intra-line word changes
 
 [review]
-# レビュー機能はMCPプラグイン (conductor plugin) に移行済みです。
-# 以下の設定は互換性のため残されていますが、通常は変更不要です。
-# prompt_template = "以下のレビューコメントに対応してください。\n\n{comments}"
-#                                       # template for review prompts ({comments} is replaced)
-# prompt_action = "clipboard"           # clipboard | send_to_session
-# walkthrough_model = "opus"            # model for AI walkthrough generation
-#                                       # (claude --model alias or full id; unset = CLI default)
+# レビューコメントの受け渡しはMCPプラグイン (conductor plugin) 経由です。
 # walkthrough_language = "日本語"        # language the walkthrough is written in
 #                                       # (unset = model's choice)
+#                                       # which MODEL writes it is [api] below — walkthrough
+#                                       # generation goes through the same configurable seam
 
 [keybinds]
 # Key-bind overrides, in key→action form. Each entry maps a key chord to an
@@ -114,10 +110,27 @@ pub fn generate_default_config() -> String {
 #                                       #   force - enable even when detection fails
 
 [api]
-# provider = "gemini"                   # "gemini" (Gemini API), "claude" (claude -p CLI), or "command" (external) — no fallback between them
-# model = "gemini-2.5-flash"            # model for smart worktree generation (Gemini API)
-# command = ["ollama", "run", "llama3"] # external command for provider = "command" (prompt on stdin, completion on stdout)
-# command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
+# Which AI answers Conductor's own prompts (smart worktree naming, walkthrough
+# generation). Conductor never runs a CLI of its own — you name the tool here.
+#
+# provider = "gemini"                   # "gemini" (Gemini API) or "command" (any CLI) — no fallback between them
+# model = "gemini-2.5-flash"            # model for the "gemini" provider
+# command_timeout_secs = 60             # wall-clock timeout (0 = none). Long tasks such as
+#                                       #   walkthrough generation set their own instead.
+#
+# `command` is the AI tool itself, as argv. Two placeholders are substituted:
+#   {prompt}   the assembled prompt. Put it where the tool expects its prompt;
+#              LEAVE IT OUT for tools that read stdin, which is then used.
+#   {workdir}  the directory the task is about (the reviewed worktree). The
+#              command also *runs* in that directory, so "." works too.
+#
+# command = ["claude", "-p", "{prompt}"]                 # Claude Code, one-shot
+# command = ["my-cli", "-w", "{workdir}", "{prompt}"]    # prompt as a positional argument
+# command = ["ollama", "run", "llama3"]                  # reads stdin, no placeholder needed
+#
+# You do not need a wrapper script: what a task requires — that the model must
+# not use tools, the output format, which directory to read — is part of the
+# prompt Conductor builds for that task.
 
 [ui]
 # theme = "catppuccin-mocha"            # UI color theme (overrides [viewer] theme when set)

--- a/src/config/sections.rs
+++ b/src/config/sections.rs
@@ -128,52 +128,12 @@ pub enum DiffView {
 }
 
 /// `[review]` section.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ReviewConfig {
-    /// Template string used to format review prompts.
-    ///
-    /// The placeholder `{comments}` is replaced with the actual review
-    /// comments at runtime.
-    pub prompt_template: String,
-    /// What to do with the rendered prompt.
-    pub prompt_action: PromptAction,
-    /// Model for the headless walkthrough-generation session, passed to
-    /// `claude --model` (alias like "opus"/"sonnet" or a full model id).
-    /// `None` uses the Claude CLI's session default.
-    pub walkthrough_model: Option<String>,
     /// Natural language the walkthrough should be written in (e.g. "日本語",
     /// "English"). `None` leaves the choice to the model.
     pub walkthrough_language: Option<String>,
-}
-
-impl Default for ReviewConfig {
-    fn default() -> Self {
-        Self {
-            prompt_template: default_prompt_template(),
-            prompt_action: PromptAction::Clipboard,
-            walkthrough_model: None,
-            walkthrough_language: None,
-        }
-    }
-}
-
-/// Default review prompt template (Japanese).
-pub(super) fn default_prompt_template() -> String {
-    String::from(
-        "\
-以下のレビューコメントに対応してください。
-
-{comments}",
-    )
-}
-
-/// Action taken with a rendered review prompt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PromptAction {
-    Clipboard,
-    SendToSession,
 }
 
 /// `[ccusage]` section.
@@ -220,17 +180,24 @@ impl Default for UpdatesConfig {
 pub struct ApiConfig {
     /// Model ID for the Gemini API.
     pub model: String,
-    /// Which LLM provider to use for smart worktree generation. Each provider stands
-    /// alone; a failure surfaces to the user rather than falling back to another.
+    /// Which LLM provider to use. Each provider stands alone; a failure surfaces to
+    /// the user rather than falling back to another.
     /// `"gemini"` (default): the Gemini HTTP API.
-    /// `"claude"`: the `claude -p` CLI.
     /// `"command"`: a user-supplied external command (see `command`).
-    pub provider: String,
-    /// External command to run when `provider = "command"`.
     ///
-    /// argv form (`["ollama", "run", "llama3"]`); run directly without a shell.
-    /// Conductor writes the prompt to the command's stdin and reads the completion
-    /// from stdout — see the "External LLM Command Protocol" in `ai_caller.rs`.
+    /// There is no built-in provider that runs the `claude` CLI: Conductor never
+    /// spawns it. A Claude-backed setup is just `provider = "command"` with
+    /// `command = ["claude", "-p", "{prompt}"]` — no wrapper script.
+    pub provider: String,
+    /// The AI tool to run when `provider = "command"`, in argv form, run
+    /// directly without a shell.
+    ///
+    /// `{prompt}` and `{workdir}` are substituted into any argument
+    /// (`["claude", "-p", "{prompt}"]`); with no `{prompt}` the
+    /// prompt goes to stdin instead (`["ollama", "run", "llama3"]`). The
+    /// completion is read from stdout. See the "External LLM Command Protocol"
+    /// in `ai_caller.rs` — and note that per-task behaviour (tool use, output
+    /// format) belongs to the feature's prompt, not to this command.
     pub command: Vec<String>,
     /// Wall-clock timeout (seconds) for the `command` provider. `0` disables it.
     pub command_timeout_secs: u64,

--- a/src/config/snapshot.rs
+++ b/src/config/snapshot.rs
@@ -97,7 +97,5 @@ pub fn has_restart_changes(old: &Config, new: &Config) -> bool {
         || old.updates.check_interval_secs != new.updates.check_interval_secs
         || old.ccusage.enabled != new.ccusage.enabled
         || old.ccusage.poll_interval_secs != new.ccusage.poll_interval_secs
-        || old.review.prompt_template != new.review.prompt_template
-        || old.review.prompt_action != new.review.prompt_action
         || old.keybinds != new.keybinds
 }

--- a/src/config/tests_config.rs
+++ b/src/config/tests_config.rs
@@ -19,7 +19,6 @@ fn default_config_round_trips_through_toml() {
     assert!(!cfg2.viewer.word_wrap);
     assert_eq!(cfg2.diff.default_view, DiffView::Unified);
     assert!(cfg2.diff.word_diff);
-    assert_eq!(cfg2.review.prompt_action, PromptAction::Clipboard);
     assert!(!cfg2.ccusage.enabled);
     assert_eq!(cfg2.ccusage.poll_interval_secs, 120);
     assert!(cfg2.updates.check_on_startup);
@@ -39,10 +38,16 @@ fn diff_view_serde() {
     assert_eq!(cfg.default_view, DiffView::SideBySide);
 }
 
+/// A config file still carrying the removed review-prompt keys must load, not
+/// fail: they were written into every generated `config.toml` and dropping
+/// them cannot break an existing install.
 #[test]
-fn prompt_action_serde() {
-    let cfg: ReviewConfig = toml::from_str(r#"prompt_action = "send_to_session""#).expect("parse");
-    assert_eq!(cfg.prompt_action, PromptAction::SendToSession);
+fn removed_review_prompt_keys_are_ignored() {
+    let cfg: ReviewConfig = toml::from_str(
+        "prompt_template = \"…{comments}\"\nprompt_action = \"send_to_session\"\n",
+    )
+    .expect("stale keys should be ignored, not rejected");
+    assert!(cfg.walkthrough_language.is_none());
 }
 
 #[test]

--- a/src/diff_state/display_list.rs
+++ b/src/diff_state/display_list.rs
@@ -212,6 +212,94 @@ impl DiffState {
         (0..self.display_list.len()).find(|&idx| self.resolve_file(idx).is_some_and(|(f, _)| f.path == path))
     }
 
+    /// Every changed path in the diff, both sections, deduplicated. Unlike
+    /// [`Self::display_index_for_path`] this ignores the display list, so a
+    /// file inside a *collapsed* directory still counts as present.
+    pub fn changed_paths(&self) -> Vec<&str> {
+        let mut paths: Vec<&str> = self
+            .committed_files
+            .iter()
+            .chain(self.uncommitted_files.iter())
+            .map(|f| f.path.as_str())
+            .collect();
+        paths.sort_unstable();
+        paths.dedup();
+        paths
+    }
+
+    /// Match an externally-supplied path (a walkthrough step's `file_path`, a
+    /// comment's anchor) against the diff, returning the diff's own spelling of
+    /// it.
+    ///
+    /// Exact equality first, so a real file always wins over any guess below.
+    /// Then, for values that name the right file the wrong way:
+    ///
+    /// 1. the normalised spelling (`./src/a.rs`, `src//a.rs`);
+    /// 2. the path minus its first segment, which is what strips a `git diff`
+    ///    `a/`/`b/` prefix — and, since it is tried only after exact matching,
+    ///    it cannot shadow a repository that really does have a top-level `b/`;
+    /// 3. a unique suffix match on a segment boundary, which is what catches a
+    ///    path written relative to a subdirectory (`app/foo.rs` for
+    ///    `src/app/foo.rs`). Ambiguity disqualifies it: two files ending the
+    ///    same way mean we don't know which was meant, and guessing would send
+    ///    the reviewer to the wrong file with no hint that it happened.
+    pub fn resolve_changed_path(&self, path: &str) -> Option<String> {
+        let paths = self.changed_paths();
+        let exact = |candidate: &str| -> Option<String> {
+            paths
+                .iter()
+                .find(|p| **p == candidate)
+                .map(|p| (*p).to_string())
+        };
+
+        if let Some(hit) = exact(path) {
+            return Some(hit);
+        }
+        let normalized = crate::repo_path::normalize(path);
+        if normalized.is_empty() {
+            return None;
+        }
+        if let Some(hit) = exact(&normalized) {
+            return Some(hit);
+        }
+        if let Some((_, rest)) = normalized.split_once('/')
+            && !rest.is_empty()
+            && let Some(hit) = exact(rest)
+        {
+            return Some(hit);
+        }
+        let suffix = format!("/{normalized}");
+        let mut matches = paths.iter().filter(|p| p.ends_with(&suffix));
+        match (matches.next(), matches.next()) {
+            (Some(only), None) => Some((*only).to_string()),
+            _ => None,
+        }
+    }
+
+    /// Expand whatever ancestor directories are collapsed so `path` has a row,
+    /// and return that row's display index.
+    ///
+    /// Without this, jumping to a file inside a directory the reviewer had
+    /// collapsed looks exactly like the file not being in the diff at all —
+    /// [`Self::display_index_for_path`] can only see rows the display list
+    /// currently has.
+    pub fn reveal_path(&mut self, path: &str) -> Option<usize> {
+        if let Some(idx) = self.display_index_for_path(path) {
+            return Some(idx);
+        }
+        let mut changed = false;
+        let mut prefix_end = 0;
+        while let Some(slash) = path[prefix_end..].find('/') {
+            prefix_end += slash;
+            changed |= self.collapsed_dirs.remove(&path[..prefix_end]);
+            prefix_end += 1;
+        }
+        if changed {
+            self.rebuild_display_list();
+        }
+        self.display_index_for_path(path)
+    }
+
     /// Toggle the collapsed state of the directory at the given display index.
     /// Returns `true` if a directory was toggled (so the caller knows the list
     /// changed). Non-directory rows (files, the summary) are a no-op.

--- a/src/diff_state/tests.rs
+++ b/src/diff_state/tests.rs
@@ -252,6 +252,98 @@ fn display_index_for_path_finds_committed_and_uncommitted_files() {
     assert_eq!(ds.display_index_for_path("src/missing.rs"), None);
 }
 
+// ── Tolerant path resolution (walkthrough steps / comment anchors) ──────
+
+/// A `DiffState` whose committed diff touches `paths`, display list built.
+fn diff_state_with(paths: &[&str]) -> super::DiffState {
+    use super::*;
+    let mut ds = DiffState::new("main", DiffViewMode::Unified);
+    ds.committed_files = paths
+        .iter()
+        .map(|p| FileDiff {
+            path: (*p).to_string(),
+            added_lines: 1,
+            deleted_lines: 0,
+            hunks: Vec::new(),
+        })
+        .collect();
+    ds.rebuild_display_list();
+    ds
+}
+
+/// The bug this whole change exists for: a step saved as `./src/b.rs` (or with
+/// a `git diff` `b/` prefix, or a doubled slash) names a file that *is* in the
+/// diff, and must resolve to the diff's own spelling of it.
+#[test]
+fn resolve_changed_path_accepts_alternate_spellings() {
+    let ds = diff_state_with(&["src/a.rs", "src/deep/c.rs", "top.txt"]);
+
+    for spelling in ["src/a.rs", "./src/a.rs", "src//a.rs", "  src/a.rs  ", "src/a.rs/"] {
+        assert_eq!(
+            ds.resolve_changed_path(spelling).as_deref(),
+            Some("src/a.rs"),
+            "spelling: {spelling}"
+        );
+    }
+    // `git diff`'s a/ and b/ prefixes, left on the path by the generator.
+    assert_eq!(ds.resolve_changed_path("b/src/a.rs").as_deref(), Some("src/a.rs"));
+    assert_eq!(ds.resolve_changed_path("a/top.txt").as_deref(), Some("top.txt"));
+    // Written relative to a subdirectory rather than the repo root.
+    assert_eq!(ds.resolve_changed_path("deep/c.rs").as_deref(), Some("src/deep/c.rs"));
+}
+
+/// A file that genuinely isn't in the diff must stay unresolved — the tolerance
+/// above must not turn "not in this diff" into a jump to some other file.
+#[test]
+fn resolve_changed_path_refuses_files_outside_the_diff() {
+    let ds = diff_state_with(&["src/a.rs", "src/deep/c.rs"]);
+    assert_eq!(ds.resolve_changed_path("src/untouched.rs"), None);
+    assert_eq!(ds.resolve_changed_path(""), None);
+    assert_eq!(ds.resolve_changed_path("./"), None);
+}
+
+/// An ambiguous suffix must not be guessed: two files ending the same way mean
+/// we don't know which one was meant, and picking either would silently land
+/// the reviewer on the wrong file.
+#[test]
+fn resolve_changed_path_refuses_an_ambiguous_suffix() {
+    let ds = diff_state_with(&["src/app/mod.rs", "src/ui/mod.rs"]);
+    assert_eq!(ds.resolve_changed_path("mod.rs"), None);
+    // Enough context to disambiguate resolves fine.
+    assert_eq!(ds.resolve_changed_path("ui/mod.rs").as_deref(), Some("src/ui/mod.rs"));
+}
+
+/// A real top-level `b/` in the repo wins over reading `b/` as a diff prefix,
+/// because exact matching is tried first.
+#[test]
+fn resolve_changed_path_prefers_an_exact_match_over_prefix_stripping() {
+    let ds = diff_state_with(&["b/src/a.rs", "src/a.rs"]);
+    assert_eq!(ds.resolve_changed_path("b/src/a.rs").as_deref(), Some("b/src/a.rs"));
+    assert_eq!(ds.resolve_changed_path("src/a.rs").as_deref(), Some("src/a.rs"));
+}
+
+/// A file inside a directory the reviewer collapsed has no display row. Jumping
+/// to it must expand the way down rather than read as "not in this diff".
+#[test]
+fn reveal_path_expands_collapsed_ancestors() {
+    let mut ds = diff_state_with(&["src/deep/nested/c.rs"]);
+    assert!(ds.display_index_for_path("src/deep/nested/c.rs").is_some());
+
+    ds.collapsed_dirs.insert("src".to_string());
+    ds.rebuild_display_list();
+    assert_eq!(
+        ds.display_index_for_path("src/deep/nested/c.rs"),
+        None,
+        "precondition: a collapsed ancestor hides the file's row"
+    );
+
+    let idx = ds.reveal_path("src/deep/nested/c.rs").expect("row after reveal");
+    assert_eq!(
+        ds.resolve_file(idx).map(|(f, _)| f.path.as_str()),
+        Some("src/deep/nested/c.rs")
+    );
+}
+
 // ── Base ref resolution ────────────────────────────────────────────────
 
 /// A worktree whose base was saved as `origin/main` (Conductor's normal case

--- a/src/gemini_api.rs
+++ b/src/gemini_api.rs
@@ -1,7 +1,9 @@
 //! Gemini API client.
 //!
-//! Provides a blocking HTTP client for the Google Gemini API,
-//! replacing the previous `claude -p` CLI invocations for lower latency.
+//! Provides a blocking HTTP client for the Google Gemini API — one of the two
+//! providers behind the `[api]` seam (see `ai_caller.rs`). Being plain HTTP, it
+//! cannot read the repository, so tasks that need the code (walkthrough
+//! generation) want the `command` provider instead.
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod overlay;
 mod pr_intake;
 mod pty_manager;
 mod refresh_pipe;
+mod repo_path;
 mod review_publish;
 mod review_state;
 mod review_store;
@@ -176,6 +177,17 @@ Options:
         }
         None => std::env::current_dir()?,
     };
+    // Climb to the enclosing worktree root. Everything keyed off `repo_path`
+    // assumes a root — most visibly `.conductor/conductor.db`, which is
+    // *created* where it is looked for, so starting conductor from a
+    // subdirectory used to open a second, empty database beside that
+    // subdirectory: no comments, no walkthrough, and a stray `.conductor/`
+    // left behind. `discover` returns the path unchanged when it already is a
+    // root, and a linked worktree resolves to its own root, not the main one.
+    let repo_path = git2::Repository::discover(&repo_path)
+        .ok()
+        .and_then(|repo| repo.workdir().map(std::path::Path::to_path_buf))
+        .unwrap_or(repo_path);
     let mut app = App::new(repo_path);
 
     // ── Set terminal window title ────────────────────────────────────

--- a/src/mcp_serve/reply.rs
+++ b/src/mcp_serve/reply.rs
@@ -63,18 +63,25 @@ pub(super) fn ensure_not_blank(value: &str, what: &str) -> Result<(), String> {
 /// turns it into `/etc/passwd`, which `Path::join` would follow straight out of
 /// the worktree. Validating the stripped form is what closes that.
 ///
+/// What comes back is [`crate::repo_path::normalize`]'s canonical spelling, not
+/// merely the stripped one: the value is stored and later matched against
+/// `FileDiff::path` by string equality, so `./src/a.rs` or `src//a.rs` has to
+/// land in the database already spelled the way git spells it.
+///
 /// Errors quote the caller's own spelling rather than the stripped form, so the
 /// message matches what it actually sent.
-pub(super) fn normalize_repo_relative<'a>(
-    file_path: &'a str,
-    what: &str,
-) -> Result<&'a str, String> {
+pub(super) fn normalize_repo_relative(file_path: &str, what: &str) -> Result<String, String> {
     ensure_not_blank(file_path, what)?;
     let stripped = file_path.strip_prefix("./").unwrap_or(file_path);
     ensure_repo_relative(stripped, what).map_err(|_| {
         format!("{what} must be repo-relative and must not escape the repo root: {file_path}")
     })?;
-    Ok(stripped)
+    let normalized = crate::repo_path::normalize(stripped);
+    // Normalisation can only remove `.`/empty segments, so it cannot introduce
+    // an escape — but it can empty the path out entirely (`"./"`), which would
+    // otherwise be stored as a step anchored to nothing.
+    ensure_not_blank(&normalized, what)?;
+    Ok(normalized)
 }
 
 /// Reject a path that would escape the repository root.
@@ -169,12 +176,41 @@ mod tests {
     fn normalize_repo_relative_keeps_ordinary_paths() {
         assert_eq!(
             normalize_repo_relative("src/foo.rs", "file_path"),
-            Ok("src/foo.rs")
+            Ok("src/foo.rs".to_string())
         );
         assert_eq!(
             normalize_repo_relative("./src/foo.rs", "file_path"),
-            Ok("src/foo.rs")
+            Ok("src/foo.rs".to_string())
         );
+    }
+
+    /// Every spelling that means `src/foo.rs` has to *become* `src/foo.rs`
+    /// before it is stored: the diff list matches these by string equality, so
+    /// a stored `./src/foo.rs` is a step that can never be jumped to.
+    #[test]
+    fn normalize_repo_relative_canonicalises_every_spelling() {
+        for spelling in [
+            "src/foo.rs",
+            "./src/foo.rs",
+            "src//foo.rs",
+            "src/./foo.rs",
+            "  src/foo.rs  ",
+            "src/foo.rs/",
+        ] {
+            assert_eq!(
+                normalize_repo_relative(spelling, "file_path"),
+                Ok("src/foo.rs".to_string()),
+                "spelling: {spelling}"
+            );
+        }
+    }
+
+    /// A path that normalises away to nothing is rejected rather than stored as
+    /// an anchor to no file at all.
+    #[test]
+    fn normalize_repo_relative_rejects_a_path_that_normalises_to_empty() {
+        assert!(normalize_repo_relative("./", "file_path").is_err());
+        assert!(normalize_repo_relative(".", "file_path").is_err());
     }
 
     /// The Node server only rejected absolute paths; `..` reaches the same

--- a/src/mcp_serve/tools.rs
+++ b/src/mcp_serve/tools.rs
@@ -284,7 +284,7 @@ impl McpServer {
         // CHECK enforcing they agree, and `commit_ref` defaults to 'HEAD'.
         let created = self.store().add_review(
             &branch,
-            rel_path,
+            &rel_path,
             args.line_start,
             args.line_end,
             kind,
@@ -318,7 +318,7 @@ impl McpServer {
         ok_text(format!(
             "Comment created (id: {}) at {} on branch \"{branch}\". ({count} unresolved self-review comment(s) now on this branch{nudge}.)",
             short_id(&created.id),
-            line_range(rel_path, args.line_start, args.line_end),
+            line_range(&rel_path, args.line_start, args.line_end),
         ))
     }
 
@@ -392,10 +392,21 @@ impl McpServer {
             }
         }
         // Validate every step before writing any of them, so a bad step late in
-        // the list cannot leave a half-saved walkthrough.
+        // the list cannot leave a half-saved walkthrough. `file_path` is also
+        // normalised here, and the normalised form is what gets stored: steps
+        // are matched against `FileDiff::path` by string equality when the
+        // Explorer jumps to one, so a step saved as `./src/a.rs` would validate,
+        // save, render — and then report "not in this diff" for a file sitting
+        // in the list. `create_comment` has always normalised; this is the same
+        // call, on the same helper.
+        let mut normalized_paths: Vec<String> = Vec::with_capacity(args.steps.len());
         for step in &args.steps {
             if let Err(msg) = ensure_repo_relative(&step.file_path, "step file_path") {
                 return err_text(msg);
+            }
+            match normalize_repo_relative(&step.file_path, "step file_path") {
+                Ok(p) => normalized_paths.push(p),
+                Err(msg) => return err_text(msg),
             }
             for (value, what) in [
                 (&step.file_path, "step file_path"),
@@ -437,8 +448,9 @@ impl McpServer {
         let steps: Vec<NewWalkthroughStep> = args
             .steps
             .iter()
-            .map(|s| NewWalkthroughStep {
-                file_path: s.file_path.clone(),
+            .zip(normalized_paths)
+            .map(|(s, file_path)| NewWalkthroughStep {
+                file_path,
                 line_start: s.line_start,
                 line_end: s.line_end,
                 kind: s.kind.into(),
@@ -647,6 +659,69 @@ mod tests {
         let (walkthrough, saved_steps) = store.get_walkthrough("feat/x").unwrap().unwrap();
         assert_eq!(saved_steps.len(), 2);
         assert!(text.contains(&format!("(id: {}, 2 step(s))", short_id(&walkthrough.id))));
+    }
+
+    /// The regression this fixes: a step whose `file_path` is spelled any way
+    /// other than git's own spelling used to be stored verbatim, and the
+    /// Explorer — which matches it against `FileDiff::path` by string equality
+    /// — then reported the file as not being in the diff. What lands in the
+    /// database has to be the canonical spelling.
+    #[test]
+    fn save_walkthrough_stores_canonical_paths() {
+        let (server, _dir) = test_server();
+        let steps = ["./src/foo.rs", "src//bar.rs", "  src/baz.rs  "]
+            .iter()
+            .enumerate()
+            .map(|(i, path)| WalkthroughStep {
+                seq: i as i64,
+                file_path: (*path).into(),
+                line_start: None,
+                line_end: None,
+                kind: StepKindArg::Core,
+                title: "Step".into(),
+                body: "Body".into(),
+            })
+            .collect();
+        let result = block_on(server.save_walkthrough(Parameters(SaveWalkthrough {
+            branch: "feat/x".into(),
+            title: "Title".into(),
+            summary: "Summary".into(),
+            steps,
+        })))
+        .unwrap();
+        assert_eq!(result.is_error, Some(false), "{}", text_of(&result));
+
+        let store = server.store();
+        let (_, saved) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(
+            saved.iter().map(|s| s.file_path.as_str()).collect::<Vec<_>>(),
+            vec!["src/foo.rs", "src/bar.rs", "src/baz.rs"]
+        );
+    }
+
+    /// A step path that normalises away to nothing anchors to no file at all,
+    /// so it is refused rather than saved.
+    #[test]
+    fn save_walkthrough_rejects_a_path_that_normalises_to_empty() {
+        let (server, _dir) = test_server();
+        let result = block_on(server.save_walkthrough(Parameters(SaveWalkthrough {
+            branch: "feat/x".into(),
+            title: "Title".into(),
+            summary: "Summary".into(),
+            steps: vec![WalkthroughStep {
+                seq: 0,
+                file_path: "./".into(),
+                line_start: None,
+                line_end: None,
+                kind: StepKindArg::Core,
+                title: "Step".into(),
+                body: "Body".into(),
+            }],
+        })))
+        .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text_of(&result).contains("must not be empty"));
     }
 
     #[test]

--- a/src/repo_path.rs
+++ b/src/repo_path.rs
@@ -1,0 +1,85 @@
+//! The canonical spelling of the repo-relative paths that review comments and
+//! walkthrough steps are keyed by.
+//!
+//! These paths are matched against `FileDiff::path`, which comes straight from
+//! `git2` and is therefore always plain (`src/foo.rs` — no `./`, no doubled
+//! separators, no trailing slash). Anything keyed by a *different* spelling of
+//! the same file silently fails to resolve: a walkthrough step reports "not in
+//! this diff" while the file sits right there in the list.
+//!
+//! Both sides go through [`normalize`]: `mcp-serve`'s tools normalize before
+//! writing, and the store normalizes again when reading rows back, so rows
+//! written before this existed resolve without a migration.
+
+/// Rewrite a repo-relative path into the spelling git uses.
+///
+/// Drops surrounding whitespace, `.` segments (including a leading `./`),
+/// empty segments (doubled slashes), and a trailing slash.
+///
+/// This is a pure spelling fix, not a validator — two things it deliberately
+/// leaves alone, so that whoever *does* validate still sees them:
+///
+/// - `..` segments are preserved. Resolving them here would turn a path that
+///   must be refused (`mcp_serve::reply::ensure_repo_relative`) into an
+///   innocuous-looking one.
+/// - A leading `/` is preserved, so an absolute path stays absolute and is
+///   still caught by that same check rather than being quietly demoted to a
+///   relative path pointing somewhere else entirely.
+pub fn normalize(path: &str) -> String {
+    let trimmed = path.trim();
+    let mut out = String::with_capacity(trimmed.len());
+    if trimmed.starts_with('/') {
+        out.push('/');
+    }
+    let mut first = true;
+    for segment in trimmed.split('/') {
+        if segment.is_empty() || segment == "." {
+            continue;
+        }
+        if !first {
+            out.push('/');
+        }
+        out.push_str(segment);
+        first = false;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_paths_are_left_alone() {
+        assert_eq!(normalize("src/foo.rs"), "src/foo.rs");
+        assert_eq!(normalize("Cargo.toml"), "Cargo.toml");
+        assert_eq!(normalize("docs/設計 メモ.md"), "docs/設計 メモ.md");
+    }
+
+    #[test]
+    fn dot_slash_doubled_slash_and_trailing_slash_are_dropped() {
+        assert_eq!(normalize("./src/foo.rs"), "src/foo.rs");
+        assert_eq!(normalize("././src//foo.rs"), "src/foo.rs");
+        assert_eq!(normalize("src/foo.rs/"), "src/foo.rs");
+        assert_eq!(normalize("  src/foo.rs  "), "src/foo.rs");
+        assert_eq!(normalize("./"), "");
+    }
+
+    /// `..` must survive normalization: the validation that rejects it runs on
+    /// the normalized form, so resolving it here would launder an escaping
+    /// path into an acceptable one.
+    #[test]
+    fn parent_dir_segments_survive() {
+        assert_eq!(normalize("../secret"), "../secret");
+        assert_eq!(normalize("a/../../b"), "a/../../b");
+        assert_eq!(normalize("./../secret"), "../secret");
+    }
+
+    /// Likewise an absolute path stays absolute, so the caller that refuses
+    /// absolute paths still gets to refuse it.
+    #[test]
+    fn absolute_paths_stay_absolute() {
+        assert_eq!(normalize("/etc/passwd"), "/etc/passwd");
+        assert_eq!(normalize("/etc//passwd/"), "/etc/passwd");
+    }
+}

--- a/src/review_store/walkthroughs.rs
+++ b/src/review_store/walkthroughs.rs
@@ -246,11 +246,19 @@ fn row_to_walkthrough_step(row: &rusqlite::Row<'_>) -> rusqlite::Result<Walkthro
         )
     })?;
 
+    // Normalised on the way out as well as on the way in: rows written before
+    // `save_walkthrough` normalised (a step stored as `./src/a.rs`) would
+    // otherwise never match `FileDiff::path` and the step could never be
+    // jumped to. Doing it here rather than in a migration means the same fix
+    // covers rows written by an older conductor against the same database.
+    let file_path: String = row.get(3)?;
+    let file_path = crate::repo_path::normalize(&file_path);
+
     Ok(WalkthroughStep {
         id: row.get(0)?,
         walkthrough_id: row.get(1)?,
         seq: row.get(2)?,
-        file_path: row.get(3)?,
+        file_path,
         line_start: row.get(4)?,
         line_end: row.get(5)?,
         kind,
@@ -338,6 +346,44 @@ mod tests {
         assert_eq!(
             walkthrough.error.as_deref(),
             Some("Claude Code exited early")
+        );
+    }
+
+    /// Rows written before paths were normalised on save must still resolve.
+    /// The step is inserted with the raw SQL the old `save_walkthrough` used,
+    /// so this is genuinely a legacy row rather than a value the current write
+    /// path could produce.
+    #[test]
+    fn legacy_step_paths_are_normalised_on_read() {
+        let store = test_store();
+        store
+            .save_walkthrough("feat/x", "title", "summary", &[])
+            .unwrap();
+        let (walkthrough, _) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        for (seq, stored) in ["./src/a.rs", "src//b.rs", "src/c.rs/"].iter().enumerate() {
+            store
+                .conn
+                .execute(
+                    "INSERT INTO walkthrough_steps
+                        (id, walkthrough_id, seq, file_path, kind, title, body)
+                     VALUES (?1, ?2, ?3, ?4, 'core', 'legacy', 'body')",
+                    params![
+                        Uuid::new_v4().to_string(),
+                        walkthrough.id,
+                        seq as i64,
+                        stored
+                    ],
+                )
+                .unwrap();
+        }
+
+        let (_, steps) = store.get_walkthrough("feat/x").unwrap().unwrap();
+        assert_eq!(
+            steps
+                .iter()
+                .map(|s| s.file_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["src/a.rs", "src/b.rs", "src/c.rs"]
         );
     }
 

--- a/src/walkthrough.rs
+++ b/src/walkthrough.rs
@@ -1,26 +1,44 @@
-//! Data model and generation trigger for AI-generated PR walkthroughs.
+//! Data model and generation for AI-generated PR walkthroughs.
 //!
-//! A walkthrough is a Claude-authored, ordered tour of a branch's diff
+//! A walkthrough is a model-authored, ordered tour of a branch's diff
 //! (`walkthroughs` + `walkthrough_steps` in the review database, persisted
 //! and queried via [`crate::review_store::ReviewStore`]). This module holds
-//! the plain data types shared by the store, the UI pane, and the generator:
-//! a headless `claude -p` process spawned in the reviewed worktree that
-//! explores the diff and saves the result through the conductor MCP server's
-//! `save_walkthrough` tool. The database row's `status` column is the source
-//! of truth for completion; the process handle here only detects failures
-//! (spawn error, non-zero exit, exit without saving, timeout).
+//! the plain data types shared by the store and the UI pane, plus the
+//! generation task itself.
+//!
+//! ## How generation runs
+//!
+//! Through the one configurable AI seam, [`crate::ai_caller`], exactly like
+//! smart-worktree naming: Conductor owns the prompt and the parsing, and the
+//! user owns *which* model answers via `[api] provider` / `[api] command`.
+//! Conductor never spawns a `claude` process of its own — that rule holds
+//! across this entire codebase, and this module used to be the last exception.
+//!
+//! The task is agentic in nature: the model has to read the branch's diff, and
+//! usually the callers/callees around it, before it can narrate anything. The
+//! command therefore runs with its working directory set to the reviewed
+//! worktree (see the protocol notes in [`crate::ai_caller`]), and the reply
+//! comes back as one JSON object that [`parse_generated`] turns into steps.
+//!
+//! ## Why the reply is JSON rather than an MCP tool call
+//!
+//! The MCP `save_walkthrough` tool still exists and is still how the external
+//! `/conductor-walkthrough` command saves its work. It is not how *this* path
+//! saves, because the seam above is a plain stdin/stdout text protocol: there
+//! is no argv Conductor controls, so there is nowhere to inject an
+//! `--mcp-config`. Conductor parses the JSON and writes the rows itself, which
+//! also means a malformed reply fails loudly here instead of leaving a row
+//! stuck in `generating`.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
-
-use anyhow::{Context, Result};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
 
 /// Generation status of a walkthrough.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalkthroughStatus {
-    /// A background Claude Code session is producing the steps.
+    /// A background generation is producing the steps.
     Generating,
     /// Steps are saved and ready to display.
     Ready,
@@ -168,226 +186,45 @@ pub struct NewWalkthroughStep {
     pub body: String,
 }
 
-/// Kill a generation that has been running longer than this. Claude writes
-/// its result through the MCP tool well before this on any reasonable PR;
-/// past it we assume the session is wedged.
+/// Wall-clock budget for one generation, handed to the AI seam as this task's
+/// timeout so it is not capped by `[api] command_timeout_secs` (which is sized
+/// for a few seconds of smart-worktree naming). Reading a branch diff and
+/// narrating it takes minutes; past this we assume the session is wedged.
 pub const GENERATION_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 
-/// Tools the headless generation session may use. `spawn_generation` always
-/// passes `--strict-mcp-config`, so the session sees only the MCP server
-/// registered by its own `--mcp-config` — whose server name is always
-/// `conductor` (see `self_mcp_config`) — and never the user's ambient
-/// marketplace-plugin server. That makes the tool-name form unambiguous:
-/// only `mcp__conductor__*` needs listing here.
+/// The system prompt: what a walkthrough is, and the exact reply shape.
 ///
-/// `create_comment` lets the session drop inline review comments on the
-/// genuinely-hard-to-understand spots it finds while touring the diff, so a
-/// single generation produces both the Explorer walkthrough and the in-Viewer
-/// 💬 annotations. It only writes to the local review DB (no network), so
-/// unlike a write-capable git subcommand it opens no exfiltration path.
-///
-/// This session reads a PR's diff, which may be adversarial (a malicious
-/// contributor's prompt-injection attempt), so the git subcommands are
-/// restricted to read-only ones — no `git push`, `git remote add`, etc. — to
-/// close off any exfiltration path that would otherwise be reachable purely
-/// through allowedTools.
-const GENERATION_ALLOWED_TOOLS: &str = "mcp__conductor__save_walkthrough,\
-mcp__conductor__create_comment,\
-Read,Grep,Glob,\
-Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),\
-Bash(git rev-parse:*),Bash(git status:*),Bash(git branch:*)";
+/// Mirrors `plugins/conductor/commands/conductor-walkthrough.md` (kept for
+/// marketplace-plugin users, which saves through the MCP tool instead) but is
+/// embedded here so generation works regardless of which slash commands the
+/// installed plugin cache has.
+const GENERATION_SYSTEM_PROMPT: &str = r#"You build reviewer walkthroughs: an ordered tour of a branch's change that a reviewer follows step by step, each step anchored to a file and line range.
 
-/// What a [`WalkthroughGeneration::poll`] observed about the child process.
-pub enum GenerationPoll {
-    /// Still running (and within the timeout).
-    Running,
-    /// Exited with success. Whether a walkthrough was actually saved is up
-    /// to the database row — the caller must check `walkthroughs.status`.
-    Exited,
-    /// Exited with a non-zero status, or polling the process failed.
-    Failed(String),
-    /// Ran past [`GENERATION_TIMEOUT`]; the process has been killed.
-    TimedOut,
-}
+Use your tools freely: this task cannot be done without reading the repository in your working directory. Run git to see the diff, and read the changed files and the code around them. Only when you have finished exploring, answer with the JSON described below and nothing else.
 
-/// Handle to an in-flight walkthrough generation: the headless `claude`
-/// child plus enough context to report failures against the right branch.
-pub struct WalkthroughGeneration {
-    pub branch: String,
-    child: Child,
-    started: Instant,
-    /// Where the child's stdout/stderr go — named in error messages so the
-    /// user can inspect what the session actually did.
-    pub log_path: PathBuf,
-}
+Order the steps as a story: intent -> core -> ripple -> test.
+- intent: what this change wanted to achieve (background, motivation).
+- core: what was changed to achieve it, and its effect on existing code. Do NOT compare alternative designs — reviewers ask those questions themselves.
+- ripple: knock-on changes (call-site updates, config/schema follow-ups).
+- test: a summary of what behavior each test verifies, detailed enough that a reviewer can skip reading the full test diff.
 
-impl WalkthroughGeneration {
-    /// Non-blocking check of the child process, enforcing the timeout.
-    pub fn poll(&mut self) -> GenerationPoll {
-        match self.child.try_wait() {
-            Ok(Some(status)) if status.success() => GenerationPoll::Exited,
-            Ok(Some(status)) => GenerationPoll::Failed(format!(
-                "claude exited with {status} (log: {})",
-                self.log_path.display()
-            )),
-            Ok(None) => {
-                if self.started.elapsed() > GENERATION_TIMEOUT {
-                    let _ = self.child.kill();
-                    let _ = self.child.wait();
-                    GenerationPoll::TimedOut
-                } else {
-                    GenerationPoll::Running
-                }
-            }
-            Err(e) => GenerationPoll::Failed(format!("failed to poll claude process: {e}")),
-        }
-    }
+There is no fixed step count — match the actual change.
 
-    /// Kill the child (used when the app shuts down mid-generation).
-    pub fn abort(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
+Output ONLY a JSON object, no markdown fences and no explanation, with these fields:
+- "title": a one-line title for the whole walkthrough.
+- "summary": the overview of the change. This is stored as the branch's change summary and shown full-panel as Conductor's SUMMARY pseudo-file, so write it like a PR description — what the change is for, why these files are touched, and anything a reviewer should know up front (including what is deliberately out of scope). Markdown is rendered.
+- "steps": an array, in tour order, of objects with:
+    "file_path"  (string, repo-relative, e.g. "src/foo.rs" — never absolute, never prefixed with "a/" or "b/", never starting with "./")
+    "line_start" (integer or null, 1-based line number on the NEW side)
+    "line_end"   (integer or null, 1-based)
+    "kind"       ("intent" | "core" | "ripple" | "test")
+    "title"      (string, one line)
+    "body"       (string, the explanation; Markdown is rendered)
+- "comments": an array (possibly empty) of inline notes for the few spots that are genuinely hard to understand — tricky logic whose intent isn't obvious at a glance, a non-obvious tradeoff, or a subtle edge case a reviewer could miss. Each object has "file_path", "line_start", "line_end" (integer or null), and "body" (1-3 sentences explaining *why* it works / where the subtlety is). This is high-signal and low-frequency: a handful per change at most, and an empty array when nothing is genuinely tricky. Do NOT comment on self-evident changes (renames, boilerplate, formatting, imports).
 
-#[cfg(test)]
-impl WalkthroughGeneration {
-    /// Wrap an arbitrary child process in a generation handle. Lets the
-    /// registry tests below drive real process lifecycles (exit, kill,
-    /// timeout) without launching a `claude` session.
-    fn for_test(branch: &str, child: Child, started: Instant) -> Self {
-        Self {
-            branch: branch.to_string(),
-            child,
-            started,
-            log_path: PathBuf::from("/dev/null"),
-        }
-    }
-}
+Every file_path must be repo-relative: the reviewer's diff list matches these against git's own paths, so a step whose path is spelled any other way cannot be opened."#;
 
-/// A generation that stopped running, as handed back by
-/// [`WalkthroughGenerations::take_finished`]. Carries the context the caller
-/// needs to reconcile the database row it left behind — which branch it was
-/// for, and where its log is — because the handle itself is gone by then.
-pub struct FinishedGeneration {
-    pub branch: String,
-    pub log_path: PathBuf,
-    pub outcome: GenerationPoll,
-}
-
-/// Every walkthrough generation in flight in this Conductor instance, at most
-/// one per branch.
-///
-/// Keyed by branch, not by "one at a time", because the branch is the only
-/// thing a generation actually contends for: `begin_walkthrough` deletes and
-/// re-inserts the `walkthroughs` row for its branch and `save_walkthrough`
-/// replaces it, so two sessions on one branch would race for a single row and
-/// the loser's steps would vanish. Sessions on *different* branches — which
-/// means different worktrees, since git won't check one branch out twice —
-/// touch disjoint rows, disjoint log files, and a database that is already
-/// WAL + `busy_timeout` (see `review_store::schema`), so they can run side by
-/// side. Serializing them was over-broad: it made a reviewer touring one
-/// worktree unable to start a walkthrough in another.
-#[derive(Default)]
-pub struct WalkthroughGenerations {
-    by_branch: HashMap<String, WalkthroughGeneration>,
-}
-
-impl WalkthroughGenerations {
-    /// Whether a generation for `branch` is currently in flight.
-    pub fn is_generating(&self, branch: &str) -> bool {
-        self.by_branch.contains_key(branch)
-    }
-
-    /// Register a freshly spawned generation. The caller is expected to have
-    /// checked [`Self::is_generating`] first: inserting over a live handle
-    /// would drop (and orphan) the running `claude` child and strand its
-    /// branch's row in `generating` forever.
-    pub fn insert(&mut self, generation: WalkthroughGeneration) {
-        debug_assert!(
-            !self.is_generating(&generation.branch),
-            "would orphan the in-flight generation for {}",
-            generation.branch
-        );
-        self.by_branch
-            .insert(generation.branch.clone(), generation);
-    }
-
-    /// Poll every in-flight generation, removing the ones that are no longer
-    /// running and returning what each one did.
-    ///
-    /// Removal is what makes a wedged or externally-killed session
-    /// self-healing: whatever the child did — saved and exited, crashed, was
-    /// `kill`ed from outside, or ran past [`GENERATION_TIMEOUT`] — its slot is
-    /// released here, so the next request for that branch starts a fresh
-    /// session instead of being told one is already running.
-    pub fn take_finished(&mut self) -> Vec<FinishedGeneration> {
-        let mut finished = Vec::new();
-        self.by_branch.retain(|branch, generation| {
-            let outcome = generation.poll();
-            if matches!(outcome, GenerationPoll::Running) {
-                return true;
-            }
-            finished.push(FinishedGeneration {
-                branch: branch.clone(),
-                log_path: generation.log_path.clone(),
-                outcome,
-            });
-            false
-        });
-        finished
-    }
-
-    /// Whether nothing is in flight (lets the caller skip polling entirely).
-    pub fn is_empty(&self) -> bool {
-        self.by_branch.is_empty()
-    }
-
-    /// Kill every in-flight generation (used when the app shuts down).
-    pub fn abort_all(&mut self) {
-        for (_, mut generation) in self.by_branch.drain() {
-            generation.abort();
-        }
-    }
-}
-
-/// Build the `--mcp-config` JSON that registers conductor's own `mcp-serve`
-/// subcommand as the headless generation session's MCP server.
-///
-/// Points at [`std::env::current_exe`] rather than a path inside the repo, so
-/// it works in any repository, not just conductor's own — see
-/// `src/mcp_serve/mod.rs`'s module doc for why the server is embedded in the
-/// binary at all.
-///
-/// Both paths are rejected outright (`bail!`, not lossy-converted) if they
-/// aren't valid UTF-8: `to_string_lossy` would silently substitute U+FFFD
-/// and register a server at a path that doesn't exist, so the session would
-/// launch tool-less and exit 0 — the exact silent-failure mode this
-/// function exists to close off (see `src/refresh_pipe.rs`'s `RefreshPipe::new`
-/// for the same pattern).
-fn self_mcp_config(db_path: &Path) -> Result<String> {
-    let exe = std::env::current_exe().context("failed to resolve conductor's own path")?;
-    let exe = exe.to_str().ok_or_else(|| {
-        anyhow::anyhow!("conductor's own path is not valid UTF-8: {}", exe.display())
-    })?;
-    let db_path = db_path.to_str().ok_or_else(|| {
-        anyhow::anyhow!("database path is not valid UTF-8: {}", db_path.display())
-    })?;
-    let config = serde_json::json!({
-        "mcpServers": {
-            "conductor": {
-                "command": exe,
-                "args": ["mcp-serve", "--db", db_path],
-            }
-        }
-    });
-    Ok(config.to_string())
-}
-
-/// The generation instructions handed to the headless session. Mirrors
-/// `plugins/conductor/commands/conductor-walkthrough.md` (kept for
-/// marketplace-plugin users) but is embedded here so generation works
-/// regardless of which slash commands the installed plugin cache has.
+/// The per-run instruction: which branch, which base, which language.
 fn generation_prompt(branch: &str, base_ref: Option<&str>, language: Option<&str>) -> String {
     let base_hint = match base_ref {
         Some(b) => format!("The base branch is `{b}`."),
@@ -401,161 +238,235 @@ fn generation_prompt(branch: &str, base_ref: Option<&str>, language: Option<&str
     };
     format!(
         "Read this branch's merge-base diff against its base branch and build a reviewer \
-walkthrough (an ordered tour of the change), then save it with the conductor MCP server's \
-`save_walkthrough` tool.\n\
+walkthrough of it.\n\
 \n\
-{base_hint} The branch under review is `{branch}`. Use `git diff <base>...HEAD` (three-dot, \
-merge-base) to see the change. Read not only the changed files but, where needed, their \
-callers/callees so you understand the whole picture.\n\
+{base_hint} The branch under review is `{branch}`, checked out in your working directory. \
+Use `git diff <base>...HEAD` (three-dot, merge-base) to see the change. Read not only the \
+changed files but, where needed, their callers/callees so you understand the whole \
+picture.\n\
 \n\
-Order the steps as a story: intent -> core -> ripple -> test.\n\
-- intent: what this change wanted to achieve (background, motivation).\n\
-- core: what was changed to achieve it, and its effect on existing code. Do NOT compare \
-alternative designs — reviewers ask those questions themselves.\n\
-- ripple: knock-on changes (call-site updates, config/schema follow-ups).\n\
-- test: a summary of what behavior each test verifies, detailed enough that a reviewer can \
-skip reading the full test diff.\n\
-\n\
-Each step needs: file_path (repo-relative), optional line_start/line_end (new-side line \
-numbers), kind, title, body. There is no fixed step count — match the actual change.\n\
-\n\
-When all steps are assembled, call the `save_walkthrough` tool exactly once with: \
-branch = `{branch}`, a one-line title, a summary, and the steps (seq starting at 0).\n\
-\n\
-The summary is not throwaway text: it is stored as the branch's change summary and shown \
-full-panel as Conductor's SUMMARY pseudo-file, so write it like a PR description — what the \
-change is for, why these files are touched, and anything a reviewer should know up front \
-(including what is deliberately out of scope). Markdown is rendered.\n\
-\n\
-After saving, for the few spots that are genuinely hard to understand — tricky logic whose \
-intent isn't obvious at a glance, a non-obvious tradeoff, or a subtle edge case a reviewer \
-could miss — drop an inline comment with the `create_comment` tool, anchored to that \
-file_path and its new-side line number(s). Use kind = \"question\", keep each to 1-3 \
-sentences, and explain *why* it works / where the subtlety is. This is high-signal and \
-low-frequency: a handful per change at most, and none at all when nothing is genuinely \
-tricky. Do NOT comment on self-evident changes (renames, boilerplate, formatting, imports).\n\
-\n\
-Then report the step count, kind breakdown, and how many inline comments you left, briefly, \
-and stop.{language_hint}"
+When you have explored enough, reply with the JSON object described above and nothing \
+else.{language_hint}"
     )
 }
 
-/// Spawn the headless generation session in `worktree_path`.
+/// One inline note the generation asked for, saved as a `question` comment.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GeneratedComment {
+    pub file_path: String,
+    pub line_start: Option<u32>,
+    pub line_end: Option<u32>,
+    pub body: String,
+}
+
+/// A step as it arrives from the model, before validation.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct GeneratedStep {
+    file_path: String,
+    #[serde(default)]
+    line_start: Option<i64>,
+    #[serde(default)]
+    line_end: Option<i64>,
+    kind: String,
+    title: String,
+    body: String,
+}
+
+/// The whole reply, before validation.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct GeneratedWalkthrough {
+    title: String,
+    summary: String,
+    steps: Vec<GeneratedStep>,
+    #[serde(default)]
+    comments: Vec<GeneratedComment>,
+}
+
+/// A validated generation result, ready for [`crate::review_store::ReviewStore`].
+#[derive(Debug, Clone)]
+pub struct Generated {
+    pub title: String,
+    pub summary: String,
+    pub steps: Vec<NewWalkthroughStep>,
+    pub comments: Vec<GeneratedComment>,
+}
+
+/// Turn the model's raw reply into a saveable walkthrough, or explain what is
+/// wrong with it.
 ///
-/// The caller must have inserted the `generating` row first
-/// ([`crate::review_store::ReviewStore::begin_walkthrough`]); on spawn
-/// failure it should flip that row to `failed`.
-pub fn spawn_generation(
+/// Tolerant about the *envelope* (markdown fences, a sentence before the JSON)
+/// because models add those regardless of instructions, and strict about the
+/// *contents*: an unknown `kind` or a path that cannot anchor to a file would
+/// otherwise be stored and only show up as a step the reviewer can't open.
+/// Mirrors the checks `mcp_serve::tools::save_walkthrough` runs on the same
+/// data arriving over MCP, so both entry points reject the same things.
+pub fn parse_generated(raw: &str) -> Result<Generated, String> {
+    let json = extract_json_object(raw)
+        .ok_or_else(|| format!("no JSON object in the model's reply\nRaw output: {raw}"))?;
+    let parsed: GeneratedWalkthrough = serde_json::from_str(json)
+        .map_err(|e| format!("could not parse the walkthrough JSON: {e}\nRaw output: {raw}"))?;
+
+    if parsed.title.trim().is_empty() {
+        return Err("the walkthrough has no title".to_string());
+    }
+    if parsed.summary.trim().is_empty() {
+        return Err("the walkthrough has no summary".to_string());
+    }
+    if parsed.steps.is_empty() {
+        return Err("the walkthrough has no steps".to_string());
+    }
+
+    let mut steps = Vec::with_capacity(parsed.steps.len());
+    for (i, step) in parsed.steps.into_iter().enumerate() {
+        let kind = WalkthroughStepKind::from_str(step.kind.trim())
+            .ok_or_else(|| format!("step {i} has an unknown kind '{}'", step.kind))?;
+        let file_path = crate::repo_path::normalize(&step.file_path);
+        if file_path.is_empty() {
+            return Err(format!("step {i} has no file_path"));
+        }
+        if file_path.starts_with('/') || file_path.split('/').any(|s| s == "..") {
+            return Err(format!(
+                "step {i} file_path must be repo-relative, got: {}",
+                step.file_path
+            ));
+        }
+        if step.title.trim().is_empty() {
+            return Err(format!("step {i} ({file_path}) has no title"));
+        }
+        if step.body.trim().is_empty() {
+            return Err(format!("step {i} ({file_path}) has no body"));
+        }
+        // Line numbers are 1-based everywhere they are read back, and a
+        // reversed range would underline nothing; drop the range rather than
+        // failing the whole walkthrough over an anchor detail.
+        let (line_start, line_end) = sane_range(step.line_start, step.line_end);
+        steps.push(NewWalkthroughStep {
+            file_path,
+            line_start,
+            line_end,
+            kind,
+            title: step.title,
+            body: step.body,
+        });
+    }
+
+    // Comments are the optional extra: a bad one is dropped with a log line
+    // rather than failing a walkthrough that is otherwise fine.
+    let comments = parsed
+        .comments
+        .into_iter()
+        .filter_map(|mut c| {
+            let path = crate::repo_path::normalize(&c.file_path);
+            if path.is_empty()
+                || path.starts_with('/')
+                || path.split('/').any(|s| s == "..")
+                || c.body.trim().is_empty()
+                || c.line_start.is_none_or(|l| l == 0)
+            {
+                log::warn!("dropping malformed inline comment for {:?}", c.file_path);
+                return None;
+            }
+            if let (Some(start), Some(end)) = (c.line_start, c.line_end)
+                && end < start
+            {
+                c.line_end = None;
+            }
+            c.file_path = path;
+            Some(c)
+        })
+        .collect();
+
+    Ok(Generated {
+        title: parsed.title,
+        summary: parsed.summary,
+        steps,
+        comments,
+    })
+}
+
+/// Keep a 1-based, non-reversed line range; anything else anchors to the file
+/// as a whole rather than to a wrong span.
+fn sane_range(start: Option<i64>, end: Option<i64>) -> (Option<i64>, Option<i64>) {
+    let start = start.filter(|s| *s >= 1);
+    let end = end.filter(|e| *e >= 1);
+    match (start, end) {
+        (Some(s), Some(e)) if e < s => (Some(s), None),
+        (None, Some(_)) => (None, None),
+        pair => pair,
+    }
+}
+
+/// Find the JSON object in a reply that may be fenced or prefaced with prose.
+///
+/// Scans for the first `{` and then tracks brace depth, skipping over braces
+/// that appear inside string literals — a `body` containing `}` (very likely,
+/// since bodies quote code) would otherwise truncate the object at the wrong
+/// place and produce a parse error the user cannot act on.
+fn extract_json_object(raw: &str) -> Option<&str> {
+    let start = raw.find('{')?;
+    let bytes = raw.as_bytes();
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for i in start..bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&raw[start..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Run one generation to completion and return the parsed walkthrough.
+///
+/// Blocking: the caller runs this on a background thread and reports the result
+/// through a channel (see `App::cmd_generate_walkthrough`). `cancel` is checked
+/// by the underlying caller too, so a cancelled generation kills its child
+/// rather than waiting out the timeout.
+pub fn generate(
+    api: &crate::config::ApiConfig,
     worktree_path: &Path,
-    db_path: &Path,
     branch: &str,
     base_ref: Option<&str>,
-    model: Option<&str>,
     language: Option<&str>,
-) -> Result<WalkthroughGeneration> {
-    let log_path = db_path
-        .parent()
-        .unwrap_or(Path::new("."))
-        .join(format!("walkthrough-{}.log", branch.replace('/', "-")));
-    let log_file = std::fs::File::create(&log_path)
-        .with_context(|| format!("failed to create log file {}", log_path.display()))?;
-    let log_err = log_file
-        .try_clone()
-        .context("failed to clone log file handle")?;
-
-    let mut cmd = Command::new("claude");
-    cmd.arg("-p")
-        .arg(generation_prompt(branch, base_ref, language))
-        .arg("--allowedTools")
-        .arg(GENERATION_ALLOWED_TOOLS)
-        .current_dir(worktree_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(log_err));
-    if let Some(model) = model {
-        cmd.arg("--model").arg(model);
-    }
-    // `--strict-mcp-config` is placed *before* `--mcp-config`: the latter
-    // takes a space-separated variable-length list of configs
-    // (`<configs...>`), so a flag placed right after it risks being
-    // swallowed as another config value instead of parsed as its own flag.
-    // Together these two are what makes generation work in any repository,
-    // not just conductor's own: the session sees only conductor's own MCP
-    // server and never a user's ambient (and possibly stale) marketplace
-    // plugin server, regardless of what that plugin's cache currently
-    // exposes.
-    cmd.arg("--strict-mcp-config");
-    cmd.arg("--mcp-config").arg(self_mcp_config(db_path)?);
-
-    let child = cmd
-        .spawn()
-        .context("failed to launch `claude` — is Claude Code installed and on PATH?")?;
-    Ok(WalkthroughGeneration {
-        branch: branch.to_string(),
-        child,
-        started: Instant::now(),
-        log_path,
-    })
+    cancel: &Arc<AtomicBool>,
+) -> Result<Generated, String> {
+    let env = crate::ai_caller::TaskEnv {
+        timeout_secs: Some(GENERATION_TIMEOUT.as_secs()),
+        working_dir: Some(worktree_path.to_path_buf()),
+    };
+    let caller = crate::ai_caller::build_caller(api, &env)?;
+    let raw = caller.complete(
+        GENERATION_SYSTEM_PROMPT,
+        &generation_prompt(branch, base_ref, language),
+        cancel,
+    )?;
+    parse_generated(&raw)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ── self_mcp_config: points at the running binary, carries the db path ──
-
-    #[test]
-    fn self_mcp_config_points_at_current_exe_with_db() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("db.sqlite");
-
-        let config = self_mcp_config(&db_path).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&config).unwrap();
-
-        let current_exe = std::env::current_exe().unwrap();
-        assert_eq!(
-            parsed["mcpServers"]["conductor"]["command"],
-            current_exe.to_str().unwrap()
-        );
-        assert_eq!(
-            parsed["mcpServers"]["conductor"]["args"],
-            serde_json::json!(["mcp-serve", "--db", db_path.to_str().unwrap()])
-        );
-    }
-
-    // ── allowedTools: MCP tool names present, git restricted to read-only ──
-
-    #[test]
-    fn generation_allowed_tools_uses_only_the_self_served_form() {
-        // `--strict-mcp-config` makes the registered server name always
-        // `conductor` (see self_mcp_config), so the marketplace-plugin form
-        // is never reachable and must not be listed.
-        assert!(GENERATION_ALLOWED_TOOLS.contains("mcp__conductor__save_walkthrough"));
-        assert!(
-            !GENERATION_ALLOWED_TOOLS.contains("mcp__plugin_conductor_conductor__save_walkthrough")
-        );
-        assert!(GENERATION_ALLOWED_TOOLS.contains("mcp__conductor__create_comment"));
-        assert!(
-            !GENERATION_ALLOWED_TOOLS.contains("mcp__plugin_conductor_conductor__create_comment")
-        );
-    }
-
-    #[test]
-    fn generation_allowed_tools_has_no_write_git_subcommands() {
-        // Matches the FIX-2 restriction: no bare `Bash(git:*)`, and none of
-        // the write-capable subcommands that would open an exfiltration path
-        // for an adversarial PR diff (push, remote, fetch with refspec-write
-        // side effects, config, etc).
-        assert!(!GENERATION_ALLOWED_TOOLS.contains("Bash(git:*)"));
-        for write_subcommand in ["push", "remote", "config", "commit", "checkout", "reset"] {
-            assert!(
-                !GENERATION_ALLOWED_TOOLS.contains(&format!("git {write_subcommand}")),
-                "allowedTools should not permit `git {write_subcommand}`"
-            );
-        }
-    }
-
-    // ── generation_prompt: branch name and no-alternatives instruction ──
+    // ── generation_prompt: branch, base, language ───────────────────────
 
     #[test]
     fn generation_prompt_includes_the_branch_name() {
@@ -565,155 +476,9 @@ mod tests {
     }
 
     #[test]
-    fn generation_prompt_tells_the_model_not_to_compare_alternative_designs() {
+    fn generation_prompt_falls_back_to_discovering_the_base() {
         let prompt = generation_prompt("pr-42", None, None);
-        assert!(prompt.to_lowercase().contains("do not compare"));
         assert!(prompt.contains("Determine the base branch"));
-    }
-
-    #[test]
-    fn generation_prompt_instructs_inline_comments_on_hard_spots() {
-        let prompt = generation_prompt("pr-42", Some("main"), None);
-        // The session must be told to annotate genuinely-tricky spots with
-        // create_comment, high-signal and low-frequency.
-        assert!(prompt.contains("create_comment"));
-        assert!(prompt.contains("hard to understand"));
-    }
-
-    // ── WalkthroughGenerations: per-branch, not per-app, exclusion ──
-
-    /// A child that stays alive well past the end of the test.
-    fn long_running_child() -> Child {
-        test_child("sleep 30")
-    }
-
-    fn test_child(script: &str) -> Child {
-        Command::new("/bin/sh")
-            .arg("-c")
-            .arg(script)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to spawn test child")
-    }
-
-    /// Poll until something finishes. `take_finished` is non-blocking, so a
-    /// child that has only just been spawned is legitimately still `Running`
-    /// on the first call.
-    fn wait_for_finished(generations: &mut WalkthroughGenerations) -> Vec<FinishedGeneration> {
-        for _ in 0..400 {
-            let finished = generations.take_finished();
-            if !finished.is_empty() {
-                return finished;
-            }
-            std::thread::sleep(Duration::from_millis(25));
-        }
-        panic!("no generation finished within 10 seconds");
-    }
-
-    #[test]
-    fn different_branches_generate_side_by_side() {
-        // The bug this replaced: one in-flight generation blocked every other
-        // worktree's branch, not just its own.
-        let mut generations = WalkthroughGenerations::default();
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            long_running_child(),
-            Instant::now(),
-        ));
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/b",
-            long_running_child(),
-            Instant::now(),
-        ));
-
-        assert!(generations.is_generating("feature/a"));
-        assert!(generations.is_generating("feature/b"));
-        // Neither displaced nor finished the other.
-        assert!(generations.take_finished().is_empty());
-
-        generations.abort_all();
-        assert!(generations.is_empty());
-    }
-
-    #[test]
-    fn only_the_same_branch_is_refused() {
-        let mut generations = WalkthroughGenerations::default();
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            long_running_child(),
-            Instant::now(),
-        ));
-
-        // This predicate is the guard `cmd_generate_walkthrough` consults.
-        assert!(generations.is_generating("feature/a"));
-        assert!(!generations.is_generating("feature/b"));
-
-        generations.abort_all();
-    }
-
-    #[test]
-    fn a_finished_generation_frees_its_branch() {
-        let mut generations = WalkthroughGenerations::default();
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            test_child("exit 0"),
-            Instant::now(),
-        ));
-
-        let finished = wait_for_finished(&mut generations);
-        assert_eq!(finished.len(), 1);
-        assert_eq!(finished[0].branch, "feature/a");
-        assert!(matches!(finished[0].outcome, GenerationPoll::Exited));
-        assert!(!generations.is_generating("feature/a"));
-    }
-
-    #[test]
-    fn an_externally_killed_generation_frees_its_branch() {
-        // Stale-lock recovery: if the session dies without Conductor asking it
-        // to, its slot must be released so the next request can regenerate
-        // rather than being told one is already running.
-        let mut generations = WalkthroughGenerations::default();
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            test_child("kill -9 $$"),
-            Instant::now(),
-        ));
-
-        let finished = wait_for_finished(&mut generations);
-        assert!(matches!(finished[0].outcome, GenerationPoll::Failed(_)));
-        assert!(!generations.is_generating("feature/a"));
-
-        // And the branch accepts a fresh generation immediately.
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            long_running_child(),
-            Instant::now(),
-        ));
-        assert!(generations.is_generating("feature/a"));
-        generations.abort_all();
-    }
-
-    #[test]
-    fn a_wedged_generation_times_out_and_frees_its_branch() {
-        let Some(started) = Instant::now().checked_sub(GENERATION_TIMEOUT + Duration::from_secs(1))
-        else {
-            // Machine booted less than GENERATION_TIMEOUT ago; no instant far
-            // enough in the past exists to backdate against.
-            return;
-        };
-        let mut generations = WalkthroughGenerations::default();
-        generations.insert(WalkthroughGeneration::for_test(
-            "feature/a",
-            long_running_child(),
-            started,
-        ));
-
-        let finished = generations.take_finished();
-        assert_eq!(finished.len(), 1);
-        assert!(matches!(finished[0].outcome, GenerationPoll::TimedOut));
-        assert!(!generations.is_generating("feature/a"));
     }
 
     #[test]
@@ -723,5 +488,179 @@ mod tests {
         // No language configured → no language directive at all.
         let unconstrained = generation_prompt("pr-42", Some("main"), None);
         assert!(!unconstrained.contains("Write the walkthrough title"));
+    }
+
+    /// The instruction not to compare alternative designs, and the step-order
+    /// story, live in the system prompt now — they must not have been lost in
+    /// the move off the headless session.
+    #[test]
+    fn system_prompt_keeps_the_walkthrough_contract() {
+        assert!(GENERATION_SYSTEM_PROMPT.to_lowercase().contains("do not compare"));
+        assert!(GENERATION_SYSTEM_PROMPT.contains("intent -> core -> ripple -> test"));
+        // Path spelling is the whole reason walkthrough steps used to fail to
+        // open, so the prompt has to be explicit about it.
+        assert!(GENERATION_SYSTEM_PROMPT.contains("repo-relative"));
+        assert!(GENERATION_SYSTEM_PROMPT.contains("never starting with \"./\""));
+        // Inline notes are asked for here rather than through an MCP tool call,
+        // but the contract is the same one the plugin command states: annotate
+        // the genuinely-tricky spots, high-signal and low-frequency.
+        assert!(GENERATION_SYSTEM_PROMPT.contains("hard to understand"));
+        assert!(GENERATION_SYSTEM_PROMPT.contains("\"comments\""));
+    }
+
+    /// The opposite constraint from smart-worktree naming, and it has to be
+    /// stated here rather than in a wrapper the user maintains: an agentic
+    /// command told nothing would answer from the prompt alone, and this task
+    /// is impossible without reading the repo.
+    #[test]
+    fn system_prompt_tells_the_model_to_read_the_repo() {
+        assert!(GENERATION_SYSTEM_PROMPT.contains("Use your tools freely"));
+        assert!(GENERATION_SYSTEM_PROMPT.contains("working directory"));
+    }
+
+    /// Conductor must not spawn `claude` itself anywhere; this module was the
+    /// last place that did. The prompt names no CLI and no MCP tool call — the
+    /// reply comes back as JSON over whatever `[api]` is pointed at.
+    #[test]
+    fn generation_never_names_a_cli_to_run() {
+        assert!(!GENERATION_SYSTEM_PROMPT.contains("claude -p"));
+        assert!(!GENERATION_SYSTEM_PROMPT.contains("save_walkthrough"));
+        let prompt = generation_prompt("pr-42", Some("main"), None);
+        assert!(!prompt.contains("claude -p"));
+        assert!(!prompt.contains("save_walkthrough"));
+    }
+
+    // ── parse_generated ────────────────────────────────────────────────
+
+    fn reply(steps: &str) -> String {
+        format!(
+            r#"{{"title":"T","summary":"S","steps":[{steps}]}}"#
+        )
+    }
+
+    #[test]
+    fn parses_a_well_formed_reply() {
+        let raw = reply(
+            r#"{"file_path":"src/a.rs","line_start":10,"line_end":12,"kind":"core","title":"t","body":"b"}"#,
+        );
+        let g = parse_generated(&raw).unwrap();
+        assert_eq!(g.title, "T");
+        assert_eq!(g.summary, "S");
+        assert_eq!(g.steps.len(), 1);
+        assert_eq!(g.steps[0].file_path, "src/a.rs");
+        assert_eq!(g.steps[0].line_start, Some(10));
+        assert_eq!(g.steps[0].line_end, Some(12));
+        assert_eq!(g.steps[0].kind, WalkthroughStepKind::Core);
+        assert!(g.comments.is_empty());
+    }
+
+    /// Models wrap JSON in fences and prefaces no matter what the prompt says,
+    /// so the envelope is tolerated even though the contents are not.
+    #[test]
+    fn parses_through_fences_and_preamble() {
+        let inner = reply(r#"{"file_path":"src/a.rs","kind":"intent","title":"t","body":"b"}"#);
+        for wrapped in [
+            format!("```json\n{inner}\n```"),
+            format!("Here you go:\n{inner}\nHope that helps!"),
+            format!("```\n{inner}\n```"),
+        ] {
+            let g = parse_generated(&wrapped).unwrap();
+            assert_eq!(g.steps.len(), 1, "wrapped: {wrapped}");
+        }
+    }
+
+    /// A body quoting code will contain braces. Counting to the *matching*
+    /// close brace, and skipping braces inside strings, is what keeps such a
+    /// reply from being truncated into a parse error.
+    #[test]
+    fn parses_a_body_containing_braces() {
+        let raw = r#"prose {"title":"T","summary":"S","steps":[{"file_path":"src/a.rs","kind":"core","title":"t","body":"fn main() { let x = {1}; }"}]} trailing"#;
+        let g = parse_generated(raw).unwrap();
+        assert_eq!(g.steps[0].body, "fn main() { let x = {1}; }");
+    }
+
+    /// The same spellings the diff list cannot match are canonicalised here, so
+    /// a generated step can always be opened.
+    #[test]
+    fn normalises_step_paths() {
+        for spelling in ["./src/a.rs", "src//a.rs", "src/a.rs/", "  src/a.rs  "] {
+            let raw = reply(&format!(
+                r#"{{"file_path":"{spelling}","kind":"core","title":"t","body":"b"}}"#
+            ));
+            let g = parse_generated(&raw).unwrap();
+            assert_eq!(g.steps[0].file_path, "src/a.rs", "spelling: {spelling}");
+        }
+    }
+
+    #[test]
+    fn rejects_paths_that_escape_the_repo() {
+        for bad in ["/etc/passwd", "../secret", ""] {
+            let raw = reply(&format!(
+                r#"{{"file_path":"{bad}","kind":"core","title":"t","body":"b"}}"#
+            ));
+            assert!(parse_generated(&raw).is_err(), "path: {bad}");
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_step_kind() {
+        let raw = reply(r#"{"file_path":"src/a.rs","kind":"summary","title":"t","body":"b"}"#);
+        let err = parse_generated(&raw).unwrap_err();
+        assert!(err.contains("summary"), "should echo the bad kind: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_title_summary_and_steps() {
+        assert!(parse_generated(r#"{"title":"","summary":"S","steps":[]}"#).is_err());
+        assert!(
+            parse_generated(
+                r#"{"title":"T","summary":"S","steps":[{"file_path":"a.rs","kind":"core","title":"t","body":"b"}]}"#
+            )
+            .is_ok()
+        );
+        assert!(parse_generated(r#"{"title":"T","summary":"S","steps":[]}"#).is_err());
+        assert!(parse_generated("no json here").is_err());
+    }
+
+    /// A bad line range anchors the step to its file rather than failing the
+    /// whole walkthrough or underlining a nonsense span.
+    #[test]
+    fn sanitises_line_ranges() {
+        assert_eq!(sane_range(Some(10), Some(5)), (Some(10), None));
+        assert_eq!(sane_range(Some(0), Some(5)), (None, None));
+        assert_eq!(sane_range(None, Some(5)), (None, None));
+        assert_eq!(sane_range(Some(3), None), (Some(3), None));
+        assert_eq!(sane_range(Some(3), Some(3)), (Some(3), Some(3)));
+    }
+
+    /// Inline comments are the optional extra: a malformed one is dropped, and
+    /// the walkthrough it came with still saves.
+    #[test]
+    fn drops_malformed_comments_but_keeps_the_walkthrough() {
+        let raw = r#"{"title":"T","summary":"S",
+            "steps":[{"file_path":"src/a.rs","kind":"core","title":"t","body":"b"}],
+            "comments":[
+              {"file_path":"./src/a.rs","line_start":4,"line_end":6,"body":"why"},
+              {"file_path":"/etc/passwd","line_start":1,"body":"escape"},
+              {"file_path":"src/a.rs","line_start":0,"body":"zero line"},
+              {"file_path":"src/a.rs","line_start":9,"body":"   "}
+            ]}"#;
+        let g = parse_generated(raw).unwrap();
+        assert_eq!(g.steps.len(), 1);
+        assert_eq!(g.comments.len(), 1);
+        assert_eq!(g.comments[0].file_path, "src/a.rs");
+        assert_eq!(g.comments[0].line_start, Some(4));
+    }
+
+    /// A reversed comment range collapses to a single line instead of being
+    /// stored as a span that renders backwards.
+    #[test]
+    fn reversed_comment_range_collapses() {
+        let raw = r#"{"title":"T","summary":"S",
+            "steps":[{"file_path":"a.rs","kind":"core","title":"t","body":"b"}],
+            "comments":[{"file_path":"a.rs","line_start":9,"line_end":2,"body":"why"}]}"#;
+        let g = parse_generated(raw).unwrap();
+        assert_eq!(g.comments[0].line_start, Some(9));
+        assert_eq!(g.comments[0].line_end, None);
     }
 }


### PR DESCRIPTION
## Summary

walkthrough を生成したあと、ステップを選んでも「ファイルが見つからない」になる不具合の修正。原因は **パスの綴りが片方だけ違っていた** こと: ステップは書き込み側の綴りのまま保存され、突き合わせ先の `FileDiff::path` は git2 が返す素の綴り (`src/foo.rs`) だったため、`./` 付き・重複スラッシュ・末尾スラッシュのいずれかが混ざるだけで、ファイルが目の前の diff リストにあるのに解決に失敗していた。

修正は綴りを1つに寄せること。新設した `src/repo_path.rs` の `normalize` を **書き込み側 (mcp-serve のツール) と読み出し側 (review_store) の両方** に通したので、この機能が入る前に書かれた行もマイグレーションなしで解決する。`..` と先頭の `/` はあえて素通しにしてある — ここで解決してしまうと、拒否すべきパスが無害な見た目に化けて `ensure_repo_relative` の検査をすり抜けるため。

あわせて、walkthrough 生成を **設定可能な AI 継ぎ目 (`ai_caller`) に載せ替えた**。conductor が `claude` プロセスを自前で起動する最後の箇所がここだったので、これでコードベース全体からその起動が消えている。どのモデルが答えるかは `[api] provider` / `[api] command` だけが決める。

- 組み込みの `provider = "claude"` を削除（未知の値としてエラーになる）。`claude -p` を使いたい場合は `command = ["claude", "-p", "{prompt}"]` と設定する旨のコメントを、削除した場所と config テンプレートに残した
- 外部コマンドのプロトコルに `{prompt}` / `{workdir}` プレースホルダを追加。`{prompt}` があれば argv 渡し（stdin は即 close）、無ければ stdin 渡し。**ラッパースクリプトが不要になった**
- タスクごとの差分（ツール使用の可否・出力形式・working dir・タイムアウト・リトライ回数）は機能側のコードが持つ。config には「AI ツールそのもの」だけを書く
- `[review] walkthrough_model` を削除（どのモデルかは `[api] command` の責務）
- `[review] prompt_template` / `prompt_action` を削除。**全歴史のどのコミットにも `{comments}` を展開するコードが存在しなかった**（実装されないまま config だけが出力されていた）。レビューコメントの受け渡しは MCP + `/conductor:address-conductor-comment` で既に動いている

## Test plan

- `cargo test` → 999 passed / 0 failed / 1 ignored
- `cargo clippy --all-targets` → 警告なし
- 綴り違い（`./` 付き・重複スラッシュ・末尾スラッシュ・`a/` `b/` 前置）を `normalize` の単体テストで固定
- `..` と絶対パスが素通しされ、`ensure_repo_relative` 側で拒否されることをテストで確認
- 外部コマンドプロトコル: argv 渡し / stdin 渡し / `{prompt}` 時に stdin が空 / `{workdir}` 展開 / タスク側タイムアウトが config を上書き / 非0 exit で stderr surface / 空 stdout をエラー扱い / キャンセル即時 — いずれも実サブプロセスで検証
- 削除した `prompt_template` / `prompt_action` が config に残っていてもロードが失敗しないことをテストで固定

## Note on the rebase

main の #305 (`f03914b`, walkthrough 生成の排他をブランチ単位にする修正) が、本 PR が差し替えた土台（headless `claude` 子プロセス）の上に実装されていたため、構造的な衝突が起きた。片方を採ると #305 の修正が消えるので、**その意図をこちらのアーキテクチャに移植** した:

- `WalkthroughGenerations`（ブランチをキーにしたレジストリ）を `app/review_walkthrough.rs` に実装。ハンドルは `Child` ではなく `Receiver` + cancel フラグ
- 「外部から kill された」は「worker がスレッドの結果を送らず死んだ（チャネル切断）」に読み替え
- ステータスメッセージにブランチ名を出す変更も取り込み
- テスト4本を移植。`a_wedged_generation_times_out_and_frees_its_branch` のみ削除 — 15分の壁時計は `CommandCaller` の中で効いて `Err` として返るため、app 側に検証対象が無くなった