### PR TITLE
fix: 非 git ディレクトリで Viewer にファイルが表示されない

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.98.1"
+version = "0.98.2"
 edition = "2024"
 
 [dependencies]

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -555,14 +555,13 @@ impl App {
             self.code_nav.history.push(loc);
         }
 
-        // Open the target file.
-        if let Some(wt) = self.worktrees.selected() {
-            let wt_path = wt.path.clone();
-            let tab_width = self.config.viewer.tab_width;
-            self.viewer_state.open_file(&wt_path, file_path, tab_width);
-            self.rehighlight_viewer();
-            self.viewer_state.reveal_file_in_tree(file_path, &wt_path);
-        }
+        // 対象ファイルを開く。索引を張ったのと同じ根に対して開く
+        // (start_symbol_index_build も selected_worktree_path を使っている)。
+        let root = self.selected_worktree_path();
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.open_file(&root, file_path, tab_width);
+        self.rehighlight_viewer();
+        self.viewer_state.reveal_file_in_tree(file_path, &root);
 
         // Scroll so the target line appears at the same screen row as the source symbol.
         let target_0 = line.saturating_sub(1);
@@ -588,15 +587,12 @@ impl App {
         };
 
         if let Some(loc) = self.code_nav.history.go_back(current) {
-            if let Some(wt) = self.worktrees.selected() {
-                let wt_path = wt.path.clone();
-                let tab_width = self.config.viewer.tab_width;
-                self.viewer_state
-                    .open_file(&wt_path, &loc.file_path, tab_width);
-                self.rehighlight_viewer();
-                self.viewer_state
-                    .reveal_file_in_tree(&loc.file_path, &wt_path);
-            }
+            let root = self.selected_worktree_path();
+            let tab_width = self.config.viewer.tab_width;
+            self.viewer_state
+                .open_file(&root, &loc.file_path, tab_width);
+            self.rehighlight_viewer();
+            self.viewer_state.reveal_file_in_tree(&loc.file_path, &root);
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;
@@ -616,15 +612,12 @@ impl App {
         };
 
         if let Some(loc) = self.code_nav.history.go_forward(current) {
-            if let Some(wt) = self.worktrees.selected() {
-                let wt_path = wt.path.clone();
-                let tab_width = self.config.viewer.tab_width;
-                self.viewer_state
-                    .open_file(&wt_path, &loc.file_path, tab_width);
-                self.rehighlight_viewer();
-                self.viewer_state
-                    .reveal_file_in_tree(&loc.file_path, &wt_path);
-            }
+            let root = self.selected_worktree_path();
+            let tab_width = self.config.viewer.tab_width;
+            self.viewer_state
+                .open_file(&root, &loc.file_path, tab_width);
+            self.rehighlight_viewer();
+            self.viewer_state.reveal_file_in_tree(&loc.file_path, &root);
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;

--- a/src/app/worktree_grep.rs
+++ b/src/app/worktree_grep.rs
@@ -58,10 +58,9 @@ impl App {
             return;
         }
 
-        let wt_path = match self.worktrees.selected() {
-            Some(wt) => wt.path.clone(),
-            None => return,
-        };
+        // 検索範囲はツリーを構築したのと同じ根。worktree 一覧が空なら諦める、では
+        // git 管理外のディレクトリで grep が黙って何も返さなくなる。
+        let wt_path = self.selected_worktree_path();
 
         // Cancel any previous search.
         self.overlays.grep_search.bg_op.clear();

--- a/src/event/explorer/comment_list.rs
+++ b/src/event/explorer/comment_list.rs
@@ -175,27 +175,26 @@ pub(in crate::event) fn navigate_to_comment_with_focus(
     comment_idx: usize,
     focus_viewer: bool,
 ) {
-    if let Some(comment) = app.review_state.comments.get(comment_idx) {
-        let file_path = comment.file_path.clone();
-        let line = comment.line_start as usize;
-        if let Some(wt) = app.worktrees.selected() {
-            let wt_path = wt.path.clone();
-            let tab_width = app.config.viewer.tab_width;
-            app.viewer_state.open_file(&wt_path, &file_path, tab_width);
-            app.rehighlight_viewer();
-            app.viewer_state.content.file_scroll = line.saturating_sub(1);
-            // A comment lives on a source line, so show source: rendered
-            // markdown would drop the reader at the top of the prose with the
-            // selection below invisible.
-            app.viewer_state.show_raw_for_line_target();
-            app.viewer_state.selection = crate::viewer::LineSelection::Selected {
-                start: line,
-                end: line,
-            };
-            app.review_state.build_file_comment_cache(&file_path);
-            if focus_viewer {
-                app.set_focus(Focus::Viewer);
-            }
-        }
+    let Some(comment) = app.review_state.comments.get(comment_idx) else {
+        return;
+    };
+    let file_path = comment.file_path.clone();
+    let line = comment.line_start as usize;
+    let wt_path = app.selected_worktree_path();
+    let tab_width = app.config.viewer.tab_width;
+    app.viewer_state.open_file(&wt_path, &file_path, tab_width);
+    app.rehighlight_viewer();
+    app.viewer_state.content.file_scroll = line.saturating_sub(1);
+    // A comment lives on a source line, so show source: rendered
+    // markdown would drop the reader at the top of the prose with the
+    // selection below invisible.
+    app.viewer_state.show_raw_for_line_target();
+    app.viewer_state.selection = crate::viewer::LineSelection::Selected {
+        start: line,
+        end: line,
+    };
+    app.review_state.build_file_comment_cache(&file_path);
+    if focus_viewer {
+        app.set_focus(Focus::Viewer);
     }
 }

--- a/src/event/explorer/tree.rs
+++ b/src/event/explorer/tree.rs
@@ -69,17 +69,18 @@ pub(in crate::event) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
         Some(Action::Select) => {
             let idx = app.viewer_state.tree.tree_selected;
             if let Some(entry) = app.viewer_state.tree.file_tree.get(idx).cloned() {
+                // ツリーを構築したときと同じ根に対して開く。
+                // selected_worktree_path() は worktree 一覧が空ならリポジトリの
+                // パスへ落ちるので、git 管理外のディレクトリでも選択が伝わる。
+                let root = app.selected_worktree_path();
                 if entry.is_dir {
-                    if !entry.is_expanded
-                        && let Some(wt) = app.worktrees.selected()
-                    {
-                        app.viewer_state.ensure_children_loaded(idx, &wt.path);
+                    if !entry.is_expanded {
+                        app.viewer_state.ensure_children_loaded(idx, &root);
                     }
                     app.viewer_state.toggle_dir(idx);
-                } else if let Some(wt) = app.worktrees.selected() {
-                    let path = wt.path.clone();
+                } else {
                     let tab_width = app.config.viewer.tab_width;
-                    app.viewer_state.open_file(&path, &entry.path, tab_width);
+                    app.viewer_state.open_file(&root, &entry.path, tab_width);
                     app.rehighlight_viewer();
                     app.review_state.build_file_comment_cache(&entry.path);
                     app.set_focus(Focus::Viewer);
@@ -88,12 +89,15 @@ pub(in crate::event) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::ExpandOrRight) => {
             let idx = app.viewer_state.tree.tree_selected;
-            if let Some(entry) = app.viewer_state.tree.file_tree.get(idx)
-                && entry.is_dir
-                && !entry.is_expanded
-                && let Some(wt) = app.worktrees.selected()
-            {
-                app.viewer_state.ensure_children_loaded(idx, &wt.path);
+            let needs_children = app
+                .viewer_state
+                .tree
+                .file_tree
+                .get(idx)
+                .is_some_and(|e| e.is_dir && !e.is_expanded);
+            if needs_children {
+                let root = app.selected_worktree_path();
+                app.viewer_state.ensure_children_loaded(idx, &root);
             }
             app.viewer_state.expand_dir(idx);
         }

--- a/src/event/mouse/explorer_panel.rs
+++ b/src/event/mouse/explorer_panel.rs
@@ -219,15 +219,17 @@ pub(super) fn handle_explorer_column_click(
                 app.viewer_state.tree.tree_selected = tree_idx;
                 // Single-click opens the file in Viewer (or toggles dir).
                 if let Some(entry) = app.viewer_state.tree.file_tree.get(tree_idx).cloned() {
+                    // ツリーを構築したときと同じ根。worktree 一覧が空 (git 管理外の
+                    // ディレクトリ) でもリポジトリのパスへ落ちるので、クリックが
+                    // 何も起こさずに握り潰されることはない。
+                    let root = app.selected_worktree_path();
                     if entry.is_dir {
                         // Lazy-load children before expanding.
-                        if !entry.is_expanded
-                            && let Some(wt) = app.worktrees.selected()
-                        {
-                            app.viewer_state.ensure_children_loaded(tree_idx, &wt.path);
+                        if !entry.is_expanded {
+                            app.viewer_state.ensure_children_loaded(tree_idx, &root);
                         }
                         app.viewer_state.toggle_dir(tree_idx);
-                    } else if let Some(wt) = app.worktrees.selected() {
+                    } else {
                         // Double-click detection.
                         let is_double = register_double_click_on(
                             &mut app.viewer_state.click.last_tree_click_time,
@@ -236,9 +238,8 @@ pub(super) fn handle_explorer_column_click(
                             std::time::Instant::now(),
                         );
 
-                        let wt_path = wt.path.clone();
                         let tab_width = app.config.viewer.tab_width;
-                        app.viewer_state.open_file(&wt_path, &entry.path, tab_width);
+                        app.viewer_state.open_file(&root, &entry.path, tab_width);
                         app.rehighlight_viewer();
                         app.review_state.build_file_comment_cache(&entry.path);
                         // Single click: keep focus on Explorer.

--- a/src/event/overlay/search.rs
+++ b/src/event/overlay/search.rs
@@ -38,15 +38,12 @@ pub(in crate::event) fn handle_filename_search_key(app: &mut App, key: KeyEvent)
                 app.viewer_state.filename_search.filename_search_active = false;
 
                 // Reveal and open the selected file (keep Focus on Explorer).
-                if let Some(wt) = app.worktrees.selected() {
-                    let wt_path = wt.path.clone();
-                    app.viewer_state.reveal_file_in_tree(&result.path, &wt_path);
-                    let tab_width = app.config.viewer.tab_width;
-                    app.viewer_state
-                        .open_file(&wt_path, &result.path, tab_width);
-                    app.rehighlight_viewer();
-                    app.review_state.build_file_comment_cache(&result.path);
-                }
+                let root = app.selected_worktree_path();
+                app.viewer_state.reveal_file_in_tree(&result.path, &root);
+                let tab_width = app.config.viewer.tab_width;
+                app.viewer_state.open_file(&root, &result.path, tab_width);
+                app.rehighlight_viewer();
+                app.review_state.build_file_comment_cache(&result.path);
             }
             app.viewer_state
                 .filename_search
@@ -188,30 +185,28 @@ pub(in crate::event) fn handle_grep_search_key(app: &mut App, key: KeyEvent) {
                 app.overlays.grep_search.debounce_deadline = None;
                 app.overlays.grep_search.phase1_active = false;
 
-                if let Some(wt) = app.worktrees.selected() {
-                    let wt_path = wt.path.clone();
-                    app.viewer_state
-                        .reveal_file_in_tree(&result.file_path, &wt_path);
-                    let tab_width = app.config.viewer.tab_width;
-                    app.viewer_state
-                        .open_file(&wt_path, &result.file_path, tab_width);
-                    app.rehighlight_viewer();
-                    let hit_0 = result.line_number.saturating_sub(1);
-                    let max = app
-                        .viewer_state
-                        .content
-                        .file_content
-                        .len()
-                        .saturating_sub(1);
-                    app.viewer_state.content.file_scroll =
-                        result.line_number.saturating_sub(6).min(max);
-                    app.viewer_state.content.grep_highlight_line = Some(result.line_number);
-                    if app.viewer_state.content.file_scroll > hit_0 {
-                        app.viewer_state.content.file_scroll = hit_0;
-                    }
-                    app.viewer_state.show_raw_for_line_target();
-                    app.set_focus(Focus::Viewer);
+                let root = app.selected_worktree_path();
+                app.viewer_state
+                    .reveal_file_in_tree(&result.file_path, &root);
+                let tab_width = app.config.viewer.tab_width;
+                app.viewer_state
+                    .open_file(&root, &result.file_path, tab_width);
+                app.rehighlight_viewer();
+                let hit_0 = result.line_number.saturating_sub(1);
+                let max = app
+                    .viewer_state
+                    .content
+                    .file_content
+                    .len()
+                    .saturating_sub(1);
+                app.viewer_state.content.file_scroll =
+                    result.line_number.saturating_sub(6).min(max);
+                app.viewer_state.content.grep_highlight_line = Some(result.line_number);
+                if app.viewer_state.content.file_scroll > hit_0 {
+                    app.viewer_state.content.file_scroll = hit_0;
                 }
+                app.viewer_state.show_raw_for_line_target();
+                app.set_focus(Focus::Viewer);
             } else {
                 app.overlays.grep_search.result_tree.toggle_expand(selected);
             }

--- a/src/event/overlay_helpers.rs
+++ b/src/event/overlay_helpers.rs
@@ -19,9 +19,10 @@ pub(in crate::event) fn open_filename_search(app: &mut App) {
         .filename_search_results
         .clear();
     app.viewer_state.filename_search.filename_search_selected = 0;
-    if let Some(wt) = app.worktrees.selected() {
-        app.viewer_state.populate_filename_search_cache(&wt.path);
-    }
+    // 検索対象はツリーを構築したのと同じ根。ここで worktree 一覧の有無を条件に
+    // すると、git 管理外のディレクトリで候補が常に空になり、検索が黙って死ぬ。
+    let root = app.selected_worktree_path();
+    app.viewer_state.populate_filename_search_cache(&root);
     app.viewer_state.execute_filename_search();
 }
 

--- a/src/git_engine/tests.rs
+++ b/src/git_engine/tests.rs
@@ -24,6 +24,35 @@ fn list_worktrees_includes_main() {
     );
 }
 
+/// `git init` した直後 (コミットが 1 つも無く HEAD が未生成) のリポジトリでも
+/// メインの worktree を 1 件返すこと。
+///
+/// ここが空を返すと、worktree を引いてからでないとファイルを開けない画面側は
+/// まるごと動かなくなる。HEAD を解決できないだけで一覧ごと落とさない、という
+/// のが `worktree_info_at` の設計 (head_oid は Option) なので、それを固定する。
+#[test]
+fn list_worktrees_handles_repo_without_commits() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let repo_path = tmp.path().join("fresh");
+    std::fs::create_dir_all(&repo_path).unwrap();
+    Repository::init(&repo_path).expect("init repo");
+    std::fs::write(repo_path.join("hello.txt"), "hi\n").unwrap();
+
+    let engine = GitEngine::open(&repo_path).expect("open fresh repo");
+    let worktrees = engine.list_worktrees().expect("list_worktrees() failed");
+
+    assert_eq!(
+        worktrees.len(),
+        1,
+        "a freshly initialised repo should still report its main worktree"
+    );
+    assert!(worktrees[0].is_main);
+    assert!(
+        worktrees[0].head_oid.is_none(),
+        "unborn HEAD has no oid, and that must not fail the listing"
+    );
+}
+
 /// Verify that `main_worktree_path()` returns the correct path even when
 /// opened from a linked worktree.
 #[test]

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -157,9 +157,25 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 
     if vs.content.file_content.is_empty() {
-        let placeholder = Paragraph::new("Select a file to view its contents.")
-            .style(Style::default().fg(theme.muted))
-            .block(block);
+        // 本文が無い理由は 3 通りあり、どれなのかを言い当てる。読めなかった場合を
+        // 「ファイルを選んでください」と出すと、選んだのに反応しなかったように
+        // 見えてしまう (タイトルには選択中のファイル名が出ているのに、本文は
+        // 未選択の案内、という食い違いになる)。
+        let (text, style) = match (&vs.content.load_error, &vs.content.current_file) {
+            (Some(err), Some(path)) => (
+                format!("Could not read {path}\n{err}"),
+                Style::default().fg(theme.error),
+            ),
+            (_, Some(_)) => (
+                "This file is empty.".to_string(),
+                Style::default().fg(theme.muted),
+            ),
+            (_, None) => (
+                "Select a file to view its contents.".to_string(),
+                Style::default().fg(theme.muted),
+            ),
+        };
+        let placeholder = Paragraph::new(text).style(style).block(block);
         frame.render_widget(placeholder, area);
         return;
     }

--- a/src/viewer/content.rs
+++ b/src/viewer/content.rs
@@ -29,6 +29,8 @@ impl ViewerState {
         // read-error branches below also replace `file_content`, and a mask
         // left over from the previous file would describe the wrong text.
         self.content.code_mask = crate::symbol_index::CodeMask::default();
+        // 前のファイルの失敗理由を持ち越さない。以降の分岐が必要なら再度立てる。
+        self.content.load_error = None;
         let full = worktree_path.join(relative_path);
 
         // Handle media files (images/videos) via aa-media.
@@ -73,8 +75,13 @@ impl ViewerState {
                 };
             }
             Err(e) => {
-                // Show error as file content so the user sees feedback.
-                self.content.file_content = vec![format!("Error reading file: {e}")];
+                // 失敗理由は専用のフィールドへ。以前はここで擬似的な 1 行を
+                // file_content に流し込んでいたが、それだと行番号もハイライトも
+                // 付いて本文と区別が付かず、Viewer 側からは「空 = 未選択」と
+                // 見分けられなかった。
+                log::warn!("failed to read {}: {e}", full.display());
+                self.content.file_content.clear();
+                self.content.load_error = Some(e.to_string());
                 self.content.current_file = Some(relative_path.to_string());
                 self.content.file_scroll = 0;
                 self.content.h_scroll = 0;
@@ -188,6 +195,55 @@ pub fn is_markdown_path(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// ファイルの中身はワークツリーの実ファイルから読む。git を一切経由しないので
+    /// `.git` の無いディレクトリでも、git 管理下の未追跡・未コミットのファイルでも
+    /// 同じように開ける。これが崩れると「git 管理外だと Viewer が空のまま」に戻る。
+    #[test]
+    fn open_file_reads_from_disk_without_git() {
+        let dir = std::env::temp_dir().join(format!("nogit_open_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("plain.txt"), "ALPHA\nBRAVO\n").unwrap();
+        assert!(!dir.join(".git").exists(), "fixture must not be a git repo");
+
+        let mut vs = ViewerState::default();
+        vs.open_file(&dir, "plain.txt", 4);
+
+        assert_eq!(vs.content.file_content, vec!["ALPHA", "BRAVO"]);
+        assert_eq!(vs.content.current_file.as_deref(), Some("plain.txt"));
+        assert!(vs.content.load_error.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 読み込みに失敗したら理由を `load_error` に残す。本文が空になるのは
+    /// 「未選択」「空ファイル」も同じなので、失敗をここで区別できないと
+    /// Viewer が「ファイル未選択」に丸めてしまう。
+    #[test]
+    fn open_file_records_why_it_failed() {
+        let dir = std::env::temp_dir().join(format!("nogit_err_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut vs = ViewerState::default();
+        vs.open_file(&dir, "missing.txt", 4);
+
+        assert!(vs.content.file_content.is_empty());
+        assert_eq!(vs.content.current_file.as_deref(), Some("missing.txt"));
+        assert!(
+            vs.content.load_error.is_some(),
+            "a failed read must record its reason, not look like 'nothing selected'"
+        );
+
+        // 次に成功したら理由は消える。持ち越すと直後の正常なファイルまで
+        // エラー表示になる。
+        std::fs::write(dir.join("ok.txt"), "OK\n").unwrap();
+        vs.open_file(&dir, "ok.txt", 4);
+        assert!(vs.content.load_error.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// Opening a file must leave behind a mask that agrees with the tab-expanded
     /// lines the viewer will render, because every navigation query indexes into

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -46,6 +46,12 @@ pub struct FileContentState {
     pub h_scroll: usize,
     /// Relative path of the file currently displayed (if any).
     pub current_file: Option<String>,
+    /// なぜ `file_content` が空なのかの理由。読み込みに失敗したときだけ入る。
+    ///
+    /// 「未選択」「中身が空のファイル」「読めなかった」はどれも `file_content` が
+    /// 空になるので、これが無いと Viewer は 3 つを見分けられず、失敗が黙って
+    /// 「ファイル未選択」に丸められる。`open_file` が成功したら必ず消す。
+    pub load_error: Option<String>,
     /// Cached syntax-highlighted tokens per line (syntect output converted to ratatui styles).
     pub highlighted_lines: Vec<Vec<(ratatui::style::Style, String)>>,
     /// Hash of (current_file, file_content) used to skip redundant re-highlighting.


### PR DESCRIPTION
## Summary

`.git` の無いディレクトリで Conductor を開くと、Explorer のファイル一覧は正常に出るのに、Enter でもクリックでもファイル名検索でも Viewer が何も表示しなかった。

**原因は「どのディレクトリを根にして相対パスを解決するか」の不一致。**

- ツリーの構築は `App::selected_worktree_path()` を使う。worktree が無ければ `repo.path` にフォールバックするので、`.git` が無くてもツリーは正常に出る
- 一方ファイルを開く側は `app.worktrees.selected()` を直に引いていてフォールバックが無く、一覧が空だと `if let` が外れて **エラーも status も出さず丸ごとスキップ** されていた

`ViewerState::open_file` は元から `fs::read_to_string` で実ファイルを直読みしており、内容取得は git 依存ではなかった。壊れていたのは根の解決だけ。

### 変更

1. **「表示中のツリーを読む」入口をすべて `selected_worktree_path()` に統一**
   （`explorer/tree.rs` / `mouse/explorer_panel.rs` / `overlay_helpers.rs` / `overlay/search.rs` / `code_nav.rs` / `worktree_grep.rs` / `explorer/comment_list.rs`）
   戻り値が infallible なので早期 return 自体が消え、同じ握り潰しが再発しない。
   worktree を実際に作る・消す・マージする系は「本物の worktree が要る」ままなので触っていない。

2. **読み込み失敗を「ファイル未選択」に丸めるのをやめた**
   `FileContentState.load_error` を追加。従来は `Error reading file: ...` を擬似的な1行として `file_content` に流し込んでおり、行番号もハイライトも付いて本文と区別できなかった。Viewer は今、未選択 / 空ファイル / 読み込み失敗を撃ち分ける。

### 補足: 「git init しても直らない」は再現せず

非 git ディレクトリを開いた状態で `git init` すると、3秒ポーリングで worktree 一覧が埋まりその場で回復する。コミット0件でも `list_worktrees` は1件返す（`worktree_info_at` の `head_oid` が `Option` なので HEAD 未生成でも落ちない）。回帰テスト `list_worktrees_handles_repo_without_commits` で固定した。

## Test plan

`cargo test` 1002 passed / `cargo clippy` clean。加えて実バイナリを pty 下で駆動し、pyte で画面を再構成して検証:

| シナリオ | 結果 |
|---|---|
| `.git` 無し + クリック / Enter / `/` 検索 | 内容表示 OK（修正前は `(no file selected)` のまま） |
| `git init` 済み・コミット無し | 内容表示 OK |
| 既存 git repo の追跡済み / 未追跡ファイル | OK（未追跡は `+1` ガター付き） |
| worktree 切替後に同名ファイル | `FEATURE_VERSION_OF_SHARED` を表示 = 選択中 worktree で正しく解決（回帰なし） |
| 読めないファイル（非 UTF-8） | `Could not read … / stream did not contain valid UTF-8` |

追加した単体テスト:
- `viewer::content::tests::open_file_reads_from_disk_without_git`
- `viewer::content::tests::open_file_records_why_it_failed`
- `git_engine::tests::list_worktrees_handles_repo_without_commits`

## 既知の残課題（別PR予定）

`ViewerState` は相対パスだけを持ち root を保持していないため、root は5つのAPI・25箇所に引数として散っている。worktree 切り替えは非同期（`poll_worktree_switch_ops` が後からツリーを差し替える）なので、**切替直後は「古いツリーのエントリ」と「新しい root」が混ざる窓が理屈上開いている**（未再現）。`git_status` は既に `file_tree` とセットで原子的に差し替えられているので、root をそのタプルに合流させるのが本筋。