### PR TITLE
refactor: let ViewerState own the tree's root so relative paths resolve one way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.98.2"
+version = "0.98.3"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.98.2"
+version = "0.98.3"
 edition = "2024"
 
 [dependencies]

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -555,13 +555,12 @@ impl App {
             self.code_nav.history.push(loc);
         }
 
-        // 対象ファイルを開く。索引を張ったのと同じ根に対して開く
-        // (start_symbol_index_build も selected_worktree_path を使っている)。
-        let root = self.selected_worktree_path();
+        // 対象ファイルを開く。根は Viewer が表示中のツリーのもの。ツリーの行を
+        // 選び直す reveal と同じ根でないと、本文と選択行が別ツリーを指す。
         let tab_width = self.config.viewer.tab_width;
-        self.viewer_state.open_file(&root, file_path, tab_width);
+        self.viewer_state.open_file(file_path, tab_width);
         self.rehighlight_viewer();
-        self.viewer_state.reveal_file_in_tree(file_path, &root);
+        self.viewer_state.reveal_file_in_tree(file_path);
 
         // Scroll so the target line appears at the same screen row as the source symbol.
         let target_0 = line.saturating_sub(1);
@@ -587,12 +586,10 @@ impl App {
         };
 
         if let Some(loc) = self.code_nav.history.go_back(current) {
-            let root = self.selected_worktree_path();
             let tab_width = self.config.viewer.tab_width;
-            self.viewer_state
-                .open_file(&root, &loc.file_path, tab_width);
+            self.viewer_state.open_file(&loc.file_path, tab_width);
             self.rehighlight_viewer();
-            self.viewer_state.reveal_file_in_tree(&loc.file_path, &root);
+            self.viewer_state.reveal_file_in_tree(&loc.file_path);
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;
@@ -612,12 +609,10 @@ impl App {
         };
 
         if let Some(loc) = self.code_nav.history.go_forward(current) {
-            let root = self.selected_worktree_path();
             let tab_width = self.config.viewer.tab_width;
-            self.viewer_state
-                .open_file(&root, &loc.file_path, tab_width);
+            self.viewer_state.open_file(&loc.file_path, tab_width);
             self.rehighlight_viewer();
-            self.viewer_state.reveal_file_in_tree(&loc.file_path, &root);
+            self.viewer_state.reveal_file_in_tree(&loc.file_path);
             let total = self.viewer_state.content.file_content.len();
             self.viewer_state.content.file_scroll = loc.line.min(total.saturating_sub(1));
             self.viewer_state.content.h_scroll = loc.h_scroll;

--- a/src/app/repo.rs
+++ b/src/app/repo.rs
@@ -45,6 +45,10 @@ impl App {
         self.worktrees.select(0);
         self.refresh_worktrees();
         self.viewer_state = ViewerState::default();
+        // ツリーの走査は遅延させる (上のコメントのとおり) が、根だけは今ここで
+        // 入れておく。空のままだと、ツリーを歩く前に開いたファイル名検索が
+        // カレントディレクトリを歩いてしまう。
+        self.viewer_state.set_root(self.selected_worktree_path());
         self.diff_state = crate::diff_state::DiffState::new(
             &self.config.general.main_branch,
             self.diff_state.view_mode,
@@ -112,6 +116,8 @@ impl App {
                 self.worktrees.select(0);
                 self.refresh_worktrees();
                 self.viewer_state = ViewerState::default();
+                // 同上。ツリーは遅延させるが根は今決まっている。
+                self.viewer_state.set_root(self.selected_worktree_path());
                 // This repo gets no view restore, so drop any restore still
                 // armed for the *previous* repo — otherwise it could fire here
                 // and open a same-named path in the newly opened tree.

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -70,13 +70,9 @@ impl App {
             Some((f, _)) => (f.path.clone(), f.clone()),
             None => return,
         };
-        let Some(wt) = self.worktrees.selected() else {
-            return;
-        };
-        let wt_path = wt.path.clone();
         let tab_width = self.config.viewer.tab_width;
-        self.viewer_state.open_file(&wt_path, &file_path, tab_width);
-        self.viewer_state.reveal_file_in_tree(&file_path, &wt_path);
+        self.viewer_state.open_file(&file_path, tab_width);
+        self.viewer_state.reveal_file_in_tree(&file_path);
         self.rehighlight_viewer();
         self.review_state.build_file_comment_cache(&file_path);
         self.expand_threads_for_file(&file_path);

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -241,11 +241,16 @@ pub struct BackgroundOps {
     pub pr_url: BackgroundOp<Option<String>>,
     /// Background diff computation (worktree switch).
     pub diff: BackgroundOp<BgDiffResult>,
-    /// Background file tree walk (worktree switch), paired with the git
-    /// status snapshot taken alongside it so `poll_worktree_switch_ops()`
-    /// can populate `FileTreeEntry::git_state` without a second `statuses()`
-    /// call on the main thread.
+    /// Background file tree walk (worktree switch): the root that was walked,
+    /// the entries, and the git status snapshot taken alongside them so
+    /// `poll_worktree_switch_ops()` can populate `FileTreeEntry::git_state`
+    /// without a second `statuses()` call on the main thread.
+    ///
+    /// 根を結果に含めるのは、走査を始めた時点の選択と、結果が届いた時点の選択が
+    /// 一致するとは限らないため。届いたエントリの相対パスを解決できるのは、
+    /// それを歩いた根だけ。
     pub file_tree: BackgroundOp<(
+        std::path::PathBuf,
         Vec<crate::viewer::FileTreeEntry>,
         crate::git_engine::status_map::GitStatusMap,
     )>,

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -125,12 +125,14 @@ impl App {
                 return;
             }
         }
-        let wt_path = self.selected_worktree_path();
-        if !wt_path.join(&restore.file).is_file() {
+        // 復元先の存在確認は Viewer の根で行う。ここは「ツリーが揃った直後」に
+        // 呼ばれる (同期の refresh_viewer と、非同期の worktree 切り替えの両方)
+        // ので、そのツリーと同じ根で見ないと確認と実際に開く先がずれる。
+        if !self.viewer_state.root().join(&restore.file).is_file() {
             return;
         }
         let tab_width = self.config.viewer.tab_width;
-        self.viewer_state.open_file(&wt_path, &restore.file, tab_width);
+        self.viewer_state.open_file(&restore.file, tab_width);
         let max = self.viewer_state.content.file_content.len().saturating_sub(1);
         self.viewer_state.content.file_scroll = restore.scroll.min(max);
     }
@@ -204,13 +206,10 @@ impl App {
     /// Optionally jumps to `line` (1-indexed). Reveals the file in the explorer
     /// tree, switches focus to Viewer, and shows a status message.
     pub fn open_file_in_viewer(&mut self, relative_path: &str, line: Option<usize>) {
-        let wt_path = self.selected_worktree_path();
         let tab_width = self.config.viewer.tab_width;
 
-        self.viewer_state
-            .open_file(&wt_path, relative_path, tab_width);
-        self.viewer_state
-            .reveal_file_in_tree(relative_path, &wt_path);
+        self.viewer_state.open_file(relative_path, tab_width);
+        self.viewer_state.reveal_file_in_tree(relative_path);
 
         if let Some(ln) = line {
             let max = self

--- a/src/app/walkthrough_view.rs
+++ b/src/app/walkthrough_view.rs
@@ -138,8 +138,8 @@ impl App {
         };
         let file_diff_clone = file_diff.clone();
         let tab_width = self.config.viewer.tab_width;
-        self.viewer_state.open_file(&wt_path, &file_path, tab_width);
-        self.viewer_state.reveal_file_in_tree(&file_path, &wt_path);
+        self.viewer_state.open_file(&file_path, tab_width);
+        self.viewer_state.reveal_file_in_tree(&file_path);
         self.rehighlight_viewer();
         self.review_state.build_file_comment_cache(&file_path);
         self.expand_threads_for_file(&file_path);

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -184,7 +184,7 @@ impl App {
                     });
                     let mut entries = Vec::new();
                     ViewerState::walk_dir(&path, &path, 0, &mut entries, &git_status);
-                    let _ = tx.send((entries, git_status));
+                    let _ = tx.send((path, entries, git_status));
                 });
             }
 
@@ -285,10 +285,10 @@ impl App {
     /// Poll background worktree-switch operations (file tree, diff, branch details).
     pub fn poll_worktree_switch_ops(&mut self) {
         // File tree result.
-        if let Some((entries, git_status)) = self.bg.file_tree.poll() {
-            self.viewer_state.tree.file_tree = entries;
-            self.viewer_state.tree.git_status = git_status;
-            self.viewer_state.invalidate_visible_cache();
+        if let Some((root, entries, git_status)) = self.bg.file_tree.poll() {
+            // 3 つまとめて差し替える。根だけ先に新しくなると、まだ古いエントリ
+            // を指しているクリックが別ブランチの同名ファイルを黙って開く。
+            self.viewer_state.replace_tree(root, entries, git_status);
             // Restore the previously viewed file + scroll for this worktree now
             // that its file tree is available (one-shot).
             self.consume_pending_view_restore();

--- a/src/app/worktree_grep.rs
+++ b/src/app/worktree_grep.rs
@@ -58,9 +58,10 @@ impl App {
             return;
         }
 
-        // 検索範囲はツリーを構築したのと同じ根。worktree 一覧が空なら諦める、では
-        // git 管理外のディレクトリで grep が黙って何も返さなくなる。
-        let wt_path = self.selected_worktree_path();
+        // 検索範囲は Viewer が表示しているツリーの根。結果を選ぶと同じ相対パスで
+        // reveal と open をするので、別の根を歩くと「ヒットしたのに開けない」
+        // 結果が並ぶ。
+        let wt_path = self.viewer_state.root().to_path_buf();
 
         // Cancel any previous search.
         self.overlays.grep_search.bg_op.clear();

--- a/src/event/explorer/comment_list.rs
+++ b/src/event/explorer/comment_list.rs
@@ -180,9 +180,8 @@ pub(in crate::event) fn navigate_to_comment_with_focus(
     };
     let file_path = comment.file_path.clone();
     let line = comment.line_start as usize;
-    let wt_path = app.selected_worktree_path();
     let tab_width = app.config.viewer.tab_width;
-    app.viewer_state.open_file(&wt_path, &file_path, tab_width);
+    app.viewer_state.open_file(&file_path, tab_width);
     app.rehighlight_viewer();
     app.viewer_state.content.file_scroll = line.saturating_sub(1);
     // A comment lives on a source line, so show source: rendered

--- a/src/event/explorer/tree.rs
+++ b/src/event/explorer/tree.rs
@@ -69,18 +69,14 @@ pub(in crate::event) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
         Some(Action::Select) => {
             let idx = app.viewer_state.tree.tree_selected;
             if let Some(entry) = app.viewer_state.tree.file_tree.get(idx).cloned() {
-                // ツリーを構築したときと同じ根に対して開く。
-                // selected_worktree_path() は worktree 一覧が空ならリポジトリの
-                // パスへ落ちるので、git 管理外のディレクトリでも選択が伝わる。
-                let root = app.selected_worktree_path();
                 if entry.is_dir {
                     if !entry.is_expanded {
-                        app.viewer_state.ensure_children_loaded(idx, &root);
+                        app.viewer_state.ensure_children_loaded(idx);
                     }
                     app.viewer_state.toggle_dir(idx);
                 } else {
                     let tab_width = app.config.viewer.tab_width;
-                    app.viewer_state.open_file(&root, &entry.path, tab_width);
+                    app.viewer_state.open_file(&entry.path, tab_width);
                     app.rehighlight_viewer();
                     app.review_state.build_file_comment_cache(&entry.path);
                     app.set_focus(Focus::Viewer);
@@ -96,8 +92,7 @@ pub(in crate::event) fn handle_explorer_key(app: &mut App, key: KeyEvent) {
                 .get(idx)
                 .is_some_and(|e| e.is_dir && !e.is_expanded);
             if needs_children {
-                let root = app.selected_worktree_path();
-                app.viewer_state.ensure_children_loaded(idx, &root);
+                app.viewer_state.ensure_children_loaded(idx);
             }
             app.viewer_state.expand_dir(idx);
         }

--- a/src/event/mouse/explorer_panel.rs
+++ b/src/event/mouse/explorer_panel.rs
@@ -219,14 +219,10 @@ pub(super) fn handle_explorer_column_click(
                 app.viewer_state.tree.tree_selected = tree_idx;
                 // Single-click opens the file in Viewer (or toggles dir).
                 if let Some(entry) = app.viewer_state.tree.file_tree.get(tree_idx).cloned() {
-                    // ツリーを構築したときと同じ根。worktree 一覧が空 (git 管理外の
-                    // ディレクトリ) でもリポジトリのパスへ落ちるので、クリックが
-                    // 何も起こさずに握り潰されることはない。
-                    let root = app.selected_worktree_path();
                     if entry.is_dir {
                         // Lazy-load children before expanding.
                         if !entry.is_expanded {
-                            app.viewer_state.ensure_children_loaded(tree_idx, &root);
+                            app.viewer_state.ensure_children_loaded(tree_idx);
                         }
                         app.viewer_state.toggle_dir(tree_idx);
                     } else {
@@ -239,7 +235,7 @@ pub(super) fn handle_explorer_column_click(
                         );
 
                         let tab_width = app.config.viewer.tab_width;
-                        app.viewer_state.open_file(&root, &entry.path, tab_width);
+                        app.viewer_state.open_file(&entry.path, tab_width);
                         app.rehighlight_viewer();
                         app.review_state.build_file_comment_cache(&entry.path);
                         // Single click: keep focus on Explorer.

--- a/src/event/mouse/terminal_panel.rs
+++ b/src/event/mouse/terminal_panel.rs
@@ -63,7 +63,9 @@ pub(super) fn handle_terminal_column_click(
                 t
             };
 
-            let wt_path = app.selected_worktree_path();
+            // 実在確認と実際に開く先を同じ根に揃える (キーボード側の
+            // open_file_from_terminal_output と同じ理由)。
+            let wt_path = app.viewer_state.root().to_path_buf();
             let links = terminal_link::detect_file_links(&text, &wt_path);
             // Prefer the link under the cursor; fall back to first on row.
             let link =

--- a/src/event/overlay/search.rs
+++ b/src/event/overlay/search.rs
@@ -38,10 +38,9 @@ pub(in crate::event) fn handle_filename_search_key(app: &mut App, key: KeyEvent)
                 app.viewer_state.filename_search.filename_search_active = false;
 
                 // Reveal and open the selected file (keep Focus on Explorer).
-                let root = app.selected_worktree_path();
-                app.viewer_state.reveal_file_in_tree(&result.path, &root);
+                app.viewer_state.reveal_file_in_tree(&result.path);
                 let tab_width = app.config.viewer.tab_width;
-                app.viewer_state.open_file(&root, &result.path, tab_width);
+                app.viewer_state.open_file(&result.path, tab_width);
                 app.rehighlight_viewer();
                 app.review_state.build_file_comment_cache(&result.path);
             }
@@ -185,12 +184,9 @@ pub(in crate::event) fn handle_grep_search_key(app: &mut App, key: KeyEvent) {
                 app.overlays.grep_search.debounce_deadline = None;
                 app.overlays.grep_search.phase1_active = false;
 
-                let root = app.selected_worktree_path();
-                app.viewer_state
-                    .reveal_file_in_tree(&result.file_path, &root);
+                app.viewer_state.reveal_file_in_tree(&result.file_path);
                 let tab_width = app.config.viewer.tab_width;
-                app.viewer_state
-                    .open_file(&root, &result.file_path, tab_width);
+                app.viewer_state.open_file(&result.file_path, tab_width);
                 app.rehighlight_viewer();
                 let hit_0 = result.line_number.saturating_sub(1);
                 let max = app

--- a/src/event/overlay_helpers.rs
+++ b/src/event/overlay_helpers.rs
@@ -19,10 +19,7 @@ pub(in crate::event) fn open_filename_search(app: &mut App) {
         .filename_search_results
         .clear();
     app.viewer_state.filename_search.filename_search_selected = 0;
-    // 検索対象はツリーを構築したのと同じ根。ここで worktree 一覧の有無を条件に
-    // すると、git 管理外のディレクトリで候補が常に空になり、検索が黙って死ぬ。
-    let root = app.selected_worktree_path();
-    app.viewer_state.populate_filename_search_cache(&root);
+    app.viewer_state.populate_filename_search_cache();
     app.viewer_state.execute_filename_search();
 }
 

--- a/src/event/terminal/mod.rs
+++ b/src/event/terminal/mod.rs
@@ -200,7 +200,10 @@ pub(super) fn open_file_from_terminal_output(app: &mut App) {
         return;
     };
 
-    let wt_path = app.selected_worktree_path();
+    // リンクの実在確認に使う根は Viewer のツリーのもの。ここで確認した相対パスを
+    // そのまま open_file_in_viewer に渡すので、別の根で確認すると「リンクとして
+    // 認識されたのに開くと空」になる。
+    let wt_path = app.viewer_state.root().to_path_buf();
 
     // Lock the parser, set scrollback, scan rows from cursor upward.
     let found = {

--- a/src/ui/layout/render.rs
+++ b/src/ui/layout/render.rs
@@ -65,7 +65,10 @@ pub(crate) fn render_ui(frame: &mut Frame, app: &mut App) {
         if app.viewer_state.is_current_file_media()
             && let Some(ref rel_path) = app.viewer_state.content.current_file.clone()
         {
-            let full_path = app.selected_worktree_path().join(rel_path);
+            // 画像も本文と同じ根から読む。current_file は Viewer のツリーの
+            // 相対パスなので、別の根に繋ぐと「タイトルは A のファイル、絵は B の
+            // ファイル」になり得る。
+            let full_path = app.viewer_state.root().join(rel_path);
             let cols = columns[2].width;
             let rows = columns[2].height;
             // Tier B: pixel-quality rendering via the graphics protocol.

--- a/src/viewer/content.rs
+++ b/src/viewer/content.rs
@@ -16,7 +16,10 @@ impl ViewerState {
     }
 
     /// Open (read) a file and store its lines in `file_content`.
-    pub fn open_file(&mut self, worktree_path: &Path, relative_path: &str, tab_width: usize) {
+    ///
+    /// `relative_path` は表示中のツリーの根からの相対。絶対パスに戻すのは
+    /// [`ViewerState::root`] だけで、呼び出し側は根を知らなくてよい。
+    pub fn open_file(&mut self, relative_path: &str, tab_width: usize) {
         self.exit_diff_mode();
         // `md_rendered` deliberately survives (the mode is sticky across files);
         // the scroll offset does not, since it indexes into the old document.
@@ -31,7 +34,7 @@ impl ViewerState {
         self.content.code_mask = crate::symbol_index::CodeMask::default();
         // 前のファイルの失敗理由を持ち越さない。以降の分岐が必要なら再度立てる。
         self.content.load_error = None;
-        let full = worktree_path.join(relative_path);
+        let full = self.tree.root.join(relative_path);
 
         // Handle media files (images/videos) via aa-media.
         if media_state::is_media_file(relative_path) {
@@ -208,7 +211,9 @@ mod tests {
         assert!(!dir.join(".git").exists(), "fixture must not be a git repo");
 
         let mut vs = ViewerState::default();
-        vs.open_file(&dir, "plain.txt", 4);
+
+        vs.set_root(dir.clone());
+        vs.open_file("plain.txt", 4);
 
         assert_eq!(vs.content.file_content, vec!["ALPHA", "BRAVO"]);
         assert_eq!(vs.content.current_file.as_deref(), Some("plain.txt"));
@@ -227,7 +232,9 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         let mut vs = ViewerState::default();
-        vs.open_file(&dir, "missing.txt", 4);
+
+        vs.set_root(dir.clone());
+        vs.open_file("missing.txt", 4);
 
         assert!(vs.content.file_content.is_empty());
         assert_eq!(vs.content.current_file.as_deref(), Some("missing.txt"));
@@ -239,7 +246,7 @@ mod tests {
         // 次に成功したら理由は消える。持ち越すと直後の正常なファイルまで
         // エラー表示になる。
         std::fs::write(dir.join("ok.txt"), "OK\n").unwrap();
-        vs.open_file(&dir, "ok.txt", 4);
+        vs.open_file("ok.txt", 4);
         assert!(vs.content.load_error.is_none());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -262,7 +269,9 @@ mod tests {
         .unwrap();
 
         let mut vs = ViewerState::default();
-        vs.open_file(&dir, "sample.go", 4);
+
+        vs.set_root(dir.clone());
+        vs.open_file("sample.go", 4);
 
         // Walk each line the way `build_symbol_hints` does and collect the
         // words it would offer as jumpable.
@@ -308,10 +317,12 @@ mod tests {
         std::fs::write(dir.join("b.py"), "def keep():\n    pass\n").unwrap();
 
         let mut vs = ViewerState::default();
-        vs.open_file(&dir, "a.rs", 4);
+
+        vs.set_root(dir.clone());
+        vs.open_file("a.rs", 4);
         assert!(vs.content.code_mask.is_code(1, 0), "Rust file is masked");
 
-        vs.open_file(&dir, "b.py", 4);
+        vs.open_file("b.py", 4);
         assert!(
             !vs.content.code_mask.is_code(1, 0),
             "Python must not inherit the Rust file's mask"

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -6,6 +6,7 @@
 //! layout.
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::git_engine::status_map::GitStatusMap;
@@ -20,6 +21,16 @@ use super::file_view::UnifiedDiffEntry;
 /// File tree management state.
 #[derive(Default)]
 pub struct FileTreeState {
+    /// このツリーを歩いた根。エントリの相対パスはすべてここからの相対で、
+    /// 絶対パスに戻せるのはこの値だけ。
+    ///
+    /// 読むのは [`ViewerState::root`]、書くのは [`ViewerState::load_file_tree`] /
+    /// [`ViewerState::replace_tree`] / [`ViewerState::set_root`] だけに限る。
+    /// 以前は根を持たず、ファイルを開くたびに呼び出し側が「今どの worktree か」
+    /// を引き直して渡していたので、表示中のツリーと開く先が食い違っても誰も
+    /// 気付けなかった (worktree 切り替えはツリーの走査を裏に回すため、古い
+    /// エントリと新しい根が同時に存在する瞬間がある)。
+    pub(in crate::viewer) root: PathBuf,
     /// Flattened file tree (directories + files, pre-order).
     pub file_tree: Vec<FileTreeEntry>,
     /// Index of the selected row in the *full* (unfiltered) tree.

--- a/src/viewer/tree.rs
+++ b/src/viewer/tree.rs
@@ -2,7 +2,7 @@
 //! flattened `Vec<FileTreeEntry>`, lazy-loading directory children, expand /
 //! collapse, and revealing a path in the tree.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use crate::git_engine::status_map::GitStatusMap;
@@ -11,6 +11,38 @@ use super::file_tree::{FileTreeEntry, file_icon};
 use super::state::ViewerState;
 
 impl ViewerState {
+    /// 表示中のツリーを歩いた根。エントリの相対パスはここに繋いで絶対パスにする。
+    pub fn root(&self) -> &Path {
+        &self.tree.root
+    }
+
+    /// 根だけを差し替える。ツリーをまだ歩いていない場面 (リポジトリを開き直した
+    /// 直後など、走査は遅延させてある) 用。
+    ///
+    /// 根が空のまま相対パスを繋ぐとカレントディレクトリ相対になり、意図しない
+    /// ファイルを黙って開くので、ツリーを空にする側は必ずここも呼ぶ。
+    pub fn set_root(&mut self, root: PathBuf) {
+        self.tree.root = root;
+    }
+
+    /// 裏で歩き終えたツリーを丸ごと差し替える。
+    ///
+    /// 根・エントリ・git status は同じ 1 回の走査から出たものなので 3 つ揃って
+    /// 入れ替える。別々に書けるようにしておくと「根は新しいのにエントリは古い」
+    /// 状態が作れてしまい、その瞬間のクリックは別ブランチの同名ファイルを静かに
+    /// 開く (worktree 切り替えは走査を裏に回すので、この隙間は実在する)。
+    pub fn replace_tree(
+        &mut self,
+        root: PathBuf,
+        entries: Vec<FileTreeEntry>,
+        git_status: GitStatusMap,
+    ) {
+        self.tree.root = root;
+        self.tree.file_tree = entries;
+        self.tree.git_status = git_status;
+        self.invalidate_visible_cache();
+    }
+
     /// Build the file tree by walking the filesystem under `worktree_path`.
     ///
     /// Directories named `.git` are skipped. The tree is sorted so that
@@ -24,7 +56,12 @@ impl ViewerState {
     ///
     /// Returns `true` when the set of visible entries changed, so callers can
     /// skip a repaint when a periodic refresh found nothing new.
+    ///
+    /// 根を受け取る唯一の入口。ここで [`ViewerState::root`] を確定させ、以降
+    /// ファイルを開く・子を読む・検索候補を集めるのはすべてこの根に対して行う。
     pub fn load_file_tree(&mut self, worktree_path: &Path, tab_width: usize) -> bool {
+        self.tree.root = worktree_path.to_path_buf();
+
         // Save state before clearing.
         let prev_file = self.content.current_file.clone();
         let prev_file_scroll = self.content.file_scroll;
@@ -86,7 +123,7 @@ impl ViewerState {
             {
                 self.tree.file_tree[idx].is_expanded = true;
                 if !self.tree.file_tree[idx].children_loaded {
-                    self.ensure_children_loaded(idx, worktree_path);
+                    self.ensure_children_loaded(idx);
                 }
             }
             idx += 1;
@@ -117,7 +154,7 @@ impl ViewerState {
                 // reader back to the top of the prose mid-read.
                 let prev_md_scroll = self.md_scroll;
 
-                self.open_file(worktree_path, rel_path, tab_width);
+                self.open_file(rel_path, tab_width);
                 self.content.file_scroll = prev_file_scroll;
                 self.content.h_scroll = prev_h_scroll;
                 self.md_scroll = prev_md_scroll;
@@ -252,7 +289,7 @@ impl ViewerState {
     /// Walks the path segments, expanding (and lazy-loading) each parent
     /// directory along the way, then sets `tree_selected` to the target
     /// entry and adjusts scroll so it is visible.
-    pub fn reveal_file_in_tree(&mut self, relative_path: &str, worktree_root: &Path) {
+    pub fn reveal_file_in_tree(&mut self, relative_path: &str) {
         let segments: Vec<&str> = relative_path.split('/').collect();
         if segments.is_empty() {
             return;
@@ -292,7 +329,7 @@ impl ViewerState {
                 }
             } else {
                 // Intermediate directory — ensure children are loaded and expand.
-                self.ensure_children_loaded(idx, worktree_root);
+                self.ensure_children_loaded(idx);
                 if let Some(entry) = self.tree.file_tree.get_mut(idx)
                     && !entry.is_expanded
                 {
@@ -338,18 +375,17 @@ impl ViewerState {
     /// Lazily load the immediate children of the directory at `idx` in
     /// `file_tree`. No-op if the entry is not a directory or if children are
     /// already loaded.
-    pub fn ensure_children_loaded(&mut self, idx: usize, worktree_root: &Path) {
-        let entry = match self.tree.file_tree.get(idx) {
-            Some(e) if e.is_dir && !e.children_loaded => e,
+    pub fn ensure_children_loaded(&mut self, idx: usize) {
+        let (rel_path, child_depth) = match self.tree.file_tree.get(idx) {
+            Some(e) if e.is_dir && !e.children_loaded => (e.path.clone(), e.depth + 1),
             _ => return,
         };
 
-        let full_path = worktree_root.join(&entry.path);
-        let child_depth = entry.depth + 1;
+        let full_path = self.tree.root.join(&rel_path);
 
         let mut children: Vec<FileTreeEntry> = Vec::new();
         Self::walk_dir(
-            worktree_root,
+            &self.tree.root,
             &full_path,
             child_depth,
             &mut children,
@@ -375,12 +411,12 @@ impl ViewerState {
     }
 
     /// Populate the filename search cache by walking the entire filesystem
-    /// tree under the given worktree root.
-    pub fn populate_filename_search_cache(&mut self, worktree_root: &Path) {
+    /// tree under the tree's root.
+    pub fn populate_filename_search_cache(&mut self) {
         self.filename_search.filename_search_all_files.clear();
         Self::collect_all_file_paths(
-            worktree_root,
-            worktree_root,
+            &self.tree.root,
+            &self.tree.root,
             0,
             &mut self.filename_search.filename_search_all_files,
         );

--- a/src/viewer/tree/tests.rs
+++ b/src/viewer/tree/tests.rs
@@ -69,6 +69,45 @@ fn walk_still_skips_heavy_dirs() {
     );
 }
 
+/// 同名のファイルを持つ 2 つの worktree があるとき、開く先は「今表示している
+/// ツリーを歩いた根」で決まる。
+///
+/// worktree の切り替えはツリーの走査を裏のスレッドに回すので、選択が B に移って
+/// からエントリが届くまでの間、選択は B・表示しているエントリは A、という状態が
+/// 実在する。根を Viewer が持ち、エントリと一緒に差し替えることでこの隙間を潰す。
+/// 呼び出し側が開くたびに「今どの worktree か」を引き直していた頃は、その隙間の
+/// クリックが A の相対パスを B の根に繋いで、別ブランチの同名ファイルを黙って
+/// 開いていた。
+#[test]
+fn tree_root_and_entries_switch_together() {
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    std::fs::write(a.path().join("shared.txt"), "FROM_A\n").unwrap();
+    std::fs::write(b.path().join("shared.txt"), "FROM_B\n").unwrap();
+
+    let mut vs = ViewerState::default();
+    vs.load_file_tree(a.path(), 4);
+    vs.open_file("shared.txt", 4);
+    assert_eq!(vs.content.file_content, vec!["FROM_A"]);
+    assert_eq!(vs.root(), a.path(), "load_file_tree が根を確定させる");
+
+    // 裏の走査が返ってきたのと同じ形で B のツリーを適用する。
+    let mut entries = Vec::new();
+    ViewerState::walk_dir(
+        b.path(),
+        b.path(),
+        0,
+        &mut entries,
+        &GitStatusMap::default(),
+    );
+    vs.replace_tree(b.path().to_path_buf(), entries, GitStatusMap::default());
+
+    // 相対パスは同じでも、読むのは差し替え後の根の下のファイル。
+    vs.open_file("shared.txt", 4);
+    assert_eq!(vs.content.file_content, vec!["FROM_B"]);
+    assert_eq!(vs.root(), b.path());
+}
+
 /// A periodic / file-watcher tree refresh re-opens the previously viewed file
 /// to pick up on-disk edits, and `open_file` goes through `exit_diff_mode`,
 /// which clears every viewer mode flag. The SUMMARY pseudo-file view must
@@ -82,7 +121,7 @@ fn tree_refresh_preserves_summary_view() {
 
     let mut vs = ViewerState::default();
     vs.load_file_tree(root, 4);
-    vs.open_file(root, "a.txt", 4);
+    vs.open_file("a.txt", 4);
     vs.enter_summary_view();
     vs.summary_scroll = 7;
 
@@ -105,7 +144,7 @@ fn tree_refresh_preserves_diff_mode() {
 
     let mut vs = ViewerState::default();
     vs.load_file_tree(root, 4);
-    vs.open_file(root, "a.txt", 4);
+    vs.open_file("a.txt", 4);
     vs.diff_view.diff_mode = true;
     vs.diff_view.diff_view_scroll = 3;
 
@@ -129,7 +168,7 @@ fn tree_refresh_preserves_rendered_markdown_scroll() {
 
     let mut vs = ViewerState::default();
     vs.load_file_tree(root, 4);
-    vs.open_file(root, "README.md", 4);
+    vs.open_file("README.md", 4);
     vs.md_rendered = true;
     vs.md_scroll = 40;
     vs.content.file_scroll = 40;


### PR DESCRIPTION
## Summary

Viewer が「今表示しているツリーをどの根から歩いたか」を持っていなかったため、
ファイルを開く側は毎回 `App::selected_worktree_path()` を引き直して根を渡していた。
同じ問いに 25 箇所が独立して答えている状態で、#308 のバグ（1 箇所だけ答え方が
違っていて、git 管理外だとクリックが握り潰される）はその構造から出たもの。

`ViewerState` が `root: PathBuf` を持ち、根を受け取るのは `load_file_tree` /
`replace_tree` / `set_root` の 3 つだけにした。ファイルを開く・子を遅延読みする・
ツリー上で選び直す・ファイル名検索の候補を集める、の 4 つは root 引数を落として
自分の根を使う。「ツリーの根 == 開く根」が型で保証される。

### 併せて閉じた穴

worktree の切り替えはツリーの走査を裏のスレッドに回すので、**選択は B・表示中の
エントリは A** という瞬間が実在する。以前はこの隙間のクリックが A の相対パスを
B の根に繋いでいた（別ブランチの同名ファイルを黙って開く / 何も出ない）。
根・エントリ・git status を `replace_tree` で 3 つまとめて差し替えることで塞いだ。
未再現・コードの形から見えた穴で、回帰テスト
`tree_root_and_entries_switch_together` で固定した。

同じ理屈で根を Viewer 側に寄せた箇所:

| 箇所 | 揃えた理由 |
|---|---|
| grep 検索の走査範囲 | 結果を選ぶと同じ相対パスで reveal + open するので、別の根を歩くと「ヒットしたのに開けない」結果が並ぶ |
| ターミナル出力のファイルリンク (キー / クリック) | 実在確認と実際に開く先が別の根だと、リンク認識されたのに開くと空になる |
| メディア（画像）の描画パス | タイトルは A のファイル、絵は B のファイル、になり得た |
| リポジトリ切り替え直後 | ツリーは遅延だが根は今決まっているので `set_root` で入れる。空のままだとファイル名検索がカレントディレクトリを歩く |

据え置いたもの: 相対パスは worktree 跨ぎの識別子のまま（レビュー DB の
`reviews_for_file(worktree, file_path)`、diff の repo-relative パス、walkthrough
プロンプトの「never absolute」指定、jump history がすべて相対パスをキーにしている）。
絶対パスは `fs::read` 直前の一時的な計算結果にとどめてある。
`start_symbol_index_build` も `selected_worktree_path()` のまま — 索引は
「これから切り替わる worktree」に向けて張るもので、まだ届いていない Viewer の
根とは意図的に別。

## Test plan

`cargo test` 1003 passed / `cargo clippy --all-targets` clean。
実機検証は pty + pyte で実バイナリを駆動（強制再描画してから画面を読む）。

| シナリオ | 結果 |
|---|---|
| `.git` 無しディレクトリ: クリック / `/` ファイル名検索 | `alpha.txt` → `ALPHA_LINE_ONE`、`charlie.txt` → `CHARLIE_LINE` |
| `git init` 直後（コミット 0 件）: 同上 | 同じく表示される |
| 2 worktree で同名 `shared.txt` を切り替えて開く | `FEATURE_VERSION_OF_SHARED`（main 側の内容は出ない） |
| 2 worktree で grep（`VERSION_OF_SHARED`） | 1 hit のみ = 走査範囲が切り替え先に閉じている |

補足 2 点:

- grep 結果に Enter で開くところまではハーネスで駆動しきれなかった（キー列の
  問題）。**変更前のバイナリ (0.98.2) でも同じ画面**になるので回帰ではない。
- `symbol_index::tests::hover_reference_count_stays_within_a_frame` が時々落ちる。
  `elapsed < 30ms` という実時間アサーションで、単独実行でも 3 回中 1 回落ちた。
  今回の変更とは無関係の既存 flake（前 PR でも観測）。
