### PR TITLE
fix: follow Claude Code session rotation on /clear so scrollback shows the live transcript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,26 @@ release channels and drifted apart.
 Never print to stdout from anything reachable by `mcp-serve`; it would corrupt the
 protocol. Logging goes to stderr (env_logger's default).
 
+### Session hook (`conductor cc-hook`, `src/cc_hook.rs`)
+
+`/clear` rotates Claude Code's log to a **new session id**, and nothing on disk
+links the old file to the new one — so a panel pinned to its spawn-time
+`--session-id` would keep showing the pre-clear transcript forever. The fix is a
+`SessionStart` hook that runs inside the panel's own Claude process and reports
+its current session id back.
+
+- **Who installs it:** `pty_manager/spawn.rs` writes `.conductor/claude-hooks.json`
+  and passes it as `--settings` on every Claude spawn, plus `CONDUCTOR_PANEL_ID`
+  and `CONDUCTOR_NOTIFY_SOCK` in the environment. `--settings` *adds a layer* —
+  the user's own settings and the project's `.claude/settings.json` keep working.
+- **Why the binary and not `plugins/`:** same reason `mcp-serve` lives here — a
+  separately released plugin drifts, and the failure is silent (scrollback just
+  shows stale history). `cargo install --path .` ships the binary and the hook
+  together.
+- **Fallback:** when the hook stays silent (hooks disabled, older CLI),
+  `claude_sessions/rotation.rs` infers the rotation from the logs instead. It is
+  deliberately conservative — see its module docs for what it refuses to guess.
+
 ## Architecture
 
 ### Application Structure
@@ -88,6 +108,8 @@ Status bar
 | `review_store.rs` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
 | `pty_manager.rs` | PTY session management — spawn, read/write, resize; vt100 parser for rendering; output scanner for Claude Code |
 | `file_watcher.rs` | Filesystem change detection via `notify` crate, debounced at 500ms |
+| `cc_notify.rs` / `cc_hook.rs` | Unix-socket channel from Claude Code hooks — waiting/active state, and the `SessionStart` report that keeps a panel's session id correct across `/clear` |
+| `claude_sessions/` | Resolving which `.jsonl` transcript backs a panel (`rotation.rs` is the hook-less fallback for `/clear`) |
 | `config.rs` | Config loading from `~/.config/conductor/config.toml` |
 | `theme.rs` | Color themes (catppuccin-mocha default, dracula, nord, solarized-dark) |
 | `term_caps.rs` | Rich-mode terminal capability detection (truecolor / graphics protocol tiers) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.98.3"
+version = "0.99.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.98.3"
+version = "0.99.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/reflow.rs
+++ b/src/app/reflow.rs
@@ -104,10 +104,12 @@ impl App {
     /// Enter the reflow transcript view for the active Claude panel's session.
     ///
     /// Resolves the log of the session backing the currently displayed Claude
-    /// panel — strictly by its pinned `claude_session_id` — then loads and parses
-    /// that `.jsonl` and activates the overlay. When the id does not resolve to a
-    /// log, or the log holds no displayable turn, a status flash explains why and
-    /// the view stays inactive; no other session's history is ever substituted.
+    /// panel from its pinned `claude_session_id` (following a `/clear`
+    /// rotation, see `claude_sessions::current_session_log`), then loads and
+    /// parses that `.jsonl` and activates the overlay. When the id does not
+    /// resolve to a log, or the log holds no displayable turn, a status flash
+    /// explains why and the view stays inactive; no other session's history is
+    /// ever substituted.
     pub fn open_reflow(&mut self) {
         // The transcript source is the session backing the *currently displayed*
         // Claude panel, identified only by its pinned session id (see
@@ -127,14 +129,27 @@ impl App {
         // session started later in the same worktree passed the test and
         // hijacked the view for as long as the subagent ran.
         //
-        // Consequence worth knowing: a mid-session `/clear` or an in-app
-        // `/resume` rotates Claude Code's live log to a new session id that
-        // Conductor cannot observe, so scrolling up then shows this session's
-        // pre-rotation transcript. Stale-but-own beats fresh-but-someone-else's.
-        let Some((working_dir, session_id)) = self
-            .terminal
-            .active_claude_session
-            .and_then(|idx| self.terminal.pty_manager.claude_session_ref(idx))
+        // 例外は `/clear` によるログのローテーションだけ。`/clear` は書き込み先
+        // を新しい session id の `.jsonl` に移すので、pin した id を据え置くと
+        // clear 前の会話を出したまま clear 後が一切出なくなる。
+        //
+        // pin は `SessionStart` フック (`cc_hook`) が更新する。フックはパネル
+        // 自身の Claude プロセスの中で走るので、これは推測ではなく事実 — 同一
+        // ワークツリーで複数パネルが同時に `/clear` しても取り違えない。
+        // フックが沈黙した環境ではここから `claude_sessions::rotation` の
+        // 推測にフォールバックするが、そちらも「先頭が `/clear` コマンドで、
+        // 前セッションの最終書き込み以降に始まり、他パネルが pin していない」
+        // ログしか後続と認めない。新規に起動しただけの `claude` はこの形に
+        // ならないので、上に書いた乗っ取りは起きない。
+        let Some(idx) = self.terminal.active_claude_session else {
+            self.set_status(
+                "No Claude session for this panel; transcript unavailable".to_string(),
+                StatusLevel::Warning,
+            );
+            return;
+        };
+        let Some((working_dir, session_id, spawned_at)) =
+            self.terminal.pty_manager.claude_session_ref(idx)
         else {
             self.set_status(
                 "No Claude session for this panel; transcript unavailable".to_string(),
@@ -142,9 +157,14 @@ impl App {
             );
             return;
         };
+        let claimed = self.terminal.pty_manager.other_claude_session_ids(idx);
 
-        let Some(path) = crate::claude_sessions::session_jsonl_path(&working_dir, &session_id)
-        else {
+        let Some(path) = crate::claude_sessions::current_session_log(
+            &working_dir,
+            &session_id,
+            spawned_at,
+            &claimed,
+        ) else {
             self.set_status(
                 format!("No session log on disk for {session_id}"),
                 StatusLevel::Warning,

--- a/src/app/terminal_cc_state.rs
+++ b/src/app/terminal_cc_state.rs
@@ -13,10 +13,34 @@ use super::*;
 impl App {
     // ── Claude Code input-waiting detection ────────────────────────────
 
-    /// Handle a single CC state notification received via the Unix socket.
+    /// Handle a single CC notification received via the Unix socket.
     pub fn handle_cc_notify(&mut self, event: crate::cc_notify::CcNotifyEvent) {
+        let (kind, cwd) = match event {
+            crate::cc_notify::CcNotifyEvent::State { kind, cwd } => (kind, cwd),
+            // `/clear` や `/resume` でこのパネルのログが別 id に移った。
+            // スクロールバックが読むファイルを差し替えるだけで、waiting/active
+            // の状態には関係しない。
+            crate::cc_notify::CcNotifyEvent::SessionRotated {
+                panel_id,
+                session_id,
+            } => {
+                if self
+                    .terminal
+                    .pty_manager
+                    .set_claude_session_id(&panel_id, session_id)
+                {
+                    // 開きっぱなしのトランスクリプトは古いログを指したままなので
+                    // 畳む。次に開いたときに新しいログから読み直される。
+                    if self.reflow.active {
+                        self.close_reflow();
+                    }
+                }
+                return;
+            }
+        };
+
         // Normalize the cwd and match against known worktrees.
-        let event_normalized: PathBuf = event.cwd.components().collect();
+        let event_normalized: PathBuf = cwd.components().collect();
         let wt_path = self
             .worktrees
             .iter()
@@ -40,7 +64,7 @@ impl App {
             return;
         }
 
-        match event.kind {
+        match kind {
             crate::cc_notify::CcNotifyKind::Waiting => {
                 self.terminal.cc_active_worktrees.remove(&wt_path);
 

--- a/src/cc_hook.rs
+++ b/src/cc_hook.rs
@@ -1,0 +1,102 @@
+//! `conductor cc-hook` — Claude Code の `SessionStart` フック本体。
+//!
+//! Conductor が spawn した Claude パネルには `--settings` で次のフックが
+//! 差し込まれる (`pty_manager::spawn`)。フックはそのパネル自身の Claude
+//! プロセスの子として走るので、spawn 時に PTY へ注入した環境変数
+//! (`CONDUCTOR_PANEL_ID` / `CONDUCTOR_NOTIFY_SOCK`) がそのまま見える。
+//!
+//! やることは 1 つだけ: stdin に来た JSON から `session_id` を取り出し、
+//! `session <panel id> <session id>` を cc-notify ソケットへ書いて終わる。
+//! これで「どのパネルがいまどの `.jsonl` を書いているか」が、ログの中身から
+//! 推測するのではなく事実として Conductor に届く。`/clear` は新しい session id
+//! へログをローテーションするが、旧ログにも新ログにも相互参照が残らないため、
+//! この経路が無いと推測に頼るしかない (`claude_sessions::rotation` がその
+//! フォールバック)。
+//!
+//! シェルスクリプトにも `jq` にも依存しないのは、バイナリと signal を同じ
+//! 成果物に載せるため。プラグイン側に置くと別リリースチャネルになり、
+//! バージョンがずれた組み合わせで黙って効かなくなる (MCP サーバをバイナリへ
+//! 取り込んだのと同じ理由 — CLAUDE.md 参照)。
+//!
+//! stdout には何も書かない。`SessionStart` フックの stdout はセッションへの
+//! 追加コンテキストとして扱われるため。失敗しても Claude 側の起動は妨げない
+//! ように、常に成功で返す。
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+
+/// 環境変数名。spawn 側と合わせる。
+pub const PANEL_ID_ENV: &str = "CONDUCTOR_PANEL_ID";
+pub const NOTIFY_SOCK_ENV: &str = "CONDUCTOR_NOTIFY_SOCK";
+
+/// stdin のフック payload を読み、パネルの現在の session id を Conductor へ通知する。
+///
+/// 常に `Ok(())`。Conductor が動いていない (ソケットが無い)、payload が壊れて
+/// いる、環境変数が無い、のいずれもフックとしては正常系 — Claude の起動を
+/// 止める理由にはならない。
+pub fn run() -> anyhow::Result<()> {
+    let mut payload = String::new();
+    if std::io::stdin().read_to_string(&mut payload).is_err() {
+        return Ok(());
+    }
+
+    let (Ok(panel_id), Ok(sock_path)) =
+        (std::env::var(PANEL_ID_ENV), std::env::var(NOTIFY_SOCK_ENV))
+    else {
+        // Conductor 経由で起動されていない Claude。通知先が無いので何もしない。
+        return Ok(());
+    };
+
+    let Some(session_id) = session_id_from_payload(&payload) else {
+        log::warn!("cc-hook: no session_id in hook payload");
+        return Ok(());
+    };
+
+    // source は見ない。startup/resume/clear のどれであれ「このパネルはいま
+    // この session を書いている」という同じ事実を運ぶので、区別する意味がない。
+    // startup では spawn 時に pin した id と同じ値が返るだけで、冪等。
+    //
+    // 1 回の `write` で送りきる。`write!`/`writeln!` はフォーマットの断片ごとに
+    // `write` を呼ぶので、受け手が 1 回の `read` で拾うと "session" だけ届く
+    // ことがある (実際にそうなった)。既存のシェル側フックが `echo | nc` で
+    // 1 回書き込みだったため、この経路まで表面化していなかった。
+    let line = format!("session {panel_id} {session_id}\n");
+    if let Ok(mut stream) = UnixStream::connect(&sock_path) {
+        let _ = stream.write_all(line.as_bytes());
+        let _ = stream.flush();
+    }
+    Ok(())
+}
+
+/// フック payload の `session_id`。
+fn session_id_from_payload(payload: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let id = value.get("session_id")?.as_str()?.trim();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_session_id() {
+        // 実測した SessionStart (source=clear) の payload 形。
+        let raw = r#"{"hook_event_name":"SessionStart","source":"clear",
+            "session_id":"6c235e9c-6872-4ffc-a765-813a96c4e471",
+            "cwd":"/tmp/wt","transcript_path":"/tmp/x.jsonl"}"#;
+        assert_eq!(
+            session_id_from_payload(raw).as_deref(),
+            Some("6c235e9c-6872-4ffc-a765-813a96c4e471")
+        );
+    }
+
+    #[test]
+    fn tolerates_unusable_payloads() {
+        // 壊れた JSON / 欠けたキー / 空文字。どれもフックを失敗させない。
+        assert!(session_id_from_payload("not json").is_none());
+        assert!(session_id_from_payload(r#"{"source":"clear"}"#).is_none());
+        assert!(session_id_from_payload(r#"{"session_id":""}"#).is_none());
+        assert!(session_id_from_payload(r#"{"session_id":42}"#).is_none());
+    }
+}

--- a/src/cc_notify.rs
+++ b/src/cc_notify.rs
@@ -1,6 +1,16 @@
 //! Claude Code の状態通知を受ける Unix ドメインソケットのリスナ。
 //!
-//! フック側がソケット経由で `"active <cwd>\n"` または `"waiting <cwd>\n"` を送る。
+//! フック側がソケット経由で次のいずれかを送る:
+//!
+//!   active <cwd>
+//!   waiting <cwd>
+//!   session <panel id> <claude session id>
+//!
+//! 前の 2 つは waiting/active 表示用。3 つ目は `SessionStart` フック
+//! ([`crate::cc_hook`]) が送る「このパネルが書き込んでいる Claude セッションが
+//! 変わった」通知で、`/clear` や `/resume` によるログのローテーションを
+//! 推測ではなく事実として受け取るためのもの。
+//!
 //! バックグラウンドスレッドが接続を受け付け、パースしたイベントを `mpsc`
 //! チャネルでメインループへ転送する。
 
@@ -12,6 +22,10 @@ use std::sync::{Arc, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+/// 1 接続から読み取るメッセージの上限。行儀の悪いクライアントに
+/// メモリを食わせないための歯止め。
+const MAX_MESSAGE_BYTES: usize = 8 * 1024;
+
 /// Claude Code の状態変化の種類。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CcNotifyKind {
@@ -21,9 +35,20 @@ pub enum CcNotifyKind {
 
 /// フックから受け取った通知イベント 1 件。
 #[derive(Debug)]
-pub struct CcNotifyEvent {
-    pub kind: CcNotifyKind,
-    pub cwd: PathBuf,
+pub enum CcNotifyEvent {
+    /// ワークツリーの waiting/active 状態が変わった。
+    State { kind: CcNotifyKind, cwd: PathBuf },
+    /// このパネルが書き込んでいる Claude セッションの id が変わった。
+    ///
+    /// `panel_id` は spawn 時に `CONDUCTOR_PANEL_ID` として PTY に注入した
+    /// [`crate::pty_manager::PtySession::id`]。フックはそのパネル自身の
+    /// Claude プロセスの中で走るので、パネルと session id の対応は推測ではなく
+    /// 同一性として得られる — 同一ワークツリーで複数パネルが同時に `/clear`
+    /// しても取り違えない。
+    SessionRotated {
+        panel_id: String,
+        session_id: String,
+    },
 }
 
 /// Claude Code の状態通知を Unix ドメインソケットで待ち受ける。
@@ -34,17 +59,29 @@ pub struct CcNotifyListener {
     thread: Option<JoinHandle<()>>,
 }
 
+/// このリポジトリの cc-notify ソケットのパス。
+///
+/// bind 側 ([`CcNotifyListener::new`]) と、フックへ渡す側
+/// ([`crate::pty_manager`]) の両方がここを使う。片方だけ変わって行き違うことが
+/// 無いように定義は 1 箇所に置く。ワークツリーではなくメインワークツリーの
+/// `.conductor/` に置くのは、1 リポジトリにつきリスナが 1 つだからで、
+/// 同じ理由でフック側も同じ解決をしなければならない。
+pub fn socket_path(repo_path: &Path) -> PathBuf {
+    crate::git_engine::GitEngine::open(repo_path)
+        .and_then(|e| e.main_worktree_path())
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+        .join(".conductor")
+        .join("cc-notify.sock")
+}
+
 impl CcNotifyListener {
     /// 指定したリポジトリルート配下の `.conductor/cc-notify.sock` に bind した
     /// リスナを作る。
     pub fn new(repo_path: &Path) -> anyhow::Result<Self> {
-        let conductor_dir = crate::git_engine::GitEngine::open(repo_path)
-            .and_then(|e| e.main_worktree_path())
-            .unwrap_or_else(|_| repo_path.to_path_buf())
-            .join(".conductor");
-        std::fs::create_dir_all(&conductor_dir)?;
-
-        let socket_path = conductor_dir.join("cc-notify.sock");
+        let socket_path = socket_path(repo_path);
+        if let Some(dir) = socket_path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
 
         // 前回のクラッシュで残ったソケットを処理する。
         if socket_path.exists() {
@@ -104,12 +141,20 @@ impl CcNotifyListener {
             // 行儀の悪いクライアントでブロックしないよう、読み取りタイムアウトは短く。
             let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
 
-            let mut buf = [0u8; 1024];
-            let n = match stream.read(&mut buf) {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            let msg = String::from_utf8_lossy(&buf[..n]);
+            // 相手が閉じるまで読む。1 回の `read` で足りるとは限らない —
+            // 送り手が複数回 `write` すると (フォーマット済み文字列を書く場合に
+            // 起きる) 先頭だけ拾って残りを捨ててしまう。
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 1024];
+            while buf.len() < MAX_MESSAGE_BYTES {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    // 読み取りタイムアウト等。ここまでに届いた分で解釈を試みる。
+                    Err(_) => break,
+                }
+            }
+            let msg = String::from_utf8_lossy(&buf);
             let msg = msg.trim();
             if msg.is_empty() {
                 continue;
@@ -127,14 +172,30 @@ impl CcNotifyListener {
     }
 
     fn parse_message(msg: &str) -> Option<CcNotifyEvent> {
-        let (kind_str, cwd_str) = msg.split_once(' ')?;
-        let kind = match kind_str {
-            "active" => CcNotifyKind::Active,
-            "waiting" => CcNotifyKind::Waiting,
-            _ => return None,
-        };
-        let cwd = PathBuf::from(cwd_str);
-        Some(CcNotifyEvent { kind, cwd })
+        let (verb, rest) = msg.split_once(' ')?;
+        match verb {
+            "active" => Some(CcNotifyEvent::State {
+                kind: CcNotifyKind::Active,
+                cwd: PathBuf::from(rest),
+            }),
+            "waiting" => Some(CcNotifyEvent::State {
+                kind: CcNotifyKind::Waiting,
+                cwd: PathBuf::from(rest),
+            }),
+            // どちらの id も UUID なので空白区切りで曖昧さは無い。
+            "session" => {
+                let (panel_id, session_id) = rest.split_once(' ')?;
+                let (panel_id, session_id) = (panel_id.trim(), session_id.trim());
+                if panel_id.is_empty() || session_id.is_empty() {
+                    return None;
+                }
+                Some(CcNotifyEvent::SessionRotated {
+                    panel_id: panel_id.to_string(),
+                    session_id: session_id.to_string(),
+                })
+            }
+            _ => None,
+        }
     }
 }
 
@@ -147,5 +208,54 @@ impl Drop for CcNotifyListener {
             let _ = thread.join();
         }
         let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_state_messages() {
+        let CcNotifyEvent::State { kind, cwd } =
+            CcNotifyListener::parse_message("waiting /tmp/wt").expect("parsed")
+        else {
+            panic!("expected a state event");
+        };
+        assert_eq!(kind, CcNotifyKind::Waiting);
+        assert_eq!(cwd, PathBuf::from("/tmp/wt"));
+    }
+
+    #[test]
+    fn parses_session_rotation() {
+        let CcNotifyEvent::SessionRotated {
+            panel_id,
+            session_id,
+        } = CcNotifyListener::parse_message("session panel-1 sess-2").expect("parsed")
+        else {
+            panic!("expected a rotation event");
+        };
+        assert_eq!(panel_id, "panel-1");
+        assert_eq!(session_id, "sess-2");
+    }
+
+    #[test]
+    fn rejects_malformed_messages() {
+        // 動詞だけ / id 片方だけ / 未知の動詞は捨てる。
+        assert!(CcNotifyListener::parse_message("session").is_none());
+        assert!(CcNotifyListener::parse_message("session only-one-id").is_none());
+        assert!(CcNotifyListener::parse_message("session  sess").is_none());
+        assert!(CcNotifyListener::parse_message("bogus /tmp/wt").is_none());
+    }
+
+    #[test]
+    fn cwd_with_spaces_survives() {
+        // パスは行末まで丸ごと。空白を含むワークツリー名でも壊れない。
+        let CcNotifyEvent::State { cwd, .. } =
+            CcNotifyListener::parse_message("active /tmp/my worktree").expect("parsed")
+        else {
+            panic!("expected a state event");
+        };
+        assert_eq!(cwd, PathBuf::from("/tmp/my worktree"));
     }
 }

--- a/src/claude_sessions/discovery.rs
+++ b/src/claude_sessions/discovery.rs
@@ -198,4 +198,6 @@ pub fn find_latest_sessions_for_paths(
 // here. The reflow transcript view used to select its source that way and it
 // leaked other sessions' conversations into the view (see `App::open_reflow`);
 // a transcript is resolved from the panel's own session id via
-// `session_jsonl_path` instead.
+// `current_session_log` instead. That function does read the directory, but
+// only to follow a `/clear` rotation, and only across logs that begin with the
+// `/clear` record itself — see `super::rotation`.

--- a/src/claude_sessions/mod.rs
+++ b/src/claude_sessions/mod.rs
@@ -7,12 +7,15 @@
 //! Shared data types and path helpers live here; session listing is in
 //! [`discovery`] and grab/ungrab session symlinking is in [`migrate`].
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use serde::Deserialize;
 
 mod discovery;
 mod migrate;
+mod rotation;
 #[cfg(test)]
 mod tests;
 
@@ -71,28 +74,53 @@ fn session_file_exists(session_id: &str, project: &str) -> bool {
     }
 }
 
-/// Return the `.jsonl` path for the given working directory and session ID.
+/// パネルがいま書き込んでいるセッションログのパス。
 ///
-/// The session id is the only key: one project directory holds the logs of
-/// *every* session ever run in that directory, so resolution must never widen to
-/// a directory-level criterion (see [`session_log_in_dir`]). Returns `None` when
-/// the home directory is unavailable or that session has no log on disk.
+/// 起点は `pinned_session_id` — 起動時に `--session-id` で決め打ちした、この
+/// パネル自身の id。1 つのプロジェクトディレクトリにはそのワークツリーで走った
+/// 全セッションのログが同居するので、解決をディレクトリ単位の条件 (最新の
+/// ログ、など) に広げてはならない。それをやると別の会話を表示する
+/// ([`session_log_in_dir`] 参照)。
 ///
-/// The working dir is canonicalized first because Claude Code encodes its
-/// *resolved* cwd; a symlinked worktree path would otherwise miss the directory.
-/// The raw path is tried as a second encoding so a worktree that no longer
-/// resolves (deleted, unmounted) still finds its log — both attempts look up the
-/// same session id, so this widens only *where* the log is looked for, never
-/// *which* session is shown.
-pub fn session_jsonl_path(working_dir: &Path, session_id: &str) -> Option<PathBuf> {
+/// 唯一の例外が `/clear` によるローテーション。`/clear` は Claude Code の
+/// 書き込み先を別 id の `.jsonl` に移すので、pin した id だけを見ていると
+/// clear 前の会話で止まる。後続と認める条件は [`rotation`] にあり、いずれも
+/// 「このパネルのログの続き」であることを担保するもの。
+///
+/// * `spawned_at` — このパネルの Claude プロセスを起動した時刻。
+/// * `claimed` — 他の Claude パネルが pin している session id。
+///
+/// working dir を先に canonicalize するのは、Claude Code が *解決後* の cwd を
+/// エンコードしてディレクトリ名にするため。シンボリックリンク越しのワークツリー
+/// パスではディレクトリを取り違える。生のパスも 2 番目の候補として試すので、
+/// 解決できなくなったワークツリー (削除・アンマウント) でもログを見つけられる。
+/// どちらも同じ session id を引くので、広がるのは「どこを探すか」だけで
+/// 「どのセッションを見せるか」ではない。
+///
+/// 後続が無ければ pin した id のログを返す。pin した id にログが無ければ
+/// `None`。
+pub fn current_session_log(
+    working_dir: &Path,
+    pinned_session_id: &str,
+    spawned_at: SystemTime,
+    claimed: &HashSet<String>,
+) -> Option<PathBuf> {
     let canonical =
         std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
     for dir in [canonical.as_path(), working_dir] {
-        if let Some(project_dir) = projects_dir_for(dir)
-            && let Some(path) = session_log_in_dir(&project_dir, session_id)
-        {
-            return Some(path);
-        }
+        let Some(project_dir) = projects_dir_for(dir) else {
+            continue;
+        };
+        let Some(pinned_path) = session_log_in_dir(&project_dir, pinned_session_id) else {
+            continue;
+        };
+        let current = rotation::resolve_current_session_id(
+            &project_dir,
+            pinned_session_id,
+            spawned_at,
+            claimed,
+        );
+        return session_log_in_dir(&project_dir, &current).or(Some(pinned_path));
     }
     None
 }

--- a/src/claude_sessions/rotation.rs
+++ b/src/claude_sessions/rotation.rs
@@ -1,0 +1,222 @@
+//! `/clear` によるセッションローテーションの追跡 — フォールバック経路。
+//!
+//! 正規の経路は `SessionStart` フック ([`crate::cc_hook`])。フックはパネル自身の
+//! Claude プロセスの中で走り、新しい session id を持って来るので、対応は推測では
+//! なく事実として決まる。このモジュールが使われるのはフックが沈黙したときだけ:
+//! ユーザ設定でフックを無効にしている、`claude` が古くて `--settings` や
+//! `SessionStart` を解さない、settings を書けなかった、など。
+//!
+//! Claude Code の `/clear` は会話を捨てるだけでなく、ログの書き込み先を新しい
+//! session id の `.jsonl` に切り替える。新ファイルの先頭には `/clear` の
+//! コマンドレコードが書かれ、以降の会話はすべてそちらに入る。旧ファイルには
+//! 一切追記されず (実測で確認済み: clear 後は mtime が 1 ミリ秒も動かない)、
+//! 両者を結ぶ id の相互参照もログに残らない。
+//!
+//! Conductor は起動時に `--session-id` で決め打ちした id を pin しているので、
+//! そのままではローテーション後もずっと旧ファイルを読むことになる。ここでは
+//! pin した id から「その続き」に当たるログへ連鎖を辿って、いま書かれている
+//! ログの id を求める。フックが届いていれば pin 自体が更新済みなので、この
+//! 連鎖は普通そのまま起点で止まる。
+//!
+//! ディレクトリ単位の推測に戻したわけではない点に注意。1 つの Claude
+//! プロジェクトディレクトリにはそのワークツリーで走った全セッションのログが
+//! 同居するので、「最新のログ」「後から始まったログ」といった条件では別の会話
+//! を掴む。後続と認めるのは次を全部満たすログだけ:
+//!
+//!   1. 先頭の表示対象ユーザレコードが `/clear` コマンドである
+//!      (新規に起動しただけの `claude` はこの形にならない)
+//!   2. 開始時刻が前セッションの最終書き込み以降である
+//!   3. 他の Claude パネルが pin している id ではない
+//!
+//! それでも曖昧さが残るのは、同一ワークツリーで複数の Claude パネルを開き、
+//! その複数が `/clear` した場合だけ。そのときは開始時刻が前セッションの
+//! 最終書き込みに最も近いものを採る。
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use super::session_log_in_dir;
+
+/// 前セッションの mtime に持たせる許容幅。
+///
+/// `/clear` の直前直後でどちらのファイルが先に書かれるかはミリ秒単位の話に
+/// なるので、比較を厳密にすると取りこぼす。逆方向 (別セッションを誤って掴む)
+/// のリスクはこの幅では実質増えない。
+const MTIME_SLACK: Duration = Duration::from_secs(2);
+
+/// 後続と認める、前セッションの最終書き込みからの間隔の上限。
+///
+/// ログだけを見ても「自分のセッションが `/clear` した」のと「同じワークツリー
+/// で別の `claude` が起動して `/clear` した」のは区別できない。両者を分ける
+/// 手がかりは間隔しかないので、そこで線を引く。
+///
+/// 実測 (手元の全プロジェクトのログ、`/clear` 始まりのログと直前のログの間隔)
+/// では中央値が約 7 分、最短のものは 0〜9 秒。`/clear` は直前のターンが終わった
+/// 直後に打たれるのが普通で、時間単位で離れているものは別の日に開いた別の実行
+/// であることが多い。
+///
+/// これを超えたら連鎖を打ち切り、自分の clear 前のログを見せる。つまり
+/// 「前のターンから 30 分以上空けてから `/clear` した」場合はこのバグの
+/// 修正が効かず、以前と同じく clear 前が表示される。それでも、他人の会話を
+/// 表示するよりは古い自分のものを見せる方がまし
+/// (`App::open_reflow` に書いてある方針と同じ)。
+const MAX_CLEAR_GAP: Duration = Duration::from_secs(1800);
+
+/// ログの先頭から読み取る行数の上限。
+///
+/// `/clear` で始まるログではコマンドレコードは先頭数行に必ず入る
+/// (`mode` / `file-history-snapshot` / caveat の後)。ここに無ければ
+/// `/clear` 始まりではない。
+const HEAD_LINES: usize = 64;
+
+/// 連鎖を辿る回数の上限。壊れたログで無限ループしないための保険。
+const MAX_HOPS: usize = 64;
+
+/// pin した `pinned` から `/clear` の連鎖を辿り、いま書き込まれているログの
+/// session id を返す。
+///
+/// * `project_dir` — 解決済みの Claude プロジェクトディレクトリ。
+/// * `not_before` — このパネルの Claude プロセスを起動した時刻。古いセッションを
+///   `--resume` した直後などに、起動より前から存在する `/clear` 始まりのログを
+///   後続と誤認しないための下限。
+/// * `claimed` — 他の Claude パネルが pin している session id。
+///
+/// 後続が見つからなければ `pinned` をそのまま返す。
+pub fn resolve_current_session_id(
+    project_dir: &Path,
+    pinned: &str,
+    not_before: SystemTime,
+    claimed: &HashSet<String>,
+) -> String {
+    let mut current = pinned.to_string();
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(current.clone());
+
+    for _ in 0..MAX_HOPS {
+        let Some(current_path) = session_log_in_dir(project_dir, &current) else {
+            break;
+        };
+        // 下限は「前セッションの最終書き込み」。ただし起動時刻より前には
+        // 遡らせない (resume 直後で mtime が何日も前のことがある)。
+        let lower = last_write(&current_path)
+            .and_then(|m| m.checked_sub(MTIME_SLACK))
+            .map_or(not_before, |m| m.max(not_before));
+
+        let Some(next) = next_cleared_log(project_dir, lower, &visited, claimed) else {
+            break;
+        };
+        visited.insert(next.clone());
+        current = next;
+    }
+    current
+}
+
+/// `lower` 以降に始まった `/clear` 始まりのログのうち、開始が最も早いものの
+/// session id。
+///
+/// `lower` から [`MAX_CLEAR_GAP`] 以内に始まった `/clear` 始まりのログのうち、
+/// 開始が最も早いものの session id。
+fn next_cleared_log(
+    project_dir: &Path,
+    lower: SystemTime,
+    visited: &HashSet<String>,
+    claimed: &HashSet<String>,
+) -> Option<String> {
+    let upper = lower.checked_add(MAX_CLEAR_GAP)?;
+    let mut best: Option<(SystemTime, String)> = None;
+
+    for entry in std::fs::read_dir(project_dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(id) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if visited.contains(id) || claimed.contains(id) {
+            continue;
+        }
+        let Some(started) = cleared_log_start(&path) else {
+            continue;
+        };
+        if started < lower || started > upper {
+            continue;
+        }
+        if best.as_ref().is_none_or(|(best_ts, _)| started < *best_ts) {
+            best = Some((started, id.to_string()));
+        }
+    }
+
+    best.map(|(_, id)| id)
+}
+
+/// ログが `/clear` で始まっているときだけ、その開始時刻を返す。
+///
+/// 判定は「最初の表示対象ユーザレコードが `/clear` コマンドかどうか」。
+/// caveat のような `isMeta` レコードや、`mode` などの会話でないレコードは
+/// 読み飛ばす。会話のある通常のセッションは最初のユーザレコードが人間の
+/// プロンプトなので、ここで弾かれる。
+fn cleared_log_start(path: &Path) -> Option<SystemTime> {
+    use std::io::BufRead;
+
+    let file = std::fs::File::open(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut first_ts: Option<SystemTime> = None;
+
+    for line in reader.lines().take(HEAD_LINES) {
+        let Ok(line) = line else { break };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        if first_ts.is_none() {
+            first_ts = record
+                .get("timestamp")
+                .and_then(|t| t.as_str())
+                .and_then(parse_timestamp);
+        }
+
+        if record.get("type").and_then(|t| t.as_str()) != Some("user") {
+            continue;
+        }
+        if record.get("isMeta").and_then(|m| m.as_bool()) == Some(true) {
+            continue;
+        }
+
+        // 最初の表示対象ユーザレコード。これが `/clear` でなければ、この
+        // ログは別の会話の始まりであってローテーション先ではない。
+        let content = record
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or_default();
+        if !content.trim_start().starts_with("<command-name>/clear<") {
+            return None;
+        }
+        return first_ts.or_else(|| {
+            record
+                .get("timestamp")
+                .and_then(|t| t.as_str())
+                .and_then(parse_timestamp)
+        });
+    }
+    None
+}
+
+/// ログへの最終書き込み時刻 (ファイルの mtime)。
+fn last_write(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+/// ログ中の RFC3339 タイムスタンプを `SystemTime` に変換する。
+fn parse_timestamp(raw: &str) -> Option<SystemTime> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|dt| SystemTime::from(dt.with_timezone(&chrono::Utc)))
+}

--- a/src/claude_sessions/tests.rs
+++ b/src/claude_sessions/tests.rs
@@ -6,11 +6,13 @@
 //! logs sharing the directory (count, mtime, first/last turn time) can change
 //! which one is picked.
 
+use std::collections::HashSet;
 use std::fs::{File, FileTimes};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use super::rotation::resolve_current_session_id;
 use super::session_log_in_dir;
 use crate::claude_log::{DisplayBlock, load_session};
 
@@ -106,6 +108,250 @@ fn unknown_session_id_resolves_to_nothing() {
 fn empty_project_dir_resolves_to_nothing() {
     let dir = tempfile::tempdir().expect("tmp dir");
     assert!(session_log_in_dir(dir.path(), "aaa").is_none());
+}
+
+// ── `/clear` によるログのローテーション追跡 ──────────────────────────────
+//
+// `/clear` は Claude Code の書き込み先を新しい session id の `.jsonl` に移す。
+// 新ファイルの先頭に `/clear` のコマンドレコードが入り、以降の会話はすべて
+// そちらへ行く。旧ファイルには追記されないし、両者を結ぶ id もログに残らない。
+// pin した id だけを見ていると clear 前で止まる、というのがここで防ぐバグ。
+
+/// `age` 前を `SystemTime` で返す。
+fn ago(age: Duration) -> SystemTime {
+    SystemTime::now() - age
+}
+
+/// `SystemTime` をログ中のタイムスタンプ形式 (RFC3339) にする。
+fn rfc3339(t: SystemTime) -> String {
+    chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339()
+}
+
+/// タイムスタンプ付きの通常セッションログを書き、mtime を `last_write` に合わせる。
+fn write_plain_log(dir: &Path, session_id: &str, start: SystemTime, turns: &[&str]) -> PathBuf {
+    write_records(dir, session_id, start, &[], turns)
+}
+
+/// `/clear` で始まるセッションログ (ローテーション先) を書く。
+///
+/// 実物と同じ並び: `mode` → caveat (`isMeta`) → `/clear` コマンド → 会話。
+fn write_cleared_log(dir: &Path, session_id: &str, start: SystemTime, turns: &[&str]) -> PathBuf {
+    let ts = rfc3339(start);
+    let head = [
+        format!(r#"{{"type":"mode","mode":"normal","sessionId":"{session_id}"}}"#),
+        format!(
+            r#"{{"type":"user","isMeta":true,"timestamp":"{ts}","sessionId":"{session_id}","message":{{"role":"user","content":"<local-command-caveat>Caveat</local-command-caveat>"}}}}"#
+        ),
+        format!(
+            r#"{{"type":"user","timestamp":"{ts}","sessionId":"{session_id}","message":{{"role":"user","content":"<command-name>/clear</command-name>\n<command-args></command-args>"}}}}"#
+        ),
+    ];
+    write_records(dir, session_id, start, &head, turns)
+}
+
+/// `head` をそのまま出力したあと、`turns` を user レコードとして書く。
+/// mtime は最後のターンの時刻 (ターンが無ければ `start`) に合わせる。
+fn write_records(
+    dir: &Path,
+    session_id: &str,
+    start: SystemTime,
+    head: &[String],
+    turns: &[&str],
+) -> PathBuf {
+    let path = dir.join(format!("{session_id}.jsonl"));
+    let mut f = File::create(&path).expect("create log");
+    for line in head {
+        writeln!(f, "{line}").expect("write head");
+    }
+    let mut last = start;
+    for (i, turn) in turns.iter().enumerate() {
+        last = start + Duration::from_secs(i as u64 + 1);
+        let ts = rfc3339(last);
+        writeln!(
+            f,
+            r#"{{"type":"user","timestamp":"{ts}","sessionId":"{session_id}","message":{{"role":"user","content":"{turn}"}}}}"#
+        )
+        .expect("write turn");
+    }
+    f.set_times(FileTimes::new().set_modified(last))
+        .expect("set mtime");
+    path
+}
+
+/// 他パネルの pin が無い前提での解決。
+fn resolve(dir: &Path, pinned: &str, spawned_at: SystemTime) -> String {
+    resolve_current_session_id(dir, pinned, spawned_at, &HashSet::new())
+}
+
+#[test]
+fn clear_rotation_is_followed() {
+    // clear 前の会話で止まらず、clear 後に書かれたログへ移ること。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(600));
+    write_plain_log(dir.path(), "before", spawned, &["clear 前のプロンプト"]);
+    write_cleared_log(
+        dir.path(),
+        "after",
+        ago(Duration::from_secs(540)),
+        &["clear 後のプロンプト"],
+    );
+
+    assert_eq!(resolve(dir.path(), "before", spawned), "after");
+}
+
+#[test]
+fn repeated_clears_chain_to_the_newest_log() {
+    // `/clear` を複数回。連鎖の末端 (いま書かれているログ) まで辿ること。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(900));
+    write_plain_log(dir.path(), "first", spawned, &["最初"]);
+    write_cleared_log(dir.path(), "second", ago(Duration::from_secs(600)), &["次"]);
+    write_cleared_log(
+        dir.path(),
+        "third",
+        ago(Duration::from_secs(300)),
+        &["最後"],
+    );
+
+    assert_eq!(resolve(dir.path(), "first", spawned), "third");
+}
+
+#[test]
+fn clear_with_no_output_yet_still_resolves() {
+    // clear 直後、まだ 1 ターンも書かれていない状態。ローテーション先は
+    // `/clear` レコードだけを持つが、それでもそちらへ移ること
+    // (clear 前の会話を見せてはいけない)。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(60));
+    write_plain_log(dir.path(), "before", spawned, &["clear 前のプロンプト"]);
+    write_cleared_log(dir.path(), "after", ago(Duration::from_secs(5)), &[]);
+
+    assert_eq!(resolve(dir.path(), "before", spawned), "after");
+}
+
+#[test]
+fn fresh_sibling_session_does_not_hijack() {
+    // 回帰: 同じワークツリーで後から起動しただけの別セッション。`/clear` で
+    // 始まっていないので後続ではない。以前はこれを続きとみなして他人の会話を
+    // 表示していた (`idle_session_is_not_displaced_by_a_newer_sibling` 参照)。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(3600));
+    write_plain_log(dir.path(), "mine", spawned, &["自分のプロンプト"]);
+    write_plain_log(
+        dir.path(),
+        "someone-else",
+        ago(Duration::from_secs(60)),
+        &["別パネルのプロンプト"],
+    );
+
+    assert_eq!(resolve(dir.path(), "mine", spawned), "mine");
+}
+
+#[test]
+fn log_pinned_by_another_panel_is_not_followed() {
+    // 別パネルが自分のログとして pin している id は後続候補から外す
+    // (そのパネルが `--resume` で clear 済みセッションを開いている場合)。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(600));
+    write_plain_log(dir.path(), "mine", spawned, &["自分のプロンプト"]);
+    write_cleared_log(
+        dir.path(),
+        "other-panel",
+        ago(Duration::from_secs(540)),
+        &["別パネルのプロンプト"],
+    );
+
+    let claimed = HashSet::from(["other-panel".to_string()]);
+    assert_eq!(
+        resolve_current_session_id(dir.path(), "mine", spawned, &claimed),
+        "mine"
+    );
+}
+
+#[test]
+fn clear_predating_the_spawn_is_not_followed() {
+    // 古いセッションを `--resume` した直後は pin したログの mtime が何日も前に
+    // なりうる。起動より前に始まっていた `/clear` 始まりのログは自分の続きでは
+    // ないので辿らない。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    write_plain_log(
+        dir.path(),
+        "resumed",
+        ago(Duration::from_secs(86400 * 3)),
+        &["3 日前のプロンプト"],
+    );
+    write_cleared_log(
+        dir.path(),
+        "unrelated",
+        ago(Duration::from_secs(86400 * 2)),
+        &["無関係な会話"],
+    );
+
+    let spawned = ago(Duration::from_secs(60));
+    assert_eq!(resolve(dir.path(), "resumed", spawned), "resumed");
+}
+
+#[test]
+fn clear_long_after_the_last_turn_is_not_followed() {
+    // 前のターンから何時間も空いて始まった `/clear` 始まりのログは、自分の
+    // 続きなのか、同じワークツリーで別に起動した `claude` なのかログからは
+    // 区別できない。推測せず自分のログに留まる (この場合はこのバグの修正が
+    // 効かず、clear 前が表示される — 他人の会話を出すよりはまし、という判断)。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(86400));
+    write_plain_log(dir.path(), "mine", spawned, &["自分のプロンプト"]);
+    write_cleared_log(
+        dir.path(),
+        "much-later",
+        ago(Duration::from_secs(7200)),
+        &["別の会話かもしれない"],
+    );
+
+    assert_eq!(resolve(dir.path(), "mine", spawned), "mine");
+}
+
+#[test]
+fn unrotated_session_resolves_to_itself() {
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(600));
+    write_plain_log(dir.path(), "solo", spawned, &["プロンプト"]);
+
+    assert_eq!(resolve(dir.path(), "solo", spawned), "solo");
+}
+
+#[test]
+fn missing_pinned_log_resolves_to_itself() {
+    // ログがまだディスクに無い (起動直後) 段階では連鎖の起点が無い。
+    // ディレクトリ内の別ログに飛ばず、pin した id をそのまま返すこと。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    write_cleared_log(
+        dir.path(),
+        "someone-else",
+        ago(Duration::from_secs(60)),
+        &["別の会話"],
+    );
+
+    let spawned = ago(Duration::from_secs(120));
+    assert_eq!(resolve(dir.path(), "not-on-disk", spawned), "not-on-disk");
+}
+
+#[test]
+fn rotated_transcript_shows_only_post_clear_turns() {
+    // 通しの確認: 解決したログを実際に読み、clear 前のターンが出ないこと。
+    let dir = tempfile::tempdir().expect("tmp dir");
+    let spawned = ago(Duration::from_secs(600));
+    write_plain_log(dir.path(), "before", spawned, &["clear 前"]);
+    write_cleared_log(
+        dir.path(),
+        "after",
+        ago(Duration::from_secs(540)),
+        &["clear 後"],
+    );
+
+    let current = resolve(dir.path(), "before", spawned);
+    let texts = transcript_texts(dir.path(), &current);
+    assert!(!texts.iter().any(|t| t.contains("clear 前")), "{texts:?}");
+    assert!(texts.iter().any(|t| t.contains("clear 後")), "{texts:?}");
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod ai_caller;
 mod anim;
 mod app;
 mod background;
+mod cc_hook;
 mod cc_notify;
 mod ccusage_cache;
 mod claude_log;

--- a/src/pty_manager/mod.rs
+++ b/src/pty_manager/mod.rs
@@ -14,12 +14,12 @@
 //! input-waiting detection), [`reader`] (the background reader thread), and
 //! [`locale`] (UTF-8 locale/chunking helpers).
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use anyhow::{Context, Result};
 use portable_pty::NativePtySystem;
@@ -89,6 +89,12 @@ pub struct PtySession {
     /// open *this* panel's log instead of merely the worktree's latest session —
     /// essential when one worktree hosts multiple Claude panels (CC:1, CC:2, …).
     pub claude_session_id: Option<String>,
+    /// 子プロセスを起動した時刻。
+    ///
+    /// `/clear` によるセッションログのローテーション追跡で、起動より前に
+    /// 始まっていたログを後続と誤認しないための下限として使う (古いセッションを
+    /// `--resume` した直後は pin したログの mtime が何日も前になりうる)。
+    pub spawned_at: std::time::SystemTime,
     /// Whether this session is the currently displayed (active) session.
     pub is_active: bool,
 
@@ -204,15 +210,52 @@ impl PtyManager {
         self.sessions.len()
     }
 
-    /// The Claude session id and working directory for the session at `idx`,
-    /// when it is a Claude panel with a known id. Used by the reflow transcript
-    /// view to open the log for a *specific* panel rather than the worktree's
-    /// most recently written session. Returns `None` for out-of-range indices,
-    /// non-Claude sessions, or Claude sessions whose id is unknown.
-    pub fn claude_session_ref(&self, idx: usize) -> Option<(PathBuf, String)> {
+    /// The Claude session id, working directory and spawn time for the session
+    /// at `idx`, when it is a Claude panel with a known id. Used by the reflow
+    /// transcript view to open the log for a *specific* panel rather than the
+    /// worktree's most recently written session. Returns `None` for
+    /// out-of-range indices, non-Claude sessions, or Claude sessions whose id
+    /// is unknown.
+    pub fn claude_session_ref(&self, idx: usize) -> Option<(PathBuf, String, SystemTime)> {
         let session = self.sessions.get(idx)?;
         let id = session.claude_session_id.as_ref()?;
-        Some((session.working_dir.clone(), id.clone()))
+        Some((session.working_dir.clone(), id.clone(), session.spawned_at))
+    }
+
+    /// `panel_id` のパネルが書き込んでいる Claude セッションの id を差し替える。
+    ///
+    /// 呼ぶのは `SessionStart` フック経由の通知 ([`crate::cc_hook`]) だけ。
+    /// フックはそのパネル自身の Claude プロセスの中で走るので、これは推測では
+    /// なく事実。`/clear` や `/resume` でログがローテーションしても、以降の
+    /// トランスクリプト解決が正しいファイルを指す。
+    ///
+    /// 該当パネルが無い (すでに閉じた等) 場合や、値が変わらない場合は `false`。
+    pub fn set_claude_session_id(&mut self, panel_id: &str, session_id: String) -> bool {
+        let Some(session) = self
+            .sessions
+            .iter_mut()
+            .find(|s| s.id == panel_id && s.kind == SessionKind::ClaudeCode)
+        else {
+            return false;
+        };
+        if session.claude_session_id.as_deref() == Some(session_id.as_str()) {
+            return false;
+        }
+        session.claude_session_id = Some(session_id);
+        true
+    }
+
+    /// `idx` 以外の Claude パネルが pin している session id の集合。
+    ///
+    /// `/clear` のローテーション追跡で、他パネルが自分のログとして持っている
+    /// セッションを後続候補から外すために使う。
+    pub fn other_claude_session_ids(&self, idx: usize) -> HashSet<String> {
+        self.sessions
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != idx)
+            .filter_map(|(_, s)| s.claude_session_id.clone())
+            .collect()
     }
 
     /// Read-only access to the sessions slice.

--- a/src/pty_manager/spawn.rs
+++ b/src/pty_manager/spawn.rs
@@ -47,6 +47,13 @@ impl PtyManager {
         // Build the command depending on the session kind, then hand off to the
         // shared spawn path. For Claude sessions we also pin down the session id
         // so the reflow transcript view can later open this exact panel's log.
+        //
+        // パネルの識別子。`SessionStart` フックへ環境変数で渡し、フックが
+        // 「どのパネルの通知か」を名乗れるようにする (`cc_hook`)。セッションを
+        // 作る前に決めるのは、コマンドを組み立てる時点で環境変数に入れる必要が
+        // あるため。
+        let panel_id = Uuid::new_v4().to_string();
+
         let (cmd, claude_session_id) = match kind {
             SessionKind::ClaudeCode => {
                 let mut c = CommandBuilder::new("claude");
@@ -71,6 +78,30 @@ impl PtyManager {
                 // Let the conductor MCP server find the review database.
                 let db_path = repo_root.join(".conductor").join("conductor.db");
                 c.env("CONDUCTOR_DB_PATH", db_path);
+
+                // `/clear` は書き込み先を新しい session id の `.jsonl` に移すが、
+                // 旧ログにも新ログにも相互参照が残らない。`SessionStart` フックは
+                // そのパネル自身の Claude プロセスの中で走り、新しい session id を
+                // 持って来てくれるので、これを差し込んでおくとローテーションを
+                // 推測ではなく事実として受け取れる。
+                //
+                // `--settings` は追加レイヤーとして重なる (実測: ユーザ全体の
+                // settings もプロジェクトの `.claude/settings.json` もそのまま
+                // 生き残る) ので、ユーザ自身のフックを潰す心配はない。
+                match Self::write_hook_settings(repo_root) {
+                    Ok(path) => {
+                        c.arg("--settings");
+                        c.arg(&path);
+                        c.env(crate::cc_hook::PANEL_ID_ENV, &panel_id);
+                        c.env(
+                            crate::cc_hook::NOTIFY_SOCK_ENV,
+                            crate::cc_notify::socket_path(repo_root),
+                        );
+                    }
+                    // 書けなくてもパネルは動かす。ローテーション追跡は
+                    // `claude_sessions::rotation` の推測にフォールバックする。
+                    Err(e) => log::warn!("could not install the Claude session hook: {e}"),
+                }
                 (c, Some(session_id))
             }
             SessionKind::Shell => (CommandBuilder::new(shell_path), None),
@@ -81,8 +112,49 @@ impl PtyManager {
         let idx = self.finish_spawn(kind, worktree, label, working_dir, rows, cols, cmd)?;
         if let Some(session) = self.sessions.get_mut(idx) {
             session.claude_session_id = claude_session_id;
+            // フックが名乗る id と一致させる。
+            session.id = panel_id;
         }
         Ok(idx)
+    }
+
+    /// `SessionStart` フックを差し込む settings を `.conductor/` に書き、その
+    /// パスを返す。
+    ///
+    /// フックのコマンドは conductor 自身 (`conductor cc-hook`)。シェルスクリプトや
+    /// `jq` を挟まないのは、signal をバイナリと同じ成果物に載せるため — 別
+    /// リリースチャネルに置くとバージョンがずれた組み合わせで黙って効かなくなる。
+    /// 実行ファイルは絶対パスで書くので、`claude` の PATH に conductor が
+    /// 無くても動く。
+    pub(super) fn write_hook_settings(repo_root: &Path) -> Result<PathBuf> {
+        let exe = std::env::current_exe().context("could not locate the conductor executable")?;
+        let dir = repo_root.join(".conductor");
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("could not create {}", dir.display()))?;
+        let path = dir.join("claude-hooks.json");
+
+        let settings = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!("{} cc-hook", Self::shell_quote(&exe.to_string_lossy())),
+                    }],
+                }],
+            },
+        });
+        // spawn のたびに書き直す。conductor の置き場所が変わっても追随する。
+        std::fs::write(&path, serde_json::to_vec_pretty(&settings)?)
+            .with_context(|| format!("could not write {}", path.display()))?;
+        Ok(path)
+    }
+
+    /// フックのコマンド行に埋める実行ファイルパスを POSIX シェル用にクォートする。
+    ///
+    /// Claude Code はフックの `command` をシェルに渡すので、空白や引用符を含む
+    /// パス (`/Users/me/my tools/conductor` など) はそのままでは分割される。
+    pub(super) fn shell_quote(raw: &str) -> String {
+        format!("'{}'", raw.replace('\'', r"'\''"))
     }
 
     /// Spawn an external editor (`$VISUAL` / `$EDITOR`) on a single `file` as a
@@ -239,6 +311,7 @@ impl PtyManager {
             // Populated by `spawn_session` for Claude panels after this returns;
             // Shell/Editor sessions keep it `None`.
             claude_session_id: None,
+            spawned_at: std::time::SystemTime::now(),
             is_active: false,
             master: pair.master,
             writer,

--- a/src/pty_manager/tests.rs
+++ b/src/pty_manager/tests.rs
@@ -324,3 +324,61 @@ fn locale_non_utf8_lang_without_lc_all_keeps_lc_all_untouched() {
     assert_eq!(sets, vec![("LC_CTYPE", "C.UTF-8")]);
     assert!(removes.is_empty());
 }
+
+// ── Claude セッションフックの差し込み ──────────────────────────────────
+//
+// `/clear` は Claude Code の書き込み先を別 id の `.jsonl` に移すが、旧ログにも
+// 新ログにも相互参照が残らない。`SessionStart` フックだけがパネルと新しい
+// session id を確実に結べるので、spawn 時にこれを差し込む。
+
+#[test]
+fn hook_settings_declare_the_conductor_session_start_hook() {
+    let repo = tempfile::tempdir().expect("tmp repo");
+    let path = PtyManager::write_hook_settings(repo.path()).expect("write settings");
+
+    // Conductor 自身のディレクトリに置く (`.conductor/` は gitignore 済み)。
+    assert_eq!(
+        path,
+        repo.path().join(".conductor").join("claude-hooks.json")
+    );
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("read back")).expect("valid json");
+    let cmd = v["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("hook command");
+    // conductor 自身を呼ぶ。シェルスクリプトにも jq にも依存しない。
+    assert!(cmd.ends_with(" cc-hook"), "{cmd}");
+    assert_eq!(v["hooks"]["SessionStart"][0]["hooks"][0]["type"], "command");
+}
+
+#[test]
+fn hook_settings_are_rewritten_each_spawn() {
+    // conductor を置き直しても追随できるよう、毎回書き直す。
+    let repo = tempfile::tempdir().expect("tmp repo");
+    let path = PtyManager::write_hook_settings(repo.path()).expect("first write");
+    std::fs::write(&path, b"{}").expect("clobber");
+    PtyManager::write_hook_settings(repo.path()).expect("second write");
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("read back")).expect("valid json");
+    assert!(v["hooks"]["SessionStart"][0]["hooks"][0]["command"].is_string());
+}
+
+#[test]
+fn hook_command_survives_awkward_executable_paths() {
+    // フックの command はシェルに渡されるので、空白や引用符を含む置き場所でも
+    // 1 語のままでなければならない。
+    assert_eq!(
+        PtyManager::shell_quote("/usr/bin/conductor"),
+        "'/usr/bin/conductor'"
+    );
+    assert_eq!(
+        PtyManager::shell_quote("/Users/me/my tools/conductor"),
+        "'/Users/me/my tools/conductor'"
+    );
+    assert_eq!(
+        PtyManager::shell_quote("/tmp/it's here/conductor"),
+        r"'/tmp/it'\''s here/conductor'"
+    );
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -32,6 +32,9 @@ pub fn handle_cli_fast_path() -> Option<Result<()>> {
             Some(Ok(()))
         }
         "mcp-serve" => Some(crate::mcp_serve::run()),
+        // Claude Code の SessionStart フックとして呼ばれる。`mcp-serve` と同じく
+        // 端末に触る前に処理する必要がある (stdin/stdout を占有するため)。
+        "cc-hook" => Some(crate::cc_hook::run()),
         _ => None,
     }
 }
@@ -42,6 +45,7 @@ fn print_help() {
 
 Usage: conductor [REPO_PATH]
        conductor mcp-serve [--db <PATH>]
+       conductor cc-hook
 
   REPO_PATH    Git repository to open (defaults to the current directory)
 
@@ -52,6 +56,13 @@ Commands:
 
     --db <PATH>    Review database to serve. Defaults to $CONDUCTOR_DB_PATH,
                    then .conductor/conductor.db in the surrounding repository.
+
+  cc-hook      Claude Code SessionStart hook. Reads the hook payload on stdin
+               and reports the panel's current session id back to the running
+               conductor, so scrolling up shows the transcript this panel is
+               actually writing after a /clear. Wired up automatically via
+               --settings when conductor spawns a Claude panel; not usually
+               run by hand.
 
 Options:
   -V, --version    Print version and exit


### PR DESCRIPTION
## Summary

`/clear` したセッションでスクロールアップすると clear 前の履歴が表示され、clear 後に書いた内容が一切出てこないバグの修正。

**原因**: Conductor は spawn 時に `--session-id` で決めた ID を pin したまま更新していなかった (`pty_manager/spawn.rs`)。一方 Claude Code の `/clear` は書き込み先を**新しい session id の `.jsonl` にローテーション**する。旧ファイルには以降一切追記されず、両者を結ぶ相互参照もログに残らないため、スクロールバック (`app/reflow.rs`) は旧ファイルを読み続けていた。

**修正**: 推測ではなく Claude Code の `SessionStart` フックから新 session id を直接受け取る。

- `src/cc_hook.rs` (新規) — `conductor cc-hook` サブコマンド。stdin のフック payload から `session_id` を取り、`session <panel id> <session id>` を既存の cc-notify ソケットへ送る
- `src/pty_manager/spawn.rs` — `.conductor/claude-hooks.json` を書いて `--settings` で渡し、`CONDUCTOR_PANEL_ID` / `CONDUCTOR_NOTIFY_SOCK` を PTY に注入
- `src/cc_notify.rs` — `CcNotifyEvent` を enum 化して `session` メッセージを追加。ソケットパスの導出を1箇所に集約
- `src/claude_sessions/rotation.rs` (新規) — フックが沈黙した環境向けのフォールバック。ログから連鎖を辿るが、「先頭が `/clear` コマンド」「前セッションの最終書き込みから30分以内」「他パネルが pin していない」ログしか後続と認めない

フックはパネル自身の Claude プロセス内で走るため、パネルと session id の対応は相関ではなく**同一性**。同一 worktree で複数パネルが同時に `/clear` しても取り違えない。

フックを `plugins/` ではなくバイナリに置いたのは、MCP サーバをバイナリへ取り込んだのと同じ理由 — 別リリースチャネルだとバージョンがずれた組み合わせで黙って効かなくなり、しかも失敗が「clear 前の履歴が出る」＝このバグの再発にしか見えないため。

## 実測で確定した挙動

使い捨て worktree で実際に `/clear` を打って計測した:

- `SessionStart` は `/clear` 時に `source: "clear"` で発火し、**新** `session_id` を渡す。PTY に注入した env はフックから見える
- `/clear` の打鍵から **265ms** で新 `.jsonl` が生成され、旧ファイルは以降 mtime が 1 ミリ秒も動かない
- 旧→新の間隔は丸ごとユーザの思考時間で機械的上限が無い ⇒ 「N 分以内」だけで当てる方式は原理的に成立しない (フォールバックの30分キャップが保険止まりなのはこのため)
- **`claude --settings <file>` はマージ**。ユーザ全体の settings もプロジェクトの `.claude/settings.json` も生き残る

## Test plan

- `cargo test` — 1022 passed / 0 failed
- `cargo clippy --all-targets` — warning 0
- **実バイナリでの通し確認**: PTY で `claude` を起動 → プロンプト → `/clear` → プロンプト。ソケットに届いた `session` 通知2件が、ディスク上の clear 前/clear 後のログと順序ごと一致 (panel id も一致)
- `cc-hook` の異常系: env 無し (Conductor 経由でない `claude`) では何も送らない / 壊れた payload・ソケット不在でも exit 0 かつ stdout 無出力
- 既存プラグインの `active`/`waiting` 通知が同じソケットで共存することを確認
- フォールバック (`rotation.rs`) の単体テスト15件: clear 追従 / 複数回 clear の連鎖 / clear 直後で出力ゼロ / 別セッションの非乗っ取り / spawn 前ログの除外 など

### 途中で踏んだバグ

`write!`/`writeln!` はフォーマットの断片ごとに `write` syscall を呼ぶため、受け手が1回の `read` で拾うと `"session"` だけ届くことがあった。既存のシェル側フックが `echo | nc` の1回書き込みだったため表面化していなかった。送信側を `format!` → `write_all` 1回に、受信側を EOF まで読むループに修正し、20回連続で欠損ゼロを確認。
