### PR TITLE
feat: Viewer のシンタックスハイライトをテーマ切り替えに追従させ、着色範囲を広げる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.101.0"
+version = "0.102.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.101.0"
+version = "0.102.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/appearance.rs
+++ b/src/app/appearance.rs
@@ -1,13 +1,51 @@
 //! 外観設定（テーマ、シンタックスハイライト、diff表示モード、レイアウト比率）の
 //! ランタイムでのテーマ切り替えと、設定ファイルのライブリロード。
 
-use syntect::highlighting::ThemeSet;
-
 use super::App;
 use crate::config;
 
 impl App {
+    /// 現在のconfigからsyntectのハイライトテーマを組み直す。
+    ///
+    /// 解決結果が前回と同じなら何もしない。変わっていれば、テーマを差し替えた
+    /// うえでハイライト済みspanを持つキャッシュをすべて無効化する。
+    ///
+    /// 「無効化」まで含めてここでやるのが肝。span色はキャッシュに焼き込まれる
+    /// ので、テーマだけ差し替えても画面には古い配色が残り続ける。テーマを
+    /// 触る経路(テーマピッカー・OSC11自動判定・configライブリロード)は必ず
+    /// ここを通す。
+    fn rebuild_syntect_theme(&mut self) {
+        let new_id = config::syntax_theme_id(&self.config);
+        if new_id == self.highlight.theme_id {
+            return;
+        }
+
+        self.highlight.theme = config::syntect_theme_for(&self.config, &self.highlight.themes);
+        self.highlight.theme_id = new_id;
+        // Viewerのハイライトキャッシュのキーに混ざる。これを進めないと、
+        // ファイル内容が同じままなのでrehighlight_viewerがキャッシュヒットで
+        // 素通りしてしまう。
+        self.highlight.generation = self.highlight.generation.wrapping_add(1);
+
+        // レビューコメント内のコードブロックが新しいsyntectテーマを反映
+        // できるよう、Markdownキャッシュをクリアする。このキャッシュは
+        // UIのカラーパレットだけを指紋にしているので、シンタックスのみの
+        // 変更ではそうしないと古いハイライトのspanが残ってしまう。
+        self.markdown_cache.clear();
+
+        // 次の描画でreflowトランスクリプトを完全に再構築させ、Markdown
+        // のspanが新しいテーマ色とsyntectパレットを反映するようにする。
+        // last_width=0にすることで、パネル幅が変わったかどうかに関わらず
+        // 次のフレームでbuild_linesが必ず実行される。
+        self.reflow.last_width = 0;
+        self.reflow.cache.clear();
+    }
+
     /// アクティブなUIテーマをランタイムで切り替える。
+    ///
+    /// UIパレットとsyntectのシンタックスハイライトテーマの両方を切り替える。
+    /// 以前はUIパレットだけを組み直していたので、テーマを変えてもViewerの
+    /// コードの配色が変わらなかった。
     ///
     /// persistがtrueのとき、選択は設定ファイル (~/.config/conductor/config.toml)
     /// に書き込まれ、再起動後も残る。書き込み失敗は致命的ではない: ログに
@@ -16,9 +54,16 @@ impl App {
         self.theme = super::build_theme(name, self.theme_sel.high_contrast);
         self.theme_sel.name = name.to_string();
         self.config.ui.theme = Some(name.to_string());
-        if persist
-            && let Err(e) = crate::config::persist_ui_theme(name)
-        {
+
+        // syntectテーマはconfigの現在値から解決されるので、ui.themeを書いた
+        // 後に呼ぶ。
+        self.rebuild_syntect_theme();
+        // 開いているファイルを新しいテーマで塗り直す。generationが進んで
+        // いるのでキャッシュは素通りしない。
+        self.rehighlight_viewer();
+        self.dirty.mark_all();
+
+        if persist && let Err(e) = crate::config::persist_ui_theme(name) {
             log::warn!("failed to persist theme '{name}': {e}");
             self.set_status(
                 format!("Theme saved in session but could not write config: {e}"),
@@ -39,6 +84,8 @@ impl App {
     ///
     /// ここで適用されるLIVEフィールドは次のとおり。
     /// - ui.theme / viewer.theme → theme + theme_name + syntectの再構築
+    ///   （syntect側もui.themeを優先する。以前はviewer.themeだけを見ていた
+    ///   ので、ui.themeだけを設定するとコードの配色が取り残されていた）
     /// - viewer.syntax_theme_file → syntectの再構築（themeと同じ経路）
     /// - viewer.tab_width → configのコピー + refresh_viewer + refresh_diff
     /// - diff.word_diff → configのコピー + refresh_diff
@@ -53,30 +100,13 @@ impl App {
         // UI / シンタックステーマ
         let new_theme_name = super::resolve_theme_name(new);
         let new_high_contrast = new.ui.high_contrast;
-        if new_theme_name != self.theme_sel.name || new_high_contrast != self.theme_sel.high_contrast {
+        if new_theme_name != self.theme_sel.name
+            || new_high_contrast != self.theme_sel.high_contrast
+        {
             self.theme = super::build_theme(&new_theme_name, new_high_contrast);
             self.theme_sel.name = new_theme_name;
             self.theme_sel.high_contrast = new_high_contrast;
         }
-
-        // viewerテーマかカスタムテーマファイルのいずれかが変わったらsyntect
-        // テーマを再構築する（両者を1回の再構築にまとめることで、半端に
-        // 更新された状態が生じないようにしている）。
-        let ts = ThemeSet::load_defaults();
-        self.highlight.theme = config::syntect_theme_for(&new.viewer, &ts);
-
-        // レビューコメント内のコードブロックが新しいsyntectテーマを反映
-        // できるよう、Markdownキャッシュをクリアする。このキャッシュは
-        // UIのカラーパレットだけを指紋にしているので、シンタックスのみの
-        // 変更ではそうしないと古いハイライトのspanが残ってしまう。
-        self.markdown_cache.clear();
-
-        // 次の描画でreflowトランスクリプトを完全に再構築させ、Markdown
-        // のspanが新しいテーマ色とsyntectパレットを反映するようにする。
-        // last_width=0にすることで、パネル幅が変わったかどうかに関わらず
-        // 次のフレームでbuild_linesが必ず実行される。
-        self.reflow.last_width = 0;
-        self.reflow.cache.clear();
 
         // diff表示モード
         // view_modeを直接適用する。diff_state.view_modeが書き込まれるのは
@@ -89,6 +119,10 @@ impl App {
         // 変化を自動検出して次のフレームで再計算するので、明示的な無効化は
         // 不要。
         self.config.adopt_appearance(new);
+
+        // syntectテーマの再構築。テーマ名もsyntax_theme_fileも self.config から
+        // 読むので、adopt_appearance の後に呼ぶ必要がある。
+        self.rebuild_syntect_theme();
 
         // Claude/Shellの分割はconfigから種を取るランタイムフィールドなので、
         // layout.terminal_split_pctへの外部からの編集がライブに反映される

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -4,7 +4,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-use syntect::highlighting::ThemeSet;
 
 use crate::config;
 use crate::diff_state::{DiffState, DiffViewMode};
@@ -46,8 +45,9 @@ impl App {
 
         // syntect のシンタックスセットとテーマを初期化する。
         let syntax_set = two_face::syntax::extra_newlines();
-        let ts = ThemeSet::load_defaults();
-        let syntect_theme = config::syntect_theme_for(&config.viewer, &ts);
+        let syntect_themes = two_face::theme::extra();
+        let syntect_theme = config::syntect_theme_for(&config, &syntect_themes);
+        let syntect_theme_id = config::syntax_theme_id(&config);
 
         // 既知リポジトリの一覧を作る: まず現在のリポジトリ、続けて config の追加分。
         let mut repo_list = vec![repo_path.clone()];
@@ -131,7 +131,10 @@ impl App {
             last_poll_status: None,
             highlight: Highlighting {
                 syntax_set,
+                themes: syntect_themes,
                 theme: syntect_theme,
+                theme_id: syntect_theme_id,
+                generation: 0,
             },
             markdown_cache: crate::ui::markdown::MarkdownCache::new(),
             expanded_panel: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -209,14 +209,11 @@ pub struct App {
 
 /// configから有効なUIテーマ名を解決する。
 ///
-/// [ui] theme が優先される。存在しない場合は、[ui] セクション導入前の
-/// configとの後方互換性のために [viewer] theme が使われる。
+/// 解決規則そのものは [config::Config::theme_name] が持つ。シンタックス
+/// ハイライト側も同じ関数を通すので、UIとコードで別のテーマ名を見てしまう
+/// ことはない。
 fn resolve_theme_name(cfg: &config::Config) -> String {
-    cfg.ui
-        .theme
-        .as_deref()
-        .unwrap_or(&cfg.viewer.theme)
-        .to_string()
+    cfg.theme_name().to_string()
 }
 
 /// 名前から有効な [Theme] を組み立て、有効ならハイコントラスト変換を

--- a/src/app/state/appearance.rs
+++ b/src/app/state/appearance.rs
@@ -1,6 +1,7 @@
 //! 見た目の決定に関わる状態: テーマの選択と、シンタックスハイライトの資源。
 
 use syntect::parsing::SyntaxSet;
+use two_face::theme::EmbeddedLazyThemeSet;
 
 /// 実際の [crate::theme::Theme] を組み立てるための「元データ」。
 ///
@@ -18,10 +19,23 @@ pub struct ThemeSelection {
 
 /// syntect によるシンタックスハイライトの共有資源。
 ///
-/// どちらも構築に時間がかかるので起動時に 1 度だけ作り、以降は使い回す。
+/// syntax_set と themes は構築に時間がかかるので起動時に 1 度だけ作り、
+/// 以降は使い回す。theme はテーマ切り替えのたびに themes から引き直す。
 pub struct Highlighting {
     /// 共有の syntect 構文定義。
     pub syntax_set: SyntaxSet,
+    /// 組み込みハイライトテーマ集 (two-face)。個々のテーマは初回参照時に
+    /// 遅延ロードされるので、保持しておいてもコストはほぼ無い。
+    pub themes: EmbeddedLazyThemeSet,
     /// 有効な syntect ハイライトテーマ。
     pub theme: syntect::highlighting::Theme,
+    /// theme を解決した入力の指紋 ([crate::config::syntax_theme_id])。
+    /// 実際にテーマが変わったときだけキャッシュを捨てるための比較用。
+    pub theme_id: String,
+    /// テーマを差し替えるたびに増える世代番号。
+    ///
+    /// ハイライト結果のキャッシュキーに混ぜる。これが無いと、キャッシュは
+    /// ファイル内容だけを指紋にしているので、テーマを変えても「内容は同じ」
+    /// と判定されて古い配色の span が残り続ける。
+    pub generation: u64,
 }

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -142,7 +142,9 @@ impl App {
         // borrow checkerを満たすため、フィールドを分離して借用する。
         let syntax_set = &self.highlight.syntax_set;
         let theme = &self.highlight.theme;
-        self.viewer_state.highlight_content(syntax_set, theme);
+        let generation = self.highlight.generation;
+        self.viewer_state
+            .highlight_content(syntax_set, theme, generation);
     }
 
     /// branch のdiffを計算すべき対象ref。

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,7 @@ pub use sections::{
 };
 #[allow(unused_imports)]
 pub use snapshot::{AppearanceSnapshot, has_restart_changes};
-pub use syntax_theme::syntect_theme_for;
+pub use syntax_theme::{syntax_theme_id, syntect_theme_for};
 
 use persist::write_atomic;
 
@@ -82,6 +82,18 @@ pub struct Config {
 }
 
 impl Config {
+    /// 有効な UI テーマ名。
+    ///
+    /// [ui] theme が優先される。存在しない場合は、[ui] セクション導入前の
+    /// config との後方互換性のために [viewer] theme が使われる。
+    ///
+    /// UI の配色もシンタックスハイライトのテーマも、必ずここを通して名前を
+    /// 決める。片方が viewer.theme を直接読んでいたせいで、テーマピッカーで
+    /// ui.theme を切り替えてもコードの配色だけが取り残されていた。
+    pub fn theme_name(&self) -> &str {
+        self.ui.theme.as_deref().unwrap_or(&self.viewer.theme)
+    }
+
     /// ~/.config/conductor/config.toml から設定を読み込む。
     ///
     /// ファイルが存在しない場合は Config::default() にフォールバックする。

--- a/src/config/syntax_theme.rs
+++ b/src/config/syntax_theme.rs
@@ -1,47 +1,62 @@
 //! syntect のシンタックスハイライトテーマ解決。
 
-use super::ViewerConfig;
+use super::Config;
+use two_face::theme::{EmbeddedLazyThemeSet, EmbeddedThemeName};
 
-/// viewer 設定から syntect のシンタックスハイライトテーマを解決する。
+/// 有効な UI テーマ名に対応する two-face 組み込みテーマを返す。
+///
+/// 対応表は theme::Theme::all_names() の全エントリを網羅する。ここに漏れが
+/// あるとそのテーマだけシンタックスハイライトが別テーマの配色のまま残り、
+/// 「テーマを切り替えてもコードの色が変わらない」ように見えてしまうので、
+/// 網羅は tests_syntax_theme.rs のテストで固定してある。
+///
+/// syntect 同梱の base16-* 系ではなく two-face (bat 由来) を使うのは、
+/// 色を付けるスコープの数が段違いに多いため。base16-mocha.dark はスコープ
+/// 規則が 47 件しかなく、TypeScript ではトークンの約半分が無着色の
+/// デフォルト前景のまま残る。Catppuccin Mocha は 185 件で、同じファイルの
+/// 約 9 割に色が付く。
+fn embedded_theme_for(theme: &str) -> EmbeddedThemeName {
+    match theme {
+        // ダークテーマ — 同名の組み込みがあるものはそのまま対応させる。
+        "catppuccin-mocha" => EmbeddedThemeName::CatppuccinMocha,
+        "dracula" => EmbeddedThemeName::Dracula,
+        "nord" => EmbeddedThemeName::Nord,
+        "solarized-dark" => EmbeddedThemeName::SolarizedDark,
+        "gruvbox" => EmbeddedThemeName::GruvboxDark,
+        // 同名の組み込みが無いダークテーマは、色相と明度が最も近いもので代用する。
+        // 背景色は使わない (ハイライト結果の背景は Reset に潰している) ので、
+        // 前景アクセントの傾向だけで選んでいる。
+        // tokyo-night は青紫寄りのダーク。
+        "tokyo-night" => EmbeddedThemeName::CatppuccinMacchiato,
+        // rose-pine は彩度を落としたパステル。
+        "rose-pine" => EmbeddedThemeName::CatppuccinFrappe,
+        // kanagawa は暖色寄りで、前景 #dcd7ba が gruvbox の #ebdbb2 に近い。
+        "kanagawa" => EmbeddedThemeName::GruvboxDark,
+        // ライトテーマ — 明るい背景でもコントラストが出るライト系を割り当てる。
+        "catppuccin-latte" => EmbeddedThemeName::CatppuccinLatte,
+        "solarized-light" => EmbeddedThemeName::SolarizedLight,
+        "github-light" => EmbeddedThemeName::InspiredGithub,
+        // 未知の名前。theme::Theme::from_name も既定テーマに落ちるので合わせる。
+        _ => EmbeddedThemeName::CatppuccinMocha,
+    }
+}
+
+/// 設定から syntect のシンタックスハイライトテーマを解決する。
 ///
 /// viewer.syntax_theme_file が設定されていればそのファイルを直接読み込む
-/// (失敗時は組み込みテーマにフォールバック)。未設定なら viewer.theme に
-/// 最も近い組み込み syntect テーマを返す。
+/// (失敗時は組み込みテーマにフォールバック)。未設定なら有効な UI テーマ名
+/// (ui.theme、無ければ後方互換で viewer.theme) に対応する組み込みテーマを返す。
 ///
-/// conductor の UI テーマ名から syntect テーマ名への対応は元々あった4つの
-/// ダークテーマのみをカバーしており、それ以外は base16-mocha.dark に
-/// フォールバックする。このヘルパーを切り出す前からあったずれであり、
-/// 対応表を拡充するのはここでは対象外。
+/// 参照するテーマ名を Config::theme_name() に一本化しているのが要点。以前は
+/// viewer.theme だけを見ていたので、テーマピッカーが書き込む ui.theme とずれ、
+/// UI の配色だけが変わってコードの配色が取り残されていた。
 pub fn syntect_theme_for(
-    viewer: &ViewerConfig,
-    ts: &syntect::highlighting::ThemeSet,
+    cfg: &Config,
+    themes: &EmbeddedLazyThemeSet,
 ) -> syntect::highlighting::Theme {
-    // conductor の viewer テーマ名を対応する syntect キーにマップする。
-    // ダークテーマは対応するダークな syntect テーマへ、ライトテーマは
-    // 明るい UI でもコードブロックが読めるようライトな syntect 組み込みへ。
-    let builtin_name = |theme: &str| -> &str {
-        match theme {
-            // ダークテーマ
-            "catppuccin-mocha" => "base16-mocha.dark",
-            "dracula" => "base16-eighties.dark",
-            "nord" => "base16-ocean.dark",
-            "solarized-dark" => "Solarized (dark)",
-            // ライトテーマ — 明るい背景でも読めるようライトな syntect 組み込みへ。
-            "catppuccin-latte" => "base16-ocean.light",
-            "solarized-light" => "Solarized (light)",
-            "github-light" => "InspiredGitHub",
-            _ => "base16-mocha.dark",
-        }
-    };
-    let fallback = || {
-        let name = builtin_name(&viewer.theme);
-        ts.themes
-            .get(name)
-            .cloned()
-            .unwrap_or_else(|| ts.themes["base16-mocha.dark"].clone())
-    };
+    let fallback = || themes.get(embedded_theme_for(cfg.theme_name())).clone();
 
-    if let Some(ref path) = viewer.syntax_theme_file {
+    if let Some(ref path) = cfg.viewer.syntax_theme_file {
         match syntect::highlighting::ThemeSet::get_theme(path) {
             Ok(theme) => theme,
             Err(e) => {
@@ -53,5 +68,17 @@ pub fn syntect_theme_for(
         }
     } else {
         fallback()
+    }
+}
+
+/// syntect テーマの解決結果を一意に決める入力の指紋。
+///
+/// ハイライト結果のキャッシュを、テーマが実際に変わったときだけ捨てるために使う。
+/// 同じ文字列なら同じテーマが解決されるので、キャッシュを持ち越してよい。
+pub fn syntax_theme_id(cfg: &Config) -> String {
+    match cfg.viewer.syntax_theme_file {
+        // ファイル指定時はパスだけで決まる (テーマ名は結果に影響しない)。
+        Some(ref path) => format!("file:{path}"),
+        None => format!("builtin:{}", cfg.theme_name()),
     }
 }

--- a/src/config/tests_syntax_theme.rs
+++ b/src/config/tests_syntax_theme.rs
@@ -1,5 +1,5 @@
-//! syntect_theme_for のダーク/ライトテーマ対応と、未知テーマ・theme ファイル
-//! 不在時のフォールバック挙動のテスト。
+//! syntect_theme_for のダーク/ライトテーマ対応、全テーマの網羅、着色範囲、
+//! および未知テーマ・theme ファイル不在時のフォールバック挙動のテスト。
 
 use super::*;
 
@@ -12,18 +12,33 @@ fn theme_bg_luma(theme: &syntect::highlighting::Theme) -> f32 {
         .unwrap_or(0.0)
 }
 
+/// ヘルパー: ui.theme を指定した Config を作る。
+fn cfg_with(theme: &str) -> Config {
+    Config {
+        ui: UiConfig {
+            theme: Some(theme.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 /// syntect_theme_for: dark UI テーマは暗い syntect テーマを返すこと。
 #[test]
 fn syntect_theme_for_dark_themes_return_dark_syntect() {
-    let ts = syntect::highlighting::ThemeSet::load_defaults();
-    let viewer_with = |theme: &str| ViewerConfig {
-        theme: theme.to_string(),
-        syntax_theme_file: None,
-        ..Default::default()
-    };
+    let ts = two_face::theme::extra();
 
-    for name in &["catppuccin-mocha", "dracula", "nord", "solarized-dark"] {
-        let theme = syntect_theme_for(&viewer_with(name), &ts);
+    for name in &[
+        "catppuccin-mocha",
+        "dracula",
+        "nord",
+        "solarized-dark",
+        "tokyo-night",
+        "gruvbox",
+        "rose-pine",
+        "kanagawa",
+    ] {
+        let theme = syntect_theme_for(&cfg_with(name), &ts);
         assert!(
             theme_bg_luma(&theme) < 128.0,
             "dark conductor theme '{name}' must map to a dark syntect theme (luma={:.0})",
@@ -35,16 +50,11 @@ fn syntect_theme_for_dark_themes_return_dark_syntect() {
 /// syntect_theme_for: ライトテーマがライト系 syntect テーマを返すこと。
 #[test]
 fn syntect_theme_for_light_themes_use_light_syntect() {
-    let ts = syntect::highlighting::ThemeSet::load_defaults();
-    let viewer_with = |theme: &str| ViewerConfig {
-        theme: theme.to_string(),
-        syntax_theme_file: None,
-        ..Default::default()
-    };
+    let ts = two_face::theme::extra();
 
     // ライト UI テーマはライトな syntect 組み込みテーマにマップされること。
     for name in &["catppuccin-latte", "solarized-light", "github-light"] {
-        let theme = syntect_theme_for(&viewer_with(name), &ts);
+        let theme = syntect_theme_for(&cfg_with(name), &ts);
         assert!(
             theme_bg_luma(&theme) >= 128.0,
             "light conductor theme '{name}' must map to a light syntect theme (luma={:.0})",
@@ -53,26 +63,212 @@ fn syntect_theme_for_light_themes_use_light_syntect() {
     }
 }
 
-/// syntect_theme_for: 未知テーマ名はパニックせず mocha フォールバック。
+/// syntect_theme_for: 組み込み UI テーマの全部が、他と重複しない自前の
+/// syntect テーマを持つこと。
+///
+/// 対応表に漏れがあると、そのテーマだけ既定のシンタックス配色にフォールバック
+/// して「テーマを切り替えてもコードの色が変わらない」ように見える。ここでは
+/// 全テーマ分の解決結果を集め、重複が過度に無いこと(=別テーマがまとめて同じ
+/// 配色に落ちていないこと)を確かめる。
 #[test]
-fn syntect_theme_for_unknown_falls_back_without_panic() {
-    let ts = syntect::highlighting::ThemeSet::load_defaults();
-    let viewer = ViewerConfig {
-        theme: String::from("nonexistent-theme-xyz"),
-        syntax_theme_file: None,
+fn syntect_theme_for_covers_every_builtin_theme() {
+    let ts = two_face::theme::extra();
+    let names = crate::theme::Theme::all_names();
+
+    let resolved: Vec<String> = names
+        .iter()
+        .map(|n| {
+            syntect_theme_for(&cfg_with(n), &ts)
+                .name
+                .clone()
+                .unwrap_or_default()
+        })
+        .collect();
+
+    // 全 11 テーマが 8 種類以上の異なる syntect テーマに散ること。
+    // (tokyo-night/rose-pine/kanagawa は同名の組み込みが無いため代用を共有
+    // しうるが、それ以外がまとめて既定に落ちていれば必ずここで落ちる)
+    let distinct: std::collections::HashSet<&String> = resolved.iter().collect();
+    assert!(
+        distinct.len() >= 8,
+        "builtin themes collapse onto too few syntect themes: {resolved:?}"
+    );
+
+    // 既定へのフォールバック(Catppuccin Mocha)を共有してよいのは
+    // catppuccin-mocha 自身だけ。
+    let mocha_users: Vec<&str> = names
+        .iter()
+        .zip(&resolved)
+        .filter(|(_, r)| r.as_str() == "Catppuccin Mocha")
+        .map(|(n, _)| *n)
+        .collect();
+    assert_eq!(
+        mocha_users,
+        vec!["catppuccin-mocha"],
+        "themes other than catppuccin-mocha are silently falling back to the default"
+    );
+}
+
+/// syntect_theme_for: 主要言語で十分な割合のトークンに色が付くこと。
+///
+/// 以前使っていた syntect 同梱の base16-* 系はスコープ規則が 47〜49 件しか
+/// なく、TypeScript ではトークンのおよそ半分が無着色のデフォルト前景のまま
+/// 残っていた。two-face のテーマに寄せたことで着色範囲が広がっているのを
+/// 固定する。
+#[test]
+fn syntect_theme_colors_most_tokens_across_languages() {
+    use syntect::easy::HighlightLines;
+    use syntect::util::LinesWithEndings;
+
+    let ss = two_face::syntax::extra_newlines();
+    let ts = two_face::theme::extra();
+
+    let samples: &[(&str, &str)] = &[
+        (
+            "ts",
+            "import {a} from 'b';\n\
+             export interface P { id: number; name?: string }\n\
+             // note\n\
+             const f = async (x: P): Promise<void> => { await a(x.id); };\n",
+        ),
+        (
+            "py",
+            "import os\n\
+             class A(Base):\n    \
+             X = 3\n    \
+             def f(self, n: int = 1) -> str:\n        \
+             # note\n        \
+             return f'{n}' if n > 0 else os.sep\n",
+        ),
+        (
+            "go",
+            "package main\n\
+             import \"fmt\"\n\
+             type T struct{ N int }\n\
+             func (t *T) M() error { fmt.Println(t.N); return nil }\n",
+        ),
+    ];
+
+    for theme_name in ["catppuccin-mocha", "dracula", "nord", "catppuccin-latte"] {
+        let theme = syntect_theme_for(&cfg_with(theme_name), &ts);
+        let default_fg = theme.settings.foreground.expect("theme has a foreground");
+
+        for (ext, src) in samples {
+            let syn = ss
+                .find_syntax_by_extension(ext)
+                .unwrap_or_else(|| panic!("syntax for .{ext} must be registered"));
+            let mut h = HighlightLines::new(syn, &theme);
+            let (mut total, mut colored) = (0usize, 0usize);
+
+            for line in LinesWithEndings::from(src) {
+                for (style, text) in h.highlight_line(line, &ss).expect("highlight succeeds") {
+                    let n = text.trim().chars().count();
+                    if n == 0 {
+                        continue;
+                    }
+                    total += n;
+                    let f = style.foreground;
+                    if (f.r, f.g, f.b) != (default_fg.r, default_fg.g, default_fg.b) {
+                        colored += n;
+                    }
+                }
+            }
+
+            let pct = colored as f64 * 100.0 / total.max(1) as f64;
+            assert!(
+                pct >= 65.0,
+                "{theme_name} colors only {pct:.0}% of .{ext} tokens (base16 baseline was ~51%)"
+            );
+        }
+    }
+}
+
+/// syntect_theme_for: ui.theme が viewer.theme より優先されること。
+///
+/// テーマピッカーは ui.theme に書き込む。以前は viewer.theme だけを見ていた
+/// ので、UI の配色だけが変わってコードの配色が取り残されていた。
+#[test]
+fn syntect_theme_for_prefers_ui_theme_over_viewer_theme() {
+    let ts = two_face::theme::extra();
+    let cfg = Config {
+        ui: UiConfig {
+            theme: Some(String::from("github-light")),
+            ..Default::default()
+        },
+        viewer: ViewerConfig {
+            theme: String::from("catppuccin-mocha"),
+            ..Default::default()
+        },
         ..Default::default()
     };
-    let _ = syntect_theme_for(&viewer, &ts); // パニックしないこと
+
+    // ui.theme (light) が勝つので、明るい syntect テーマが返るはず。
+    assert!(
+        theme_bg_luma(&syntect_theme_for(&cfg, &ts)) >= 128.0,
+        "ui.theme must win over viewer.theme"
+    );
+}
+
+/// syntect_theme_for: ui.theme 未設定なら viewer.theme に後方互換で落ちること。
+#[test]
+fn syntect_theme_for_falls_back_to_viewer_theme() {
+    let ts = two_face::theme::extra();
+    let cfg = Config {
+        ui: UiConfig::default(),
+        viewer: ViewerConfig {
+            theme: String::from("github-light"),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert!(theme_bg_luma(&syntect_theme_for(&cfg, &ts)) >= 128.0);
+}
+
+/// syntax_theme_id: テーマが変われば別の指紋になり、同じなら同じになること。
+#[test]
+fn syntax_theme_id_tracks_theme_and_file() {
+    let a = cfg_with("dracula");
+    let b = cfg_with("nord");
+    assert_ne!(syntax_theme_id(&a), syntax_theme_id(&b));
+    assert_eq!(syntax_theme_id(&a), syntax_theme_id(&cfg_with("dracula")));
+
+    // ファイル指定はテーマ名に関わらずパスで決まる。
+    let with_file = |theme: &str| Config {
+        ui: UiConfig {
+            theme: Some(theme.to_string()),
+            ..Default::default()
+        },
+        viewer: ViewerConfig {
+            syntax_theme_file: Some(String::from("/tmp/x.tmTheme")),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert_eq!(
+        syntax_theme_id(&with_file("dracula")),
+        syntax_theme_id(&with_file("nord"))
+    );
+    assert_ne!(syntax_theme_id(&with_file("dracula")), syntax_theme_id(&a));
+}
+
+/// syntect_theme_for: 未知テーマ名はパニックせず既定へフォールバック。
+#[test]
+fn syntect_theme_for_unknown_falls_back_without_panic() {
+    let ts = two_face::theme::extra();
+    let _ = syntect_theme_for(&cfg_with("nonexistent-theme-xyz"), &ts); // パニックしないこと
 }
 
 /// syntect_theme_for: 存在しないパスの syntax_theme_file はパニックしないこと。
 #[test]
 fn syntect_theme_for_missing_theme_file_falls_back_without_panic() {
-    let ts = syntect::highlighting::ThemeSet::load_defaults();
-    let viewer = ViewerConfig {
-        theme: String::from("catppuccin-mocha"),
-        syntax_theme_file: Some(String::from("/nonexistent/path/theme.tmTheme")),
+    let ts = two_face::theme::extra();
+    let cfg = Config {
+        viewer: ViewerConfig {
+            theme: String::from("catppuccin-mocha"),
+            syntax_theme_file: Some(String::from("/nonexistent/path/theme.tmTheme")),
+            ..Default::default()
+        },
         ..Default::default()
     };
-    let _ = syntect_theme_for(&viewer, &ts); // パニックしないこと
+    let _ = syntect_theme_for(&cfg, &ts); // パニックしないこと
 }

--- a/src/viewer/highlight.rs
+++ b/src/viewer/highlight.rs
@@ -12,21 +12,85 @@ use syntect::util::LinesWithEndings;
 
 use super::state::ViewerState;
 
+/// syntect が拡張子を持たない一部の言語。ここに無いと plain text 扱いになり、
+/// ほとんど色が付かなくなる。値は syntect 側が知っている拡張子。
+const EXTENSION_ALIASES: &[(&str, &str)] = &[
+    // JSX / ESM・CJS のモジュール拡張子は syntect の JavaScript 定義には
+    // 登録されていない。
+    ("jsx", "js"),
+    ("mjs", "js"),
+    ("cjs", "js"),
+];
+
+/// ファイル名と先頭行から syntect のシンタックス定義を決める。
+///
+/// 解決順は「ファイル名まるごと → 拡張子 → 拡張子のエイリアス → 先頭行の
+/// shebang → plain text」。
+///
+/// ファイル名を拡張子より先に見るのが要点。拡張子だけで引くと
+/// Dockerfile・Makefile・Gemfile・.gitignore・.env のような拡張子を持たない
+/// ファイルが軒並み plain text になり、さらに CMakeLists.txt は .txt に
+/// 引っかかって積極的に間違った plain text になる。
+fn find_syntax<'a>(
+    syntax_set: &'a SyntaxSet,
+    path: Option<&str>,
+    first_line: Option<&str>,
+) -> &'a syntect::parsing::SyntaxReference {
+    let path = path.map(Path::new);
+
+    // 1. ファイル名まるごと (Dockerfile, Makefile, .gitignore, CMakeLists.txt)
+    let by_name = path
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .and_then(|n| syntax_set.find_syntax_by_extension(n));
+
+    // 2. 拡張子、3. 拡張子のエイリアス
+    let by_ext = || {
+        let ext = path.and_then(|p| p.extension()).and_then(|e| e.to_str())?;
+        syntax_set.find_syntax_by_extension(ext).or_else(|| {
+            let alias = EXTENSION_ALIASES
+                .iter()
+                .find(|(from, _)| *from == ext)
+                .map(|(_, to)| *to)?;
+            syntax_set.find_syntax_by_extension(alias)
+        })
+    };
+
+    // 4. 先頭行の shebang (拡張子の無いスクリプト)
+    let by_first_line = || syntax_set.find_syntax_by_first_line(first_line?);
+
+    by_name
+        .or_else(by_ext)
+        .or_else(by_first_line)
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text())
+}
+
 impl ViewerState {
     /// file_content に syntect のハイライトをかけ、結果をキャッシュする。
     ///
-    /// (current_file, file_content) のハッシュを計算し、前回呼び出し以降
-    /// 内容が変わっていなければ再ハイライトをスキップする。
-    pub fn highlight_content(&mut self, syntax_set: &SyntaxSet, theme: &SyntectTheme) {
+    /// (theme_generation, current_file, file_content) のハッシュを計算し、
+    /// 前回呼び出し以降どれも変わっていなければ再ハイライトをスキップする。
+    ///
+    /// theme_generation は呼び出し側 (App::highlight.generation) がテーマを
+    /// 差し替えるたびに進める世代番号。これをキーに含めないと、テーマだけが
+    /// 変わったとき「内容は同じ」と判定されてキャッシュを素通りし、古い配色の
+    /// span が画面に残り続ける。
+    pub fn highlight_content(
+        &mut self,
+        syntax_set: &SyntaxSet,
+        theme: &SyntectTheme,
+        theme_generation: u64,
+    ) {
         if self.content.file_content.is_empty() {
             self.content.highlighted_lines.clear();
             self.content.highlighted_cache_key = None;
             return;
         }
 
-        // ファイルパスと内容からキャッシュキーを計算する。
+        // テーマ世代・ファイルパス・内容からキャッシュキーを計算する。
         let hash = {
             let mut hasher = DefaultHasher::new();
+            theme_generation.hash(&mut hasher);
             self.content.current_file.hash(&mut hasher);
             self.content.file_content.hash(&mut hasher);
             hasher.finish()
@@ -38,18 +102,11 @@ impl ViewerState {
 
         self.content.highlighted_lines.clear();
 
-        // ファイル拡張子からシンタックスを決定する。
-        let ext = self
-            .content
-            .current_file
-            .as_ref()
-            .and_then(|p| Path::new(p).extension())
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
-
-        let syntax = syntax_set
-            .find_syntax_by_extension(ext)
-            .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+        let syntax = find_syntax(
+            syntax_set,
+            self.content.current_file.as_deref(),
+            self.content.file_content.first().map(|s| s.as_str()),
+        );
 
         let mut h = HighlightLines::new(syntax, theme);
 
@@ -90,5 +147,129 @@ impl ViewerState {
         }
 
         self.content.highlighted_cache_key = Some(hash);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn syntax_name(path: &str, first_line: Option<&str>) -> String {
+        let ss = two_face::syntax::extra_newlines();
+        find_syntax(&ss, Some(path), first_line).name.clone()
+    }
+
+    /// 拡張子を持たないファイルがファイル名で正しく判定されること。
+    ///
+    /// 拡張子だけで引いていた頃はすべて Plain Text に落ち、色がほぼ
+    /// 付かなかった。
+    #[test]
+    fn resolves_extensionless_files_by_name() {
+        for (path, expected) in [
+            ("Dockerfile", "Dockerfile"),
+            ("deep/dir/Dockerfile", "Dockerfile"),
+            ("Makefile", "Makefile"),
+            (".gitignore", "Git Ignore"),
+            (".env", "DotENV"),
+            ("Gemfile", "Ruby"),
+            ("go.mod", "Gomod"),
+        ] {
+            assert_eq!(syntax_name(path, None), expected, "for {path}");
+        }
+    }
+
+    /// ファイル名は拡張子より優先されること。
+    ///
+    /// CMakeLists.txt は .txt にマッチして積極的に間違った Plain Text に
+    /// なっていた。
+    #[test]
+    fn file_name_wins_over_extension() {
+        assert_eq!(syntax_name("CMakeLists.txt", None), "CMake");
+    }
+
+    /// 通常の拡張子は今までどおり引けること。
+    #[test]
+    fn resolves_ordinary_extensions() {
+        for (path, expected) in [
+            ("src/main.rs", "Rust"),
+            ("a.tsx", "TypeScriptReact"),
+            ("b.py", "Python"),
+            ("c.go", "Go"),
+        ] {
+            assert_eq!(syntax_name(path, None), expected, "for {path}");
+        }
+    }
+
+    /// syntect に登録の無い拡張子がエイリアス経由で解決されること。
+    #[test]
+    fn resolves_aliased_extensions() {
+        for path in ["a.jsx", "b.mjs", "c.cjs"] {
+            let name = syntax_name(path, None);
+            assert_ne!(
+                name, "Plain Text",
+                "{path} must not fall back to plain text"
+            );
+            assert!(name.contains("JavaScript"), "{path} resolved to {name}");
+        }
+    }
+
+    /// 拡張子もファイル名も手がかりにならない場合、shebang で判定すること。
+    #[test]
+    fn falls_back_to_shebang() {
+        assert_eq!(
+            syntax_name("bin/deploy", Some("#!/usr/bin/env python3")),
+            "Python"
+        );
+        assert!(syntax_name("bin/run", Some("#!/bin/bash")).contains("bash"));
+    }
+
+    /// 手がかりが何も無ければ plain text に落ちること（パニックしない）。
+    #[test]
+    fn falls_back_to_plain_text() {
+        assert_eq!(
+            syntax_name("LICENSE", Some("Copyright (c) 2026")),
+            "Plain Text"
+        );
+    }
+
+    /// テーマ世代が変わるとハイライトのキャッシュが無効化されること。
+    ///
+    /// これが効かないと、テーマを切り替えても内容が同じ限りキャッシュヒットで
+    /// 素通りし、古い配色の span が残り続ける。
+    #[test]
+    fn theme_generation_invalidates_the_highlight_cache() {
+        let ss = two_face::syntax::extra_newlines();
+        let themes = two_face::theme::extra();
+        let dark = themes.get(two_face::theme::EmbeddedThemeName::CatppuccinMocha);
+        let light = themes.get(two_face::theme::EmbeddedThemeName::InspiredGithub);
+
+        let mut vs = ViewerState::default();
+        vs.content.current_file = Some(String::from("main.rs"));
+        vs.content.file_content = vec![String::from("fn main() { let x = 1; }")];
+
+        vs.highlight_content(&ss, dark, 0);
+        let first: Vec<_> = vs.content.highlighted_lines[0]
+            .iter()
+            .map(|(s, _)| s.fg)
+            .collect();
+
+        // 同じ世代なら再ハイライトされない（キャッシュが効く）。
+        vs.highlight_content(&ss, light, 0);
+        let cached: Vec<_> = vs.content.highlighted_lines[0]
+            .iter()
+            .map(|(s, _)| s.fg)
+            .collect();
+        assert_eq!(cached, first, "same generation must reuse the cache");
+
+        // 世代が進めばテーマが実際に反映される。
+        vs.highlight_content(&ss, light, 1);
+        let recolored: Vec<_> = vs.content.highlighted_lines[0]
+            .iter()
+            .map(|(s, _)| s.fg)
+            .collect();
+        assert_ne!(
+            recolored, first,
+            "bumping the generation must re-highlight with the new theme"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Viewer のシンタックスハイライトに関する2つの問題を修正する。

### 1. テーマを切り替えてもコードの配色が変わらない

独立した3つの欠陥が重なっていた。どれか1つでも残っていると症状は消えない。

- `App::set_theme` が UI パレットしか組み直しておらず、syntect テーマに一切触れていなかった。テーマピッカー・Esc での復帰・OSC11 の自動判定はすべてここを通る。
- syntect のテーマ解決が `viewer.theme` を読んでいた。テーマピッカーが書き込むのは `ui.theme` なので、両者が食い違う設定では UI だけが切り替わってコードが取り残されていた。
- ハイライト結果のキャッシュキーが `(current_file, file_content)` だけで、テーマを含んでいなかった。このため正しく再ハイライトを呼んでもキャッシュヒットで素通りしていた。config ファイルのライブリロード経路（テーマの再構築自体は行っていた）も、同じ理由で開いているファイルには効いていなかった。

対応として、UI とシンタックスの両方が `Config::theme_name()` という単一の解決点を通るようにし、`rebuild_syntect_theme` ヘルパーがキャッシュ世代を進めて Markdown/reflow の span キャッシュもまとめて捨てるようにした。`set_theme` と `apply_appearance` の両方がこのヘルパーを経由する。

あわせて、組み込みテーマ11個のうち対応表にあったのは7個だけで、`tokyo-night` / `gruvbox` / `rose-pine` / `kanagawa` は既定テーマへ黙って落ちていた。全11個を対応させ、漏れると落ちるテストを追加した。

### 2. 色が付くトークンの種類が少ない

原因は2つ。

**テーマ側のスコープ定義が薄い。** syntect 同梱の `base16-*` はスコープ規則が47〜49件しかない。非空白トークンのうち無着色のデフォルト前景のまま残る割合を実測した。

| | TypeScript | Python | Go | Rust |
|---|---|---|---|---|
| base16-mocha.dark (旧) | 51% | 61% | 80% | 73% |
| Catppuccin Mocha (新) | 89% | 88% | 89% | 78% |

すでに依存に入っている `two_face::theme::extra()` (bat 由来) へ寄せた。Catppuccin はスコープ規則185件。新規の依存追加は無し。

**言語判定が拡張子だけだった。** `Dockerfile` / `Makefile` / `Gemfile` / `.gitignore` / `.env` / `go.mod` が軒並み plain text になり、`CMakeLists.txt` は `.txt` に引っかかって積極的に誤判定していた。判定順を「ファイル名 → 拡張子 → 拡張子エイリアス (`jsx`/`mjs`/`cjs`。syntect に定義が無い) → shebang → plain text」に変更した。

## Test plan

- `cargo test` — 1016 passed / 0 failed
- `cargo clippy --all-targets` — 新規の警告なし（既存2件は本PRで触れていないファイル）
- 実機検証: pty 上で実バイナリを起動し、修正前後のバイナリに同一のキー列（同一の開始テーマから dracula → solarized-dark へ切り替え）を流して画面を採取・比較した。バッジや diff 背景の影響を除くため、背景が既定のセルのみを対象に前景色の変化を数えた。
  - 修正前: 1084セル中42セルのみ変化。しかもその42セルは単一色でガター（UIクローム）。シンタックス7色は切り替え前後で完全に同一。
  - 修正後: 940/940セルが変化。Dracula 配色 (`ff79c6`, `bd93f9`, `50fa7b`) → Solarized 配色 (`586e75`, `268bd2`, `d33682`)。
  - `.gitignore`: `d0c8c6`（プレーンの既定前景）→ `f1fa8c`（Dracula の文字列色）。構文が認識されるようになったことを確認。
- 追加したユニットテスト: 全11テーマの対応網羅、主要言語での着色率、`ui.theme` の優先、拡張子なしファイル・エイリアス・shebang の判定、テーマ世代によるキャッシュ無効化。

### 既知のトレードオフ

テーマピッカーのライブプレビューは、キー入力ごとに開いているファイルの再ハイライトが走る（130行で1.5ms、4300行で38ms）。プレビューで配色を見せる以上は再ハイライトが必須なので原理的なコスト。巨大なファイルを開いたまま `j` を押しっぱなしにすると多少重く感じうる。
