### PR TITLE
feat: 変更ファイル一覧を1ファイル1行に統合してコミット後の再編集で分裂しないようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.102.1"
+version = "0.103.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conductor"
-version = "0.102.1"
+version = "0.103.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -95,9 +95,7 @@ impl App {
                 if self.viewer_state.tree.file_tree.is_empty() {
                     self.refresh_viewer();
                 }
-                if self.diff_state.committed_files.is_empty()
-                    && self.diff_state.uncommitted_files.is_empty()
-                {
+                if self.diff_state.files.is_empty() {
                     self.refresh_diff();
                 }
             }

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -65,7 +65,7 @@ impl App {
     pub fn open_diff_file_at_selected(&mut self) {
         let idx = self.viewer_state.explorer.diff_list_selected;
         let (file_path, file_diff_clone) = match self.diff_state.resolve_file(idx) {
-            Some((f, _)) => (f.path.clone(), f.clone()),
+            Some(f) => (f.path.clone(), f.clone()),
             None => return,
         };
         let tab_width = self.config.viewer.tab_width;

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -251,8 +251,7 @@ pub struct BackgroundOps {
 
 /// バックグラウンド diff 計算の結果。
 pub struct BgDiffResult {
-    pub committed: Vec<crate::diff_state::FileDiff>,
-    pub uncommitted: Vec<crate::diff_state::FileDiff>,
+    pub files: Vec<crate::diff_state::FileDiff>,
     pub error: Option<String>,
 }
 

--- a/src/app/walkthrough_view.rs
+++ b/src/app/walkthrough_view.rs
@@ -122,7 +122,7 @@ impl App {
 
         // 折りたたまれたディレクトリの中にあるファイルは、展開されるまで表示行が
         // 存在しないため、行を探す前に reveal する。
-        let Some((file_diff, _)) = self
+        let Some(file_diff) = self
             .diff_state
             .reveal_path(&file_path)
             .and_then(|i| self.diff_state.resolve_file(i))
@@ -189,7 +189,7 @@ mod tests {
     /// を通じて解決される。
     #[test]
     fn saved_walkthrough_round_trips_for_ui_consumption() {
-        use crate::diff_state::{DiffListEntry, DiffSection, DiffState, DiffViewMode, FileDiff};
+        use crate::diff_state::{DiffListEntry, DiffState, DiffViewMode, FileDiff};
         use crate::review_store::ReviewStore;
         use crate::walkthrough::{NewWalkthroughStep, WalkthroughStatus, WalkthroughStepKind};
 
@@ -235,14 +235,13 @@ mod tests {
         // jump_to_walkthrough_step が要求するのと全く同じ形で diff リストを
         // 通じて解決できなければならない。
         let mut ds = DiffState::new("main", DiffViewMode::Unified);
-        ds.committed_files = vec![FileDiff {
+        ds.files = vec![FileDiff {
             path: core.file_path.clone(),
             added_lines: 3,
             deleted_lines: 0,
             hunks: Vec::new(),
         }];
         ds.display_list = vec![DiffListEntry::File {
-            section: DiffSection::Committed,
             file_index: 0,
             depth: 0,
         }];

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -368,40 +368,26 @@ impl App {
     }
 }
 
-/// バックグラウンドのワークツリー切り替えワーカーのために、両方の diff 範囲を計算する。
+/// バックグラウンドのワークツリー切り替えワーカーのために diff を計算する。
 ///
-/// 直接テストできるようワーカーのクロージャから切り出してある。ここが表現している
-/// ルール — コミット済み側の失敗はエラーとして記録するが、ベース ref に依存しない
-/// 未コミット側の diff は止めてはいけない — をこのモジュールはかつて誤って実装して
-/// おり、bg.diff.start のクロージャの中では何もそれを確認できなかった。同じ2つの
-/// 範囲を扱う [DiffState::load_diff] と対応する。
+/// 直接テストできるようワーカーのクロージャから切り出してある。同期版の
+/// [DiffState::load_diff] と対応する。
 fn compute_bg_diff(
     path: &std::path::Path,
     base_branch: &str,
     word_diff: bool,
     tab_width: usize,
 ) -> BgDiffResult {
-    let mut result = BgDiffResult {
-        committed: Vec::new(),
-        uncommitted: Vec::new(),
-        error: None,
-    };
-    match DiffState::compute_diff_range_static(path, base_branch, true, word_diff, tab_width) {
-        Ok(mut files) => {
-            files.sort_by(|a, b| a.path.cmp(&b.path));
-            result.committed = files;
-        }
-        Err(e) => result.error = Some(format!("{e:#}")),
+    match DiffState::compute_changed_files(path, base_branch, word_diff, tab_width) {
+        Ok((files, base_error)) => BgDiffResult {
+            files,
+            error: base_error,
+        },
+        Err(e) => BgDiffResult {
+            files: Vec::new(),
+            error: Some(format!("{e:#}")),
+        },
     }
-    match DiffState::compute_diff_range_static(path, base_branch, false, word_diff, tab_width) {
-        Ok(mut files) => {
-            files.sort_by(|a, b| a.path.cmp(&b.path));
-            result.uncommitted = files;
-        }
-        // これ単体では致命的ではない: コミット済み側はまだ表示する価値があるかもしれない。
-        Err(e) => log::warn!("failed to compute uncommitted diff: {e:#}"),
-    }
-    result
 }
 
 /// 完了したバックグラウンド diff を [DiffState] へ反映する。
@@ -411,14 +397,11 @@ fn compute_bg_diff(
 /// に依存しないで済むようにするため — 依存すればモジュールの依存関係が逆転して
 /// しまう。
 ///
-/// 2つのファイル一覧は error が設定されている場合も含めて無条件に反映する。
-/// エラーはベース ref の解決からしか発生せず、未コミット一覧（HEAD と
-/// workdir+index の比較）はベース ref に依存しない。コミット済み一覧と一緒に
-/// エラーをクリアしてしまうと、不正なベース ref とクリーンなツリーが見分け
-/// つかなくなっていた。
+/// ファイル一覧は error が設定されている場合も無条件に反映する。ベース ref を
+/// 解決できないときは HEAD 基準にフォールバックした一覧が入っており、一緒に
+/// 捨ててしまうと不正なベース ref とクリーンなツリーが見分けつかなくなる。
 fn apply_bg_diff_result(diff_state: &mut DiffState, result: BgDiffResult) {
-    diff_state.committed_files = result.committed;
-    diff_state.uncommitted_files = result.uncommitted;
+    diff_state.files = result.files;
     diff_state.error = result.error;
     diff_state.rebuild_display_list();
 }
@@ -437,39 +420,33 @@ mod tests {
         }
     }
 
-    /// 報告されたバグ: 解決できないベース ref を指定すると、以前は未コミット一覧まで
+    /// 報告されたバグ: 解決できないベース ref を指定すると、以前は手元の変更まで
     /// 消えてしまい、17個の変更ファイルが (0) と表示されていた。
     #[test]
-    fn bg_diff_result_with_error_keeps_uncommitted() {
+    fn bg_diff_result_with_error_keeps_the_files() {
         let mut ds = DiffState::new("origin/main", DiffViewMode::Unified);
         apply_bg_diff_result(
             &mut ds,
             BgDiffResult {
-                committed: Vec::new(),
-                uncommitted: vec![file("CLAUDE.md"), file("src/config.rs")],
+                files: vec![file("CLAUDE.md"), file("src/config.rs")],
                 error: Some("base ref 'origin/main' not found".to_string()),
             },
         );
 
-        assert!(ds.committed_files.is_empty());
         assert_eq!(
-            ds.uncommitted_files
-                .iter()
-                .map(|f| f.path.as_str())
-                .collect::<Vec<_>>(),
+            ds.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
             vec!["CLAUDE.md", "src/config.rs"],
         );
         assert!(ds.error.is_some(), "the failure must stay visible");
 
         // 単に空でないことを確認するのではなく、display list を通してすべての File
-        // エントリを解決する。diff_list.rs はエントリの file_index で
-        // committed_files/uncommitted_files を参照するため、ファイルのベクタを
-        // 差し替えたあとに display list を再構築し忘れていると、次の描画で
-        // out-of-bounds パニックが起きる。これは「何かがリストされた」ではなく
-        // 「常に再構築する」という不変条件を確かめるためのものである。
+        // エントリを解決する。diff_list.rs はエントリの file_index で files を
+        // 参照するため、ファイルのベクタを差し替えたあとに display list を再構築し
+        // 忘れていると、次の描画で out-of-bounds パニックが起きる。これは「何かが
+        // リストされた」ではなく「常に再構築する」という不変条件を確かめるためのもの。
         let listed: Vec<&str> = (0..ds.display_list.len())
             .filter_map(|idx| ds.resolve_file(idx))
-            .map(|(f, _section)| f.path.as_str())
+            .map(|f| f.path.as_str())
             .collect();
         // 入力順ではなくディレクトリでグループ化した順序: ディレクトリノード配下の
         // ファイルはトップレベルのファイルより前に来る。
@@ -500,24 +477,18 @@ mod tests {
     }
 
     /// 修正のうち bg ワーカー側の半分を検証する。apply_bg_diff_result は
-    /// 「反映」側しか証明しないので、こちらはコミット済み側が失敗した後もワーカーが
-    /// 未コミット側の diff を計算し続けることを証明する。Err アームに return を
-    /// 戻すとこのテストが検知する。
+    /// 「反映」側しか証明しないので、こちらはベースを解決できなくてもワーカーが
+    /// HEAD 基準の diff を返し続けることを証明する。
     #[test]
-    fn compute_bg_diff_keeps_uncommitted_when_base_is_unresolvable() {
+    fn compute_bg_diff_keeps_the_files_when_base_is_unresolvable() {
         let dir = repo_with_uncommitted_change();
 
         let result = compute_bg_diff(dir.path(), "no-such-base", false, 4);
 
         let err = result.error.as_deref().expect("base failure must be recorded");
         assert!(err.contains("no-such-base"), "error was: {err}");
-        assert!(result.committed.is_empty());
         assert_eq!(
-            result
-                .uncommitted
-                .iter()
-                .map(|f| f.path.as_str())
-                .collect::<Vec<_>>(),
+            result.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
             vec!["dirty.txt"],
         );
     }
@@ -530,13 +501,8 @@ mod tests {
         let result = compute_bg_diff(dir.path(), "main", false, 4);
 
         assert_eq!(result.error, None);
-        assert!(result.committed.is_empty(), "feature == main, so nothing committed");
         assert_eq!(
-            result
-                .uncommitted
-                .iter()
-                .map(|f| f.path.as_str())
-                .collect::<Vec<_>>(),
+            result.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
             vec!["dirty.txt"],
         );
     }
@@ -550,13 +516,12 @@ mod tests {
         apply_bg_diff_result(
             &mut ds,
             BgDiffResult {
-                committed: vec![file("src/main.rs")],
-                uncommitted: Vec::new(),
+                files: vec![file("src/main.rs")],
                 error: None,
             },
         );
 
         assert!(ds.error.is_none());
-        assert_eq!(ds.committed_files.len(), 1);
+        assert_eq!(ds.files.len(), 1);
     }
 }

--- a/src/diff_state/compute.rs
+++ b/src/diff_state/compute.rs
@@ -10,9 +10,7 @@ use git2::Repository;
 use regex::Regex;
 use similar::{ChangeTag, TextDiff};
 
-use super::model::{
-    DiffHunk, DiffLine, DiffLineTag, DiffRange, DiffState, FileDiff, InlineSegment,
-};
+use super::model::{DiffHunk, DiffLine, DiffLineTag, DiffState, FileDiff, InlineSegment};
 
 /// ハンクの前後に付けるコンテキスト行数。git の既定と同じ 3 行。
 const CONTEXT_LINES: u32 = 3;
@@ -57,11 +55,8 @@ fn resolve_base_commit(repo: &Repository, base: &str) -> Result<git2::Oid> {
 }
 
 impl DiffState {
-    /// worktree_path のリポジトリについて base_branch と HEAD の diff を読み込み、
+    /// worktree_path のリポジトリについてベースからの変更を読み込み、
     /// 以前に保持していた diff データを置き換える。
-    ///
-    /// コミット済み(merge-base..HEAD)と未コミット(HEAD vs workdir+index)の
-    /// 両方の diff を計算する。
     pub fn load_diff(
         &mut self,
         worktree_path: &Path,
@@ -70,45 +65,15 @@ impl DiffState {
         tab_width: usize,
     ) {
         self.base_branch = base_branch.to_string();
-        self.error = None;
 
-        // コミット済みの diff を計算する。
-        match Self::compute_diff_range(
-            worktree_path,
-            base_branch,
-            DiffRange::Committed,
-            word_diff,
-            tab_width,
-        ) {
-            Ok(mut files) => {
-                files.sort_by(|a, b| a.path.cmp(&b.path));
-                self.committed_files = files;
+        match Self::compute_changed_files(worktree_path, base_branch, word_diff, tab_width) {
+            Ok((files, base_error)) => {
+                self.files = files;
+                self.error = base_error;
             }
             Err(e) => {
-                self.committed_files.clear();
+                self.files.clear();
                 self.error = Some(format!("{e:#}"));
-                // 下の未コミット計算にはそのまま進む。未コミット側は base_branch
-                // に依存しないので、不正なベースが未コミットの変更まで隠してしまっては
-                // ならない。
-            }
-        }
-
-        // 未コミットの diff を計算する。
-        match Self::compute_diff_range(
-            worktree_path,
-            base_branch,
-            DiffRange::Uncommitted,
-            word_diff,
-            tab_width,
-        ) {
-            Ok(mut files) => {
-                files.sort_by(|a, b| a.path.cmp(&b.path));
-                self.uncommitted_files = files;
-            }
-            Err(e) => {
-                self.uncommitted_files.clear();
-                // 致命的ではない: コミット済みの diff は正常に読み込めている。
-                log::warn!("failed to compute uncommitted diff: {e:#}");
             }
         }
 
@@ -173,32 +138,19 @@ impl DiffState {
         None
     }
 
-    /// バックグラウンドでの diff 計算用の公開ラッパー。
+    /// merge-base(base, HEAD) から作業ツリー(index 込み)までのファイル単位 diff を
+    /// パス順に並べて返す。コミット済みと未コミットを1本の diff にまとめているので、
+    /// コミット後に再編集したファイルも1エントリのままになる。
     ///
-    /// committed: true なら merge-base..HEAD、false なら HEAD vs workdir+index を計算する。
-    pub fn compute_diff_range_static(
+    /// 2つ目の戻り値は「ベースを解決できず HEAD を基準にフォールバックした」理由。
+    /// ベース解決の失敗で一覧ごと空にすると手元の未コミット変更まで見えなくなるので、
+    /// 一覧は返した上で理由だけを別に渡す。
+    pub fn compute_changed_files(
         worktree_path: &Path,
         base_branch: &str,
-        committed: bool,
         word_diff: bool,
         tab_width: usize,
-    ) -> Result<Vec<FileDiff>> {
-        let range = if committed {
-            DiffRange::Committed
-        } else {
-            DiffRange::Uncommitted
-        };
-        Self::compute_diff_range(worktree_path, base_branch, range, word_diff, tab_width)
-    }
-
-    /// git2 + similar を使い、指定した範囲についてファイル単位の diff を計算する。
-    pub(super) fn compute_diff_range(
-        worktree_path: &Path,
-        base_branch: &str,
-        range: DiffRange,
-        word_diff: bool,
-        tab_width: usize,
-    ) -> Result<Vec<FileDiff>> {
+    ) -> Result<(Vec<FileDiff>, Option<String>)> {
         let repo = Repository::open(worktree_path)
             .with_context(|| format!("cannot open repo at {}", worktree_path.display()))?;
 
@@ -208,39 +160,49 @@ impl DiffState {
             .with_context(|| "cannot resolve HEAD")?
             .peel_to_commit()
             .with_context(|| "cannot peel HEAD to commit")?;
-        let head_oid = head_commit.id();
+        let head_tree = head_commit.tree()?;
 
-        // range に応じて git2 の diff を構築する。
-        let diff = match range {
-            DiffRange::Committed => {
-                // merge-base(base, HEAD)..HEAD
-                let base_oid = resolve_base_commit(&repo, base_branch)?;
-                let merge_base_oid = repo.merge_base(base_oid, head_oid).with_context(|| {
-                    format!("cannot find merge-base between '{base_branch}' and HEAD")
-                })?;
-                let merge_base_tree = repo
-                    .find_commit(merge_base_oid)?
-                    .tree()
-                    .with_context(|| "cannot get merge-base tree")?;
-                let head_tree = head_commit.tree()?;
-                let mut opts = git2::DiffOptions::new();
-                opts.context_lines(CONTEXT_LINES);
-                repo.diff_tree_to_tree(Some(&merge_base_tree), Some(&head_tree), Some(&mut opts))?
-            }
-            DiffRange::Uncommitted => {
-                // HEAD..workdir+index
-                let head_tree = head_commit.tree()?;
-                let mut opts = git2::DiffOptions::new();
-                opts.include_untracked(true);
-                opts.recurse_untracked_dirs(true);
-                // これが無いと未追跡ファイルは一覧に出るだけで中身が読まれず、
-                // パッチが作られないので追加行数が 0 になってしまう。
-                opts.show_untracked_content(true);
-                opts.context_lines(CONTEXT_LINES);
-                repo.diff_tree_to_workdir_with_index(Some(&head_tree), Some(&mut opts))?
-            }
-        };
+        let (base_tree, base_error) =
+            match Self::merge_base_tree(&repo, base_branch, head_commit.id()) {
+                Ok(tree) => (tree, None),
+                Err(e) => (head_tree, Some(format!("{e:#}"))),
+            };
 
+        let mut opts = git2::DiffOptions::new();
+        opts.include_untracked(true);
+        opts.recurse_untracked_dirs(true);
+        // これが無いと未追跡ファイルは一覧に出るだけで中身が読まれず、
+        // パッチが作られないので追加行数が 0 になってしまう。
+        opts.show_untracked_content(true);
+        opts.context_lines(CONTEXT_LINES);
+        let diff = repo.diff_tree_to_workdir_with_index(Some(&base_tree), Some(&mut opts))?;
+        let files = Self::file_diffs_from(&repo, &diff, word_diff, tab_width)?;
+        Ok((files, base_error))
+    }
+
+    /// base と HEAD の merge-base のツリーを解決する。
+    fn merge_base_tree<'r>(
+        repo: &'r Repository,
+        base_branch: &str,
+        head_oid: git2::Oid,
+    ) -> Result<git2::Tree<'r>> {
+        let base_oid = resolve_base_commit(repo, base_branch)?;
+        let merge_base_oid = repo
+            .merge_base(base_oid, head_oid)
+            .with_context(|| format!("cannot find merge-base between '{base_branch}' and HEAD"))?;
+        repo.find_commit(merge_base_oid)?
+            .tree()
+            .with_context(|| "cannot get merge-base tree")
+    }
+
+    /// git2 の diff をファイル単位の [FileDiff] に展開する(行内 diff は
+    /// word_diff のときだけ計算する)。返り値はパス順。
+    fn file_diffs_from(
+        repo: &Repository,
+        diff: &git2::Diff<'_>,
+        word_diff: bool,
+        tab_width: usize,
+    ) -> Result<Vec<FileDiff>> {
         let mut file_diffs = Vec::new();
 
         // スキップするデルタのインデックス集合を作る: 大文字小文字だけ異なり
@@ -248,7 +210,7 @@ impl DiffState {
         // ファイル内容が同一でもパスの大文字小文字だけが異なる削除+追加のペア
         // (例: "Photo.png" 削除、"photo.png" 追加)を git が報告することがある。
         // blob の OID と小文字化したパスを比較してこれらのペアを検出する。
-        let skip_indices = Self::find_case_only_rename_indices(&diff);
+        let skip_indices = Self::find_case_only_rename_indices(diff);
 
         let num_deltas = diff.deltas().len();
         for delta_idx in 0..num_deltas {
@@ -271,7 +233,7 @@ impl DiffState {
             // として表示される事故の発生源だった。libgit2 に任せると内容の取得も
             // 行数も git 本体と同じ経路になり、.gitattributes のフィルタや改行
             // 正規化、バイナリ判定もそのまま効く。
-            let patch = match git2::Patch::from_diff(&diff, delta_idx) {
+            let patch = match git2::Patch::from_diff(diff, delta_idx) {
                 Ok(p) => p,
                 Err(e) => {
                     // 1ファイルの失敗で一覧全体を落とさない。数字を捏造するより
@@ -315,7 +277,7 @@ impl DiffState {
                 .and_then(|e| e.to_str())
                 .unwrap_or("");
             let func_pattern = Self::func_pattern_for_ext(ext);
-            let old_content = Self::blob_content(&repo, &delta.old_file());
+            let old_content = Self::blob_content(repo, &delta.old_file());
             let old_lines: Vec<&str> = old_content.lines().collect();
 
             let mut hunks = Vec::new();
@@ -378,6 +340,7 @@ impl DiffState {
             });
         }
 
+        file_diffs.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(file_diffs)
     }
 

--- a/src/diff_state/display_list.rs
+++ b/src/diff_state/display_list.rs
@@ -4,14 +4,13 @@
 
 use std::collections::{BTreeMap, HashSet};
 
-use super::model::{DiffListEntry, DiffSection, DiffState, DiffViewMode, FileDiff};
+use super::model::{DiffListEntry, DiffState, DiffViewMode, FileDiff};
 
 impl DiffState {
     /// 空の DiffState を新規作成する。
     pub fn new(base_branch: &str, view_mode: DiffViewMode) -> Self {
         let mut state = Self {
-            committed_files: Vec::new(),
-            uncommitted_files: Vec::new(),
+            files: Vec::new(),
             display_list: Vec::new(),
             collapsed_dirs: HashSet::new(),
             scroll: 0,
@@ -24,10 +23,7 @@ impl DiffState {
         state
     }
 
-    /// フラット化した表示リストを再構築する。コミット済みと未コミットの変更を
-    /// 1つのディレクトリツリーに統合する。ファイルは C/U マークと解決のために
-    /// 出自(DiffSection)を保持し、ディレクトリは出自をまたいで統合されるので
-    /// src/ は両方の種類の変更があっても1回しか現れない。
+    /// フラット化した表示リストを再構築する。
     pub fn rebuild_display_list(&mut self) {
         self.display_list.clear();
 
@@ -36,46 +32,28 @@ impl DiffState {
             self.display_list.push(DiffListEntry::Summary {});
         }
 
-        Self::build_tree_entries(
-            &self.committed_files,
-            &self.uncommitted_files,
-            &self.collapsed_dirs,
-            &mut self.display_list,
-        );
+        Self::build_tree_entries(&self.files, &self.collapsed_dirs, &mut self.display_list);
     }
 
-    /// 両方の出自のファイルにまたがる1つのディレクトリツリーを構築する。
-    /// コミット済みと未コミットの両方で変更されたファイルは、統合された同じ
-    /// ディレクトリノード配下に、出自ごとに2回(マークで区別して)現れる。
+    /// 変更ファイルからディレクトリツリーを構築する。
     fn build_tree_entries(
-        committed: &[FileDiff],
-        uncommitted: &[FileDiff],
+        files: &[FileDiff],
         collapsed_dirs: &HashSet<String>,
         display_list: &mut Vec<DiffListEntry>,
     ) {
-        // 統合ツリーの葉: どの出自リスト・インデックスに解決されるかを保持する。
+        // ツリーの葉: 元の files のどのインデックスに解決されるかを保持する。
         struct Leaf {
-            section: DiffSection,
             index: usize,
             path: String,
         }
-        let mut leaves: Vec<Leaf> = Vec::with_capacity(committed.len() + uncommitted.len());
-        for (i, f) in committed.iter().enumerate() {
-            leaves.push(Leaf {
-                section: DiffSection::Committed,
-                index: i,
+        let mut leaves: Vec<Leaf> = files
+            .iter()
+            .enumerate()
+            .map(|(index, f)| Leaf {
+                index,
                 path: f.path.clone(),
-            });
-        }
-        for (i, f) in uncommitted.iter().enumerate() {
-            leaves.push(Leaf {
-                section: DiffSection::Uncommitted,
-                index: i,
-                path: f.path.clone(),
-            });
-        }
-        // 同じパスの兄弟をまとめる。安定ソートなので同一パスではコミット済みが
-        // 未コミットより先に来る。
+            })
+            .collect();
         leaves.sort_by(|a, b| a.path.cmp(&b.path));
 
         // ディレクトリパスと、そこに直接属する葉のインデックスを集める。
@@ -164,7 +142,6 @@ impl DiffState {
                 }
                 for &li in &node.leaves {
                     display_list.push(DiffListEntry::File {
-                        section: leaves[li].section,
                         file_index: leaves[li].index,
                         depth: depth + 1,
                     });
@@ -177,29 +154,18 @@ impl DiffState {
         }
         for &li in &top_level {
             display_list.push(DiffListEntry::File {
-                section: leaves[li].section,
                 file_index: leaves[li].index,
                 depth: 0,
             });
         }
     }
 
-    /// 表示リストのインデックスをファイル参照とそのセクションに解決する。
+    /// 表示リストのインデックスをファイル参照に解決する。
     ///
-    /// セクションヘッダーまたは範囲外のインデックスの場合は None を返す。
-    pub fn resolve_file(&self, display_idx: usize) -> Option<(&FileDiff, DiffSection)> {
+    /// ディレクトリ行、サマリー行、範囲外のインデックスの場合は None を返す。
+    pub fn resolve_file(&self, display_idx: usize) -> Option<&FileDiff> {
         match self.display_list.get(display_idx)? {
-            DiffListEntry::File {
-                section,
-                file_index,
-                ..
-            } => {
-                let files = match section {
-                    DiffSection::Committed => &self.committed_files,
-                    DiffSection::Uncommitted => &self.uncommitted_files,
-                };
-                files.get(*file_index).map(|f| (f, *section))
-            }
+            DiffListEntry::File { file_index, .. } => self.files.get(*file_index),
             DiffListEntry::Directory { .. } | DiffListEntry::Summary {} => None,
         }
     }
@@ -209,19 +175,14 @@ impl DiffState {
     /// ファイルを開いた際(例: walkthrough のステップのファイルへジャンプする場合)に、
     /// diff リストのカーソルを同期させておくために使う。
     pub fn display_index_for_path(&self, path: &str) -> Option<usize> {
-        (0..self.display_list.len()).find(|&idx| self.resolve_file(idx).is_some_and(|(f, _)| f.path == path))
+        (0..self.display_list.len())
+            .find(|&idx| self.resolve_file(idx).is_some_and(|f| f.path == path))
     }
 
-    /// diff 内の全ての変更パス。両セクションを合わせて重複を除いたもの。
-    /// [Self::display_index_for_path] と違い表示リストを無視するので、
-    /// 折りたたまれたディレクトリ内のファイルも存在するものとして数える。
+    /// diff 内の全ての変更パス。[Self::display_index_for_path] と違い表示リストを
+    /// 無視するので、折りたたまれたディレクトリ内のファイルも存在するものとして数える。
     pub fn changed_paths(&self) -> Vec<&str> {
-        let mut paths: Vec<&str> = self
-            .committed_files
-            .iter()
-            .chain(self.uncommitted_files.iter())
-            .map(|f| f.path.as_str())
-            .collect();
+        let mut paths: Vec<&str> = self.files.iter().map(|f| f.path.as_str()).collect();
         paths.sort_unstable();
         paths.dedup();
         paths

--- a/src/diff_state/mod.rs
+++ b/src/diff_state/mod.rs
@@ -1,9 +1,9 @@
 //! Diff state — Diff モードのためのデータモデル。
 //!
-//! git2 と similar を使って HEAD とベースブランチを比較した結果として得られる、
-//! ファイル単位の diff、ハンク情報、行単位の変更を保持する。
-//! ファイルはコミット済み(merge-base..HEAD)と未コミット(HEAD vs workdir+index)の
-//! 2セクションに分かれる。
+//! ベースブランチとの merge-base から作業ツリーまでを git2 と similar で比較した
+//! 結果として得られる、ファイル単位の diff、ハンク情報、行単位の変更を保持する。
+//! コミット済みと未コミットは1本の diff にまとまっているので、1ファイルは常に
+//! 1エントリになる。
 //!
 //! 責務ごとに分割している: [model] はデータ型(DiffState とその構成要素)、
 //! [display_list] はフラット化した explorer 表示リストの構築とナビゲーション、
@@ -16,8 +16,7 @@ mod model;
 mod tests;
 
 pub use model::{
-    DiffHunk, DiffLineTag, DiffListEntry, DiffSection, DiffState, DiffViewMode, FileDiff,
-    InlineSegment,
+    DiffHunk, DiffLineTag, DiffListEntry, DiffState, DiffViewMode, FileDiff, InlineSegment,
 };
 // #[cfg(test)] のコード(review_publish のテスト)からしか参照されないため、
 // 通常ビルドでは未使用と判定される。

--- a/src/diff_state/model.rs
+++ b/src/diff_state/model.rs
@@ -23,14 +23,7 @@ impl From<DiffView> for DiffViewMode {
     }
 }
 
-// セクション / 表示リスト
-
-/// diff ファイルがどちらのセクションに属するか。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DiffSection {
-    Committed,
-    Uncommitted,
-}
+// 表示リスト
 
 /// explorer パネルに表示するフラット化リストの1エントリ。
 #[derive(Debug, Clone)]
@@ -46,10 +39,8 @@ pub enum DiffListEntry {
         /// このディレクトリが折りたたまれているか。
         collapsed: bool,
     },
-    /// 変更のあったファイル。section は行の C/U マーク表示と、元のリストへの
-    /// 逆引きの両方に使う出自(コミット済みか未コミットか)を記録する。
+    /// 変更のあったファイル。file_index は DiffState::files への添字。
     File {
-        section: DiffSection,
         file_index: usize,
         /// ネスト深度(0 がトップレベルのファイル)。
         depth: usize,
@@ -58,17 +49,6 @@ pub enum DiffListEntry {
     /// 選択すると Viewer にサマリー全文が開く。将来メタデータ(鮮度など)を
     /// 追加しても既存の match アームを壊さないよう struct variant にしている。
     Summary {},
-}
-
-// 内部の diff 範囲(旧・公開型 DiffScope の置き換え)
-
-/// どの範囲を計算するか。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum DiffRange {
-    /// merge-base(base, HEAD)..HEAD — コミット済みの変更のみ。
-    Committed,
-    /// HEAD..workdir+index — 未コミットの変更のみ。
-    Uncommitted,
 }
 
 // 行レベルの型
@@ -135,10 +115,10 @@ pub struct FileDiff {
 /// Diff モード UI の全状態。
 #[derive(Debug, Clone)]
 pub struct DiffState {
-    /// コミット済みの変更(merge-base..HEAD)。
-    pub committed_files: Vec<FileDiff>,
-    /// 未コミットの変更(HEAD vs workdir+index)。
-    pub uncommitted_files: Vec<FileDiff>,
+    /// ブランチがベースに対して加えた変更(merge-base..workdir+index)。
+    /// コミット済みと未コミットを1つの diff にまとめてあるので、コミット後に
+    /// 再編集したファイルも1エントリのままになる。
+    pub files: Vec<FileDiff>,
     /// explorer パネル用にフラット化した表示リスト。
     pub display_list: Vec<DiffListEntry>,
     /// 折りたたまれているディレクトリパスの集合(素のリポジトリ相対パスをキーにする)。

--- a/src/diff_state/tests.rs
+++ b/src/diff_state/tests.rs
@@ -1,7 +1,7 @@
 //! diff_state モジュールのテスト。インラインセグメントの強調、大文字小文字だけの
 //! リネームのフィルタリング、display list ナビゲーションのエッジケース、
 //! ベース ref の解決(リモート追跡 ref・タグ・OID、および解決不能なベースが
-//! 未コミット diff まで巻き込まないこと)を検証する。
+//! 変更一覧を消し去らないこと)を検証する。
 
 use similar::{ChangeTag, TextDiff};
 
@@ -52,6 +52,28 @@ fn set_remote_tracking_ref(repo: &git2::Repository, name: &str, oid: git2::Oid) 
         .unwrap();
 }
 
+/// ベースからの変更ファイル一覧。ベース解決に失敗した理由は [base_error] で見る。
+fn changed_files(dir: &std::path::Path, base: &str) -> Vec<super::FileDiff> {
+    super::DiffState::compute_changed_files(dir, base, false, 4)
+        .unwrap()
+        .0
+}
+
+/// 変更ファイルのパス一覧。
+fn changed_paths(dir: &std::path::Path, base: &str) -> Vec<String> {
+    changed_files(dir, base)
+        .iter()
+        .map(|f| f.path.clone())
+        .collect()
+}
+
+/// ベースを解決できず HEAD にフォールバックした理由(成功時は None)。
+fn base_error(dir: &std::path::Path, base: &str) -> Option<String> {
+    super::DiffState::compute_changed_files(dir, base, false, 4)
+        .unwrap()
+        .1
+}
+
 #[test]
 fn test_inline_segments_populated_for_replace() {
     let old = "hello world\n";
@@ -76,9 +98,6 @@ fn test_inline_segments_populated_for_replace() {
 /// はこれらを除外すべきである。
 #[test]
 fn test_case_only_rename_filtered_out() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -121,8 +140,7 @@ fn test_case_only_rename_filtered_out() {
         .unwrap();
     repo.set_head("refs/heads/feature").unwrap();
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4).unwrap();
+    let files = changed_files(dir.path(), "main");
 
     // 内容が同一の大文字小文字だけのリネームは除外されるべき。
     assert!(
@@ -135,9 +153,6 @@ fn test_case_only_rename_filtered_out() {
 /// 内容変更を伴う大文字小文字リネームはフィルタで除外されないことを検証する。
 #[test]
 fn test_case_rename_with_content_change_kept() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -179,8 +194,7 @@ fn test_case_rename_with_content_change_kept() {
         .unwrap();
     repo.set_head("refs/heads/feature").unwrap();
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "main", DiffRange::Committed, false, 4).unwrap();
+    let files = changed_files(dir.path(), "main");
 
     // 実際に内容変更を伴うリネームは表示されるべき。
     assert!(
@@ -223,7 +237,7 @@ fn expand_already_expanded_dir_does_not_panic() {
 /// インデックスではなくパス(walkthrough のステップへのジャンプなど)で開かれた
 /// 際に diff リストのカーソルを再同期するために使う。
 #[test]
-fn display_index_for_path_finds_committed_and_uncommitted_files() {
+fn display_index_for_path_finds_files() {
     use super::*;
     let file = |path: &str| FileDiff {
         path: path.to_string(),
@@ -232,17 +246,14 @@ fn display_index_for_path_finds_committed_and_uncommitted_files() {
         hunks: Vec::new(),
     };
     let mut ds = DiffState::new("main", DiffViewMode::Unified);
-    ds.committed_files = vec![file("src/a.rs")];
-    ds.uncommitted_files = vec![file("src/b.rs")];
+    ds.files = vec![file("src/a.rs"), file("src/b.rs")];
     ds.display_list = vec![
         DiffListEntry::File {
-            section: DiffSection::Committed,
             file_index: 0,
             depth: 0,
         },
         DiffListEntry::File {
-            section: DiffSection::Uncommitted,
-            file_index: 0,
+            file_index: 1,
             depth: 0,
         },
     ];
@@ -254,11 +265,11 @@ fn display_index_for_path_finds_committed_and_uncommitted_files() {
 
 // 寛容なパス解決(walkthrough のステップ / コメントのアンカー)
 
-/// コミット済み diff が paths に触れる DiffState を作り、display list を構築する。
+/// diff が paths に触れる DiffState を作り、display list を構築する。
 fn diff_state_with(paths: &[&str]) -> super::DiffState {
     use super::*;
     let mut ds = DiffState::new("main", DiffViewMode::Unified);
-    ds.committed_files = paths
+    ds.files = paths
         .iter()
         .map(|p| FileDiff {
             path: (*p).to_string(),
@@ -341,7 +352,7 @@ fn reveal_path_expands_collapsed_ancestors() {
 
     let idx = ds.reveal_path("src/deep/nested/c.rs").expect("row after reveal");
     assert_eq!(
-        ds.resolve_file(idx).map(|(f, _)| f.path.as_str()),
+        ds.resolve_file(idx).map(|f| f.path.as_str()),
         Some("src/deep/nested/c.rs")
     );
 }
@@ -353,9 +364,6 @@ fn reveal_path_expands_collapsed_ancestors() {
 /// 解決できなければならない。
 #[test]
 fn base_ref_resolves_remote_tracking_ref() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -371,11 +379,8 @@ fn base_ref_resolves_remote_tracking_ref() {
         "test setup invariant: no local 'main' branch should exist"
     );
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "origin/main", DiffRange::Committed, false, 4)
-            .unwrap();
-    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
-    assert_eq!(paths, vec!["b.txt"]);
+    assert_eq!(changed_paths(dir.path(), "origin/main"), vec!["b.txt"]);
+    assert_eq!(base_error(dir.path(), "origin/main"), None);
 }
 
 /// 同じ解決は、メイン worktree だけでなくリンクされた worktree の Repository
@@ -383,9 +388,6 @@ fn base_ref_resolves_remote_tracking_ref() {
 /// 共有の commondir に存在するからである。
 #[test]
 fn base_ref_resolves_from_linked_worktree() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -422,20 +424,14 @@ fn base_ref_resolves_from_linked_worktree() {
         .unwrap();
     assert!(status.success(), "git worktree add failed");
 
-    let files =
-        DiffState::compute_diff_range(&wt_path, "origin/main", DiffRange::Committed, false, 4)
-            .unwrap();
-    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
-    assert_eq!(paths, vec!["b.txt"]);
+    assert_eq!(changed_paths(&wt_path, "origin/main"), vec!["b.txt"]);
+    assert_eq!(base_error(&wt_path, "origin/main"), None);
 }
 
 /// 軽量タグ、注釈付きタグ、完全な OID、短縮 OID のいずれも同じベースコミットに
 /// 解決しなければならない。
 #[test]
 fn base_ref_resolves_tag_lightweight_annotated_and_oid() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -455,11 +451,13 @@ fn base_ref_resolves_tag_lightweight_annotated_and_oid() {
     let short_oid = &full_oid[..7];
 
     for base in ["v-lw", "v-ann", full_oid.as_str(), short_oid] {
-        let files = DiffState::compute_diff_range(dir.path(), base, DiffRange::Committed, false, 4)
-            .unwrap_or_else(|e| panic!("base '{base}' failed to resolve: {e:#}"));
-        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
         assert_eq!(
-            paths,
+            base_error(dir.path(), base),
+            None,
+            "base '{base}' failed to resolve"
+        );
+        assert_eq!(
+            changed_paths(dir.path(), base),
             vec!["b.txt"],
             "base '{base}' produced unexpected diff"
         );
@@ -470,9 +468,6 @@ fn base_ref_resolves_tag_lightweight_annotated_and_oid() {
 /// ない)設定済みベースは、origin/ フォールバック経由で解決しなければならない。
 #[test]
 fn base_ref_falls_back_to_origin_prefix() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -489,30 +484,21 @@ fn base_ref_falls_back_to_origin_prefix() {
         "test setup invariant: no local 'develop' branch should exist"
     );
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "develop", DiffRange::Committed, false, 4)
-            .unwrap();
-    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
-    assert_eq!(paths, vec!["b.txt"]);
+    assert_eq!(changed_paths(dir.path(), "develop"), vec!["b.txt"]);
+    assert_eq!(base_error(dir.path(), "develop"), None);
 }
 
 /// 直接にも origin/ 経由にも解決しないベースは、呼び出し側が実際に指定した
 /// ベース名を含むエラーを報告しなければならない。
 #[test]
 fn base_ref_unresolvable_reports_error() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
     let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
     checkout_branch(&repo, "main", oid);
 
-    let err =
-        DiffState::compute_diff_range(dir.path(), "nonexistent", DiffRange::Committed, false, 4)
-            .unwrap_err();
-    let msg = format!("{err:#}");
+    let msg = base_error(dir.path(), "nonexistent").expect("expected an error to be set");
     assert!(msg.contains("nonexistent"), "error message was: {msg}");
 }
 
@@ -525,9 +511,6 @@ fn base_ref_unresolvable_reports_error() {
 /// エラーメッセージの文言だけでなく予期しない Ok として現れるようにする。
 #[test]
 fn base_ref_error_does_not_double_the_origin_prefix() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -538,10 +521,7 @@ fn base_ref_error_does_not_double_the_origin_prefix() {
     // 失敗する代わりにここに着地してしまう。
     set_remote_tracking_ref(&repo, "origin/origin/weird", oid);
 
-    let err =
-        DiffState::compute_diff_range(dir.path(), "origin/weird", DiffRange::Committed, false, 4)
-            .unwrap_err();
-    let msg = format!("{err:#}");
+    let msg = base_error(dir.path(), "origin/weird").expect("expected an error to be set");
     assert!(msg.contains("origin/weird"), "error message was: {msg}");
     assert!(
         !msg.contains("origin/origin"),
@@ -559,9 +539,6 @@ fn base_ref_error_does_not_double_the_origin_prefix() {
 /// 2つの選択肢のうちより紛らわしい方になってしまう。
 #[test]
 fn base_ref_prefers_tag_over_branch_like_git_rev_parse() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -586,24 +563,18 @@ fn base_ref_prefers_tag_over_branch_like_git_rev_parse() {
     let head_oid = commit_files(&repo, Some(&tag_commit), &[("head.txt", b"c")]);
     checkout_branch(&repo, "feature", head_oid);
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "dup", DiffRange::Committed, false, 4).unwrap();
-    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
     assert_eq!(
-        paths,
+        changed_paths(dir.path(), "dup"),
         vec!["head.txt"],
         "expected 'dup' to resolve to the tag (only head.txt ahead of it), \
          not the branch (which would also include from_tag.txt)"
     );
 }
 
-/// 未コミット diff(HEAD vs workdir+index)はベースに一切依存しないので、
-/// 解決不能なベースがあってもその計算を妨げてはならない。
+/// 解決不能なベースは HEAD 基準へのフォールバックで扱う。手元の変更が
+/// ベース設定のミスで丸ごと見えなくなってはならない。
 #[test]
-fn uncommitted_range_ignores_unresolvable_base() {
-    use super::model::DiffRange;
-    use super::*;
-
+fn unresolvable_base_falls_back_to_head() {
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -612,19 +583,15 @@ fn uncommitted_range_ignores_unresolvable_base() {
 
     std::fs::write(dir.path().join("c.txt"), b"new file").unwrap();
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "nonexistent", DiffRange::Uncommitted, false, 4)
-            .unwrap();
-    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
-    assert_eq!(paths, vec!["c.txt"]);
+    assert_eq!(changed_paths(dir.path(), "nonexistent"), vec!["c.txt"]);
 }
 
-// ベースの解決失敗時に load_diff が未コミットをクリアしてはならない
+// ベースの解決失敗時に load_diff が手元の変更をクリアしてはならない
 
-/// 解決不能なベースを与えた load_diff は、両方の diff セクションをクリアするのではなく、
-/// 未コミットの変更とエラーの両方をきちんと表に出さなければならない。
+/// 解決不能なベースを与えた load_diff は、一覧をクリアするのではなく、
+/// 手元の変更とエラーの両方をきちんと表に出さなければならない。
 #[test]
-fn load_diff_keeps_uncommitted_when_base_unresolvable() {
+fn load_diff_keeps_files_when_base_unresolvable() {
     use super::*;
 
     let dir = tempfile::tempdir().unwrap();
@@ -638,25 +605,19 @@ fn load_diff_keeps_uncommitted_when_base_unresolvable() {
     let mut ds = DiffState::new("nonexistent", DiffViewMode::Unified);
     ds.load_diff(dir.path(), "nonexistent", false, 4);
 
-    assert!(ds.committed_files.is_empty());
     let err = ds.error.as_deref().expect("expected an error to be set");
     assert!(err.contains("nonexistent"), "error message was: {err}");
 
-    let uncommitted_paths: Vec<&str> = ds
-        .uncommitted_files
-        .iter()
-        .map(|f| f.path.as_str())
-        .collect();
-    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+    let paths: Vec<&str> = ds.files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["c.txt"]);
     assert!(
         ds.display_index_for_path("c.txt").is_some(),
-        "display_list should still include the uncommitted file"
+        "display_list should still include the file"
     );
 }
 
 /// HEAD が設定されたベースとの merge-base に等しい場合(0コミット先行)、
-/// コミット済みセクションは正当に空であり、エラーも出ない
-/// 未コミットの変更だけが表示されるべきである。
+/// エラーは出ず、未コミットの変更だけが表示されるべきである。
 #[test]
 fn load_diff_head_equals_merge_base_shows_uncommitted_only() {
     use super::*;
@@ -676,33 +637,18 @@ fn load_diff_head_equals_merge_base_shows_uncommitted_only() {
     let mut ds = DiffState::new("release", DiffViewMode::Unified);
     ds.load_diff(dir.path(), "release", false, 4);
 
-    assert!(ds.committed_files.is_empty());
     assert!(ds.error.is_none());
 
-    let uncommitted_paths: Vec<&str> = ds
-        .uncommitted_files
-        .iter()
-        .map(|f| f.path.as_str())
-        .collect();
-    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+    let paths: Vec<&str> = ds.files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["c.txt"]);
 }
 
 /// 元のバグ報告をエンドツーエンドで再現する: ベースが origin/main として
 /// 保存され(ローカルの main ブランチはない)、大量の未コミット変更を抱えたまま
 /// origin/main から1コミット遅れている worktree。修正前は main が
-/// find_branch(Local) 経由での解決に失敗し、その失敗が両方の diff セクションを
-/// 消し去っていた ─ 変更済み/未追跡ファイルが実際には全て存在するにもかかわらず
+/// find_branch(Local) 経由での解決に失敗し、その失敗が diff 一覧を消し去って
+/// いた ─ 変更済み/未追跡ファイルが実際には全て存在するにもかかわらず
 /// "Changed files (0)" と報告されていた。
-///
-/// このテストが確かめたい微妙な点: ここでコミット済みが0件であること自体は
-/// 正しく、バグの症状ではない。1コミット遅れとは merge-base(origin/main, HEAD)
-/// == HEAD を意味するので、修正の有無にかかわらずコミット済みセクションは
-/// 正当に空である。修正が変えるのは ds.error が(ベースが解決したので)
-/// None になり、uncommitted_files が全ての変更済み/未追跡ファイルを
-/// 保持し続ける点である ─ 修正前はコミット済みセクションと一緒にどちらも
-/// クリアされ、全てが黙って(0)に潰れていた。下のコミット済みが空である
-/// アサーションを「バグはコミット済みが0と表示されること」と読んではならない。
-/// それは元々0以外を示すべきではない。
 #[test]
 fn load_diff_reproduces_the_silent_zero_files_report() {
     use super::*;
@@ -742,16 +688,10 @@ fn load_diff_reproduces_the_silent_zero_files_report() {
 
     // 修正の効果: ベースが解決したのでエラーなし。
     assert_eq!(ds.error, None);
-    // 正当に空(1コミット遅れ)であり、バグではない。
-    assert!(ds.committed_files.is_empty());
 
-    let uncommitted_paths: Vec<&str> = ds
-        .uncommitted_files
-        .iter()
-        .map(|f| f.path.as_str())
-        .collect();
+    let paths: Vec<&str> = ds.files.iter().map(|f| f.path.as_str()).collect();
     assert_eq!(
-        uncommitted_paths,
+        paths,
         vec!["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"]
     );
     for path in ["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"] {
@@ -766,11 +706,9 @@ fn load_diff_reproduces_the_silent_zero_files_report() {
 
 /// ベースと HEAD が共通の履歴を持たない(shallow clone が生む形と同じ、
 /// 無関係な2つのルートコミット)場合、repo.merge_base() は失敗する。
-/// 計画の「やらないこと」リストは、これがコミット済みを未コミットと一緒に
-/// 巻き込まないこと、そして理由が見える形になっていることを約束しており、
-/// このテストはその両方を確かめる。
+/// このときも一覧は HEAD 基準で残り、理由が見える形になっていること。
 #[test]
-fn load_diff_keeps_uncommitted_when_merge_base_is_unrelated() {
+fn load_diff_keeps_files_when_merge_base_is_unrelated() {
     use super::*;
 
     let dir = tempfile::tempdir().unwrap();
@@ -789,7 +727,6 @@ fn load_diff_keeps_uncommitted_when_merge_base_is_unrelated() {
     let mut ds = DiffState::new("other", DiffViewMode::Unified);
     ds.load_diff(dir.path(), "other", false, 4);
 
-    assert!(ds.committed_files.is_empty());
     let err = ds.error.as_deref().expect("expected an error to be set");
     // 失敗モードとベースの両方を名指ししなければならない。そうしないと
     // base_ref_unresolvable_reports_error の解決不能 ref エラーと区別が
@@ -798,23 +735,17 @@ fn load_diff_keeps_uncommitted_when_merge_base_is_unrelated() {
     assert!(err.contains("merge-base"), "error message was: {err}");
     assert!(err.contains("other"), "error message was: {err}");
 
-    let uncommitted_paths: Vec<&str> = ds
-        .uncommitted_files
-        .iter()
-        .map(|f| f.path.as_str())
-        .collect();
-    assert_eq!(uncommitted_paths, vec!["c.txt"]);
+    let paths: Vec<&str> = ds.files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["c.txt"]);
 }
 
 /// コミットが0件の worktree(git init しただけで HEAD が "unborn")は
 /// panic してはならず、変更0件と黙って報告するのではなくエラーを表に
 /// 出さなければならない。
 ///
-/// これは既存の制限であり、この変更が退行させたものではない: ここでの
-/// workdir ファイルは技術的には全て未追跡だが、未コミット diff はそれでも
-/// 比較対象となる HEAD ツリーを必要とし、それが存在しない。この変更が
-/// もたらすのは、説明のつかない "Changed files (0)" の代わりに理由が
-/// error に載るようになることである。
+/// ここでの workdir ファイルは技術的には全て未追跡だが、diff はそれでも
+/// 比較対象となるツリーを必要とし、それが存在しない。説明のつかない
+/// "Changed files (0)" ではなく、理由が error に載る。
 #[test]
 fn load_diff_on_unborn_head_reports_error_without_panicking() {
     use super::*;
@@ -828,43 +759,33 @@ fn load_diff_on_unborn_head_reports_error_without_panicking() {
 
     let err = ds.error.as_deref().expect("expected an error to be set");
     assert!(err.contains("HEAD"), "error message was: {err}");
-    assert!(ds.committed_files.is_empty());
-    assert!(ds.uncommitted_files.is_empty());
+    assert!(ds.files.is_empty());
     assert!(ds.display_list.is_empty());
 }
 
-/// ベースとして "HEAD" を指定すると diff エンジン上は no-op になる:
-/// merge-base(HEAD, HEAD) == HEAD なので、コミット済み diff は常に空で
-/// エラーにもならない。これは diff エンジンとしては正しい挙動である —
-/// "HEAD" はそもそもベースとして役に立たないというだけの話だ。worktree が
-/// "HEAD" をベースとして保存してしまわないようにするのは書き込み側の責務
-/// (GitEngine::resolve_base_ref / worktree_crud.rs)であり、この関数が
-/// 特別扱いすべきことではない。
+/// ベースとして "HEAD" を指定すると、merge-base(HEAD, HEAD) == HEAD なので
+/// コミット済みの変更は何も出ず、作業ツリーの変更だけが残る。エラーにもならない。
+/// これは diff エンジンとしては正しい挙動である — "HEAD" はそもそもベースとして
+/// 役に立たないというだけの話だ。worktree が "HEAD" をベースとして保存して
+/// しまわないようにするのは書き込み側の責務(GitEngine::resolve_base_ref /
+/// worktree_crud.rs)であり、この関数が特別扱いすべきことではない。
 #[test]
-fn base_ref_head_yields_an_empty_committed_diff() {
-    use super::model::DiffRange;
-    use super::*;
-
+fn base_ref_head_yields_only_the_working_tree_changes() {
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
     let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
     checkout_branch(&repo, "main", oid);
 
-    let files =
-        DiffState::compute_diff_range(dir.path(), "HEAD", DiffRange::Committed, false, 4).unwrap();
-    assert!(files.is_empty());
+    assert!(changed_files(dir.path(), "HEAD").is_empty());
+    assert_eq!(base_error(dir.path(), "HEAD"), None);
 }
 
 /// コミット以外のオブジェクトに解決されるベース(ここでは blob を直接
-/// 指す軽量タグ)は、黙って空の diff を返すのではなくエラーを報告しな
-/// ければならない — Ok(vec![]) だけを見ている呼び出し側からは両者が
-/// 同じに見えてしまう。
+/// 指す軽量タグ)は、黙ってフォールバックするのではなく理由を報告しな
+/// ければならない — 一覧だけを見ている呼び出し側からは両者が同じに見える。
 #[test]
 fn base_ref_pointing_at_a_blob_reports_error() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -875,10 +796,7 @@ fn base_ref_pointing_at_a_blob_reports_error() {
     let blob_obj = repo.find_object(blob_oid, None).unwrap();
     repo.tag_lightweight("blob-tag", &blob_obj, false).unwrap();
 
-    let err =
-        DiffState::compute_diff_range(dir.path(), "blob-tag", DiffRange::Committed, false, 4)
-            .unwrap_err();
-    let msg = format!("{err:#}");
+    let msg = base_error(dir.path(), "blob-tag").expect("expected an error to be set");
     assert!(msg.contains("blob-tag"), "error message was: {msg}");
 }
 
@@ -887,21 +805,61 @@ fn base_ref_pointing_at_a_blob_reports_error() {
 /// 済み: revparse_single("") は何かに解決されるのではなく InvalidSpec で
 /// エラーになるので、これは既に安全である — このテストはそれを固定する
 /// ためのもので、将来の git2 アップグレードでこれが
-/// base_ref_head_yields_an_empty_committed_diff と同じ "HEAD" の罠に
+/// base_ref_head_yields_only_the_working_tree_changes と同じ "HEAD" の罠に
 /// 黙って変わってしまわないようにする。
 #[test]
 fn base_ref_empty_string_reports_error() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
     let oid = commit_files(&repo, None, &[("a.txt", b"a")]);
     checkout_branch(&repo, "main", oid);
 
-    let result = DiffState::compute_diff_range(dir.path(), "", DiffRange::Committed, false, 4);
-    assert!(result.is_err(), "empty-string base should not resolve");
+    assert!(
+        base_error(dir.path(), "").is_some(),
+        "empty-string base should not resolve"
+    );
+}
+
+// 1ファイル = 1エントリ
+
+/// この変更の存在理由: コミット済みと未コミットを別々に計算していた頃は、
+/// コミットしたファイルを再編集すると同じファイルが2行に分かれて出ていた。
+/// 1本の diff にまとめた今は、行数もベースからの合計になっていること。
+#[test]
+fn a_file_edited_after_commit_stays_one_entry() {
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    let base_oid = commit_files(&repo, None, &[("a.txt", b"base\n")]);
+    checkout_branch(&repo, "main", base_oid);
+    let base_commit = repo.find_commit(base_oid).unwrap();
+
+    // ブランチ側で1行追加してコミット。
+    let head_oid = commit_files(&repo, Some(&base_commit), &[("a.txt", b"base\ncommitted\n")]);
+    checkout_branch(&repo, "feature", head_oid);
+
+    // コミット済みのファイルをさらに編集する。
+    std::fs::write(dir.path().join("a.txt"), b"base\ncommitted\nedited\n").unwrap();
+
+    let files = changed_files(dir.path(), "main");
+    assert_eq!(
+        files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+        vec!["a.txt"],
+        "a file changed both in a commit and in the worktree must not be listed twice"
+    );
+    assert_eq!((files[0].added_lines, files[0].deleted_lines), (2, 0));
+
+    // 表示リストも同じで、行は1つだけ。
+    let mut ds = DiffState::new("main", DiffViewMode::Unified);
+    ds.load_diff(dir.path(), "main", false, 4);
+    let listed: Vec<&str> = (0..ds.display_list.len())
+        .filter_map(|idx| ds.resolve_file(idx))
+        .map(|f| f.path.as_str())
+        .collect();
+    assert_eq!(listed, vec!["a.txt"]);
 }
 
 // 新内容が空で返ってきたときに全行削除へ化ける件
@@ -912,8 +870,6 @@ fn base_ref_empty_string_reports_error() {
 /// 読めなかったことは削除された証拠ではない。
 #[test]
 fn unreadable_workdir_file_does_not_fabricate_full_deletion() {
-    use super::model::DiffRange;
-    use super::*;
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -932,14 +888,14 @@ fn unreadable_workdir_file_does_not_fabricate_full_deletion() {
     perms.set_mode(0o000);
     std::fs::set_permissions(&path, perms).unwrap();
 
-    let files = DiffState::compute_diff_range(dir.path(), "main", DiffRange::Uncommitted, false, 4);
+    let files = changed_files(dir.path(), "main");
 
     // tempdir の後始末が権限で失敗しないよう、判定より先に戻す。
     let mut perms = std::fs::metadata(&path).unwrap().permissions();
     perms.set_mode(0o644);
     std::fs::set_permissions(&path, perms).unwrap();
 
-    if let Some(f) = files.unwrap().iter().find(|f| f.path == "a.txt") {
+    if let Some(f) = files.iter().find(|f| f.path == "a.txt") {
         assert!(
             f.deleted_lines < 20,
             "read failure was reported as a full-file deletion: +{} -{}",
@@ -953,9 +909,6 @@ fn unreadable_workdir_file_does_not_fabricate_full_deletion() {
 /// ファイルは読めなくて当然で、全行削除が正しい表示。
 #[test]
 fn deleted_workdir_file_still_reports_full_deletion() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -965,8 +918,7 @@ fn deleted_workdir_file_still_reports_full_deletion() {
 
     std::fs::remove_file(dir.path().join("a.txt")).unwrap();
 
-    let files = DiffState::compute_diff_range(dir.path(), "main", DiffRange::Uncommitted, false, 4)
-        .unwrap();
+    let files = changed_files(dir.path(), "main");
 
     let f = files
         .iter()
@@ -980,9 +932,6 @@ fn deleted_workdir_file_still_reports_full_deletion() {
 /// 区別せずに落とすと、変更したバイナリが Changed files に現れなくなる。
 #[test]
 fn binary_file_stays_listed_without_line_counts() {
-    use super::model::DiffRange;
-    use super::*;
-
     let dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
@@ -991,8 +940,7 @@ fn binary_file_stays_listed_without_line_counts() {
 
     std::fs::write(dir.path().join("logo.png"), [0u8, 9, 9, 0, 7, 7, 7]).unwrap();
 
-    let files = DiffState::compute_diff_range(dir.path(), "main", DiffRange::Uncommitted, false, 4)
-        .unwrap();
+    let files = changed_files(dir.path(), "main");
 
     let f = files
         .iter()
@@ -1001,4 +949,3 @@ fn binary_file_stays_listed_without_line_counts() {
     assert_eq!((f.added_lines, f.deleted_lines), (0, 0));
     assert!(f.hunks.is_empty());
 }
-

--- a/src/event/explorer/diff_list.rs
+++ b/src/event/explorer/diff_list.rs
@@ -64,7 +64,7 @@ pub(super) fn handle_explorer_diff_list_key(app: &mut App, key: KeyEvent) {
         }
         Some(Action::ToggleViewed) => {
             let selected = app.viewer_state.explorer.diff_list_selected;
-            if let Some((file_diff, _)) = app.diff_state.resolve_file(selected) {
+            if let Some(file_diff) = app.diff_state.resolve_file(selected) {
                 let path = file_diff.path.clone();
                 app.toggle_path_viewed(&path);
             }

--- a/src/review_publish.rs
+++ b/src/review_publish.rs
@@ -86,13 +86,10 @@ pub fn filter_publishable(
 }
 
 /// [start, end] (新側の行番号) の両方が、file_path の同一の差分ハンクに
-/// 収まるかどうか。どちらの差分セクション (コミット済み・未コミット) も対象にする。
-/// レビューコメントはどちらのセクションに対して付けられたかを記録しないため、
-/// 両方を調べる。
+/// 収まるかどうか。
 fn line_range_in_diff(file_path: &str, start: u32, end: u32, diff: &DiffState) -> bool {
-    diff.committed_files
+    diff.files
         .iter()
-        .chain(diff.uncommitted_files.iter())
         .filter(|fd| fd.path == file_path)
         .any(|fd| {
             fd.hunks.iter().any(|hunk| {
@@ -350,7 +347,7 @@ mod tests {
                 content: String::new(),
             })
             .collect();
-        ds.committed_files = vec![FileDiff {
+        ds.files = vec![FileDiff {
             path: path.to_string(),
             added_lines: new_lines.len(),
             deleted_lines: 0,

--- a/src/ui/explorer_panel/diff_list.rs
+++ b/src/ui/explorer_panel/diff_list.rs
@@ -1,5 +1,5 @@
-//! エクスプローラ下半分の変更ファイル一覧（Committed / Uncommitted セクション）と
-//! ファイルごとのレビューコメント数バッジの描画。
+//! エクスプローラ下半分の変更ファイル一覧と、ファイルごとのレビューコメント数
+//! バッジの描画。
 
 use crate::app::{App, Focus};
 use crate::viewer::file_icon;
@@ -10,9 +10,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem};
 
 /// Changed-files の各行のファイル名色が表す、4種類の git ステージ状態のいずれか。
-/// DiffSection（committed/uncommitted、どちらのセクションに対して diff を
-/// 取るか）とは別物 — ファイルが Uncommitted でも、ここでの色は Staged に
-/// なりうる。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FileStageState {
     Untracked,
@@ -62,9 +59,9 @@ fn status_color(theme: &crate::theme::Theme, state: FileStageState) -> ratatui::
     }
 }
 
-/// diff 対象ファイル一覧（下半分）を Committed / Uncommitted セクション付きで描画する。
+/// diff 対象ファイル一覧（下半分）をディレクトリツリーとして描画する。
 pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_focused: bool) {
-    use crate::diff_state::{DiffListEntry, DiffSection};
+    use crate::diff_state::DiffListEntry;
 
     let theme = &app.theme;
     let vs_explorer = &app.viewer_state.explorer;
@@ -80,7 +77,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
         theme.border_unfocused
     };
 
-    let total = app.diff_state.committed_files.len() + app.diff_state.uncommitted_files.len();
+    let total = app.diff_state.files.len();
     let title = diff_list_title(total, app.diff_state.error.is_some());
 
     // ボーダーの太さは Explorer カラム全体、タイトルの強調はその下半分に
@@ -97,9 +94,9 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     let inner_height = area.height.saturating_sub(2) as usize;
     let scroll = vs_explorer.diff_list_scroll;
 
-    // 以前は base 解決の失敗が完全に無音だった: committed セクションが単に
-    // 空で返ってきて「変更なし」に見えてしまっていた。メッセージを先頭行に
-    // 固定して両者を混同しないようにする。このバナーは display_list の
+    // 以前は base 解決の失敗が完全に無音だった: 一覧が単に空で返ってきて
+    // 「変更なし」に見えてしまっていた。メッセージを先頭行に固定して両者を
+    // 混同しないようにする。このバナーは display_list の
     // 一部ではないため選択もできず、ナビゲーションキーが扱うインデックスも
     // ずらさない — コストはリストの高さ1行分だけ。改行はスペースに潰す。
     // 複数行の ListItem はここで確保した1行より多くの行を静かに消費して
@@ -148,40 +145,25 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                     Span::styled(name.clone(), style),
                 ])))
             }
-            DiffListEntry::File {
-                section,
-                file_index,
-                depth,
-            } => {
-                let files = match section {
-                    DiffSection::Committed => &app.diff_state.committed_files,
-                    DiffSection::Uncommitted => &app.diff_state.uncommitted_files,
-                };
+            DiffListEntry::File { file_index, depth } => {
                 // インデックスアクセスではなく .get を使う: display_list と
-                // セクションごとのファイル vector は異なるティックで再構築される
-                // ため、片方が古いままレンダリングされるフレームがありうる。
-                // 行をスキップすればチラつきで済むが、インデックスアクセスだと
-                // 描画処理の内側からアプリ全体を落としかねない。上のファイル
-                // ツリーも同様の対応をしている。
-                let file_diff = files.get(*file_index)?;
+                // ファイル vector は異なるティックで再構築されるため、片方が
+                // 古いままレンダリングされるフレームがありうる。行をスキップ
+                // すればチラつきで済むが、インデックスアクセスだと描画処理の
+                // 内側からアプリ全体を落としかねない。上のファイルツリーも
+                // 同様の対応をしている。
+                let file_diff = app.diff_state.files.get(*file_index)?;
 
                 let filename = file_diff.path.rsplit('/').next().unwrap_or(&file_diff.path);
 
                 let indent = "  ".repeat(*depth);
                 let icon = file_icon(filename);
-                // 由来マーカー: C = committed（HEAD にある）、U = uncommitted
-                // （作業ツリー）。両方で変更されたファイルは2回表示される。
-                let marker = match section {
-                    DiffSection::Committed => "C",
-                    DiffSection::Uncommitted => "U",
-                };
-                let prefix = format!("  {indent}{marker} {icon} ");
+                let prefix = format!("  {indent}{icon} ");
 
                 // ファイル名の色はファイルの git ステージ状態
                 // （untracked / unstaged / staged / committed）を表す。
-                // is_new/is_deleted によるセクション分けとは連動しない —
-                // 既に追跡済みで単に変更されただけのファイルは "new" でも
-                // "deleted" でもなく、以前は一律 theme.fg に落ちていた。
+                // 行数はベースからの合計なので、その内訳がコミット済みか
+                // 手元の編集かはこの色でしか分からない。
                 let stage_state =
                     file_stage_state(app.viewer_state.tree.git_status.status(&file_diff.path));
                 let base_fg = status_color(theme, stage_state);
@@ -192,9 +174,8 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                     diff_focused,
                     app.list_hover.diff_list.phase(idx),
                 );
-                // ファイル名以外の部分 — インデント、由来マーカー、アイコン、
-                // 行数 — は hover の下線を外し、下線がファイル名だけに
-                // 付くようにする。
+                // ファイル名以外の部分 — インデント、アイコン、行数 — は
+                // hover の下線を外し、下線がファイル名だけに付くようにする。
                 let decoration = crate::ui::common::list_row::decoration_style(style);
                 // 行の背景/選択スタイルは style（row_style 経由）から来るが、
                 // +added/-deleted はステージ状態に関わらず自前の前景色を保つ
@@ -263,7 +244,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
 }
 
 /// changed-files ブロックのタイトルを組み立てる。— diff error サフィックスは
-/// 「何かが失敗して committed セクションが欠けている」場合と、本当に
+/// 「何かが失敗してベースからの変更が欠けている」場合と、本当に
 /// (0) である場合を区別するためのもの。これが無いと両者は同じ見た目になる。
 /// あえて "base error" とはしていない: base ref の解決失敗はよくある原因の
 /// 一つに過ぎず、HEAD が解決できない場合や merge-base が見つからない場合も
@@ -333,8 +314,8 @@ mod tests {
         assert!(diff_list_title(0, true).contains("error"));
     }
 
-    /// base 解決が失敗しても uncommitted セクションは生き残るので、件数は
-    /// 0 以外になり、かつエラーマーカーも表示される — 両方が出ていること。
+    /// base 解決が失敗しても HEAD 基準の一覧は生き残るので、件数は 0 以外に
+    /// なり、かつエラーマーカーも表示される — 両方が出ていること。
     #[test]
     fn error_title_keeps_the_count() {
         let title = diff_list_title(17, true);

--- a/src/ui/viewer_panel/syntax.rs
+++ b/src/ui/viewer_panel/syntax.rs
@@ -42,16 +42,7 @@ pub(super) fn ensure_diff_annotations_cached(app: &mut App) {
             }
         };
 
-        // 未コミット分を先に処理する（ビューアでは未コミット分が優先される）。
-        for file_diff in &app.diff_state.uncommitted_files {
-            if file_diff.path == *current {
-                insert_annotations(file_diff, &mut annotations);
-                break;
-            }
-        }
-
-        // コミット済み分は後で処理する（or_insert により未コミット分の上書きは起きない）。
-        for file_diff in &app.diff_state.committed_files {
+        for file_diff in &app.diff_state.files {
             if file_diff.path == *current {
                 insert_annotations(file_diff, &mut annotations);
                 break;


### PR DESCRIPTION
## Summary

コミット済みのファイルを再編集すると、Changed files 一覧に同じファイルが2行（`C` と `U`）に分かれて出ていた。

これは設計どおりの挙動だった: `DiffState` が diff を2本持ち、`committed_files`（merge-base → HEAD）と `uncommitted_files`（HEAD → 作業ツリー）を同じディレクトリツリーに流し込んでいたため、両方に現れるファイルは2行になる。パス順に並ぶので2行が隣接し、重複に見えていた。

「間違ってはいないが VSCode のような UX にしたい」という要望を受けて、diff を **merge-base(base, HEAD) → 作業ツリー(index 込み)** の1本に統合した。GitHub の Files changed と同じ「ブランチがベースに対して何を変えたか」のビューになる。

- `DiffState.files: Vec<FileDiff>` の1本に統合し、`DiffSection` / `DiffRange` を削除
- 一覧行から `C` / `U` マーカーを削除。未コミット編集の有無は従来どおりファイル名の色（untracked=灰 / unstaged=赤 / staged=黄 / clean=緑）が示す
- 行数はベースからの合計になる（コミットで +240、その後 +7 -7 なら **+245 -2**）
- ベース ref を解決できないときは HEAD 基準にフォールバックして一覧を残し、理由だけをエラーバナーに出す。従来の「不正な base が手元の変更まで隠さない」保証を維持するため

二重管理していたコードが落ちて実質的な減量になっている（+298 / -518）。

## Test plan

- [x] `cargo test` — 1020 passed / 0 failed
- [x] `cargo clippy --all-targets` — この変更由来の警告なし
- [x] 新規テスト `a_file_edited_after_commit_stays_one_entry`: コミット後に再編集したファイルが一覧・display_list の両方で1エントリのままで、行数がベースからの合計になること
- [x] 実 git との突き合わせ（base → commit(+1行, 新規ファイル) → 再編集(+1行) の scratch リポジトリ）

  | | `git diff --numstat <merge-base>` | conductor |
  |---|---|---|
  | a.txt（コミット後に再編集） | `2 0` | `+2 -0` |
  | b.txt（コミットのみ） | `1 0` | `+1 -0` |
  | c.txt（未追跡） | (対象外) | `+1 -0` |

- [x] ベース解決失敗系の既存テストを新しい契約（HEAD 基準にフォールバック + 理由を表示）に更新
- [x] `cargo install --path .`
