### PR TITLE
fix: revidere をベースから作業ツリーまでの全差分でレビューする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "revidere"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "log",
  "revidere-fixtures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.104.0"
+version = "0.105.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/revidere/Cargo.toml
+++ b/crates/revidere/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revidere"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 description = "Reading order and coverage checking for AI-assisted git diff review"

--- a/crates/revidere/src/analyze.rs
+++ b/crates/revidere/src/analyze.rs
@@ -70,46 +70,38 @@ pub struct Options {
     pub repo: PathBuf,
     /// 比較のベース。None なら origin/HEAD → main → master の順に推定する。
     pub base: Option<String>,
-    /// 比較の先端。[git::WORKTREE] を渡すと、コミット間ではなく作業ツリーを見る。
-    pub head: String,
     /// 貯めた応答を使うか。false なら AI に聞き直す（結果は貯め直す）。
     pub cache: bool,
 }
 
 /// 差分を解析して `<root>/.conductor/review.json` を書き、その内容を返す。
 ///
+/// 対象は毎回「ベースとの共通祖先から今の作業ツリーまで」で、成果物があっても
+/// 無くても同じ。前回の分類は一切引き継がない — コミットが進んでも、戻っても、
+/// force push で履歴ごと変わっても、今あるものだけで作り直せば正しい。
+/// 前回からの進みは [Review::since_previous] に別途持たせる。
+///
 /// 説明もれが残っていても成果物は書いて返す。読めるレビューを捨てないため。
 /// 呼ぶ側は `review.coverage.is_complete()` で見分ける。
 pub fn analyze(o: &Options, ai: &dyn Ai) -> Result<Review, AnalyzeError> {
     let root = git::root(&o.repo)?;
-    let base = match (o.base.as_deref(), o.head.as_str()) {
-        (Some(b), _) => b.to_string(),
-        // 作業ツリーを見るときのベースは HEAD しかあり得ない。
-        (None, git::WORKTREE) => "HEAD".to_string(),
-        (None, _) => git::guess_base(&root)?,
+    let base_ref = match o.base.as_deref() {
+        Some(b) => b.to_string(),
+        None => git::guess_base(&root)?,
     };
-    let head = o.head.clone();
-    let base_oid = git::short_oid(&root, &base).unwrap_or_else(|_| base.clone());
-    let head_oid = git::short_oid(&root, &head).unwrap_or_else(|_| head.clone());
+    let base_oid = git::short_oid(&root, &git::merge_base(&root, &base_ref)?)?;
+    let head_oid = git::short_oid(&root, "HEAD")?;
 
-    if head != git::WORKTREE && git::is_dirty(&root).unwrap_or(false) {
-        log::warn!(
-            "{} has uncommitted changes; the review covers {base}...{head}, \
-             which may differ from what is on screen",
-            root.display()
-        );
-    }
-
-    let text = git::diff(&root, &base, &head)?;
+    let text = git::diff(&root, &base_oid)?;
     if text.trim().is_empty() {
         return Err(AnalyzeError::NoDiff(format!(
-            "{base}...{head} に差分が無い"
+            "{base_oid} から作業ツリーまでに差分が無い"
         )));
     }
     let d = diff::parse(&text);
     let ledger = d.positions();
     log::info!(
-        "revidere: {} {base}...{head} / {} files / {} changed positions",
+        "revidere: {} {base_oid}..worktree (head {head_oid}) / {} files / {} changed positions",
         root.display(),
         d.files.len(),
         ledger.len()
@@ -140,7 +132,7 @@ pub fn analyze(o: &Options, ai: &dyn Ai) -> Result<Review, AnalyzeError> {
 
     // プロンプトには解決済みの ID を入れる。同じ範囲を HEAD~2 と呼んでも
     // コミット ID で呼んでも、同じ問いになって貯めた応答に当たる。
-    let raw = ask(&prompt::user(&base_oid, &head_oid, &d.ledger_summary()))?;
+    let raw = ask(&prompt::user(&base_oid, &d.ledger_summary()))?;
 
     let mut r = parse::review(&raw, &base_oid, &head_oid)?;
     r.coverage = coverage::check(&ledger, &r.sections);

--- a/crates/revidere/src/analyze_tests.rs
+++ b/crates/revidere/src/analyze_tests.rs
@@ -118,11 +118,10 @@ impl Repo {
         Review::from_json(&text).unwrap()
     }
 
-    fn options(&self, base: Option<&str>, head: &str) -> Options {
+    fn options(&self, base: Option<&str>) -> Options {
         Options {
             repo: self.dir.clone(),
             base: base.map(str::to_string),
-            head: head.to_string(),
             cache: true,
         }
     }
@@ -159,7 +158,7 @@ fn write_artifact_creates_the_parent_directory_when_it_is_missing() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
-// base...head に差分が無いのは、0 件成功ではなく明示的なエラー。
+// 対象範囲に差分が無いのは、0 件成功ではなく明示的なエラー。
 // AI を起こす前に分かるので、起こさないことも併せて見る。
 #[test]
 fn a_range_with_no_changes_is_an_explicit_error_not_a_silent_success() {
@@ -167,30 +166,36 @@ fn a_range_with_no_changes_is_an_explicit_error_not_a_silent_success() {
     repo.write("a.txt", "1\n2\n3\n");
     let oid = repo.commit_all("base");
     let ai = StubAi::new("", "");
-    let e = analyze(&repo.options(Some(&oid), &oid), &ai).unwrap_err();
+    let e = analyze(&repo.options(Some(&oid)), &ai).unwrap_err();
     assert!(matches!(e, AnalyzeError::NoDiff(_)), "{e:?}");
     assert_eq!(ai.calls(), 0, "差分が無いなら AI を起こす理由が無い");
 }
 
-// コミット範囲を見ているときに作業ツリーが汚れていても、
-// 処理は止めずに進む（警告だけを出す）。
+// レビューはベースから今の作業ツリーまでが対象で、直近のコミット 1 つ分では
+// ない。台帳が最後のコミットだけになっていると、それより前のコミットを指した
+// 節は「存在しない行を指した」側に落ちるので、充足検査で捕まる。
 #[test]
-fn analyze_does_not_stop_when_the_worktree_is_dirty_during_a_commit_range_review() {
+fn analyze_covers_every_commit_since_the_base_plus_the_uncommitted_work() {
     let repo = Repo::new();
+    repo.write("a.txt", "1\n");
+    repo.commit_all("base");
+    repo.git(&["checkout", "-q", "-b", "feature"]);
+    repo.write("a.txt", "1\n2\n");
+    repo.commit_all("first");
     repo.write("a.txt", "1\n2\n3\n");
-    let base = repo.commit_all("base");
+    repo.commit_all("second");
+    // まだコミットしていない手元の変更。
     repo.write("a.txt", "1\n2\n3\n4\n");
-    let head = repo.commit_all("head");
-    // レビュー対象は上のコミット範囲。その後で作業ツリーだけ汚す。
-    repo.write("a.txt", "1\n2\n3\n4\nscratch\n");
 
     let full = answer(
-        r#"{"title":"add line 4","importance":"core","reason":"main change","body":"","ranges":[{"path":"a.txt","side":"new","start":4,"end":4}]}"#,
+        r#"{"title":"lines 2-4","importance":"core","reason":"main change","body":"","ranges":[{"path":"a.txt","side":"new","start":2,"end":4}]}"#,
     );
     let ai = StubAi::new(&full, &full);
-    let r = analyze(&repo.options(Some(&base), &head), &ai)
-        .expect("汚れた作業ツリーで analyze を止めてはいけない");
-    assert!(r.coverage.is_complete());
+    let r = analyze(&repo.options(Some("main")), &ai).unwrap();
+
+    assert_eq!(r.coverage.total, 3, "2 つのコミットと手元の変更で 3 行");
+    assert!(r.coverage.is_complete(), "{:?}", r.coverage);
+    assert_eq!(ai.calls(), 1, "全部説明できていれば差し戻しは要らない");
 }
 
 // 差し戻し（repair）で説明なしが減らなかったら、差し戻し後の結果は
@@ -202,7 +207,7 @@ fn analyze_keeps_the_first_result_when_repair_makes_coverage_worse() {
     let base = repo.commit_all("base");
     // 追加行を 2 つにして、初回で 1 件だけ説明なしのまま残す。
     repo.write("a.txt", "1\n2\n3\n4\n5\n");
-    let head = repo.commit_all("head");
+    repo.commit_all("head");
 
     let initial = answer(
         r#"{"title":"add line 4","importance":"core","reason":"main change","body":"","ranges":[{"path":"a.txt","side":"new","start":4,"end":4}]}"#,
@@ -212,7 +217,7 @@ fn analyze_keeps_the_first_result_when_repair_makes_coverage_worse() {
         r#"{"title":"nothing classified","importance":"minor","reason":"placeholder","body":"","ranges":[]}"#,
     );
     let ai = StubAi::new(&initial, &repaired);
-    let r = analyze(&repo.options(Some(&base), &head), &ai).unwrap();
+    let r = analyze(&repo.options(Some(&base)), &ai).unwrap();
 
     assert_eq!(ai.calls(), 2, "説明なしが残ったなら差し戻しているはず");
     assert!(!r.coverage.is_complete(), "説明なしが残っている");

--- a/crates/revidere/src/git.rs
+++ b/crates/revidere/src/git.rs
@@ -75,20 +75,29 @@ pub fn guess_base(repo: &Path) -> Result<String, GitError> {
     ))
 }
 
-/// レビュー対象の diff。
+/// base と HEAD の共通祖先。レビューの起点。
 ///
-/// 3 点（merge-base）を使う。2 点だとベース側の進みが差分に混ざり、
-/// 「このブランチで何をしたか」ではなくなる。
+/// ベース側の進みを差分に混ぜないための解決で、`git diff base...HEAD` の
+/// base 側にあたる。先に 1 つのコミットへ潰しておくと、そこから作業ツリーまでの
+/// 2 点指定で「ベース以降にこのブランチでしたこと全部」が 1 枚に収まる。
+pub fn merge_base(repo: &Path, base: &str) -> Result<String, GitError> {
+    Ok(run(repo, &["merge-base", base, "HEAD"])?.trim().to_string())
+}
+
+/// レビュー対象の diff。`from` から現在の作業ツリーまで。
+///
+/// 終点をコミットではなく作業ツリーにするのは、レビューしたいものが大抵まだ
+/// コミットされていないため。起点が merge-base なので、コミット済みの変更と
+/// 手元の変更が 1 枚の差分に収まる。
+///
+/// 未追跡ファイルは `git diff` に出ないので、1 件ずつ `--no-index` で
+/// 追加ファイルの差分として起こして繋ぐ。`git add -N` を使えば 1 回で済むが、
+/// それは相手の index を書き換えるので採らない。
 ///
 /// 文脈行はモデルには不要（自分でファイルを読む）だが、
 /// 変更一覧の行番号を正しく数えるには必須なので既定の 3 行を保つ。
-pub fn diff(repo: &Path, base: &str, head: &str) -> Result<String, GitError> {
-    // 作業ツリーを見るときは 3 点指定が意味を持たない。
-    if head == WORKTREE {
-        return diff_worktree(repo);
-    }
-    let spec = format!("{base}...{head}");
-    run(
+pub fn diff(repo: &Path, from: &str) -> Result<String, GitError> {
+    let mut out = run(
         repo,
         &[
             "diff",
@@ -97,30 +106,7 @@ pub fn diff(repo: &Path, base: &str, head: &str) -> Result<String, GitError> {
             "--find-renames",
             "--no-color",
             "--no-ext-diff",
-            &spec,
-        ],
-    )
-}
-
-/// `--head` にこれを渡すと、コミット間ではなく作業ツリーを見る。
-pub const WORKTREE: &str = "worktree";
-
-/// 作業ツリーの差分（HEAD vs 作業ツリー + index）。
-///
-/// レビューしたいものは大抵まだコミットされていない。
-///
-/// 未追跡ファイルは `git diff HEAD` に出ないので、1 件ずつ `--no-index` で
-/// 追加ファイルの差分として起こして繋ぐ。`git add -N` を使えば 1 回で済むが、
-/// それは相手の index を書き換えるので採らない。
-pub fn diff_worktree(repo: &Path) -> Result<String, GitError> {
-    let mut out = run(
-        repo,
-        &[
-            "diff",
-            "--find-renames",
-            "--no-color",
-            "--no-ext-diff",
-            "HEAD",
+            from,
         ],
     )?;
     for path in untracked(repo)? {
@@ -152,12 +138,6 @@ pub fn untracked(repo: &Path) -> Result<Vec<String>, GitError> {
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .collect())
-}
-
-/// 作業ツリーに未コミットの変更があるか。
-/// レビュー対象は commit なので、汚れていたら見ているものとずれる可能性がある。
-pub fn is_dirty(repo: &Path) -> Result<bool, GitError> {
-    Ok(!run(repo, &["status", "--porcelain"])?.trim().is_empty())
 }
 
 #[cfg(test)]
@@ -216,6 +196,11 @@ mod tests {
             self.git(&["add", "-A"]);
             self.git(&["commit", "-q", "-m", msg]);
         }
+
+        /// レビューの起点。実際の呼ばれ方どおり merge-base を経由する。
+        fn from(&self, base: &str) -> String {
+            merge_base(&self.dir, base).unwrap()
+        }
     }
 
     impl Drop for Repo {
@@ -225,21 +210,74 @@ mod tests {
     }
 
     #[test]
-    fn diff_uses_the_three_point_merge_base_not_a_two_point_range() {
+    fn the_range_starts_at_the_merge_base_so_the_bases_own_progress_stays_out() {
         let r = Repo::new();
         r.write("a.txt", "1\n2\n3\n");
         r.commit_all("base");
         r.git(&["checkout", "-q", "-b", "feature"]);
         r.write("a.txt", "1\n2\n3\nfeature\n");
         r.commit_all("feature change");
-        // ベース側もそのあと進める。2 点だとこの進みまで差分に混ざる。
+        // ベース側もそのあと進める。共通祖先ではなく main の先端を起点にすると、
+        // この進みまで差分に混ざる。
         r.git(&["checkout", "-q", "main"]);
         r.write("b.txt", "main only\n");
         r.commit_all("main moved on");
+        r.git(&["checkout", "-q", "feature"]);
 
-        let out = diff(&r.dir, "main", "feature").unwrap();
+        let out = diff(&r.dir, &r.from("main")).unwrap();
         assert!(out.contains("feature"), "{out}");
         assert!(!out.contains("main only"), "{out}");
+    }
+
+    /// ベースからの全差分になっていること。ここが「最後のコミット以降」だけに
+    /// なると、レビューは PR 全体ではなく直近の一手しか映さなくなる。
+    #[test]
+    fn the_range_covers_every_commit_since_the_base_not_only_the_latest_one() {
+        let r = Repo::new();
+        r.write("a.txt", "1\n");
+        r.commit_all("base");
+        r.git(&["checkout", "-q", "-b", "feature"]);
+        r.write("first.txt", "first commit\n");
+        r.commit_all("first");
+        r.write("second.txt", "second commit\n");
+        r.commit_all("second");
+        // さらに未コミットの手元の変更。
+        r.write("third.txt", "not committed yet\n");
+
+        let out = diff(&r.dir, &r.from("main")).unwrap();
+        assert!(
+            out.contains("first commit"),
+            "1 つ目のコミットが無い: {out}"
+        );
+        assert!(
+            out.contains("second commit"),
+            "2 つ目のコミットが無い: {out}"
+        );
+        assert!(out.contains("not committed yet"), "手元の変更が無い: {out}");
+    }
+
+    /// 履歴が書き換わった (rebase / amend / force push) ときも、起点は
+    /// 今の HEAD とベースから引き直される。
+    #[test]
+    fn the_range_is_rebuilt_from_the_current_head_after_the_history_is_rewritten() {
+        let r = Repo::new();
+        r.write("a.txt", "1\n");
+        r.commit_all("base");
+        r.git(&["checkout", "-q", "-b", "feature"]);
+        r.write("old.txt", "abandoned work\n");
+        r.commit_all("work that will be dropped");
+
+        // 履歴ごと差し替える。前のコミットはもう辿れない。
+        r.git(&["reset", "-q", "--hard", "main"]);
+        r.write("new.txt", "rewritten work\n");
+        r.commit_all("rewritten");
+
+        let out = diff(&r.dir, &r.from("main")).unwrap();
+        assert!(out.contains("rewritten work"), "{out}");
+        assert!(
+            !out.contains("abandoned work"),
+            "捨てたはずの変更が残っている: {out}"
+        );
     }
 
     #[test]
@@ -263,7 +301,7 @@ mod tests {
 
         // 変更は 5 行目 1 つだけ。既定の文脈 3 行なら、ハンクは
         // 2〜8 行目（7 行）を覆う。
-        let out = diff(&r.dir, "main", "feature").unwrap();
+        let out = diff(&r.dir, &r.from("main")).unwrap();
         assert!(out.contains("@@ -2,7 +2,7 @@"), "{out}");
     }
 
@@ -277,24 +315,24 @@ mod tests {
         r.git(&["mv", "a.rs", "b.rs"]);
         r.commit_all("rename a.rs to b.rs");
 
-        let out = diff(&r.dir, "main", "feature").unwrap();
+        let out = diff(&r.dir, &r.from("main")).unwrap();
         assert!(out.contains("rename from a.rs"), "{out}");
         assert!(out.contains("rename to b.rs"), "{out}");
     }
 
     #[test]
-    fn worktree_diff_stitches_untracked_files_into_the_committed_diff() {
+    fn the_diff_stitches_untracked_files_into_the_committed_diff() {
         let r = Repo::new();
         r.write("a.txt", "1\n2\n3\n");
         r.commit_all("base");
         // コミット済みファイルへの未コミットの変更。
         r.write("a.txt", "1\n2\nX\n");
-        // 未追跡ファイル。`git diff HEAD` にはこれが出ない。
+        // 未追跡ファイル。`git diff` にはこれが出ない。
         r.write("new.txt", "brand new\n");
 
         // 差分がある未追跡ファイルは --no-index の終了コードが 1 になる。
         // それをエラー扱いしていたら、この呼び出し自体が失敗する。
-        let out = diff(&r.dir, "main", WORKTREE).unwrap();
+        let out = diff(&r.dir, &r.from("main")).unwrap();
         assert!(out.contains("-3") && out.contains("+X"), "{out}");
         assert!(
             out.contains("new.txt") && out.contains("brand new"),
@@ -315,7 +353,7 @@ mod tests {
         r.write("あ.txt", "2\n");
         r.commit_all("change");
 
-        let out = diff(&r.dir, "main", "feature").unwrap();
+        let out = diff(&r.dir, &r.from("main")).unwrap();
         assert!(out.contains("diff --git a/あ.txt b/あ.txt"), "{out}");
         assert!(!out.contains("\\343"), "8 進エスケープが残っている: {out}");
     }
@@ -368,15 +406,5 @@ mod tests {
         r.commit_all("init");
         let got = root(&r.dir.join("sub/dir")).unwrap();
         assert_eq!(got.canonicalize().unwrap(), r.dir.canonicalize().unwrap());
-    }
-
-    #[test]
-    fn is_dirty_reflects_uncommitted_changes() {
-        let r = Repo::new();
-        r.write("a.txt", "1\n");
-        r.commit_all("init");
-        assert!(!is_dirty(&r.dir).unwrap());
-        r.write("a.txt", "2\n");
-        assert!(is_dirty(&r.dir).unwrap());
     }
 }

--- a/crates/revidere/src/prompt.rs
+++ b/crates/revidere/src/prompt.rs
@@ -132,39 +132,22 @@ ranges の決まり:
 
 /// 実行ごとの指示。どの範囲を、どの台帳に対して整理するか。
 ///
-/// base/head には解決済みのコミット ID を渡すこと。`HEAD~2` のような呼び名を
-/// そのまま入れると、同じ範囲でも呼び方が違うだけでプロンプトが変わり、
-/// 貯めた応答（cache.rs）に当たらなくなる。同じ差分を二度聞くのは数分の損。
-pub fn user(base: &str, head: &str, ledger: &str) -> String {
-    // 作業ツリーを見るときは `A...B` が意味を持たない。`worktree` は git の
-    // リビジョンではないので、そのまま組むとモデルは失敗するコマンドを実行し、
-    // 差分を読まないまま台帳だけを頼りに答えることになる。
-    let worktree = head == crate::git::WORKTREE;
-    let range = if worktree {
-        format!("`{base}` から作業ツリーまでの変更")
-    } else {
-        format!("`{base}...{head}` の変更")
-    };
-    let command = if worktree {
-        "git diff HEAD".to_string()
-    } else {
-        format!("git diff {base}...{head}")
-    };
-    // 未追跡ファイルは `git diff HEAD` に出ないが、台帳には載っている
-    // （git.rs が 1 件ずつ --no-index で起こして繋いでいる）。この食い違いを
-    // 黙っていると、モデルは台帳の側を作り話だと思って無視しかねない。
-    let note = if worktree {
-        "\n未追跡ファイルは `git diff HEAD` に出ないが、台帳には載せてある。\
-         台帳にあって差分に出ないパスは、新規追加のファイルとして中身をそのまま読むこと。"
-    } else {
-        ""
-    };
+/// base には解決済みのコミット ID を渡すこと。`HEAD~2` や `origin/main` の
+/// ような呼び名をそのまま入れると、同じ範囲でも呼び方が違うだけでプロンプトが
+/// 変わり、貯めた応答（cache.rs）に当たらなくなる。同じ差分を二度聞くのは
+/// 数分の損。
+///
+/// 終点は書かない。base から先は作業ツリーまで全部が対象で、そこにコミット ID
+/// を添えるとモデルは `base...head` を読んでしまい、未コミットの変更を落とす。
+pub fn user(base: &str, ledger: &str) -> String {
     format!(
-        r#"作業ディレクトリのリポジトリで、{range}を上記の 3 段階に整理してほしい。
+        r#"作業ディレクトリのリポジトリで、`{base}` から作業ツリーまでの変更を上記の 3 段階に整理してほしい。
 
-まず自分で差分を読むこと。`{command}` を実行し、変更されたファイルと、
+まず自分で差分を読むこと。`git diff {base}` を実行し、変更されたファイルと、
 必要なら呼び出し元・呼び出し先まで読んで、何が起きているのかを掴んでから答える。
-段階 3 は変更されたコードだけを見ても書けない。それを使っている側を読む必要がある。{note}
+段階 3 は変更されたコードだけを見ても書けない。それを使っている側を読む必要がある。
+未追跡ファイルは `git diff` に出ないが、台帳には載せてある。
+台帳にあって差分に出ないパスは、新規追加のファイルとして中身をそのまま読むこと。
 
 以下が変更位置の台帳。ここに載っている位置を 1 つ残らず、ちょうど 1 つの節へ
 割り当てること。new は追加行の後像行番号、old は削除行の前像行番号。
@@ -226,38 +209,20 @@ mod tests {
 
     #[test]
     fn user_prompt_embeds_the_range_and_the_ledger() {
-        let p = user("main", "HEAD", "src/a.rs [modified]\n  new: 1-3\n");
-        assert!(p.contains("main...HEAD"));
+        let p = user("abc1234", "src/a.rs [modified]\n  new: 1-3\n");
+        assert!(p.contains("`abc1234` から作業ツリーまで"), "{p}");
         assert!(p.contains("src/a.rs [modified]"));
-    }
-
-    /// 作業ツリーを見るときは `worktree` を git のリビジョンとして書かない。
-    /// 書くとモデルが実行するコマンドが失敗し、差分を読まないまま答える。
-    #[test]
-    fn the_worktree_prompt_does_not_ask_git_for_a_revision_named_worktree() {
-        let p = user("abc1234", crate::git::WORKTREE, "src/a.rs\n  new: 1\n");
-        assert!(
-            !p.contains("...worktree"),
-            "存在しないリビジョンを指している: {p}"
-        );
-        assert!(p.contains("git diff HEAD"), "{p}");
-        assert!(p.contains("作業ツリー"), "{p}");
         // 台帳に載る未追跡ファイルが差分に出ないことを断ってある。
         assert!(p.contains("未追跡"), "{p}");
     }
 
-    /// コミット範囲のときの文面は変えない。プロンプトは貯めた応答の鍵の
-    /// 一部なので、1 文字動かすと過去の応答に当たらなくなる。
+    /// モデルに読ませる差分は、起点から作業ツリーまでの 2 点。3 点の
+    /// `base...head` を読ませると、未コミットの変更が丸ごと落ちる。
     #[test]
-    fn the_commit_range_prompt_is_unchanged_by_the_worktree_branch() {
-        let p = user("abc1234", "def5678", "src/a.rs\n  new: 1\n");
-        assert!(p.contains("`abc1234...def5678` の変更を"), "{p}");
-        assert!(p.contains("`git diff abc1234...def5678` を実行し"), "{p}");
-        assert!(
-            !p.contains("未追跡"),
-            "作業ツリー用の断りが混ざっている: {p}"
-        );
-        assert!(!p.contains("作業ツリーまで"), "{p}");
+    fn the_command_the_model_runs_ends_at_the_worktree_not_at_a_commit() {
+        let p = user("abc1234", "src/a.rs\n  new: 1\n");
+        assert!(p.contains("`git diff abc1234` を実行し"), "{p}");
+        assert!(!p.contains("..."), "3 点指定を読ませている: {p}");
     }
 
     #[test]

--- a/crates/revidere/src/review.rs
+++ b/crates/revidere/src/review.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 /// 成果物のスキーマ版。破壊的変更で上げる。
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// revidere が書き出すものの置き場。成果物も貯めた応答もこの下。
 ///
@@ -235,7 +235,9 @@ impl Coverage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Review {
     pub schema: u32,
+    /// レビューの起点。ベースと HEAD の共通祖先のコミット ID。
     pub base: String,
+    /// 解析時の HEAD コミット ID。差分の終点はここではなく作業ツリー。
     pub head: String,
     pub overview: Overview,
     /// 重要度順に並べる。同じ重要度の中は元の順を保つ。

--- a/crates/revidere/tests/data/review.json
+++ b/crates/revidere/tests/data/review.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "base": "82a8a0a",
   "head": "914ef61",
   "overview": {

--- a/crates/revidere/tests/wire_compat.rs
+++ b/crates/revidere/tests/wire_compat.rs
@@ -1,8 +1,8 @@
 // 実データが読めることを固定する。手書きのフィクスチャは形を writer 側に
 // 合わせて書いてしまうので、writer が壊れたときに一緒に壊れて気付けない。
 //
-// 中身は同梱のデモ（このリポジトリ自身の差分を解析した成果物）。make demo-update
-// で採り直されるので、項目の数のような採るたびに変わる値は見ない。
+// 中身は同梱のデモ（このリポジトリ自身の差分を解析した成果物）。採り直すたびに
+// 変わる値（項目の数など）は見ない。
 
 fn demo() -> revidere::Annotations {
     revidere::Annotations::from_json(include_str!("data/review.json"))

--- a/src/app/revidere.rs
+++ b/src/app/revidere.rs
@@ -8,10 +8,11 @@
 //! 一覧までで、中身はモデルが自分でリポジトリを読む前提のため、素の HTTP 補完
 //! ではなくエージェント型の CLI を指した `provider = "command"` が要る。
 //!
-//! 見るのは常に作業ツリー
+//! 見るのはベースから作業ツリーまで
 //!
-//! レビューしたいものは大抵まだコミットされていない。merge-base 固定だと、
-//! いま手元で書いているものが画面に出るまで一度コミットしなければならない。
+//! 起点はベースとの共通祖先で、終点は今の作業ツリー。ブランチでやったこと
+//! 全部が対象になり、まだコミットしていない手元の変更もそこに入る。作り直す
+//! ときも同じで、前回の成果物は何も引き継がない。
 //! 出力先は `<worktree>/.conductor/review.json` — conductor の worktree は
 //! それぞれ別ディレクトリなので、ブランチごとに自然に分かれる。
 
@@ -395,7 +396,6 @@ fn run_analyze(
     let options = ::revidere::Options {
         repo: worktree.to_path_buf(),
         base: None,
-        head: ::revidere::git::WORKTREE.to_string(),
         cache: !force,
     };
     match ::revidere::analyze(&options, &ai) {

--- a/src/revidere.rs
+++ b/src/revidere.rs
@@ -25,9 +25,9 @@ pub struct Review {
     pub annotations: Annotations,
     /// diff を歩いて重要度順に並べたもの。画面に出るのはこちら。
     pub order: ReadingOrder,
-    /// 成果物が対象にしていた区間。画面の見出しに出す。
+    /// 成果物が対象にしていた区間の起点。画面の見出しに出す。終点は作業ツリー
+    /// なので、対になる commit id は無い (解析時の HEAD は annotations 側)。
     pub base: String,
-    pub head: String,
 }
 
 impl Review {
@@ -71,10 +71,10 @@ pub fn load(worktree: &Path) -> LoadOutcome {
         Err(e) => return LoadOutcome::Broken(format!("{}: {e}", path.display())),
     };
 
-    // 成果物が見ていたのと同じ区間の diff を取る。作業ツリーを見ている前提で
-    // 固定しているのは、レビューしたいものが大抵まだコミットされていないため
-    // (S4 の analyze も --head worktree で走らせる)。
-    let raw = match revidere::git::diff_worktree(worktree) {
+    // 成果物が見ていたのと同じ区間の diff を取る。起点は成果物に書いてある
+    // コミット ID をそのまま使う — ここで base を推定し直すと、解析のあとに
+    // ベースが動いただけで項目の指す位置が全部ずれる。
+    let raw = match revidere::git::diff(worktree, annotations.base()) {
         Ok(d) => d,
         Err(e) => return LoadOutcome::Broken(format!("diff を取れない: {}", e.0)),
     };
@@ -83,7 +83,6 @@ pub fn load(worktree: &Path) -> LoadOutcome {
 
     LoadOutcome::Loaded(Box::new(Review {
         base: annotations.base().to_string(),
-        head: annotations.head().to_string(),
         annotations,
         order,
     }))

--- a/src/ui/revidere_view.rs
+++ b/src/ui/revidere_view.rs
@@ -135,10 +135,7 @@ fn render_overview(frame: &mut Frame, area: Rect, app: &mut App, review: &Review
     app.revidere.overview_scroll = scroll;
     let visible: Vec<Line> = lines.into_iter().skip(scroll).take(height).collect();
 
-    let title = format!(
-        " 概要  {}..{}  (d: 項目と diff へ) ",
-        review.base, review.head
-    );
+    let title = format!(" 概要  {}..作業ツリー  (d: 項目と diff へ) ", review.base);
     frame.render_widget(Paragraph::new(visible).block(bordered(&title, app)), area);
 }
 
@@ -285,9 +282,8 @@ fn render_diff_column(frame: &mut Frame, area: Rect, app: &mut App, review: &Rev
         .collect();
 
     let title = format!(
-        " {}..{}  変更行 {}  {} ",
+        " {}..作業ツリー  変更行 {}  {} ",
         review.base,
-        review.head,
         review.total_positions(),
         if review.is_complete() {
             "全部の変更行に説明あり"


### PR DESCRIPTION
## Summary

revidere のレビュー対象が「ベースからの全差分」ではなく「未コミットの変更だけ」になっていた。

`analyze` は `head` に `worktree` を渡されると base を `HEAD` に固定し (`analyze.rs`)、`git diff HEAD` + 未追跡ファイルを見ていた。初回生成と再生成で経路の差は無く、どちらもこの範囲。結果としてレビューは「最後のコミット以降にやったこと」しか映さず、ブランチ全体を読むという用途に対して常に不足していた。

対象を **merge-base(base, HEAD) → 今の作業ツリー** の一本にした。コミット済みの変更と手元の変更が 1 枚の差分に収まり、コミットが進んでも戻っても force push で履歴が変わっても、毎回この範囲を引き直す。

- コミット範囲モード (`Options.head` と三点 diff 経路) は削除。呼び出し側は 1 箇所で、常に作業ツリーを渡していた
- 成果物の `base` は merge-base のコミット ID を記録し、読み側 (`src/revidere.rs`) は同じ ID から diff を取る。書き手と読み手の範囲がズレようがない形にした
- `head` は解析時の HEAD コミット ID になった (以前は文字列 `worktree`)
- プロンプトがモデルに実行させるコマンドも `git diff <base>` の 2 点に統一。3 点を読ませると未コミットの変更が落ちる
- 上記に伴い成果物のスキーマを 2 に上げた

### 影響

既存の `review.json` は読めなくなる (スキーマ不一致)。再生成すれば直るが、開いた瞬間はエラー表示が出る。

`Review.head` は書き込むだけで読む側がまだいない。前回のレビューからの差分サマリ (追従ブランチ `feat/revidere-since-previous`) で使う。

## Test plan

- [x] `cargo test --workspace` — 996 + 104 + 2 パス
- [x] `cargo clippy --workspace --all-targets` — 新規の警告なし (既存の無関係な 2 件のみ)
- [x] 追加テスト: ベース以降の全コミット + 未コミット分が範囲に入ること / 履歴が書き換わったあとも今の HEAD から引き直されること / 起点が merge-base でベース側の進みが混ざらないこと
- [x] `cargo install --path .`
