### PR TITLE
feat: revidere の状態を Changed files パネルに常設表示する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.107.0"
+version = "0.108.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -123,6 +123,7 @@ impl App {
         self.wtbar.hover = None;
         self.terminal.claude_tab_hover = None;
         self.terminal.shell_tab_hover = None;
+        self.revidere.badge_hover = false;
     }
 
     /// マウスが現在乗っているシンボルを記録する（マウス移動イベントから呼ばれる）。

--- a/src/app/revidere.rs
+++ b/src/app/revidere.rs
@@ -198,6 +198,40 @@ impl App {
         self.set_focus(Focus::Revidere);
     }
 
+    /// 選択中の worktree の解析がいまどの状態か。
+    ///
+    /// 常設表示もクリックもここだけを見る。画面が「最新」と言っているのに
+    /// 押すと解析が始まる、のような食い違いが起きようがないようにするため。
+    pub fn revidere_artifact_state(&self) -> crate::revidere::ArtifactState {
+        let head_time = self
+            .worktrees
+            .get(self.worktrees.selected_index())
+            .and_then(|w| w.head_time);
+        crate::revidere::artifact_state(
+            &self.selected_worktree_path(),
+            head_time,
+            self.revidere
+                .runs
+                .is_running(&self.selected_worktree_branch()),
+        )
+    }
+
+    /// Changed files パネルの状態チップを押したとき。
+    ///
+    /// 解析中は止めない。数分かかる仕事を、枠の中の 10 セルを 1 回押しただけで
+    /// 確認も無く捨てられるようにはしない。
+    pub fn cmd_revidere_badge_click(&mut self) {
+        use crate::revidere::ArtifactState;
+        match self.revidere_artifact_state() {
+            ArtifactState::Running => self.set_status(
+                "revidere is analysing this branch — this takes a few minutes.".to_string(),
+                StatusLevel::Info,
+            ),
+            ArtifactState::Fresh => self.cmd_show_revidere(),
+            ArtifactState::None | ArtifactState::Stale => self.cmd_analyze_revidere(false),
+        }
+    }
+
     /// 選択中の worktree の解析を起こす。
     ///
     /// `force` は貯めた応答を捨てる。既定では効くので、diff が動いていなければ

--- a/src/app/state/revidere.rs
+++ b/src/app/state/revidere.rs
@@ -56,6 +56,10 @@ pub struct RevidereState {
     /// ジオメトリでは当たらない。
     pub list_area: ratatui::layout::Rect,
     pub diff_area: ratatui::layout::Rect,
+    /// Changed files パネル右上の状態チップにマウスが乗っているか。
+    /// 当たり判定は描画側 ([crate::ui::explorer_panel::revidere_badge_cols]) が
+    /// 持っていて、ここに残るのは光らせるかどうかだけ。
+    pub badge_hover: bool,
 }
 
 impl RevidereState {

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -208,6 +208,24 @@ fn has_blocking_overlay(app: &App) -> bool {
         || app.code_nav.symbol_action.active
 }
 
+/// Changed files パネル右上の revidere 状態チップの上にセル (col, row) があるか。
+///
+/// クリックとホバーの両方がここを通るので、光っている場所と押せる場所は
+/// 構造的にずれない。矩形は描画側と同じ [crate::ui::explorer_panel::revidere_badge_cols]
+/// から引く。埋め込みエディタが出ている間は Explorer カラムがその PTY に隠れる
+/// ので、チップも無いものとして扱う。
+fn revidere_badge_hit(app: &App, col: u16, row: u16, geom: &ClickGeometry) -> bool {
+    if app.editor.is_some()
+        || row != geom.explorer_mid_y
+        || app.viewer_state.explorer.explorer_bottom_view
+            != crate::viewer::ExplorerBottomView::DiffList
+    {
+        return false;
+    }
+    crate::ui::explorer_panel::revidere_badge_cols(app, geom.left_end, geom.explorer_w)
+        .is_some_and(|cols| cols.contains(&col))
+}
+
 /// 指定した divider が現在マウスリサイズのためにつかめる状態かどうか。パネルが
 /// 最大化されている間は常に不可（列が両端に折りたたまれ、境界の意味が失われるため）。
 /// また、エディタがExplorer+Viewer列を1つのPTYに合体させている間は、Explorer側の
@@ -517,6 +535,14 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 return;
             }
 
+            // revidere の状態チップは Explorer の横境界と同じ行にあるので、
+            // 境界より先に見る。そうしないと 10 セルぶんが常に境界に食われて
+            // 押せない。チップは右枠の内側にあり、縦の境界のセルとは重ならない。
+            if revidere_badge_hit(app, col, row, &geom) {
+                app.cmd_revidere_badge_click();
+                return;
+            }
+
             // パネル境界をつかんでマウスリサイズを開始する。下のエディタ再フォーカスや
             // カラムのルーティングより先にチェックすることで、境界は常にその上に
             // 乗っているパネルより優先される（[<=>] 展開ボタンは境界より数セル内側に
@@ -649,6 +675,10 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             let tree_scroll = app.viewer_state.tree.tree_scroll;
             app.list_hover.explorer_tree
                 .set(explorer_tree_row_at(&geom, tree_scroll, col, row));
+
+            // revidere の状態チップ。カーソルがそこから外れれば false に戻るので、
+            // 離れたときの消灯も同じ 1 行で済む。
+            app.revidere.badge_hover = revidere_badge_hit(app, col, row, &geom);
 
             // Explorerの下半分にある変更ファイル（diff）リストについても同様。
             let diff_scroll = app.viewer_state.explorer.diff_list_scroll;

--- a/src/ui/explorer_panel/diff_list.rs
+++ b/src/ui/explorer_panel/diff_list.rs
@@ -2,12 +2,61 @@
 //! バッジの描画。
 
 use crate::app::{App, Focus};
+use crate::revidere::ArtifactState;
 use crate::viewer::file_icon;
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem};
+
+/// 右上に出す revidere の状態チップの幅。
+///
+/// 状態が変わっても幅は変わらない。当たり判定はここから導いていて、描画された
+/// 文字列を測っているわけではないので、状態ごとに幅が動くと押せる場所がずれる。
+const REVIDERE_BADGE_W: u16 = 10;
+
+/// 状態チップが占める画面の列。左のタイトルと重なるほど狭ければ None
+/// (描画側もクリック側もこれで揃って諦めるので、見えないチップは押せない)。
+///
+/// 右寄せタイトルは右枠の 1 つ内側で終わる。
+pub(crate) fn revidere_badge_cols(app: &App, x: u16, width: u16) -> Option<std::ops::Range<u16>> {
+    let title = diff_list_title(app.diff_state.files.len(), app.diff_state.error.is_some());
+    badge_cols(x, width, title.chars().count() as u16)
+}
+
+fn badge_cols(x: u16, width: u16, title_w: u16) -> Option<std::ops::Range<u16>> {
+    let end = x + width.checked_sub(1)?;
+    let start = end.checked_sub(REVIDERE_BADGE_W)?;
+    (start > x + title_w).then_some(start..end)
+}
+
+/// 状態チップの文字列。幅は常に [REVIDERE_BADGE_W]。
+///
+/// 色だけで区別すると色覚や配色によって読めなくなるので、形でも分かるように
+/// している (worktree ストリップの印と同じ考え方)。
+fn revidere_badge_label(state: ArtifactState, ui_tick: u64) -> String {
+    let marker = match state {
+        ArtifactState::Running => crate::ui::common::spinner_frame(ui_tick),
+        ArtifactState::Fresh => "\u{2713}",
+        ArtifactState::Stale => "!",
+        ArtifactState::None => "\u{25cb}",
+    };
+    format!(" {marker} review ")
+}
+
+/// 状態チップの色。muted は複数のテーマで見えなくなるので使わない。
+fn revidere_badge_color(
+    theme: &crate::theme::Theme,
+    state: ArtifactState,
+) -> ratatui::style::Color {
+    match state {
+        ArtifactState::None => theme.hint,
+        ArtifactState::Running => theme.accent,
+        ArtifactState::Fresh => theme.success,
+        ArtifactState::Stale => theme.warning,
+    }
+}
 
 /// Changed-files の各行のファイル名色が表す、4種類の git ステージ状態のいずれか。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,9 +136,30 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     } else {
         Style::default().fg(theme.muted)
     };
-    let block = crate::ui::common::PanelChrome::new(theme, title, panel_focused, border_color)
+    let mut block = crate::ui::common::PanelChrome::new(theme, title, panel_focused, border_color)
         .with_title_style(title_style)
         .into_block();
+
+    // revidere の状態は消えない場所に出す。ステータス行のフラッシュだけだと、
+    // 数分かかる解析が終わったのか、そもそも走っているのかが後から分からない。
+    if revidere_badge_cols(app, area.x, area.width).is_some() {
+        let state = app.revidere_artifact_state();
+        let mut style = Style::default()
+            .fg(revidere_badge_color(theme, state))
+            .add_modifier(Modifier::BOLD);
+        // hover は前景の下線で示す。背景を敷くとテーマによっては枠線ごと
+        // 潰れて、どこが押せるのか逆に読めなくなる。
+        if app.revidere.badge_hover {
+            style = style.add_modifier(Modifier::UNDERLINED);
+        }
+        block = block.title_top(
+            Line::from(Span::styled(
+                revidere_badge_label(state, app.ui_tick),
+                style,
+            ))
+            .alignment(Alignment::Right),
+        );
+    }
 
     let inner_height = area.height.saturating_sub(2) as usize;
     let scroll = vs_explorer.diff_list_scroll;
@@ -138,10 +208,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
                 // prefix を切り離すことで、hover 時の下線が名前の位置で
                 // 止まるようにする（list_row::decoration_style を参照）。
                 Some(ListItem::new(Line::from(vec![
-                    Span::styled(
-                        prefix,
-                        crate::ui::common::list_row::decoration_style(style),
-                    ),
+                    Span::styled(prefix, crate::ui::common::list_row::decoration_style(style)),
                     Span::styled(name.clone(), style),
                 ])))
             }
@@ -369,6 +436,71 @@ mod tests {
         // None は「GitStatusMap にこのパスのエントリが無い」ことを表し、
         // つまり HEAD に対してクリーンな状態。
         assert_eq!(diff_file_status_color(&theme, None), theme.success);
+    }
+
+    /// 状態が変わっても幅が変わらないこと。当たり判定は幅を定数から導いて
+    /// いるので、ここがずれると「見えている場所と押せる場所」が食い違う。
+    #[test]
+    fn every_state_renders_the_same_width() {
+        for state in [
+            ArtifactState::None,
+            ArtifactState::Running,
+            ArtifactState::Fresh,
+            ArtifactState::Stale,
+        ] {
+            let label = revidere_badge_label(state, 0);
+            assert_eq!(
+                unicode_width::UnicodeWidthStr::width(label.as_str()),
+                REVIDERE_BADGE_W as usize,
+                "{state:?}: {label:?}"
+            );
+        }
+    }
+
+    /// 右寄せタイトルが実際に落ちる位置と、当たり判定の矩形が一致すること。
+    /// この 2 つは別々に計算されているので、ratatui の右寄せの寸法が変われば
+    /// クリックだけ 1 セルずれる、という壊れ方をする。
+    #[test]
+    fn the_hit_box_is_where_ratatui_puts_the_badge() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::widgets::{Block, Borders};
+
+        let width = 40u16;
+        let title = diff_list_title(3, false);
+        let cols = badge_cols(0, width, title.chars().count() as u16).expect("40 幅なら出る");
+        let label = revidere_badge_label(ArtifactState::Fresh, 0);
+
+        let mut terminal = Terminal::new(TestBackend::new(width, 3)).unwrap();
+        terminal
+            .draw(|f| {
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .title(title.clone())
+                    .title_top(Line::from(label.clone()).alignment(Alignment::Right));
+                f.render_widget(block, f.area());
+            })
+            .unwrap();
+
+        let buf = terminal.backend().buffer();
+        let top: String = (0..width).map(|x| buf[(x, 0)].symbol()).collect();
+        let at = top
+            .chars()
+            .position(|c| c == '\u{2713}')
+            .expect("チップが上枠に出ている");
+        assert_eq!(at as u16, cols.start + 1, "枠内の位置: {top:?}");
+        assert!(cols.contains(&(at as u16)));
+        // 縦の境界のセル (右枠とその 1 つ外) は掴む余地を残すこと。
+        assert!(cols.end < width);
+    }
+
+    /// 狭いパネルではチップを出さない。出さないものは押せないことが同じ
+    /// 判定から導かれるので、見えないボタンは生まれない。
+    #[test]
+    fn a_narrow_panel_hides_the_badge() {
+        let title_w = diff_list_title(0, false).chars().count() as u16;
+        assert!(badge_cols(0, 20, title_w).is_none());
+        assert!(badge_cols(0, 40, title_w).is_some());
     }
 
     /// 編集して git add し、さらに編集したファイルは WT_* と INDEX_* の

--- a/src/ui/explorer_panel/mod.rs
+++ b/src/ui/explorer_panel/mod.rs
@@ -20,6 +20,7 @@ mod file_tree;
 mod search_box;
 
 pub use comment_list::render_comment_list_overlay;
+pub(crate) use diff_list::revidere_badge_cols;
 
 /// 指定領域に Explorer (ファイルツリー) パネルを描画する。
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {


### PR DESCRIPTION
## Summary

revidere の状態がステータス行のフラッシュにしか出ていなかったため、数分かかる解析が「走っているのか / 終わったのか / 出来たものが古いのか」を後から確認する手段が無かった。Changed files パネルのタイトル行右端に、消えないチップとして常設する。

- 状態の enum は新規に作らず、worktree ストリップが使っている `crate::revidere::ArtifactState` (None / Running / Fresh / Stale) をそのまま共有する
- 算出は `App::revidere_artifact_state()` 一箇所。描画もマウスもここだけを見るので、画面が「最新」と言っているのに押すと解析が始まる、という食い違いが起きない
- クリック: 未生成・古い → 解析開始 / 最新 → revidere ビュー / 実行中 → 何もせずステータス表示のみ (10 セルの 1 クリックで数分の仕事を確認なく捨てさせないため)
- hover は前景の下線のみ。`muted` は複数テーマで不可視になるため状態色には使わない
- チップは Explorer の上下分割の境界線と同じ行にあるので、境界のつかみ判定より先にヒットテストする。右端 10 セルだけ境界としてつかめなくなるが、残りの幅と `Ctrl+Alt+↑↓` は従来どおり

## Test plan

- `cargo clippy --workspace --all-targets` — 新規警告なし (残る 2 件は既存の doc lint)
- `cargo test --workspace` — 1116 件通過。追加したのは 3 件:
  - 4 状態すべてで表示幅が一定であること (当たり判定を定数から導いているため)
  - ratatui の右寄せタイトルが実際に落ちる位置と、当たり判定の矩形が一致すること
  - 狭いパネルではチップを出さず、同じ判定で押せなくもなること
- `cargo install --path .` 実行済み

## 実機で確認してほしい点

チップの位置 (枠上端の右) で境界ドラッグが 10 セル分犠牲になっている。気になる場合は枠下端 (`✨ Ask Claude All` と同じ位置) へ移せば干渉しない。