### PR TITLE
feat: Review メニューをレビューとコメントの入れ子で組み直し、生成前に確認を挟む

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.108.0"
+version = "0.109.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.108.0"
+version = "0.109.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -111,17 +111,18 @@ PR review is built into the normal Explorer/Viewer/Terminal accordion — there'
 no separate full-screen mode to enter or exit, so all the usual navigation and
 terminal keybindings keep working while you review:
 
-1. **Pull Request → local worktree** — palette: *Review: Review Pull Request…*,
-   enter a PR number or URL. Conductor fetches it (via `gh`) into a worktree and
-   focuses the Explorer's changed-files list.
+1. **Pull Request → local worktree** — menu: *Review ▸ Review Pull Request…*,
+   enter a PR number or URL. Conductor fetches it (via `gh`) into a worktree,
+   focuses the Explorer's changed-files list, and offers to run the AI review
+   below on it.
 2. **Changed files and comments** — the Explorer's bottom pane cycles between
    the changed-files diff list and the review comment list.
 3. **Jump into the code** — the diff pane supports the Viewer's `gd`/`gi`/`gr`
    symbol-jump hints (go to definition / implementation / references). **Symbol
    jumps only work for Rust, Go, and TypeScript** — other languages show no
    hints.
-4. **AI review** — `W` (palette: *Review: Analyse with revidere*) runs
-   **revidere** over the worktree's
+4. **AI review** — `W` (menu: *Review ▸ Review current branch*) asks first, then
+   runs **revidere** over the worktree's
    diff. It sorts every changed line into sections by importance
    (core / ripple / follow / minor) and checks that **no changed line is left
    unexplained**. `w` then opens the result as a full-screen two-column view:
@@ -135,7 +136,9 @@ terminal keybindings keep working while you review:
    that this one needs `provider = "command"` pointing at an agentic CLI: the
    model is expected to read the repository itself, which a plain HTTP
    completion cannot do. Replies are cached on the diff itself, so re-running on
-   an unchanged diff returns instantly — `alt+w` skips the cache.
+   an unchanged diff returns instantly — the confirmation offers a re-analysis
+   that ignores the cache when a review for this commit already exists, and
+   `alt+w` skips both the question and the cache.
 5. **Publish comments** — palette: *Review: Publish Comments to GitHub* posts
    your inline review comments (and replies) back to the PR via `gh`.
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -49,7 +49,7 @@ impl App {
             }
             CommandId::SessionHistory => self.cmd_session_history(),
             CommandId::ReviewPullRequest => self.cmd_review_pull_request(),
-            CommandId::AnalyzeRevidere => self.cmd_analyze_revidere(false),
+            CommandId::AnalyzeRevidere => self.cmd_confirm_analyze_revidere(),
             CommandId::ForceAnalyzeRevidere => self.cmd_analyze_revidere(true),
             CommandId::PublishReview => self.cmd_publish_review(),
             CommandId::OpenRepo => self.cmd_open_repo(),

--- a/src/app/revidere.rs
+++ b/src/app/revidere.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, TryRecvError, channel};
 
 use super::*;
+use crate::overlay::{ActiveOverlay, RevidereArtifact, RevidereConfirmOverlay};
 
 /// 解析 1 回の AI 呼び出しに与える実時間の上限 (秒)。
 ///
@@ -170,7 +171,7 @@ impl App {
         }
     }
 
-    /// 2 列のレビュービューを開く (w)。成果物が無ければ作り方を案内して開かない。
+    /// 2 列のレビュービューを開く (w)。成果物が無ければ、その場で作るかを聞く。
     pub fn cmd_show_revidere(&mut self) {
         // 門を通さずに読み直す。成果物が同じでも作業ツリーが動いていれば
         // 読む順は変わっている。
@@ -183,16 +184,8 @@ impl App {
             return;
         }
         if self.revidere.current.is_none() {
-            let branch = self.selected_worktree_branch();
-            let hint = if self.revidere.runs.is_running(&branch) {
-                "analysing now — this takes a few minutes"
-            } else {
-                "press W (or the palette's Analyze entry) to build one"
-            };
-            self.set_status(
-                format!("No review artifact for this worktree — {hint}."),
-                StatusLevel::Warning,
-            );
+            // 「無い」と言って終わるより、作る口をその場で出したほうが早い。
+            self.cmd_confirm_analyze_revidere();
             return;
         }
         self.set_focus(Focus::Revidere);
@@ -219,7 +212,7 @@ impl App {
     /// Changed files パネルの状態チップを押したとき。
     ///
     /// 解析中は止めない。数分かかる仕事を、枠の中の 10 セルを 1 回押しただけで
-    /// 確認も無く捨てられるようにはしない。
+    /// 確認も無く捨てられるようにはしない。始めるほうも同じ理由で確認を通す。
     pub fn cmd_revidere_badge_click(&mut self) {
         use crate::revidere::ArtifactState;
         match self.revidere_artifact_state() {
@@ -228,8 +221,48 @@ impl App {
                 StatusLevel::Info,
             ),
             ArtifactState::Fresh => self.cmd_show_revidere(),
-            ArtifactState::None | ArtifactState::Stale => self.cmd_analyze_revidere(false),
+            ArtifactState::None | ArtifactState::Stale => self.cmd_confirm_analyze_revidere(),
         }
+    }
+
+    /// 解析の前に確認を出す (W、メニューの 2 つの入口、PR の取り込みの後)。
+    ///
+    /// AI の呼び出しは数分と費用がかかるので、走り出す前に一度止める。
+    /// worktree が無いときや既に走っているときの断り方は解析側が持っている
+    /// ので、ここでは確認を挟まずそのまま渡す。
+    pub fn cmd_confirm_analyze_revidere(&mut self) {
+        let branch = self.selected_worktree_branch();
+        if branch.is_empty() || self.revidere.runs.is_running(&branch) {
+            self.cmd_analyze_revidere(false);
+            return;
+        }
+        let scope = self.revidere.scope;
+        let head = self.worktrees.selected().and_then(|w| w.head_oid.clone());
+        let artifact = match crate::revidere::artifact_head(&self.selected_worktree_path(), scope) {
+            None => RevidereArtifact::None,
+            Some(analysed) if Some(&analysed) == head.as_ref() => RevidereArtifact::Current,
+            Some(_) => RevidereArtifact::Stale,
+        };
+        self.overlays.revidere_confirm = RevidereConfirmOverlay {
+            branch,
+            scope: crate::revidere::scope_label(scope),
+            artifact,
+        };
+        self.overlays.active = ActiveOverlay::RevidereConfirm;
+    }
+
+    /// 確認を通ったので解析を始める。
+    ///
+    /// 同じコミットの成果物があるなら貯めた応答を捨てる。捨てないと、作り直しを
+    /// 選んだのに前と同じ答えがそのまま返ってくる。
+    pub fn confirm_analyze_revidere(&mut self) {
+        let force = self.overlays.revidere_confirm.artifact == RevidereArtifact::Current;
+        self.overlays.active = ActiveOverlay::None;
+        self.cmd_analyze_revidere(force);
+    }
+
+    pub fn cancel_analyze_revidere(&mut self) {
+        self.overlays.active = ActiveOverlay::None;
     }
 
     /// 選択中の worktree の解析を起こす。

--- a/src/app/worktree_pr.rs
+++ b/src/app/worktree_pr.rs
@@ -74,6 +74,10 @@ impl App {
                     ),
                     StatusLevel::Success,
                 );
+                // 取り込んだだけでは読む順が無い。「Review Pull Request」は
+                // ブランチのレビューと同じ解析へ続く 1 本の道なので、そのまま
+                // 確認へ渡す。
+                self.cmd_confirm_analyze_revidere();
             }
             crate::pr_intake::PrIntakeOutcome::Failed { error } => {
                 self.overlays.pr_input.error = Some(error.to_string());

--- a/src/command_palette/commands.rs
+++ b/src/command_palette/commands.rs
@@ -266,10 +266,10 @@ pub const COMMANDS: &[PaletteCommand] = &[
     },
     PaletteCommand {
         id: CommandId::SessionHistory,
-        label: "Review: Session History",
-        category: CommandCategory::Review,
+        label: "Terminal: Saved Output…",
+        category: CommandCategory::Terminal,
         action: Some(Action::SessionHistory),
-        keywords: "history log",
+        keywords: "history log session output snapshot saved terminal claude shell",
     },
     PaletteCommand {
         id: CommandId::ReviewPullRequest,
@@ -280,14 +280,14 @@ pub const COMMANDS: &[PaletteCommand] = &[
     },
     PaletteCommand {
         id: CommandId::AnalyzeRevidere,
-        label: "Review: Analyse with revidere",
+        label: "Review: Review Current Branch…",
         category: CommandCategory::Review,
         action: Some(Action::AnalyzeRevidere),
-        keywords: "revidere analyse analyze generate ai review sections coverage",
+        keywords: "revidere analyse analyze generate ai review sections coverage branch",
     },
     PaletteCommand {
         id: CommandId::ForceAnalyzeRevidere,
-        label: "Review: Re-analyse (ignore cache)",
+        label: "Review: Re-analyse Current Branch",
         category: CommandCategory::Review,
         action: Some(Action::ForceAnalyzeRevidere),
         keywords: "revidere reanalyse regenerate force ignore cache rebuild ai review",
@@ -343,10 +343,10 @@ pub const COMMANDS: &[PaletteCommand] = &[
     },
     PaletteCommand {
         id: CommandId::SaveSessionHistory,
-        label: "Session: Save History",
-        category: CommandCategory::Review,
+        label: "Terminal: Save Output",
+        category: CommandCategory::Terminal,
         action: None,
-        keywords: "save record session",
+        keywords: "save record session output snapshot scrollback",
     },
     // Repository
     PaletteCommand {

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -185,7 +185,7 @@ pub(super) fn dispatch_global_action(app: &mut App, action: Action) -> bool {
             true
         }
         Action::AnalyzeRevidere => {
-            app.cmd_analyze_revidere(false);
+            app.cmd_confirm_analyze_revidere();
             true
         }
         Action::ForceAnalyzeRevidere => {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -241,6 +241,7 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
                 ActiveOverlay::WorktreeSwitcher => handle_worktree_key(app, key),
                 ActiveOverlay::CommentList => handle_explorer_comment_list_key(app, key),
                 ActiveOverlay::ThemePicker => handle_theme_picker_key(app, key),
+                ActiveOverlay::RevidereConfirm => handle_revidere_confirm_key(app, key),
                 ActiveOverlay::None => unreachable!(),
             }
             return;

--- a/src/event/overlay/mod.rs
+++ b/src/event/overlay/mod.rs
@@ -23,8 +23,8 @@ mod worktree;
 pub(super) use misc::{handle_command_palette_key, handle_help_key, handle_theme_picker_key};
 pub(super) use repo::{handle_open_repo_key, handle_pr_input_key, handle_repo_selector_key};
 pub(super) use review::{
-    handle_comment_detail_key, handle_review_input_key, handle_review_search_key,
-    handle_review_template_key,
+    handle_comment_detail_key, handle_revidere_confirm_key, handle_review_input_key,
+    handle_review_search_key, handle_review_template_key,
 };
 pub(super) use search::{
     handle_filename_search_key, handle_grep_search_key, handle_viewer_search_key,

--- a/src/event/overlay/review.rs
+++ b/src/event/overlay/review.rs
@@ -79,6 +79,20 @@ pub(in crate::event) fn handle_comment_detail_key(app: &mut App, key: KeyEvent) 
     }
 }
 
+// オーバーレイ: レビュー生成の確認
+
+pub(in crate::event) fn handle_revidere_confirm_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+            app.confirm_analyze_revidere();
+        }
+        KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+            app.cancel_analyze_revidere();
+        }
+        _ => {}
+    }
+}
+
 // オーバーレイ: レビュー入力
 
 pub(in crate::event) fn handle_review_input_key(app: &mut App, key: KeyEvent) {

--- a/src/event/revidere.rs
+++ b/src/event/revidere.rs
@@ -32,7 +32,7 @@ pub(super) fn handle_revidere_key(app: &mut App, key: KeyEvent) {
             return;
         }
         Action::AnalyzeRevidere => {
-            app.cmd_analyze_revidere(false);
+            app.cmd_confirm_analyze_revidere();
             return;
         }
         Action::ForceAnalyzeRevidere => {

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -162,7 +162,7 @@ keymap_suite::actions! {
 
         // PR レビュー
         /// revidere の 2 列レビュービュー (節一覧 + diff) を開く。成果物が
-        /// 無ければ開かず、作り方を案内する。
+        /// 無ければ開かず、その場で作るかを聞く。
         ShowRevidere => "show_revidere",
         /// 2 列ビューの中で、次/前の節へ飛ぶ。左の選択と右の diff が一緒に動く。
         RevidereNextSection => "revidere_next_section",
@@ -183,11 +183,12 @@ keymap_suite::actions! {
         /// PR番号/URL 入力のオーバーレイを開き、プルリクエスト用の worktree を
         /// 取得する（または既存のものを再利用する）。
         ReviewPullRequest => "review_pull_request",
-        /// 選択中の worktree に `revidere analyze` をかける。数分かかるので、
-        /// 押し間違いで走り出さないよう Shift を要求している。
+        /// 選択中の worktree のレビューを作る。数分と費用がかかるので、
+        /// 走り出す前に確認を挟む。
         AnalyzeRevidere => "analyze_revidere",
-        /// 貯めた応答を使わずに聞き直す (revidere の --no-cache)。プロンプトを
-        /// 直したときなど、diff が同じでも結果を作り直したい場合の抜け道。
+        /// 確認も、貯めた応答も飛ばして聞き直す (revidere の --no-cache)。
+        /// プロンプトを直したときなど、diff が同じでも結果を作り直したい
+        /// 場合の抜け道。
         ForceAnalyzeRevidere => "force_analyze_revidere",
         /// このブランチの未公開のレビューコメントを、それらが開かれた元の
         /// GitHub PR に公開する。パレット限定: 取り消せない外部アクションであり、
@@ -236,7 +237,7 @@ impl Action {
             Action::ResetMainToOrigin => "Reset main to origin",
             Action::CherryPick => "Cherry-pick",
             Action::PullWorktree => "Pull worktree",
-            Action::SessionHistory => "Session history",
+            Action::SessionHistory => "Saved terminal output",
             Action::OpenPullRequest => "Open pull request",
             Action::ShowRevidere => "Show the review (sections + diff)",
             Action::RevidereNextSection => "Jump to next section",
@@ -246,8 +247,8 @@ impl Action {
             Action::RevidereToggleScope => {
                 "Switch between the whole branch and what changed since the last review"
             }
-            Action::AnalyzeRevidere => "Analyse this worktree with revidere",
-            Action::ForceAnalyzeRevidere => "Re-analyse, ignoring the cached reply",
+            Action::AnalyzeRevidere => "Review this branch (asks first)",
+            Action::ForceAnalyzeRevidere => "Re-analyse without asking, ignoring the cached reply",
             Action::ToggleViewed => "Toggle file viewed",
             Action::ReviewPullRequest => "Review a pull request by number or URL",
             Action::PublishReview => "Publish unpublished review comments to the GitHub PR",

--- a/src/menu/enabled.rs
+++ b/src/menu/enabled.rs
@@ -67,21 +67,6 @@ pub fn command_enabled(id: CommandId, app: &App) -> bool {
         CommandId::ToggleMarkdownRender => app.viewer_state.markdown_toggle_available(),
 
         // Review
-        // コメントは Viewer で開いているファイルに紐づく
-        // (app/review_commands.rs の if let Some(file_path) = …current_file)。
-        CommandId::AddReviewComment => app.viewer_state.content.current_file.is_some(),
-
-        // どちらもコメントリストがフォーカスされたサブパネルであり、かつ
-        // 空でないことを前提とする(app/review_commands.rs)。
-        CommandId::DeleteComment | CommandId::ToggleCommentResolve => comment_list_focused(app),
-
-        // どちらもまず選択中のコメントを解決し、なければ "No comment
-        // selected." で打ち切る(app/review_commands.rs)。
-        CommandId::EditComment | CommandId::ReplyToComment => app
-            .review_state
-            .selected_comment_idx(app.viewer_state.explorer.comment_list_selected)
-            .is_some(),
-
         // レビュー DB と worktree が必要(app/review_publish.rs)。ブランチに
         // 紐づく PR があるかは get_pr_review_meta クエリが必要なので、
         // そこはコマンド側に任せる。
@@ -89,13 +74,4 @@ pub fn command_enabled(id: CommandId, app: &App) -> bool {
 
         _ => true,
     }
-}
-
-/// Explorer 下部ペインがコメントリストを表示し、フォーカスがあり、行を持つか
-/// どうか — cmd_delete_comment と cmd_toggle_comment_resolve の双方が
-/// 明示する前提条件。
-fn comment_list_focused(app: &App) -> bool {
-    app.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
-        && app.viewer_state.explorer.explorer_focus_on_diff_list
-        && !app.review_state.comment_list_rows.is_empty()
 }

--- a/src/menu/model.rs
+++ b/src/menu/model.rs
@@ -76,10 +76,25 @@ const SEP: MenuItem = MenuItem::Separator;
 // tests::every_command_is_reachable が読む。このリストはメニューが意図的に
 // 省いているものの記録であり、テストがその記録を黙って古びさせないようにする。
 // 読み手はそのテストだけなので cfg(test) に閉じてある。
-//
-// 現在は空である。つまり、すべての CommandId がメニューから到達できる。
 #[cfg(test)]
-pub const INTENTIONALLY_UNLISTED: &[(CommandId, &str)] = &[];
+pub const INTENTIONALLY_UNLISTED: &[(CommandId, &str)] = &[
+    (
+        CommandId::AddReviewComment,
+        "コメントは Viewer で行を選んでから書くもので、メニューから始めても宛先が無い",
+    ),
+    (
+        CommandId::EditComment,
+        "対象は一覧で選択中のコメント。選択を持たないメニューからは指せない",
+    ),
+    (CommandId::ReplyToComment, "EditComment と同じ"),
+    (CommandId::DeleteComment, "EditComment と同じ"),
+    (CommandId::ToggleCommentResolve, "EditComment と同じ"),
+    (CommandId::ViewCommentDetail, "EditComment と同じ"),
+    (
+        CommandId::ForceAnalyzeRevidere,
+        "作り直しは Review current branch の確認ダイアログが兼ねる。こちらは確認を飛ばす近道",
+    ),
+];
 
 /// メニューバーの並び (左から右)。
 pub const MENUS: &[Menu] = &[
@@ -118,31 +133,24 @@ pub const MENUS: &[Menu] = &[
             cmd(CommandId::OpenPullRequest, "Open Pull Request in Browser"),
         ],
     },
+    // レビューを作る → 読む → コメントを書く → 公開する、の順。コメントは
+    // レビューの中にあるものなので、レビュー側の行より下に置く。
     Menu {
         title: "Review",
         items: &[
-            cmd(CommandId::AddReviewComment, "Add Comment"),
-            cmd(CommandId::EditComment, "Edit Comment"),
-            cmd(CommandId::ReplyToComment, "Reply to Comment"),
-            cmd(CommandId::DeleteComment, "Delete Comment"),
-            cmd(CommandId::ToggleCommentResolve, "Toggle Resolved"),
-            cmd(CommandId::ViewCommentDetail, "View Comment Detail"),
+            // 作る口は 2 つだけ。どちらも同じ解析に続き、違うのは対象の
+            // worktree をどこから持ってくるかだけ。
+            cmd(CommandId::AnalyzeRevidere, "Review current branch"),
+            cmd(CommandId::ReviewPullRequest, "Review Pull Request…"),
+            SEP,
+            // revidere の行は View 配下の他の表示切り替えとではなく Review 配下に
+            // まとめている。レビューを読むこと自体がレビュー活動だから。
+            cmd(CommandId::ShowRevidere, "Show Review"),
             SEP,
             cmd(CommandId::ShowReviewComments, "Show Comments"),
             cmd(CommandId::ShowReviewTemplates, "Show Templates"),
             SEP,
-            cmd(CommandId::ReviewPullRequest, "Review Pull Request…"),
-            // revidere の行は View 配下の他の表示切り替えとではなく Review 配下に
-            // まとめている。レビューを読むこと自体がレビュー活動であり、まだ
-            // 解析していない場合に "show" の隣に "analyse" があるのが望ましい。
-            cmd(CommandId::ShowRevidere, "Show Review"),
-            cmd(CommandId::AnalyzeRevidere, "Analyse with revidere"),
-            cmd(CommandId::ForceAnalyzeRevidere, "Re-analyse (ignore cache)"),
-            SEP,
             cmd(CommandId::PublishReview, "Publish Comments to GitHub…"),
-            SEP,
-            cmd(CommandId::SessionHistory, "Session History"),
-            cmd(CommandId::SaveSessionHistory, "Save Session History"),
         ],
     },
     Menu {
@@ -187,6 +195,9 @@ pub const MENUS: &[Menu] = &[
             cmd(CommandId::NewClaudeCode, "New Claude Code Session"),
             cmd(CommandId::NewShell, "New Shell Session"),
             cmd(CommandId::ResumeClaudeSession, "Resume Claude Session…"),
+            SEP,
+            cmd(CommandId::SaveSessionHistory, "Save Terminal Output"),
+            cmd(CommandId::SessionHistory, "Saved Terminal Output…"),
         ],
     },
     Menu {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -44,6 +44,34 @@ pub enum ActiveOverlay {
     /// テーマピッカー。上下で切り替え、移動のたびにライブプレビュー、Enter で
     /// 確定、Esc でピッカーを開いた時点のテーマへ戻す。
     ThemePicker,
+    /// レビューを作る前の確認。
+    RevidereConfirm,
+}
+
+/// 確認を出した時点で、その worktree の成果物がどうなっているか。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RevidereArtifact {
+    /// まだ無い。
+    #[default]
+    None,
+    /// あるが、解析したときのコミットから先へ進んでいる。
+    Stale,
+    /// いまのコミットを見て作られている。
+    Current,
+}
+
+/// レビューを作る前の確認のオーバーレイ状態。
+///
+/// AI の呼び出しは数分と費用がかかるので、w / W の押し間違いや、メニューの
+/// 隣の行を選んだだけで走り出さないようにしている。文言と、作り直しに
+/// 貯めた応答を捨てるかどうかは artifact が決める。
+#[derive(Default)]
+pub struct RevidereConfirmOverlay {
+    pub branch: String,
+    /// 見る区間の呼び名 ([crate::revidere::scope_label])。区間はビューを
+    /// 閉じても残るので、いまどちらを作ろうとしているかを名乗る。
+    pub scope: &'static str,
+    pub artifact: RevidereArtifact,
 }
 
 /// テーマピッカーのオーバーレイ状態。
@@ -377,4 +405,5 @@ pub struct OverlayManager {
     pub help: HelpOverlay,
     pub command_palette: CommandPaletteOverlay,
     pub theme_picker: ThemePickerOverlay,
+    pub revidere_confirm: RevidereConfirmOverlay,
 }

--- a/src/revidere.rs
+++ b/src/revidere.rs
@@ -113,6 +113,16 @@ pub fn previous_head(worktree: &Path) -> Option<String> {
     Some(annotations.since_previous()?.previous_head.clone())
 }
 
+/// その区間の成果物が解析したときの HEAD。成果物が無ければ None。
+///
+/// 読む順を組む [load] と違って diff を取らないので、確認ダイアログのように
+/// 「作り直しか、初めてか」だけを知りたい場面で使える。
+pub fn artifact_head(worktree: &Path, scope: Scope) -> Option<String> {
+    let text = std::fs::read_to_string(revidere::review::artifact_path(worktree, scope)).ok()?;
+    let annotations = Annotations::from_json(&text).ok()?;
+    Some(annotations.head().to_string())
+}
+
 /// 画面とステータスに出す区間の呼び名。1 か所で持つ。
 pub fn scope_label(scope: Scope) -> &'static str {
     match scope {
@@ -275,6 +285,19 @@ mod tests {
             load(dir.path(), Scope::SincePrevious),
             LoadOutcome::Broken(_)
         ));
+    }
+
+    /// 確認ダイアログは「作り直しか、初めてか」をこれで見分ける。無いのに
+    /// 何かを返すと、押していないのに作り直しの文言が出る。
+    #[test]
+    fn artifact_head_reads_the_commit_the_review_was_made_for() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(artifact_head(dir.path(), Scope::Base), None);
+
+        let path = revidere::review::artifact_path(dir.path(), Scope::Base);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, artifact("b0", None)).unwrap();
+        assert_eq!(artifact_head(dir.path(), Scope::Base).as_deref(), Some("h"));
     }
 
     /// 成果物を書いてから積んだコミットは、成果物を古くすること。

--- a/src/ui/dashboard/mod.rs
+++ b/src/ui/dashboard/mod.rs
@@ -15,6 +15,7 @@ mod history;
 mod input;
 mod repo;
 mod resume_session;
+mod review_confirm;
 mod update;
 mod worktree;
 
@@ -28,6 +29,7 @@ pub use help::render_help_overlay;
 pub use history::render_history_overlay;
 pub use repo::{render_open_repo_overlay, render_pr_input_overlay, render_repo_selector_overlay};
 pub use resume_session::render_resume_session_overlay;
+pub use review_confirm::render_revidere_confirm_overlay;
 pub use update::{
     render_publish_confirm_overlay, render_update_confirm_overlay, render_update_progress_overlay,
 };

--- a/src/ui/dashboard/review_confirm.rs
+++ b/src/ui/dashboard/review_confirm.rs
@@ -1,0 +1,71 @@
+//! レビューを作る前の確認ダイアログ。
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::App;
+use crate::overlay::RevidereArtifact;
+
+pub fn render_revidere_confirm_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = &app.theme;
+    let confirm = &app.overlays.revidere_confirm;
+    let popup_width = 64_u16.min(area.width.saturating_sub(4));
+    let popup_height = 7_u16;
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+    // 作り直しなのか初めてなのかで、押す前に知りたいことが変わる。
+    let (title, situation, verb) = match confirm.artifact {
+        RevidereArtifact::None => (" Review ", "No review for this worktree yet.", "analyse"),
+        RevidereArtifact::Stale => (
+            " Review ",
+            "A review exists, but commits have landed since.",
+            "analyse",
+        ),
+        RevidereArtifact::Current => (
+            " Re-analyse ",
+            "A review for this commit already exists.",
+            "re-analyse",
+        ),
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.warning));
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let accent = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+    let lines = vec![
+        Line::from(Span::styled(
+            format!(" {situation}"),
+            Style::default().fg(theme.fg),
+        )),
+        Line::from(Span::styled(
+            format!(" {} [{}]", confirm.branch, confirm.scope),
+            Style::default().fg(theme.muted),
+        )),
+        Line::from(Span::styled(
+            " It calls the AI and takes a few minutes.",
+            Style::default().fg(theme.muted),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(" Enter", accent),
+            Span::styled(format!(": {verb} / "), Style::default().fg(theme.muted)),
+            Span::styled("Esc", accent),
+            Span::styled(": cancel", Style::default().fg(theme.muted)),
+        ]),
+    ];
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/ui/layout/overlays.rs
+++ b/src/ui/layout/overlays.rs
@@ -113,6 +113,9 @@ pub(super) fn render_overlays(frame: &mut Frame, area: Rect, app: &mut App) {
         crate::overlay::ActiveOverlay::ThemePicker => {
             super::super::theme_picker::render_theme_picker_overlay(frame, area, app);
         }
+        crate::overlay::ActiveOverlay::RevidereConfirm => {
+            super::super::dashboard::render_revidere_confirm_overlay(frame, area, app);
+        }
     }
     // ファジーなファイル名検索（「ジャンプ先」）モーダル ―― explorer カラムが
     // 折りたたまれていて（viewer 最大化時）も動くようトップレベルで描画する。


### PR DESCRIPTION
## Summary

Review メニューが「行を選んでから行うコメント操作」と「レビューそのものを作る/読む」を同じ平面に並べていたのを、レビューとコメントの入れ子が伝わる構成に組み直し、あわせて AI 呼び出しの前に確認を挟むようにした。

### 1. メニューの構成 (`src/menu/model.rs`)

```
Review current branch          W
Review Pull Request…
──────────────────────────────
Show Review                    w
──────────────────────────────
Show Comments
Show Templates
──────────────────────────────
Publish Comments to GitHub…
```

- 生成の入口は 2 つだけ。どちらも同じ解析に続き、違うのは対象 worktree をどこから持ってくるかだけ。
- `Analyse with revidere` / `Re-analyse (ignore cache)` という実装用語のラベルを廃止。
- 行を選んでから行うコメント操作 (Add / Edit / Reply / Delete / Toggle Resolved / View Detail) をメニューから削除。キーバインドとコマンドパレットはそのままで、`INTENTIONALLY_UNLISTED` に理由付きで登録した (到達性テストが担保)。

### 2. 生成前の確認オーバーレイ

`ActiveOverlay::RevidereConfirm` を追加。`w` / `W` / メニューの生成 2 項目 / PR 取り込み完了後 / Changed files パネルの状態チップ、の全経路が通る。成果物の HEAD コミット (`revidere::artifact_head`) と worktree の `head_oid` を突き合わせて出し分ける:

| 状況 | 文面 | Enter |
|---|---|---|
| 成果物なし | No review for this worktree yet. | analyse (キャッシュ有効) |
| コミットが進んでいる | A review exists, but commits have landed since. | analyse |
| 同じコミットの成果物あり | A review for this commit already exists. | re-analyse (キャッシュ破棄) |

作り直しは独立したメニュー項目ではなくこのダイアログに畳んだ。`ForceAnalyzeRevidere` は確認を飛ばす近道として `alt+w` とパレットにのみ残す。

### 3. Review Pull Request → 解析の連結

`poll_pr_intake` の Ready で worktree を切り替えた直後にこの確認へ繋げた。PR の取り込みと解析が 1 本の道になる。

### 4. Session History の扱い

コードを追うと、これは PTY セッション出力のスナップショット (`session_history` テーブル、Claude Code / Shell パネルのスクロールバック) で、レビューともコメントとも無関係だった。機能はしているので削除せず、対になる Save と一緒に **Terminal メニューへ移動**し、`Save Terminal Output` / `Saved Terminal Output…` に改名した (パレットも `Terminal:` カテゴリへ)。

### 設計上の前提

コマンドのロジックは `execute_palette_command` 側に置いたまま、メニューはタクソノミーとラベルのみを持つ現在の設計を崩していない。

## Test plan

- [x] `cargo test --workspace` — 1117 passed / 0 failed (メニュー到達性テストを含む)
- [x] `cargo clippy --workspace` — 新規警告なし (既存の doc 警告 2 件のみ)
- [x] 実機確認 (pty 経由でキー注入し画面を採取):
  - F10 → Review メニューの新しい並びを確認
  - Enter → 確認ダイアログ表示 (`A review exists, but commits have landed since.`)
  - 別 worktree に切り替えて `w` → `No review for this worktree yet.` → Esc で復帰
  - Terminal メニューの `Save Terminal Output` / `Saved Terminal Output…` を確認

## Note

rebase 中に main の #321 (revidere の状態を Changed files パネルに常設表示) と隣接衝突。両方を残したうえで、`cmd_revidere_badge_click` の未解析/古い場合の分岐を `cmd_analyze_revidere(false)` から確認経由に変更した (チップを 1 回押しただけで AI が走らないように)。version は #321 が 0.108.0 を取ったため 0.109.0 とした。
