### PR TITLE
fix: revidere の状態マーカーを worktree チップの塗りの外に出す

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.109.0"
+version = "0.109.1"
 edition = "2024"
 
 [dependencies]

--- a/src/revidere.rs
+++ b/src/revidere.rs
@@ -152,21 +152,6 @@ pub enum ArtifactState {
     Stale,
 }
 
-impl ArtifactState {
-    /// ストリップに出す 1 文字。空なら出さない。
-    ///
-    /// 色だけで区別すると、色が近いテーマや色覚の違いで読めなくなるので、
-    /// 形でも分かるようにしてある。実行中はここを呼ばず、呼び出し側が
-    /// 回るスピナーに差し替える — 動いているものは動いて見えるのが早い。
-    pub fn marker(self) -> &'static str {
-        match self {
-            Self::None | Self::Running => "",
-            Self::Fresh => "\u{2713}", // ✓
-            Self::Stale => "!",
-        }
-    }
-}
-
 /// worktree の解析の状態を返す。
 ///
 /// 古いかどうかは「成果物のファイルが HEAD コミットより前に書かれたか」で
@@ -326,13 +311,14 @@ mod tests {
         assert!(artifact_state(dir.path(), Some(now + 60), true) == ArtifactState::Running);
     }
 
-    /// 成果物が無ければ何も出さないこと。走らせていないだけの worktree に
-    /// 印が付くと、印そのものが意味を失う。
+    /// 走らせていない worktree は None。ストリップに印が付かないことは
+    /// [crate::ui::worktree_bar] 側で担保している。
     #[test]
-    fn no_artifact_shows_nothing() {
+    fn no_artifact_is_none() {
         let dir = tempfile::tempdir().unwrap();
-        let state = artifact_state(dir.path(), Some(0), false);
-        assert_eq!(state, ArtifactState::None);
-        assert!(state.marker().is_empty());
+        assert_eq!(
+            artifact_state(dir.path(), Some(0), false),
+            ArtifactState::None
+        );
     }
 }

--- a/src/ui/common/mod.rs
+++ b/src/ui/common/mod.rs
@@ -32,3 +32,36 @@ const BRAILLE_SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "�
 pub fn spinner_frame(ui_tick: u64) -> &'static str {
     BRAILLE_SPINNER[(ui_tick as usize / 4) % BRAILLE_SPINNER.len()]
 }
+
+/// revidere の状態を表す 1 文字。幅は常に 1。
+///
+/// 色だけで区別すると配色や色覚によって読めなくなるので、形でも分かるように
+/// してある。✓ は「作業ツリーが綺麗」「ファイルを読んだ」に既に使っていて、
+/// レビューの印に流用すると git の情報と見分けが付かない。
+pub fn revidere_marker(state: crate::revidere::ArtifactState, ui_tick: u64) -> &'static str {
+    use crate::revidere::ArtifactState as S;
+    match state {
+        S::Running => spinner_frame(ui_tick),
+        S::Fresh => "\u{25a4}", // ▤
+        S::Stale => "!",
+        S::None => "\u{25cb}", // ○
+    }
+}
+
+/// revidere の状態の色。muted は複数のテーマで見えなくなるので使わない。
+///
+/// この色は必ず素の背景の上で使う。選択中の worktree チップのような塗りの
+/// 上に重ねてはいけない — 全テーマで accent と selected_bg が同じ色なので、
+/// 実行中の印が背景と完全に同色になって消える。
+pub fn revidere_color(
+    theme: &crate::theme::Theme,
+    state: crate::revidere::ArtifactState,
+) -> ratatui::style::Color {
+    use crate::revidere::ArtifactState as S;
+    match state {
+        S::None => theme.hint,
+        S::Running => theme.accent,
+        S::Fresh => theme.success,
+        S::Stale => theme.warning,
+    }
+}

--- a/src/ui/explorer_panel/diff_list.rs
+++ b/src/ui/explorer_panel/diff_list.rs
@@ -32,30 +32,11 @@ fn badge_cols(x: u16, width: u16, title_w: u16) -> Option<std::ops::Range<u16>> 
 }
 
 /// 状態チップの文字列。幅は常に [REVIDERE_BADGE_W]。
-///
-/// 色だけで区別すると色覚や配色によって読めなくなるので、形でも分かるように
-/// している (worktree ストリップの印と同じ考え方)。
 fn revidere_badge_label(state: ArtifactState, ui_tick: u64) -> String {
-    let marker = match state {
-        ArtifactState::Running => crate::ui::common::spinner_frame(ui_tick),
-        ArtifactState::Fresh => "\u{2713}",
-        ArtifactState::Stale => "!",
-        ArtifactState::None => "\u{25cb}",
-    };
-    format!(" {marker} review ")
-}
-
-/// 状態チップの色。muted は複数のテーマで見えなくなるので使わない。
-fn revidere_badge_color(
-    theme: &crate::theme::Theme,
-    state: ArtifactState,
-) -> ratatui::style::Color {
-    match state {
-        ArtifactState::None => theme.hint,
-        ArtifactState::Running => theme.accent,
-        ArtifactState::Fresh => theme.success,
-        ArtifactState::Stale => theme.warning,
-    }
+    format!(
+        " {} review ",
+        crate::ui::common::revidere_marker(state, ui_tick)
+    )
 }
 
 /// Changed-files の各行のファイル名色が表す、4種類の git ステージ状態のいずれか。
@@ -145,7 +126,7 @@ pub(super) fn render_diff_list(frame: &mut Frame, area: Rect, app: &App, panel_f
     if revidere_badge_cols(app, area.x, area.width).is_some() {
         let state = app.revidere_artifact_state();
         let mut style = Style::default()
-            .fg(revidere_badge_color(theme, state))
+            .fg(crate::ui::common::revidere_color(theme, state))
             .add_modifier(Modifier::BOLD);
         // hover は前景の下線で示す。背景を敷くとテーマによっては枠線ごと
         // 潰れて、どこが押せるのか逆に読めなくなる。
@@ -484,9 +465,10 @@ mod tests {
 
         let buf = terminal.backend().buffer();
         let top: String = (0..width).map(|x| buf[(x, 0)].symbol()).collect();
+        let marker = crate::ui::common::revidere_marker(ArtifactState::Fresh, 0);
         let at = top
             .chars()
-            .position(|c| c == '\u{2713}')
+            .position(|c| c.to_string() == marker)
             .expect("チップが上枠に出ている");
         assert_eq!(at as u16, cols.start + 1, "枠内の位置: {top:?}");
         assert!(cols.contains(&(at as u16)));

--- a/src/ui/worktree_bar.rs
+++ b/src/ui/worktree_bar.rs
@@ -55,6 +55,26 @@ fn w(s: &str) -> u16 {
     UnicodeWidthStr::width(s) as u16
 }
 
+/// チップの外に出す revidere の印。走らせていない worktree では空 — 印の
+/// 付いていない状態が「まだ解析していない」を意味するので、印そのものが
+/// 情報として効く。
+fn review_mark(state: crate::revidere::ArtifactState, ui_tick: u64) -> String {
+    match state {
+        crate::revidere::ArtifactState::None => String::new(),
+        state => format!(" {}", crate::ui::common::revidere_marker(state, ui_tick)),
+    }
+}
+
+/// 印の見た目。背景は敷かない。
+///
+/// 全テーマで accent と selected_bg が同じ色なので、選択中チップの塗りを
+/// 引き継ぐと実行中の印が背景と完全に同色になって消える。
+fn review_style(theme: &crate::theme::Theme, state: crate::revidere::ArtifactState) -> Style {
+    Style::default()
+        .fg(crate::ui::common::revidere_color(theme, state))
+        .add_modifier(Modifier::BOLD)
+}
+
 /// 描画前に集めた worktree ごとのデータ。可変幅のウィンドウを app への
 /// 借用を保持したまま計算できるようにする。
 struct Chip {
@@ -68,8 +88,7 @@ struct Chip {
     is_current: bool,
     /// revidere の解析の状態。マーカーの色を決めるのに使う。
     review: crate::revidere::ArtifactState,
-    /// マーカーとチップ末尾の空白。解析していない worktree では空白だけ。
-    /// チップ本体とは別の Span にして色を変えるので、幅も別に持つ。
+    /// チップの外に置くマーカー。解析していない worktree では空。
     review_text: String,
     review_width: u16,
 }
@@ -216,22 +235,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             {
                 text.push_str(&format!(" \u{2193}{b}"));
             }
+            text.push(' ');
             // revidere の状態は常に見えていてほしい。複数の worktree で
             // 走らせると、終わったのがどれかはステータス行の 1 本では追えない。
-            // チップ末尾の空白と一緒に別 Span にするのは、状態ごとに色を
-            // 変えるため — 形でも色でも分かるようにしておく。
+            // 出すのはチップの外 — 中に入れると、選択中チップの塗りと同じ色に
+            // なって消えるうえ、~3 や ↑1 と並んで git の情報に見える。
             let review = crate::revidere::artifact_state(
                 &wt.path,
                 wt.head_time,
                 app.revidere.runs.is_running(&wt.branch),
             );
-            let review_text = match review {
-                crate::revidere::ArtifactState::None => " ".to_string(),
-                crate::revidere::ArtifactState::Running => {
-                    format!(" {} ", crate::ui::common::spinner_frame(app.ui_tick))
-                }
-                other => format!(" {} ", other.marker()),
-            };
+            let review_text = review_mark(review, app.ui_tick);
 
             // Claude/Shell セッションタブに合わせて [x]（以前は ✕）。チップの
             // 塗りつぶし背景のすぐ外側に置くので、危険色の赤が読みやすいまま
@@ -337,24 +351,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             chip_style
         };
         spans.push(Span::styled(chip.text.clone(), chip_style));
-        // マーカーは前景色だけ差し替える。背景はチップのまま（選択中の塗り
-        // つぶしや hover の上に別の背景を重ねると、どちらの状態か読めなくなる）。
-        let review_style = match chip.review {
-            crate::revidere::ArtifactState::None => chip_style,
-            crate::revidere::ArtifactState::Running => chip_style.fg(app.theme.accent),
-            crate::revidere::ArtifactState::Fresh => chip_style.fg(success),
-            crate::revidere::ArtifactState::Stale => chip_style.fg(warning),
-        };
-        spans.push(Span::styled(
-            chip.review_text.clone(),
-            review_style.add_modifier(Modifier::BOLD),
-        ));
         hits.push(WtbarHit {
             x0: x,
-            x1: x + chip.width + chip.review_width,
+            x1: x + chip.width,
             action: WtbarAction::Select(i),
         });
-        x += chip.width + chip.review_width;
+        x += chip.width;
 
         if !chip.del.is_empty() {
             let del_style = Style::default().fg(error);
@@ -370,6 +372,23 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 action: WtbarAction::Delete(i),
             });
             x += chip.del_width;
+        }
+
+        // revidere のマーカーはチップの塗りの外に置く。背景を敷かないので
+        // 全テーマで色がそのまま出るし、塗りの外にあること自体が「チップ本体
+        // とは別のもの」という手掛かりになる。押したときはチップと同じく
+        // その worktree へ移る。
+        if chip.review_width > 0 {
+            spans.push(Span::styled(
+                chip.review_text.clone(),
+                review_style(&app.theme, chip.review),
+            ));
+            hits.push(WtbarHit {
+                x0: x,
+                x1: x + chip.review_width,
+                action: WtbarAction::Select(i),
+            });
+            x += chip.review_width;
         }
     }
 
@@ -429,7 +448,42 @@ pub fn render_switcher_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use super::{WtbarAction, WtbarHit, hit_at, visible_window};
+    use super::{WtbarAction, WtbarHit, hit_at, review_mark, review_style, visible_window};
+    use crate::revidere::ArtifactState;
+    use crate::theme::Theme;
+
+    /// 走らせていない worktree には何も出さない。印が付いていないこと自体が
+    /// 「まだ解析していない」を意味するので、ここが空でなくなると印が意味を失う。
+    #[test]
+    fn an_unanalysed_worktree_gets_no_mark() {
+        assert_eq!(review_mark(ArtifactState::None, 0), "");
+        for state in [
+            ArtifactState::Running,
+            ArtifactState::Fresh,
+            ArtifactState::Stale,
+        ] {
+            assert_eq!(
+                unicode_width::UnicodeWidthStr::width(review_mark(state, 0).as_str()),
+                2,
+                "{state:?}"
+            );
+        }
+    }
+
+    /// 印に背景を敷かないこと。どのテーマでも accent は selected_bg と同じ色で、
+    /// 選択中チップの塗りを引き継いだ瞬間に実行中の印が背景と同色になって消える。
+    #[test]
+    fn the_mark_never_carries_a_background() {
+        let theme = Theme::from_name("catppuccin-mocha");
+        assert_eq!(theme.accent, theme.selected_bg, "前提が変わっている");
+        for state in [
+            ArtifactState::Running,
+            ArtifactState::Fresh,
+            ArtifactState::Stale,
+        ] {
+            assert!(review_style(&theme, state).bg.is_none(), "{state:?}");
+        }
+    }
 
     // 幅が均一な10個のチップ、区切り文字幅は1。
     const W: &[u16] = &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10];


### PR DESCRIPTION
## Summary

worktree ストリップの revidere 状態マーカー (解析中のスピナー / ✓ / !) が、選択中の worktree では**完全に見えなくなっていた**問題の修正。

原因は色の調整不足ではなく構造的なもので、マーカーをチップのべた塗り (`selected_bg`) の上に `accent` を前景として描いていた。この2色は11テーマすべてで同じ RGB リテラルなので、選択中チップでは文字色と背景色が一致して消える。gruvbox と solarized-dark は `warning` も同値なので Stale の `!` も同様に消えていた。テーマ別のチューニングでは直らない。

- **マーカーをチップの塗りの外 (`[x]` の後ろ) に移し、背景を敷かないようにした。** これで全テーマで色がそのまま出る。あわせて `~3` や `↑1` といった git の情報の並びから外れるので、worktree の状態ではなくレビューの状態だと読めるようになる。クリックの挙動はチップと同じ (その worktree へ移る)。
- **Fresh の印を ✓ から ▤ に変更。** ✓ は「作業ツリーが綺麗」(`worktree_panel/list.rs`) と「ファイルを読んだ」(`diff_list.rs`) で既に使われており、レビューの印に流用すると git の情報と見分けが付かない。
- **glyph と色の表を `ui/common` の `revidere_marker` / `revidere_color` に集約。** ストリップと Changed files のバッジが別々の表を持っていて、片方だけ直すと食い違う状態だった。不要になった `ArtifactState::marker()` は削除。

## Test plan

- [x] `cargo test --workspace` — 1119 passed / 0 failed
- [x] `cargo clippy --workspace` — 新規の警告なし
- [x] 回帰テスト2件を追加: 印に背景を敷かないこと (前提が崩れたら落ちるよう `accent == selected_bg` も併せて主張)、未解析の worktree には何も出さないこと
- [x] pty 経由で実バイナリを起動して実機確認 (dracula, 200x50)。選択中チップの塗りが `48;2;255;121;198` で描かれた直後、マーカーが `49` (既定の背景) で描かれることを生バイト列で確認

実行中のスピナーだけは未確認 (再現に実際の解析と API 呼び出しが必要なため)。Fresh / Stale と同じコードパスを通る。