### PR TITLE
feat: Viewer にコードブロックの折りたたみを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.109.1"
+version = "0.110.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.109.1"
+version = "0.110.0"
 edition = "2024"
 
 [dependencies]

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -264,6 +264,10 @@
 # rendered prose. Bound in this layer only — the rendered view resolves its keys
 # against it too, so one binding covers both directions.
 "m" = "toggle_markdown_render"
+# 'z' opens the Vim fold chord: za toggles, zc closes, zo opens, zR opens every
+# fold, zM closes every fold. Only the prefix is bound — the second key is read
+# by the viewer handler, exactly like the g-prefixed jumps (gd/gi/gr).
+"z" = "fold_prefix"
 "space" = "toggle_inline_thread"
 "esc" = "exit_to_explorer"
 # Ctrl+Esc is the app-wide "leave focus" chord (it is the only way out of the

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -82,6 +82,17 @@ fn resolve_screen_line(app: &App, screen_offset: usize) -> Option<usize> {
     }
 }
 
+/// col が折りたたみマーカーの当たり判定に入るか。gutter_end はガターの右端
+/// （排他）。
+///
+/// マーカーの1列だけでは三角が小さすぎて狙えないので、行番号より右のガター
+/// （隙間・マーカー・区切り線・その右の空白）をまとめて受ける。行番号そのもの
+/// はコメント作成に残す。ホバーの罫線とクリックが同じ範囲を見るように、判定は
+/// ここにしかない。
+pub(super) fn in_fold_zone(col: u16, gutter_end: u16) -> bool {
+    col < gutter_end && col + 5 >= gutter_end
+}
+
 /// 何らかのオーバーレイ/モーダルがアクティブな場合に true を返す。この場合は
 /// マウスイベントを全て消費し、背景のパネルに届かないようにする。
 /// マウスイベントをインタラクティブなホバーモーダルのスタックに対して振り分ける。
@@ -710,6 +721,15 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
                 app.viewer_state.click.hover_line = resolved;
                 app.viewer_state.click.hover_gutter_line = if on_gutter { resolved } else { None };
 
+                // 折りたたみマーカーの上にいる間だけ、その範囲の端から端までを
+                // マーカー列の罫線で示す。
+                let on_fold = !app.viewer_state.diff_view.diff_mode
+                    && in_fold_zone(col, inner_x + marker_w + gutter_w);
+                app.viewer_state
+                    .content
+                    .folds
+                    .set_hover(if on_fold { resolved } else { None });
+
                 let has_jump_modifier = mouse.modifiers.contains(KeyModifiers::SUPER)
                     || mouse.modifiers.contains(KeyModifiers::CONTROL);
 
@@ -771,6 +791,7 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
             } else {
                 app.viewer_state.click.hover_line = None;
                 app.viewer_state.click.hover_gutter_line = None;
+                app.viewer_state.content.folds.set_hover(None);
                 app.set_underline_candidate(None, false);
                 app.set_mouse_hover_candidate(None);
             }

--- a/src/event/mouse/scroll.rs
+++ b/src/event/mouse/scroll.rs
@@ -160,20 +160,10 @@ pub(super) fn handle_mouse_scroll(
                 }
             }
         } else {
-            let total = app.viewer_state.content.file_content.len();
-            if total > 0 {
-                if delta > 0 {
-                    app.viewer_state.content.file_scroll = (app.viewer_state.content.file_scroll
-                        + delta.unsigned_abs() as usize)
-                        .min(total.saturating_sub(1));
-                } else {
-                    app.viewer_state.content.file_scroll = app
-                        .viewer_state
-                        .content
-                        .file_scroll
-                        .saturating_sub(delta.unsigned_abs() as usize);
-                }
-            }
+            // 折りたたんだ行を跨がないよう、可視行を歩いて動かす。生の加減算だと
+            // 畳んだぶんだけ行き過ぎ、着地点が隠れていれば描画側が畳みを開いて
+            // しまう（ホイールで畳みが勝手に開く）。
+            app.viewer_state.move_cursor_lines(delta as isize);
         }
     } else {
         // ターミナルパネル（右カラム）。

--- a/src/event/mouse/tests.rs
+++ b/src/event/mouse/tests.rs
@@ -5,7 +5,7 @@ use super::explorer_panel::{diff_list_row_at, explorer_tree_row_at};
 use super::viewer_panel::{
     MarginClickAction, MarginZone, classify_margin_click, thread_anchor_line,
 };
-use super::{ClickGeometry, Column, register_double_click, register_double_click_on};
+use super::{ClickGeometry, Column, in_fold_zone, register_double_click, register_double_click_on};
 use std::time::{Duration, Instant};
 
 /// 指定したカラム境界でClickGeometryを構築する。幅/高さは、[<=>] 展開ボタン
@@ -527,4 +527,21 @@ mod menu_clicks {
             MenuClick::Open(_)
         ));
     }
+}
+
+/// 折りたたみマーカーの当たり判定。三角の1列だけだと狙えないので、行番号より
+/// 右のガターをまとめて受ける — ただし行番号（コメント作成）とガターの外
+/// （バッジの「+」）までは広げない。
+#[test]
+fn the_fold_marker_claims_the_gutter_right_of_the_line_number() {
+    // ガターは [10, 20)。隙間が 15、マーカーが 16、隙間が 17、区切り線が 18、
+    // 空白が 19。
+    let gutter_end = 20;
+    assert!(!in_fold_zone(14, gutter_end), "行番号の最終桁はコメント側の担当");
+    assert!(in_fold_zone(15, gutter_end));
+    assert!(in_fold_zone(16, gutter_end));
+    assert!(in_fold_zone(17, gutter_end));
+    assert!(in_fold_zone(18, gutter_end));
+    assert!(in_fold_zone(19, gutter_end));
+    assert!(!in_fold_zone(20, gutter_end), "バッジ列はコメント側の担当");
 }

--- a/src/event/mouse/viewer_panel.rs
+++ b/src/event/mouse/viewer_panel.rs
@@ -145,9 +145,8 @@ pub(super) fn handle_viewer_column_click(
             use crate::ui::viewer_panel::thread_actions;
             // 列オフセットからどのアクションがクリックされたかを判定する。レンダラが
             // その行を描画するのに使うのと同じレイアウト定数を使う。
-            // レンダラとのオフセットの対応: gutter_total_width() は digits+4、
-            // レンダラのインデントは marker(2) + digits + 6 (left_pad) + 4
-            // ("  │ ") = marker + gutter_total_width() + 2 + 4。
+            // レンダラとのオフセットの対応: left_pad は marker +
+            // gutter_total_width() + 2（バッジ）で、そこに "  │ " の4列が続く。
             let content_x = inner_x + marker_w + gutter_w + 2 + 4;
             let click_col = col.saturating_sub(content_x) as usize;
             if click_col < thread_actions::reply_end() {
@@ -237,6 +236,21 @@ pub(super) fn handle_viewer_column_click(
             )
         {
             app.viewer_state.expand_context_at(idx, false);
+        }
+    }
+
+    // 折りたたみマーカー。ガターの中にあるので、コメント作成へ落ちる前に
+    // ここで捌く。当たり判定の列は in_fold_zone が持つ（ホバーの罫線と共有）。
+    if !app.viewer_state.diff_view.diff_mode
+        && row >= inner_y
+        && super::in_fold_zone(col, inner_x + marker_w + gutter_w)
+    {
+        let screen_offset = (row - inner_y) as usize;
+        if let Some(line_1) = resolve_screen_line(app, screen_offset)
+            && app.viewer_state.content.folds.is_foldable(line_1)
+        {
+            app.viewer_state.fold_toggle_at(line_1);
+            return;
         }
     }
 

--- a/src/event/viewer/mod.rs
+++ b/src/event/viewer/mod.rs
@@ -115,6 +115,17 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         }
     }
 
+    // 保留中の 'z' キー — 折りたたみの2打鍵目を待っている。プレーンファイル
+    // 表示専用: diff 表示の折りたたみは ExpandableContext という別の仕組みで、
+    // 同じキーに2つの意味を持たせない。
+    if app.viewer_state.pending_z_key {
+        app.viewer_state.pending_z_key = false;
+        if !app.viewer_state.diff_view.diff_mode {
+            handle_fold_key(app, key);
+            return;
+        }
+    }
+
     // 統合 diff モードは独自のナビゲーションを持つ。
     if app.viewer_state.diff_view.diff_mode {
         handle_viewer_diff_mode_key(app, key);
@@ -152,25 +163,14 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
     }
 
     match action {
-        Some(Action::NavigateDown) if app.viewer_state.content.file_scroll + 1 < total => {
-            app.viewer_state.content.file_scroll += 1;
-        }
-        Some(Action::NavigateUp) => {
-            app.viewer_state.content.file_scroll =
-                app.viewer_state.content.file_scroll.saturating_sub(1);
-        }
-        Some(Action::ScrollHalfPageDown) => {
-            app.viewer_state.content.file_scroll =
-                (app.viewer_state.content.file_scroll + 15).min(total.saturating_sub(1));
-        }
-        Some(Action::ScrollHalfPageUp) => {
-            app.viewer_state.content.file_scroll =
-                app.viewer_state.content.file_scroll.saturating_sub(15);
-        }
+        // 移動はすべて可視行を歩く（畳んだ中にカーソルが入らない）。
+        Some(Action::NavigateDown) => app.viewer_state.move_cursor_lines(1),
+        Some(Action::NavigateUp) => app.viewer_state.move_cursor_lines(-1),
+        Some(Action::ScrollHalfPageDown) => app.viewer_state.move_cursor_lines(15),
+        Some(Action::ScrollHalfPageUp) => app.viewer_state.move_cursor_lines(-15),
         Some(Action::GoToTop) => enter_g_prefix_mode(app),
-        Some(Action::GoToBottom) => {
-            app.viewer_state.content.file_scroll = total.saturating_sub(1);
-        }
+        Some(Action::GoToBottom) => app.viewer_state.goto_last_visible_line(),
+        Some(Action::FoldPrefix) => app.viewer_state.pending_z_key = true,
         Some(Action::SearchInFile) => {
             app.viewer_state.search.search_active = true;
             app.viewer_state.search.search_query.clear();
@@ -214,6 +214,28 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         Some(Action::ToggleMarkdownRender) => {
             app.cmd_toggle_markdown_render();
         }
+        _ => {}
+    }
+}
+
+/// 'z' の2打鍵目を処理する（vim の折りたたみ）。
+///
+/// 対象はカーソル行（＝ビューポート最上行）。その行がブロックの見出しでなければ、
+/// それを含む最も内側のブロックが動く — vim の za/zc と同じ。
+fn handle_fold_key(app: &mut App, key: KeyEvent) {
+    let vs = &mut app.viewer_state;
+    match key.code {
+        KeyCode::Char('a') => {
+            vs.fold_toggle_cursor();
+        }
+        KeyCode::Char('c') => {
+            vs.fold_close_cursor();
+        }
+        KeyCode::Char('o') => {
+            vs.fold_open_cursor();
+        }
+        KeyCode::Char('R') => vs.fold_open_all(),
+        KeyCode::Char('M') => vs.fold_close_all(),
         _ => {}
     }
 }

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -180,6 +180,10 @@ keymap_suite::actions! {
         /// ファイル（diff リストの行、または現在 Viewer の diff モードで
         /// 開いているファイル）の「viewed」マークを切り替える。
         ToggleViewed => "toggle_viewed",
+        /// 'z' — コードブロックの折りたたみの2打鍵目（za/zc/zo/zR/zM）を待つ。
+        /// 2打鍵目そのものは gd/gi/gr と同じくハンドラ側で直接読む: 折りたたみ
+        /// だけが独自の再割り当て可能な語彙を持つ理由がない。
+        FoldPrefix => "fold_prefix",
         /// PR番号/URL 入力のオーバーレイを開き、プルリクエスト用の worktree を
         /// 取得する（または既存のものを再利用する）。
         ReviewPullRequest => "review_pull_request",
@@ -249,6 +253,7 @@ impl Action {
             }
             Action::AnalyzeRevidere => "Review this branch (asks first)",
             Action::ForceAnalyzeRevidere => "Re-analyse without asking, ignoring the cached reply",
+            Action::FoldPrefix => "Fold block (za/zc/zo/zR/zM)",
             Action::ToggleViewed => "Toggle file viewed",
             Action::ReviewPullRequest => "Review a pull request by number or URL",
             Action::PublishReview => "Publish unpublished review comments to the GitHub PR",

--- a/src/symbol_index/code_mask.rs
+++ b/src/symbol_index/code_mask.rs
@@ -295,22 +295,31 @@ fn grammar_for(ext: &str) -> Option<Grammar> {
     // つけずに済む。
     const TS: &[&str] = &["comment", "string_fragment"];
 
-    let (language, masked, format_capable) = match ext {
-        "rs" => (tree_sitter_rust::LANGUAGE.into(), RUST, RUST_FORMAT),
-        "go" => (tree_sitter_go::LANGUAGE.into(), GO, NONE),
-        "ts" | "js" => (
-            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            TS,
-            NONE,
-        ),
-        "tsx" | "jsx" => (tree_sitter_typescript::LANGUAGE_TSX.into(), TS, NONE),
+    let (masked, format_capable) = match ext {
+        "rs" => (RUST, RUST_FORMAT),
+        "go" => (GO, NONE),
+        "ts" | "js" | "tsx" | "jsx" => (TS, NONE),
         _ => return None,
     };
     Some(Grammar {
-        language,
+        language: language_for_ext(ext)?,
         masked,
         format_capable,
     })
+}
+
+/// 拡張子から tree-sitter の文法を引く。
+///
+/// マスクと折りたたみで別々に持つと、対応言語が片方だけ増えたときに、同じ
+/// ファイルがジャンプはできるのに畳めない（あるいはその逆）という状態になる。
+pub(crate) fn language_for_ext(ext: &str) -> Option<tree_sitter::Language> {
+    match ext {
+        "rs" => Some(tree_sitter_rust::LANGUAGE.into()),
+        "go" => Some(tree_sitter_go::LANGUAGE.into()),
+        "ts" | "js" => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "tsx" | "jsx" => Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
+        _ => None,
+    }
 }
 
 /// pre-order 走査でマスク対象ノードのバイト範囲を集める。一度一致したら

--- a/src/symbol_index/mod.rs
+++ b/src/symbol_index/mod.rs
@@ -24,6 +24,7 @@ mod model;
 mod tests;
 
 pub use code_mask::{CodeMask, identifier_occurrences};
+pub(crate) use code_mask::language_for_ext;
 pub use index::SymbolIndex;
 // Reference は現在 app/ から crate::symbol_index::Reference として外部利用されている。
 // Symbol/SymbolKind は今のところこのモジュールツリー内で super::model::X としてのみ

--- a/src/ui/viewer_panel/code_line.rs
+++ b/src/ui/viewer_panel/code_line.rs
@@ -57,8 +57,8 @@ pub(super) fn render_code_line_rows(
         _ => (" ", None),
     };
 
-    // ガター（行番号）。
-    let num = format!("{gutter_prefix}{line_1:>gutter_width$} \u{2502} ");
+    // ガター（行番号）。末尾の空白は折りたたみマーカーとの間の隙間。
+    let num = format!("{gutter_prefix}{line_1:>gutter_width$} ");
     let is_grep_highlight = vs.content.grep_highlight_line == Some(line_1);
     let gutter_style = if is_selected {
         Style::default()
@@ -84,6 +84,28 @@ pub(super) fn render_code_line_rows(
         Style::default().fg(theme.muted)
     };
     let gutter_span = Span::styled(num, gutter_style);
+
+    // 折りたたみマーカー。マウスが乗っている間は、その1列を罫線として使って
+    // 範囲のどこからどこまでかを見せる。入れ子のブロックのマーカーは残す。
+    let folds = &vs.content.folds;
+    let own_glyph = if folds.is_collapsed(line_1) {
+        Some("\u{25b6}")
+    } else if folds.is_foldable(line_1) {
+        Some("\u{25bc}")
+    } else {
+        None
+    };
+    let accent = gutter_style.fg(theme.accent);
+    let (fold_glyph, fold_style) = match (folds.hover_rule(line_1), own_glyph) {
+        (Some(crate::viewer::FoldRule::Tail), _) => ("\u{2570}", accent),
+        (Some(_), Some(g)) => (g, accent.add_modifier(Modifier::BOLD)),
+        (Some(_), None) => ("\u{2502}", accent),
+        (None, Some(g)) if folds.is_collapsed(line_1) => (g, accent.add_modifier(Modifier::BOLD)),
+        (None, Some(g)) => (g, gutter_style.fg(theme.hint)),
+        (None, None) => (" ", gutter_style),
+    };
+    let fold_span = Span::styled(fold_glyph, fold_style);
+    let separator_span = Span::styled(" \u{2502} ", gutter_style);
 
     // コメントマーカー列（行番号より前、一番左）: コメント範囲の最終行には 💬、
     // それより前の行には │ を表示する。クリックするとスレッドの開閉を切り替える —
@@ -190,7 +212,7 @@ pub(super) fn render_code_line_rows(
     // コンテンツの span に水平スクロールを適用し、パネル幅（枠線＋マーカー列＋
     // ガター＋バッジ）でクリップする。
     let content_max_w = (ctx.area_width as usize)
-        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 8);
+        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4);
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
     // ジャンプ用の下線を適用する（ジャンプ可能なシンボル上でのホバーであれば
@@ -264,7 +286,22 @@ pub(super) fn render_code_line_rows(
         content_spans
     };
 
-    let mut spans = vec![marker, gutter_span, badge];
+    // 畳んだ行は、隠れている行数を見出し行の末尾に出す。畳んだこと自体は
+    // マーカーで分かるが、どれだけ隠れているかはここでしか分からない。
+    let content_spans = match vs.content.folds.hidden_count(line_1) {
+        Some(n) => {
+            let mut spans = content_spans;
+            let unit = if n == 1 { "line" } else { "lines" };
+            spans.push(Span::styled(
+                format!(" \u{22ef} {n} {unit}"),
+                Style::default().fg(theme.muted).add_modifier(Modifier::DIM),
+            ));
+            spans
+        }
+        None => content_spans,
+    };
+
+    let mut spans = vec![marker, gutter_span, fold_span, separator_span, badge];
     spans.extend(content_spans);
 
     let mut rows: Vec<(Line<'static>, ScreenRow)> =

--- a/src/ui/viewer_panel/comment_thread.rs
+++ b/src/ui/viewer_panel/comment_thread.rs
@@ -38,7 +38,7 @@ pub(super) fn build_inline_thread_lines<'a>(
 
     use crate::viewer::ScreenRow;
     let mut out: Vec<(Line, ScreenRow)> = Vec::new();
-    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 4 + 2; // マーカー + ガター + バッジ
+    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2; // マーカー + ガター + バッジ
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     // 執筆者ごとに面の色味を変え、「誰が書いたか」を一目でわかるようにする。Claude の
@@ -329,7 +329,7 @@ pub(super) fn build_inline_compose_lines<'a>(
 ) -> Vec<(Line<'a>, crate::viewer::ScreenRow)> {
     use crate::viewer::ScreenRow;
     let bg = theme.comment_user_bg;
-    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 4 + 2;
+    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2;
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     let bg_style = Style::default().bg(bg);

--- a/src/ui/viewer_panel/diff_line.rs
+++ b/src/ui/viewer_panel/diff_line.rs
@@ -64,7 +64,10 @@ pub(super) fn render_diff_content_line(
         None => " ".repeat(gutter_width),
     };
 
-    let num = format!("{gutter_prefix}{line_num_str} \u{2502} ");
+    // 空白2つのうち1つは、ファイル表示で折りたたみマーカーが入る列。diff 表示
+    // には折りたたみが無いが、幅を揃えておかないとモードを切り替えるたびに
+    // コードが1列ずれる。
+    let num = format!("{gutter_prefix}{line_num_str}   \u{2502} ");
     let gutter_style = if is_selected {
         Style::default()
             .fg(theme.gutter_selected_fg)
@@ -212,7 +215,7 @@ pub(super) fn render_diff_content_line(
 
     // 水平スクロールを適用し、パネル幅（枠線 + マーカー列 + ガター + バッジ）でクリップする。
     let content_max_w = (ctx.area_width as usize)
-        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + 8);
+        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4);
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
     let mut spans = vec![marker, gutter_span, badge];

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -43,6 +43,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // 共有借用を取る前に diff 注釈キャッシュを埋める。
     ensure_diff_annotations_cached(app);
 
+    // 描画の直前に、カーソル行が畳みの中に隠れていないかだけを正す。file_scroll を
+    // 書く経路（検索・定義ジャンプ・grep・履歴復元）はどれもここに合流するので、
+    // 「飛んだ先が畳まれていたら開く」の判断はこの1か所で足りる。
+    //
+    // diff 表示は除く。そこでの file_scroll は diff カーソルの写しでしかなく、
+    // 画面に出ない畳みを開いてしまうと、素の表示へ戻ったときに理由の分からない
+    // 開き方をして見える。
+    if !app.viewer_state.diff_view.diff_mode {
+        app.viewer_state.reveal_cursor_line();
+    }
+
     let theme = &app.theme;
     let vs = &app.viewer_state;
     let tab_width = app.config.viewer.tab_width;
@@ -206,16 +217,19 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         comment_end_lines: &comment_end_lines,
     };
 
-    for (line_no, content) in vs
+    // 畳まれた行を飛ばして可視行だけを描く。どの行が画面に出るかを決めるのは
+    // FoldState ひとつで、ここは受け取った並びをそのまま流すだけ。
+    let total_lines = vs.content.file_content.len();
+    for line_1 in vs
         .content
-        .file_content
-        .iter()
-        .enumerate()
-        .skip(vs.content.file_scroll)
+        .folds
+        .visible_from(vs.content.file_scroll + 1, total_lines)
     {
         if remaining == 0 {
             break;
         }
+        let line_no = line_1 - 1;
+        let content = &vs.content.file_content[line_no];
 
         let rows = render_code_line_rows(
             app,
@@ -253,7 +267,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // ファイルの行数がパネルに収まりきらない場合にスクロールバーを描画する —
     // トリガーも見た目も Explorer のファイルツリーと同じ。
-    if vs.content.file_content.len() > inner_height {
+    // 尺もつまみも可視行で数える。ファイルの総行数のままだと、畳んだ直後に
+    // つまみだけが縮まずに残り、どれだけ隠れているのか読めなくなる。
+    let visible_total = vs.visible_line_count();
+    if visible_total > inner_height {
         let mut scrollbar_area = area.inner(Margin {
             horizontal: 0,
             vertical: 1,
@@ -261,9 +278,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         // トラックをパンくず行より下に置き、コード領域だけをカバーするようにする。
         scrollbar_area.y += breadcrumb_height;
         scrollbar_area.height = scrollbar_area.height.saturating_sub(breadcrumb_height);
-        let mut scrollbar_state =
-            ScrollbarState::new(vs.content.file_content.len().saturating_sub(inner_height))
-                .position(vs.content.file_scroll);
+        let mut scrollbar_state = ScrollbarState::new(visible_total.saturating_sub(inner_height))
+            .position(vs.cursor_visible_index());
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None);

--- a/src/viewer/content.rs
+++ b/src/viewer/content.rs
@@ -38,6 +38,7 @@ impl ViewerState {
 
         // メディアファイル（画像/動画）は aa-media 経由で扱う。
         if media_state::is_media_file(relative_path) {
+            self.content.folds.clear();
             self.content.file_content.clear();
             self.content.current_file = Some(relative_path.to_string());
             self.content.file_scroll = 0;
@@ -69,6 +70,10 @@ impl ViewerState {
                 // タブも含めて書かれたままのファイルが必要なため。
                 self.content.code_mask =
                     crate::symbol_index::CodeMask::compute(&text, relative_path);
+                // 折りたたみ範囲も展開前の text から求める（tree-sitter もインデント
+                // 幅も、書かれたままのファイルを前提にしている）。同じファイルの
+                // 再読み込みなら開閉は FoldState 側が引き継ぐ。
+                self.content.folds.rebuild(&text, relative_path);
                 // ▶ 実行ボタン向けに、実行可能なテストを検出する。言語ごとに振り分ける:
                 // Go の *_test.go と Rust の *.rs。
                 self.content.test_runs = if relative_path.ends_with(".rs") {
@@ -83,6 +88,7 @@ impl ViewerState {
                 // 付いて本文と区別が付かず、Viewer 側からは「空 = 未選択」と
                 // 見分けられなかった。
                 log::warn!("failed to read {}: {e}", full.display());
+                self.content.folds.clear();
                 self.content.file_content.clear();
                 self.content.load_error = Some(e.to_string());
                 self.content.current_file = Some(relative_path.to_string());

--- a/src/viewer/diff_view.rs
+++ b/src/viewer/diff_view.rs
@@ -7,10 +7,8 @@ use super::file_view::UnifiedDiffEntry;
 use super::state::ViewerState;
 
 impl ViewerState {
-    /// viewer パネルの行番号領域が使う gutter の総幅（列数）を返す。gutter の
-    /// 構成は次の通り:
-    ///   prefix(1) + digits(gutter_width) + space(1) + '│'(1) + space(1)
-    /// = gutter_width + 4
+    /// viewer パネルの行番号領域が使う gutter の総幅（列数）を返す。行番号の
+    /// 桁数に [crate::viewer::GUTTER_FIXED_W] を足したもの。
     pub fn gutter_total_width(&self) -> u16 {
         let digit_w = if self.diff_view.diff_mode {
             // renderer の gutter 幅と厳密に一致させないと、マウスの当たり判定
@@ -23,7 +21,7 @@ impl ViewerState {
         } else {
             digit_count(self.content.file_content.len())
         };
-        (digit_w + 4) as u16
+        (digit_w + crate::viewer::GUTTER_FIXED_W) as u16
     }
 
     // unified diff 表示

--- a/src/viewer/fold.rs
+++ b/src/viewer/fold.rs
@@ -1,0 +1,856 @@
+//! コードの折りたたみ — 折りたたみ可能な範囲の算出と、その開閉状態。
+//!
+//! 範囲は tree-sitter で求める。文法を持たない言語やブロックを1つも取れなかった
+//! ファイルは、インデント幅から求めるフォールバックに落ちる。
+//!
+//! # 行の可視性はここが唯一の答えを持つ
+//!
+//! 折りたたみは「ファイルの行」と「画面に出る行」を初めて食い違わせる。両者を
+//! 別々に数える場所が2つできた時点で、描画とマウスのヒットテスト、検索の着地点が
+//! 静かにずれる。そのため可視行の列挙 ([FoldState::visible_from]) と歩幅
+//! ([FoldState::step]) はここにしかなく、描画・キー・マウスはすべてこれを通る。
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// 折りたたみ可能な1ブロック。行番号はどちらも1始まり。
+///
+/// 畳んだときに隠れるのは start+1..=end で、start（ブロックの見出し行）は
+/// 残る。閉じ括弧の行まで隠して見出し行に "{ … }" を出すのは VSCode と同じ。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FoldRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// ホバー中の折りたたみ範囲の、その行での位置。マーカーの1列だけで範囲の
+/// 端から端までを示すために使う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldRule {
+    /// ホバーされている見出し行。
+    Head,
+    /// 範囲の途中。
+    Body,
+    /// 範囲の最終行。
+    Tail,
+}
+
+/// 開いているファイルの折りたたみ範囲と、そのうち今閉じているもの。
+#[derive(Debug, Default, Clone)]
+pub struct FoldState {
+    /// start 昇順・同一 start は無し。
+    ranges: Vec<FoldRange>,
+    /// 閉じている範囲の見出し行。
+    collapsed: HashSet<usize>,
+    /// hidden[line-1]。collapsed から導出したキャッシュで、collapsed を
+    /// 触ったら必ず rebuild_hidden() で作り直す。
+    hidden: Vec<bool>,
+    /// この状態が誰のものか。ファイルを跨いで開閉を持ち越さないための鍵。
+    path: Option<String>,
+    /// マウスが乗っているマーカーの見出し行。範囲を罫線で示すためだけの
+    /// 状態で、開閉には関わらない。
+    hover: Option<usize>,
+}
+
+impl FoldState {
+    /// source から範囲を計算し直す。
+    ///
+    /// path が変わっていなければ開閉状態は引き継ぐ（ファイルウォッチャーによる
+    /// 再読み込みで、読んでいた場所が勝手に開かないようにする）。引き継ぐのは
+    /// 「今もそこがブロックの見出しである」ものだけで、編集で消えた折りたたみは
+    /// 落ちる。別のファイルなら開閉は捨てる。
+    pub fn rebuild(&mut self, source: &str, path: &str) {
+        let same_file = self.path.as_deref() == Some(path);
+        self.ranges = compute_ranges(source, path);
+        self.hover = None;
+        self.path = Some(path.to_string());
+        if same_file {
+            let starts: HashSet<usize> = self.ranges.iter().map(|r| r.start).collect();
+            self.collapsed.retain(|line| starts.contains(line));
+        } else {
+            self.collapsed.clear();
+        }
+        self.rebuild_hidden();
+    }
+
+    /// 範囲も開閉も捨てる（メディアファイルや読み込み失敗など、行が無いとき）。
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// line_1 がブロックの見出し行か。
+    pub fn is_foldable(&self, line_1: usize) -> bool {
+        self.range_starting_at(line_1).is_some()
+    }
+
+    /// line_1 のブロックが閉じているか。
+    pub fn is_collapsed(&self, line_1: usize) -> bool {
+        self.collapsed.contains(&line_1)
+    }
+
+    /// line_1 が閉じたブロックの内側にあって画面に出ないか。
+    pub fn is_hidden(&self, line_1: usize) -> bool {
+        line_1 > 0 && self.hidden.get(line_1 - 1).copied().unwrap_or(false)
+    }
+
+    /// line_1 を見出しとする閉じたブロックが隠している行数。
+    pub fn hidden_count(&self, line_1: usize) -> Option<usize> {
+        if !self.is_collapsed(line_1) {
+            return None;
+        }
+        self.range_starting_at(line_1).map(|r| r.end - r.start)
+    }
+
+    // ホバー中の範囲
+
+    /// マーカーにマウスが乗っている見出し行を覚える。見出し行でなければ忘れる。
+    pub fn set_hover(&mut self, line_1: Option<usize>) {
+        self.hover = line_1.filter(|l| self.is_foldable(*l));
+    }
+
+    /// ホバー中の範囲に line_1 が含まれるなら、その中でどの位置か。
+    pub fn hover_rule(&self, line_1: usize) -> Option<FoldRule> {
+        let range = self.range_starting_at(self.hover?)?;
+        if line_1 == range.start {
+            Some(FoldRule::Head)
+        } else if line_1 == range.end {
+            Some(FoldRule::Tail)
+        } else if line_1 > range.start && line_1 < range.end {
+            Some(FoldRule::Body)
+        } else {
+            None
+        }
+    }
+
+    // 開閉
+
+    /// line_1 のブロックを開閉する。line_1 が見出し行でなければ、それを含む
+    /// 最も内側のブロックを対象にする（vim の za と同じ）。
+    pub fn toggle(&mut self, line_1: usize) -> bool {
+        let Some(start) = self.target_start(line_1) else {
+            return false;
+        };
+        if self.collapsed.contains(&start) {
+            self.collapsed.remove(&start);
+        } else {
+            self.collapsed.insert(start);
+        }
+        self.rebuild_hidden();
+        true
+    }
+
+    /// line_1 のブロック（なければそれを含む最も内側のブロック）を閉じる。
+    pub fn close(&mut self, line_1: usize) -> bool {
+        let Some(start) = self.target_start(line_1) else {
+            return false;
+        };
+        let changed = self.collapsed.insert(start);
+        if changed {
+            self.rebuild_hidden();
+        }
+        changed
+    }
+
+    /// line_1 のブロック（なければそれを含む最も内側のブロック）を開く。
+    pub fn open(&mut self, line_1: usize) -> bool {
+        let Some(start) = self.target_start(line_1) else {
+            return false;
+        };
+        let changed = self.collapsed.remove(&start);
+        if changed {
+            self.rebuild_hidden();
+        }
+        changed
+    }
+
+    /// すべて開く（zR）。
+    pub fn open_all(&mut self) {
+        self.collapsed.clear();
+        self.rebuild_hidden();
+    }
+
+    /// すべて閉じる（zM）。
+    pub fn close_all(&mut self) {
+        self.collapsed = self.ranges.iter().map(|r| r.start).collect();
+        self.rebuild_hidden();
+    }
+
+    /// line_1 が画面に出るまで、それを隠しているブロックを外側から開く。
+    ///
+    /// 検索・定義ジャンプ・grep のヒットはどれも隠れた行に着地し得る。そこで
+    /// 黙って別の行を見せるより、畳んだ本人に開いて見せる方が驚きが小さい。
+    pub fn reveal(&mut self, line_1: usize) -> bool {
+        if !self.is_hidden(line_1) {
+            return false;
+        }
+        let opened: Vec<usize> = self
+            .ranges
+            .iter()
+            .filter(|r| r.start < line_1 && line_1 <= r.end)
+            .map(|r| r.start)
+            .collect();
+        let mut changed = false;
+        for start in opened {
+            changed |= self.collapsed.remove(&start);
+        }
+        if changed {
+            self.rebuild_hidden();
+        }
+        changed
+    }
+
+    // 可視行のマッピング
+
+    /// start_1 から total までの、画面に出る行番号（1始まり）。
+    pub fn visible_from(&self, start_1: usize, total: usize) -> impl Iterator<Item = usize> + '_ {
+        (start_1.max(1)..=total).filter(move |l| !self.is_hidden(*l))
+    }
+
+    /// 画面に出る行の総数。スクロールバーの尺として使う。
+    pub fn visible_count(&self, total: usize) -> usize {
+        (1..=total).filter(|l| !self.is_hidden(*l)).count()
+    }
+
+    /// line_1 が可視行の何番目か（0始まり）。スクロールバーのつまみの位置。
+    pub fn visible_index(&self, line_1: usize, total: usize) -> usize {
+        (1..=line_1.min(total)).filter(|l| !self.is_hidden(*l)).count().saturating_sub(1)
+    }
+
+    /// line_1 から可視行を delta 行ぶん進める（負なら戻る）。端で止まる。
+    ///
+    /// j/k もマウスホイールも Ctrl+D もここを通るので、「1行進む」の意味が
+    /// 折りたたみの有無で変わらない。
+    pub fn step(&self, line_1: usize, delta: isize, total: usize) -> usize {
+        if total == 0 {
+            return 1;
+        }
+        let mut cur = line_1.clamp(1, total);
+        let forward = delta > 0;
+        for _ in 0..delta.unsigned_abs() {
+            let next = if forward {
+                self.next_visible(cur, total)
+            } else {
+                self.prev_visible(cur)
+            };
+            match next {
+                Some(l) => cur = l,
+                None => break,
+            }
+        }
+        cur
+    }
+
+    /// line_1 より後ろにある最初の可視行。
+    pub fn next_visible(&self, line_1: usize, total: usize) -> Option<usize> {
+        (line_1 + 1..=total).find(|l| !self.is_hidden(*l))
+    }
+
+    /// line_1 より手前にある最後の可視行。
+    pub fn prev_visible(&self, line_1: usize) -> Option<usize> {
+        (1..line_1).rev().find(|l| !self.is_hidden(*l))
+    }
+
+    /// 最後の可視行（G の行き先）。
+    pub fn last_visible(&self, total: usize) -> usize {
+        (1..=total).rev().find(|l| !self.is_hidden(*l)).unwrap_or(1)
+    }
+
+    /// line_1 が隠れているなら、それを隠している見出し行へ寄せる。
+    ///
+    /// 閉じる操作でカーソル行が隠れたときに使う。隠れた行のすぐ上の可視行は
+    /// 定義上その行を隠している見出し行なので、探し直す必要はない。
+    pub fn visible_anchor(&self, line_1: usize) -> usize {
+        if !self.is_hidden(line_1) {
+            return line_1;
+        }
+        self.prev_visible(line_1).unwrap_or(1)
+    }
+
+    // 内部
+
+    fn range_starting_at(&self, line_1: usize) -> Option<&FoldRange> {
+        self.ranges.iter().find(|r| r.start == line_1)
+    }
+
+    /// 操作の対象になる見出し行。見出し行そのものを優先し、無ければ line_1 を
+    /// 含む最も内側のブロック。
+    fn target_start(&self, line_1: usize) -> Option<usize> {
+        if self.is_foldable(line_1) {
+            return Some(line_1);
+        }
+        self.ranges
+            .iter()
+            .filter(|r| r.start < line_1 && line_1 <= r.end)
+            .max_by_key(|r| r.start)
+            .map(|r| r.start)
+    }
+
+    fn rebuild_hidden(&mut self) {
+        let total = self.ranges.iter().map(|r| r.end).max().unwrap_or(0);
+        self.hidden = vec![false; total];
+        for r in &self.ranges {
+            if !self.collapsed.contains(&r.start) {
+                continue;
+            }
+            for line in r.start + 1..=r.end {
+                self.hidden[line - 1] = true;
+            }
+        }
+    }
+}
+
+// 範囲の算出
+
+/// source の折りたたみ範囲。tree-sitter で1つも取れなければインデントで求める。
+fn compute_ranges(source: &str, path: &str) -> Vec<FoldRange> {
+    let ranges = syntax_ranges(source, path).unwrap_or_default();
+    if ranges.is_empty() {
+        normalize(indent_ranges(source))
+    } else {
+        ranges
+    }
+}
+
+/// tree-sitter の構文木からブロックを拾う。文法が無い・パースできない場合は None。
+fn syntax_ranges(source: &str, path: &str) -> Option<Vec<FoldRange>> {
+    let ext = Path::new(path).extension()?.to_str()?;
+    let language = crate::symbol_index::language_for_ext(ext)?;
+    let kinds = foldable_kinds(ext);
+
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(source, None)?;
+
+    let mut out = Vec::new();
+    let mut cursor = tree.walk();
+    loop {
+        let node = cursor.node();
+        if kinds.contains(&node.kind()) {
+            let start = node.start_position().row + 1;
+            let end = node.end_position().row + 1;
+            // 1行に収まっているブロックは畳んでも何も減らない。
+            if end > start {
+                out.push(FoldRange { start, end });
+            }
+        }
+        if cursor.goto_first_child() {
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return Some(normalize(out));
+            }
+        }
+    }
+}
+
+/// 拡張子ごとの、折りたためるノード種別。
+///
+/// 「複数行にまたがるノード全部」ではなく列挙にしているのは、式や引数リストまで
+/// 畳めると1行あたりのマーカーが増えすぎて、どれがブロックなのか読めなくなるため。
+fn foldable_kinds(ext: &str) -> &'static [&'static str] {
+    const RUST: &[&str] = &[
+        "block",
+        "declaration_list",
+        "field_declaration_list",
+        "ordered_field_declaration_list",
+        "enum_variant_list",
+        "match_block",
+        "use_list",
+        "field_initializer_list",
+    ];
+    const GO: &[&str] = &[
+        "block",
+        "field_declaration_list",
+        "interface_type",
+        "expression_switch_statement",
+        "type_switch_statement",
+        "select_statement",
+        "import_spec_list",
+        "const_declaration",
+        "var_declaration",
+    ];
+    const TS: &[&str] = &[
+        "statement_block",
+        "class_body",
+        "switch_body",
+        "object",
+        "array",
+        "object_type",
+        "enum_body",
+        "named_imports",
+    ];
+
+    match ext {
+        "rs" => RUST,
+        "go" => GO,
+        "ts" | "js" | "tsx" | "jsx" => TS,
+        _ => &[],
+    }
+}
+
+/// インデント幅だけを頼りにブロックを組み立てる（文法を持たない言語向け）。
+///
+/// ある行より深くインデントされた行が続く限り、その行の子とみなす。空行は
+/// ブロックを切らないが、末尾の空行は範囲に含めない（畳んだときに空行だけが
+/// 残るのを避けるため）。
+fn indent_ranges(source: &str) -> Vec<FoldRange> {
+    fn indent_of(line: &str) -> Option<usize> {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(line.len() - trimmed.len())
+        }
+    }
+
+    let mut out = Vec::new();
+    // (インデント幅, 開始行の0始まりインデックス) を浅い順に積む。
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+    let mut prev_nonblank: Option<usize> = None;
+
+    // limit より浅いところまで積みを崩し、崩した範囲を確定させる。
+    // limit が None なら全部崩す（ファイル末尾）。
+    fn close_to(
+        stack: &mut Vec<(usize, usize)>,
+        out: &mut Vec<FoldRange>,
+        prev_nonblank: Option<usize>,
+        limit: Option<usize>,
+    ) {
+        while let Some(&(top_indent, top_start)) = stack.last() {
+            if limit.is_some_and(|ind| top_indent < ind) {
+                break;
+            }
+            stack.pop();
+            if let Some(last) = prev_nonblank
+                && last > top_start
+            {
+                out.push(FoldRange {
+                    start: top_start + 1,
+                    end: last + 1,
+                });
+            }
+        }
+    }
+
+    for (i, line) in source.lines().enumerate() {
+        let Some(indent) = indent_of(line) else {
+            continue;
+        };
+        close_to(&mut stack, &mut out, prev_nonblank, Some(indent));
+        stack.push((indent, i));
+        prev_nonblank = Some(i);
+    }
+    close_to(&mut stack, &mut out, prev_nonblank, None);
+
+    out
+}
+
+/// start 昇順に並べ、同じ見出し行の範囲は最も広いものだけ残す。
+///
+/// 見出し行がひとつなら折りたたみもひとつでなければならない: 同じ行に2つ
+/// あると、開閉が collapsed の1エントリを取り合って、開いたのにまだ隠れている
+/// 行が出る。
+fn normalize(mut ranges: Vec<FoldRange>) -> Vec<FoldRange> {
+    ranges.sort_by(|a, b| a.start.cmp(&b.start).then(b.end.cmp(&a.end)));
+    ranges.dedup_by(|a, b| a.start == b.start);
+    ranges
+}
+
+// ViewerState 側の入口
+
+use super::state::ViewerState;
+
+impl ViewerState {
+    /// カーソル行（＝ビューポート最上行、1始まり）。Viewer は独立したカーソルを
+    /// 持たず file_scroll がその役目を兼ねている。
+    pub fn cursor_line(&self) -> usize {
+        self.content.file_scroll + 1
+    }
+
+    /// カーソルを可視行で delta 行ぶん動かす（負なら上へ）。
+    pub fn move_cursor_lines(&mut self, delta: isize) {
+        let total = self.content.file_content.len();
+        if total == 0 {
+            return;
+        }
+        let line = self.content.folds.step(self.cursor_line(), delta, total);
+        self.content.file_scroll = line - 1;
+    }
+
+    /// カーソルを最後の可視行へ（G）。
+    pub fn goto_last_visible_line(&mut self) {
+        let total = self.content.file_content.len();
+        if total == 0 {
+            return;
+        }
+        self.content.file_scroll = self.content.folds.last_visible(total) - 1;
+    }
+
+    /// 画面に出る行の総数（スクロールバーの尺）。
+    pub fn visible_line_count(&self) -> usize {
+        self.content
+            .folds
+            .visible_count(self.content.file_content.len())
+    }
+
+    /// カーソル行が可視行の何番目か（スクロールバーのつまみ）。
+    pub fn cursor_visible_index(&self) -> usize {
+        self.content
+            .folds
+            .visible_index(self.cursor_line(), self.content.file_content.len())
+    }
+
+    /// カーソル行が隠れているなら、隠しているブロックを開く。
+    ///
+    /// 描画の直前に一度だけ呼ぶ。file_scroll を書く経路は検索・定義ジャンプ・
+    /// grep・履歴復元と多く、そのすべてに「開いてから飛ぶ」を書いて回ると
+    /// 必ずどれかが漏れる。可視性の判断を描画の一歩手前に集めておけば、
+    /// 行き先が隠れていたときの扱いは1か所で決まる。
+    ///
+    /// j/k やホイールは可視行を歩くので、ここには決して到達しない — つまり
+    /// これが開くのは常に「畳んだ場所の外から飛んできた」ときだけ。
+    pub fn reveal_cursor_line(&mut self) {
+        let line = self.cursor_line();
+        self.content.folds.reveal(line);
+    }
+
+    /// カーソル行のブロックを開閉する（za）。
+    pub fn fold_toggle_cursor(&mut self) -> bool {
+        let line = self.cursor_line();
+        let changed = self.content.folds.toggle(line);
+        self.clamp_cursor_to_visible();
+        changed
+    }
+
+    /// カーソル行のブロックを閉じる（zc）。
+    pub fn fold_close_cursor(&mut self) -> bool {
+        let line = self.cursor_line();
+        let changed = self.content.folds.close(line);
+        self.clamp_cursor_to_visible();
+        changed
+    }
+
+    /// カーソル行のブロックを開く（zo）。
+    pub fn fold_open_cursor(&mut self) -> bool {
+        let line = self.cursor_line();
+        self.content.folds.open(line)
+    }
+
+    /// すべて開く（zR）。
+    pub fn fold_open_all(&mut self) {
+        self.content.folds.open_all();
+    }
+
+    /// すべて閉じる（zM）。
+    pub fn fold_close_all(&mut self) {
+        self.content.folds.close_all();
+        self.clamp_cursor_to_visible();
+    }
+
+    /// マウスで折りたたみマーカーが押されたときの入口。
+    pub fn fold_toggle_at(&mut self, line_1: usize) -> bool {
+        let changed = self.content.folds.toggle(line_1);
+        self.clamp_cursor_to_visible();
+        changed
+    }
+
+    /// 閉じる操作でカーソル行が隠れたら、それを隠している見出し行へ寄せる。
+    ///
+    /// 開くのではなく寄せるのは、閉じたのは操作した本人だから: 直後に開き直す
+    /// のでは操作が無かったことになる。
+    fn clamp_cursor_to_visible(&mut self) {
+        let line = self.content.folds.visible_anchor(self.cursor_line());
+        self.content.file_scroll = line.saturating_sub(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn starts(ranges: &[FoldRange]) -> Vec<(usize, usize)> {
+        ranges.iter().map(|r| (r.start, r.end)).collect()
+    }
+
+    /// マーカーにマウスが乗ると、その範囲の見出し・途中・最終行が区別できる。
+    /// 描画側はこの3つだけを見て罫線の字形を決める。
+    #[test]
+    fn hovering_a_marker_marks_its_whole_range() {
+        let mut folds = FoldState::default();
+        folds.rebuild("fn outer() {\n    if cond {\n        inner();\n    }\n}\n", "a.rs");
+        folds.set_hover(Some(1));
+        assert_eq!(folds.hover_rule(1), Some(FoldRule::Head));
+        assert_eq!(folds.hover_rule(2), Some(FoldRule::Body));
+        assert_eq!(folds.hover_rule(3), Some(FoldRule::Body));
+        assert_eq!(folds.hover_rule(4), Some(FoldRule::Body));
+        assert_eq!(folds.hover_rule(5), Some(FoldRule::Tail));
+        assert_eq!(folds.hover_rule(6), None);
+    }
+
+    /// 見出し行でないところを指しても範囲は出ない。ホバーは「マーカーを
+    /// 狙っている」ことの印なので、za のように内側のブロックへ寄せない。
+    #[test]
+    fn hovering_a_non_header_line_shows_nothing() {
+        let mut folds = FoldState::default();
+        folds.rebuild("fn outer() {\n    body();\n}\n", "a.rs");
+        folds.set_hover(Some(2));
+        assert_eq!(folds.hover_rule(1), None);
+        assert_eq!(folds.hover_rule(2), None);
+    }
+
+    /// ファイルを読み直したらホバーは消える（マウスはもうそこに無い）。
+    #[test]
+    fn reload_forgets_the_hover() {
+        let mut folds = FoldState::default();
+        folds.rebuild("fn outer() {\n    body();\n}\n", "a.rs");
+        folds.set_hover(Some(1));
+        folds.rebuild("fn outer() {\n    body();\n}\n", "a.rs");
+        assert_eq!(folds.hover_rule(1), None);
+    }
+
+    /// ネストしたブロックはそれぞれ独立した範囲になる。外側を畳んでも内側の
+    /// 範囲は残り、外側を開けば内側の状態がそのまま見える。
+    #[test]
+    fn rust_nesting_yields_one_range_per_block() {
+        let src = "\
+fn outer() {
+    if cond {
+        inner();
+    }
+}
+";
+        let ranges = compute_ranges(src, "a.rs");
+        assert_eq!(starts(&ranges), vec![(1, 5), (2, 4)]);
+    }
+
+    /// 1行に収まったブロックは畳んでも隠れる行が無いので、範囲にしない
+    /// （マーカーだけ出て押しても何も起きない、を避ける）。
+    #[test]
+    fn single_line_blocks_are_not_foldable() {
+        let src = "fn empty() {}\nfn other() { call(); }\n";
+        let ranges = compute_ranges(src, "a.rs");
+        assert!(ranges.is_empty(), "{ranges:?}");
+    }
+
+    /// ファイル末尾で閉じ括弧のあとに改行が無くても、範囲は最終行まで届く。
+    #[test]
+    fn a_block_reaching_the_end_of_file_is_complete() {
+        let src = "fn last() {\n    body();\n}";
+        let ranges = compute_ranges(src, "a.rs");
+        assert_eq!(starts(&ranges), vec![(1, 3)]);
+    }
+
+    /// 構造体リテラルの本体も畳める。let 束縛の右辺に長いリテラルが来るのは
+    /// よくある形で、ここが畳めないと本文の大半が畳めないファイルが出る。
+    #[test]
+    fn rust_struct_literal_bodies_fold() {
+        let src = "fn f() {\n    let c = C {\n        a: 1,\n    };\n}\n";
+        let ranges = compute_ranges(src, "a.rs");
+        assert!(starts(&ranges).contains(&(2, 4)), "{:?}", starts(&ranges));
+    }
+
+    /// struct / impl / match も畳める（関数の block だけではない）。
+    #[test]
+    fn rust_type_and_match_bodies_fold() {
+        let src = "\
+struct S {
+    a: u32,
+}
+impl S {
+    fn f(&self) {
+        match self.a {
+            0 => {}
+            _ => {}
+        }
+    }
+}
+";
+        let ranges = compute_ranges(src, "a.rs");
+        let s = starts(&ranges);
+        assert!(s.contains(&(1, 3)), "struct body: {s:?}");
+        assert!(s.contains(&(4, 11)), "impl body: {s:?}");
+        assert!(s.contains(&(5, 10)), "fn body: {s:?}");
+        assert!(s.contains(&(6, 9)), "match body: {s:?}");
+    }
+
+    /// 文法を持たない言語はインデントで範囲を出す。ここが空になると、
+    /// 対応言語以外では機能そのものが消える。
+    #[test]
+    fn unsupported_language_falls_back_to_indentation() {
+        let src = "\
+def outer():
+    if cond:
+        inner()
+    done()
+after()
+";
+        let ranges = compute_ranges(src, "a.py");
+        let s = starts(&ranges);
+        assert!(s.contains(&(1, 4)), "def body: {s:?}");
+        assert!(s.contains(&(2, 3)), "if body: {s:?}");
+        // 一番浅い最終行は誰の子でもない。
+        assert!(!s.iter().any(|(start, _)| *start == 5), "{s:?}");
+    }
+
+    /// パースできない中身でも（拡張子は対応言語でも）折りたたみは出る。
+    /// tree-sitter がブロックを1つも取れなかったときにインデントへ落ちる。
+    #[test]
+    fn unparsable_source_still_folds_by_indentation() {
+        let src = "\
+outer:
+    child one
+    child two
+tail
+";
+        let ranges = compute_ranges(src, "a.rs");
+        assert_eq!(starts(&ranges), vec![(1, 3)]);
+    }
+
+    /// インデントのフォールバックでは、ブロックのあとの空行を範囲に含めない。
+    /// 含めると畳んだ跡に空行だけが残って、詰まったように見えない。
+    #[test]
+    fn indentation_ranges_exclude_trailing_blank_lines() {
+        let src = "outer:\n    child\n\n\nafter\n";
+        let ranges = compute_ranges(src, "a.txt");
+        assert_eq!(starts(&ranges), vec![(1, 2)]);
+    }
+
+    /// 空行はブロックを切らない（段落で分けて書かれた本文が細切れにならない）。
+    #[test]
+    fn indentation_ranges_span_interior_blank_lines() {
+        let src = "outer:\n    a\n\n    b\nafter\n";
+        let ranges = compute_ranges(src, "a.txt");
+        assert_eq!(starts(&ranges), vec![(1, 4)]);
+    }
+
+    fn state(src: &str, path: &str) -> FoldState {
+        let mut fs = FoldState::default();
+        fs.rebuild(src, path);
+        fs
+    }
+
+    const NEST: &str = "\
+fn outer() {
+    if cond {
+        inner();
+    }
+}
+";
+
+    /// 畳んだ範囲は見出し行を残して隠れる。
+    #[test]
+    fn collapsing_hides_the_body_but_keeps_the_header() {
+        let mut fs = state(NEST, "a.rs");
+        assert!(fs.toggle(1));
+        assert!(!fs.is_hidden(1));
+        for line in 2..=5 {
+            assert!(fs.is_hidden(line), "line {line}");
+        }
+        assert_eq!(fs.hidden_count(1), Some(4));
+    }
+
+    /// 外側を開いても、内側の畳みは畳まれたまま（vim と同じ）。
+    #[test]
+    fn opening_an_outer_fold_preserves_the_inner_one() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close(2);
+        fs.close(1);
+        fs.open(1);
+        assert!(!fs.is_hidden(2), "inner header is visible again");
+        assert!(fs.is_hidden(3), "inner body stays folded");
+        assert!(!fs.is_hidden(5));
+    }
+
+    /// 見出し行でない行を対象にすると、それを含む最も内側のブロックが動く。
+    #[test]
+    fn operating_inside_a_block_targets_the_innermost_one() {
+        let mut fs = state(NEST, "a.rs");
+        assert!(fs.close(3));
+        assert!(fs.is_collapsed(2), "innermost block closed");
+        assert!(!fs.is_collapsed(1));
+    }
+
+    /// 可視行の列挙・歩幅・番号はすべて同じ隠れ方を見る。
+    #[test]
+    fn visible_mapping_skips_folded_lines() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close(2);
+
+        assert_eq!(fs.visible_from(1, 5).collect::<Vec<_>>(), vec![1, 2, 5]);
+        assert_eq!(fs.visible_count(5), 3);
+        assert_eq!(fs.visible_index(5, 5), 2);
+        // 2 の次の可視行は 5 — 畳んだ中を通らない。
+        assert_eq!(fs.step(1, 1, 5), 2);
+        assert_eq!(fs.step(1, 2, 5), 5);
+        // 端では止まる（行き過ぎて末尾を超えない）。
+        assert_eq!(fs.step(1, 99, 5), 5);
+        assert_eq!(fs.step(5, -99, 5), 1);
+    }
+
+    /// 畳んだ中へ飛んできたときは、それを隠している範囲だけを開く。
+    #[test]
+    fn revealing_opens_only_the_folds_that_hide_the_line() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close_all();
+        assert!(fs.is_hidden(3));
+        assert!(fs.reveal(3));
+        assert!(!fs.is_hidden(3));
+        assert!(!fs.is_collapsed(1) && !fs.is_collapsed(2));
+        // すでに見えている行に対しては何もしない。
+        assert!(!fs.reveal(1));
+    }
+
+    /// zM のあとカーソルが隠れたら、それを隠している見出し行へ寄せる。
+    #[test]
+    fn the_anchor_of_a_hidden_line_is_its_header() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close_all();
+        assert_eq!(fs.visible_anchor(4), 1);
+        assert_eq!(fs.visible_anchor(1), 1);
+    }
+
+    /// 同じファイルの再読み込みでは開閉を保つ。読んでいた場所が、ウォッチャーが
+    /// 走るたびに勝手に開き直さないため。
+    #[test]
+    fn reloading_the_same_file_keeps_the_folds() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close(1);
+        fs.rebuild(NEST, "a.rs");
+        assert!(fs.is_collapsed(1));
+    }
+
+    /// 編集でブロックでなくなった行の畳みは落とす。残すと、開く手段の無い
+    /// 隠れた行ができる。
+    #[test]
+    fn reloading_drops_folds_that_no_longer_exist() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close(2);
+        fs.rebuild("fn outer() {\n    done();\n}\n", "a.rs");
+        assert!(!fs.is_collapsed(2));
+        assert!(!fs.is_hidden(2));
+    }
+
+    /// 別のファイルへ移ったら開閉は捨てる。行番号は移った先で別の意味を持つ。
+    #[test]
+    fn switching_files_discards_the_folds() {
+        let mut fs = state(NEST, "a.rs");
+        fs.close(1);
+        fs.rebuild(NEST, "b.rs");
+        assert!(!fs.is_collapsed(1));
+    }
+
+    /// 折りたたみが無いファイルでは、すべての行がそのまま可視行になる。
+    #[test]
+    fn a_file_without_folds_is_entirely_visible() {
+        let fs = FoldState::default();
+        assert_eq!(fs.visible_from(1, 3).collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(fs.visible_count(3), 3);
+        assert_eq!(fs.step(1, 1, 3), 2);
+        assert_eq!(fs.last_visible(3), 3);
+        assert!(!fs.is_foldable(1));
+    }
+}

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -7,10 +7,11 @@
 //! 他のサブモジュールへ分割されている（[content] はファイルを開く処理、
 //! [tree] はファイルツリーの走査・展開、[search] はファイル内検索とファイル名検索、
 //! [diff_view] は unified diff 表示、[highlight] は syntect によるシンタックスハイライト、
-//! [selection] はガター行選択）。
+//! [selection] はガター行選択、[fold] はコードブロックの折りたたみ）。
 
 mod content;
 mod diff_view;
+mod fold;
 mod file_tree;
 mod file_view;
 mod highlight;
@@ -20,6 +21,7 @@ mod state;
 mod tree;
 
 pub use file_tree::{FileTreeEntry, file_icon};
+pub use fold::{FoldRule, FoldState};
 // revidere の 2 列ビューは開いているファイルではなく diff の行を直接ハイライト
 // するので、ViewerState を経由せず構文定義だけを引く。拡張子のエイリアス表を
 // 2 つ持つと、片方だけ直したときに同じファイルが場所によって色付いたり

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -85,6 +85,10 @@ pub struct FileContentState {
     /// render 中に構築される画面行のマッピング。マウスイベントハンドラが
     /// 画面上の位置をファイルの行/スレッドアクションへ変換するのに使う。
     pub screen_row_map: Vec<ScreenRow>,
+    /// 開いているファイルの折りたたみ範囲と、そのうち今閉じているもの。
+    /// 「ファイルの行」と「画面に出る行」の食い違いはここだけが知っている
+    /// （[crate::viewer::FoldState] のモジュールコメントを参照）。
+    pub folds: crate::viewer::FoldState,
     /// 現在のファイル中の実行可能なテスト。1始まりの行番号をキーにする。
     /// 言語ごとのスキャナ（*_test.go には [crate::go_test]、*.rs には
     /// [crate::rust_test]）が埋める。それ以外のファイルでは空。▶ 実行ボタンを
@@ -323,6 +327,14 @@ impl Default for ClickTracker {
 /// 常に新規コメントを開始する。
 pub const COMMENT_MARKER_W: u16 = 2;
 
+/// ガターのうち行番号が使わない列数:
+///   diff の +/-(1) + 空白(1) + 折りたたみマーカー(1) + 空白(1) + '│'(1) + 空白(1)
+///
+/// 行番号の桁数と足して [ViewerState::gutter_total_width] になる。描画も
+/// マウスのヒットテストもインラインスレッドのインデントもこの幅ぶんだけ
+/// 右にずれるので、別々の数字で持つと1列ずれて気づかれない。
+pub const GUTTER_FIXED_W: usize = 6;
+
 /// Viewer モードが保持する全ての状態。
 #[derive(Default)]
 pub struct ViewerState {
@@ -346,6 +358,8 @@ pub struct ViewerState {
     pub click: ClickTracker,
     /// 'g' が押されて2つ目のキー（gd, gi, gr）待ちかどうか。
     pub pending_g_key: bool,
+    /// 'z' が押されて2つ目のキー（za, zc, zo, zR, zM）待ちかどうか。
+    pub pending_z_key: bool,
     /// viewer がファイル内容/diff の代わりにブランチの change summary 疑似
     /// ファイル（"SUMMARY" エントリ）を表示しているか。diff_view.diff_mode とは
     /// 排他。enter_summary_view / exit_summary_view を参照。


### PR DESCRIPTION
## Summary

Viewer のファイル表示に VSCode 風のコードブロック折りたたみを追加する。

**折りたたみ範囲**は tree-sitter で求める（rs / go / ts / js / tsx / jsx）。文法が無い言語やブロックを1つも取れなかったファイルは、インデント幅ベースのフォールバックに落ちる。重複していた「拡張子 → 文法」の表は `symbol_index::language_for_ext` に一本化した。

**「ファイルの行」と「画面に出る行」の食い違いは `FoldState` (`src/viewer/fold.rs`) だけが知っている。** 可視行の列挙 (`visible_from`) と歩幅 (`step`) はそこにしかなく、描画・キー・マウスはすべてこれを通る。両者を別々に数える場所が2つできた時点で、描画とヒットテストと検索の着地点が静かにずれるため。

**ジャンプ時の自動展開は描画直前の1箇所。** `file_scroll` を書く経路（検索・gd・grep・履歴復元・コメント一覧）は10箇所以上あり、全部に「開いてから飛ぶ」を書くと必ず漏れる。代わりに `render()` の先頭で `reveal_cursor_line()` を1回だけ呼ぶ。j/k・ホイールは可視行を歩くのでここに到達せず、「畳んだ外から飛んできたときだけ開く」が自動的に成立する。

### 決めた挙動

| 論点 | 決定 |
|---|---|
| カーソル | 畳んだ行には乗らない（j/k/ホイール/Ctrl+D は可視行を歩く） |
| ジャンプ・検索 | 着地先が隠れていたら包む折りたたみを自動で開く |
| `zc`/`za` を本文行で | それを含む最も内側のブロックが動く（vim と同じ） |
| 閉じてカーソルが隠れた | 開き直さず、見出し行へ寄せる |
| ファイル再読み込み | 同じパスなら開閉を維持（ウォッチャーが走るたびに開き直さない）、別ファイルなら破棄 |
| diff モード | 折りたたみは効かない（既存の ExpandableContext と役割が衝突するため） |

### 操作

- キー: `za` / `zc` / `zo` / `zR` / `zM`。`z` だけを `fold_prefix` として viewer レイヤーに割り当て、2打鍵目はハンドラ側で読む — 既存の `g` プレフィックス（gd/gi/gr）と同じ形。`z` は viewer レイヤーで未使用だった
- マウス: マーカー周辺をクリックで開閉。当たり判定は「行番号より右のガター」5列で、行番号そのものは従来どおりコメント作成に残してある
- ホバー: マーカーにマウスを乗せると、その範囲の端から端までがマーカー列の罫線でつながる（`▼ … │ … ╰`）。入れ子のブロックのマーカーは潰さない

背景色は使っていない。以前の実測で `gutter_hover_bg` と `selected_bg_inactive` の差が11テーマ中7テーマで ΔRGB 3〜15 しかなく、背景で hover を表現できないため。同じ理由で開いているマーカーの色は `muted`（7テーマでサーフェス色）ではなく `hint` を使う。

### ガター幅

折りたたみマーカーと前後の隙間で3列増えた。「ガターのうち行番号以外の列数」は `gutter_total_width()`、コメントスレッドのインデント、コンテンツ幅の3箇所に別々のリテラルで書かれていたので、`viewer::GUTTER_FIXED_W` に集約した。1箇所忘れると「クリック位置が1列ずれる」という気づきにくい壊れ方をするため。diff 表示にも同じ空白列を入れてある（入れないとモード切替のたびにコードが1列横に飛ぶ）。

## Test plan

- `cargo test --workspace` — 1142 passed / 0 failed（うち `viewer::fold` に22件、マウスの当たり判定に1件を追加）
  - 範囲の算出: ネスト、1行ブロック、ファイル末尾、struct/impl/match/struct リテラル、未対応言語のインデントフォールバック、パース失敗時のフォールバック、空行の扱い
  - 行マッピング: 可視行の列挙・歩幅・件数・インデックス、reveal、隠れた行のアンカー
  - 状態の寿命: 再読み込みでの維持、消えた折りたたみの破棄、ファイル切り替えでの破棄
  - ホバー: 範囲の Head/Body/Tail、見出し行以外を指しても範囲は出ない、再読み込みでホバーが消える、当たり判定の列とその境界
- `cargo clippy --workspace --all-targets` — 追加警告なし
- **実機（PTY 上で起動して画面を採取）**
  - マーカーの表示とガターの桁ずれが無いこと
  - `zM` / `zR` / `zo`（内側は畳んだまま = vim 準拠）
  - 全畳み状態で `jj` → 畳んだ中にカーソルが乗らない
  - 全畳み状態で `/alphanumeric` → 3階層が開いて着地
  - マウス: マーカー周辺の各列で開閉する / 行番号の桁では開閉しない（コメント作成が生きている）
  - ホバーの罫線が範囲の端から端まで出ること、畳んだ状態では出ないこと
  - diff 表示とファイル表示でコードの開始列が一致すること
