### PR TITLE
feat: リポジトリごとの単独起動へ倒し、多重起動で Ctrl+Q が効かなくなる問題を解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Status bar
 | `review_store.rs` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
 | `pty_manager.rs` | PTY session management — spawn, read/write, resize; vt100 parser for rendering; output scanner for Claude Code |
 | `file_watcher.rs` | Filesystem change detection via `notify` crate, debounced at 500ms |
+| `instance_lock.rs` | `.conductor/conductor.lock` の flock による単独起動の担保 — リポジトリ (全 worktree 込み) につき 1 ウィンドウ。ロックは fd の寿命に紐づくので、クラッシュ後の後始末は要らない |
 | `cc_notify.rs` / `cc_hook.rs` | Unix-socket channel from Claude Code hooks — waiting/active state, and the `SessionStart` report that keeps a panel's session id correct across `/clear` |
 | `claude_sessions/` | Resolving which `.jsonl` transcript backs a panel (`rotation.rs` is the hook-less fallback for `/clear`) |
 | `config.rs` | Config loading from `~/.config/conductor/config.toml` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.109.1"
+version = "0.110.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.109.1"
+version = "0.110.0"
 edition = "2024"
 
 [dependencies]

--- a/src/background.rs
+++ b/src/background.rs
@@ -76,6 +76,22 @@ impl<T> BackgroundOp<T> {
     }
 }
 
+/// スレッドの終了を待つ。ただし期限を切って、超えたら見捨てる。
+///
+/// 終了時の join が外部リソース待ちのスレッドで固まると、端末を戻す前に
+/// プロセスごと止まってユーザーが Ctrl+Q で抜けられなくなる。後始末より
+/// 抜けられることを優先する。
+pub fn join_or_abandon(thread: std::thread::JoinHandle<()>, timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while !thread.is_finished() {
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    thread.join().is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,5 +134,28 @@ mod tests {
         assert!(op.is_running());
         op.clear();
         assert!(!op.is_running());
+    }
+
+    #[test]
+    fn join_or_abandon_gives_up_on_a_wedged_thread() {
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        let wedged = std::thread::spawn(move || {
+            let _ = rx.recv();
+        });
+        let start = std::time::Instant::now();
+        assert!(!super::join_or_abandon(
+            wedged,
+            std::time::Duration::from_millis(100)
+        ));
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
+        drop(tx);
+    }
+
+    #[test]
+    fn join_or_abandon_waits_for_a_thread_that_finishes() {
+        let t = std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        });
+        assert!(super::join_or_abandon(t, std::time::Duration::from_secs(5)));
     }
 }

--- a/src/cc_notify.rs
+++ b/src/cc_notify.rs
@@ -26,6 +26,9 @@ use std::time::Duration;
 /// メモリを食わせないための歯止め。
 const MAX_MESSAGE_BYTES: usize = 8 * 1024;
 
+/// 終了時に accept ループの終了を待つ上限。
+const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// Claude Code の状態変化の種類。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CcNotifyKind {
@@ -205,7 +208,9 @@ impl Drop for CcNotifyListener {
         // accept() のブロックを解くためにソケットへ接続する。
         let _ = UnixStream::connect(&self.socket_path);
         if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
+            // accept() は突いても起きないことがある (ソケットが外から消された等)。
+            // 後始末より、端末を戻して抜けられることを優先する。
+            crate::background::join_or_abandon(thread, SHUTDOWN_JOIN_TIMEOUT);
         }
         let _ = std::fs::remove_file(&self.socket_path);
     }

--- a/src/git_engine/mod.rs
+++ b/src/git_engine/mod.rs
@@ -40,6 +40,18 @@ use git2::Repository;
 
 pub use recently_modified::recently_modified_files;
 
+/// このリポジトリの .conductor ディレクトリ。
+///
+/// linked worktree から起動されても、メインワークツリー側の 1 つを指す。
+/// ここに置くリソース (データベース、ソケット、ロック) はリポジトリ単位で
+/// 1 つなので、worktree ごとに分かれてしまうと相手が見えなくなる。
+pub fn conductor_dir(repo_path: &Path) -> PathBuf {
+    GitEngine::open(repo_path)
+        .and_then(|e| e.main_worktree_path())
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+        .join(".conductor")
+}
+
 /// 1つの worktree に関する情報。
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {

--- a/src/instance_lock.rs
+++ b/src/instance_lock.rs
@@ -1,0 +1,122 @@
+//! 同じリポジトリを 2 つの Conductor が同時に開かないようにする排他ロック。
+//!
+//! .conductor/ に置くリソース (レビュー DB、cc-notify ソケット、リフレッシュ用
+//! FIFO) はどれもリポジトリにつき 1 つを前提にしていて、2 つ目のインスタンスは
+//! それを奪うか諦めるかしかできない。取り合いを個別に捌くより、そもそも
+//! 2 つ目を起動させないほうが単純で、壊れ方も読める。
+//!
+//! flock を使うのは、ロックの寿命をプロセスの寿命に縛れるため。pid を書いた
+//! ファイルだと、クラッシュや SIGKILL のあとに「誰も持っていないのに開けない」
+//! ロックが残り、それを掃除するコードがまた別の壊れ方をする。flock なら
+//! fd が閉じた時点でカーネルが解放するので、後始末そのものが要らない。
+
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// 保持している間だけ、このリポジトリを開く権利を持つ。
+///
+/// ロックはファイル記述子に紐づくので、drop (プロセス終了を含む) で解放される。
+pub struct InstanceLock {
+    _file: std::fs::File,
+}
+
+/// このリポジトリのロックファイルのパス。
+pub fn lock_path(repo_path: &Path) -> PathBuf {
+    crate::git_engine::conductor_dir(repo_path).join("conductor.lock")
+}
+
+/// このロックが覆うリポジトリのルート。
+///
+/// linked worktree から起動してもメインワークツリーを返す。ロックは
+/// リポジトリ単位なので、断るときに「どれが開いているのか」として見せるべき
+/// なのは、ユーザーがいま打ったパスではなくこちら。
+pub fn locked_repo_root(repo_path: &Path) -> PathBuf {
+    crate::git_engine::conductor_dir(repo_path)
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| repo_path.to_path_buf())
+}
+
+/// リポジトリのロックを取る。
+///
+/// - `Ok(Some(_))`: 取れた。保持している間だけ起動してよい。
+/// - `Ok(None)`: 別の Conductor が持っている。
+/// - `Err(_)`: ロックの仕組みが使えなかった (権限、flock 非対応のファイル
+///   システムなど)。呼び出し側は起動を止めずに続ける — 排他できないことを
+///   理由にリポジトリを開けなくするほうが害が大きい。
+pub fn acquire(repo_path: &Path) -> Result<Option<InstanceLock>> {
+    let path = lock_path(repo_path);
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("could not create {}", dir.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("could not open {}", path.display()))?;
+
+    // SAFETY: 標準的な POSIX の flock。fd は file が所有していて有効。
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(Some(InstanceLock { _file: file }));
+    }
+
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
+        return Ok(None);
+    }
+    Err(anyhow::Error::new(err).context(format!("could not lock {}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ロックファイルは残る。掃除しないのが正しい — 消しに行くと、別の
+    /// プロセスが既に作って掴んだ実体を消してしまう。
+    #[test]
+    fn a_second_acquire_is_refused_until_the_first_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = acquire(dir.path())
+            .unwrap()
+            .expect("first acquire succeeds");
+        assert!(
+            acquire(dir.path()).unwrap().is_none(),
+            "a second instance must be refused"
+        );
+
+        drop(first);
+        assert!(
+            acquire(dir.path()).unwrap().is_some(),
+            "the lock must be free once the holder is gone"
+        );
+    }
+
+    #[test]
+    fn different_repositories_do_not_block_each_other() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        let _lock_a = acquire(a.path()).unwrap().expect("repo a");
+        assert!(acquire(b.path()).unwrap().is_some(), "repo b is unrelated");
+    }
+
+    /// 更新後の再起動は exec でプロセスイメージを置き換える (startup.rs)。
+    /// ロックの fd がそこを生き延びると、新しいイメージは自分自身が握った
+    /// ロックに弾かれて「既に開いています」で起動できなくなる。
+    #[test]
+    fn the_lock_does_not_survive_exec() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = acquire(dir.path()).unwrap().expect("acquire");
+        // SAFETY: fd は lock が所有していて有効。F_GETFD は何も変更しない。
+        let flags = unsafe { libc::fcntl(lock._file.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0, "F_GETFD failed");
+        assert!(
+            flags & libc::FD_CLOEXEC != 0,
+            "the lock fd must be close-on-exec or the post-update restart refuses to start"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod git_engine;
 mod go_test;
 mod grep_search;
 mod hover_info;
+mod instance_lock;
 mod jump_history;
 mod keymap;
 mod mcp_serve;
@@ -80,12 +81,31 @@ fn main() -> Result<()> {
         return result;
     }
 
+    // 端末に触る前に。断られたら通常スクリーンのまま理由を出して終わりたい。
+    let repo_path = startup::resolve_repo_path()?;
+    let _instance_lock = match instance_lock::acquire(&repo_path) {
+        Ok(Some(lock)) => Some(lock),
+        Ok(None) => {
+            anyhow::bail!(
+                "conductor is already open on this repository:\n  {}\n\n\
+                 All worktrees of a repository share one window.\n\
+                 Switch to that window, or close it first.",
+                instance_lock::locked_repo_root(&repo_path).display()
+            );
+        }
+        // 排他できないことを理由にリポジトリを開けなくするほうが害が大きい。
+        Err(e) => {
+            log::warn!("could not take the single-instance lock: {e:#}");
+            None
+        }
+    };
+
     let keyboard_enhanced = supports_keyboard_enhancement().unwrap_or(false);
     log::debug!("keyboard_enhanced = {keyboard_enhanced}");
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
     enter_tui(terminal.backend_mut(), keyboard_enhanced)?;
 
-    let mut app = App::new(startup::resolve_repo_path()?);
+    let mut app = App::new(repo_path);
     execute!(io::stdout(), SetTitle(format!("conductor - {}", app.repo.main_name)))?;
 
     // raw mode に入ったあと・イベントループが stdin を読み始める前でなければ

--- a/src/refresh_pipe.rs
+++ b/src/refresh_pipe.rs
@@ -13,6 +13,12 @@ use std::sync::{Arc, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+/// 終了時に読み取りスレッドの終了を待つ上限。
+///
+/// 突いても起きないスレッド (FIFO が外から消された等) のために終了そのものを
+/// 諦めるより、後始末を捨てて抜けられるほうがよい。
+const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// MCP がリフレッシュ用パイプへ書いたときに送られるイベント。
 #[derive(Debug)]
 pub struct RefreshEvent;
@@ -247,7 +253,7 @@ impl Drop for RefreshPipe {
         }
 
         if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
+            crate::background::join_or_abandon(thread, SHUTDOWN_JOIN_TIMEOUT);
         }
         let _ = std::fs::remove_file(&self.pipe_path);
     }
@@ -369,5 +375,26 @@ mod tests {
             original,
             "signal_refresh overwrote a regular file"
         );
+    }
+
+    /// Ctrl+Q が効かなくなる退行の番人。
+    ///
+    /// FIFO が外から消えると読み取りスレッドは誰も辿り着けない inode の
+    /// open() で寝たままになり、突いても起きない。終了はそれでも進むこと。
+    #[test]
+    fn dropping_a_listener_whose_pipe_vanished_does_not_hang() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipe_path = dir.path().join("refresh.pipe");
+        let listener = RefreshPipe::from_path(pipe_path.clone()).unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        std::fs::remove_file(&pipe_path).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            drop(listener);
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("shutdown hung on a vanished FIFO");
     }
 }


### PR DESCRIPTION
## Summary

同じリポジトリで conductor を 2 つ開くと、1 つ目が Ctrl+Q で終了できなくなる不具合を直し、あわせてリポジトリ単位の単独起動に倒した。

### 原因

リフレッシュ用 FIFO のパスが `.conductor/refresh.pipe` 固定で、`RefreshPipe::new` が起動のたびに既存の FIFO を unlink して mkfifo し直していた。

1. 1 つ目の読み取りスレッドは、誰も辿り着けなくなった inode の `open(O_RDONLY)` で寝たままになる
2. 終了時の `Drop` は「パスを O_WRONLY で突いて起こす」設計だが、そのパスは既に 2 つ目の inode。1 つ目は起きない
3. `thread.join()` が返らない
4. `loop_state` は `run_loop` のローカルなので、`main` の `leave_tui` より前に drop される → 端末が代替スクリーンのまま固まる

同時起動では 1 つ目のスレッドがまだ `open()` に入っておらず再現しない。2 つ目を後から開いたときだけ起きる。

### 対応

- **単独起動 (`src/instance_lock.rs`)**: `.conductor/conductor.lock` に `flock(LOCK_EX|LOCK_NB)`。取れなければ理由を出して終了する。`flock` を選んだのはロックの寿命をプロセスの寿命に縛れるため — pid ファイルだとクラッシュ後に「誰も持っていないのに開けない」ロックが残り、その掃除がまた別の壊れ方をする。flock なら fd が閉じた時点でカーネルが解放するので後始末のコードが要らない
- **終了時 join の上限 (`background::join_or_abandon`)**: ロックが効かない環境 (flock 非対応の FS など) では fail-open で起動を許すので、そこで Ctrl+Q を守る保険として残す。後始末より端末を戻して抜けられることを優先する

### 挙動の変更

同じリポジトリの別 worktree から開くのも拒否される。ロックは `.conductor/` にあり、それはメインワークツリー側の 1 つなので、リポジトリ単位 = 全 worktree 込みになるのは設計上必然。conductor はもともと 1 ウィンドウで複数 worktree を扱う道具なので思想としては一貫している。

`mcp-serve` / `cc-hook` はロックの対象外。同じバイナリだが TUI が起動した Claude パネルの中で走るため、ロックすると MCP サーバが全部起動不能になる。

## Test plan

実プロセス 2 つでの検証:

```
1st instance running : True
2nd instance exited  : True | exit code: 1
2nd instance said    : conductor is already open on this repository:
                         /Users/.../conductor
                       All worktrees of a repository share one window.
mcp-serve blocked?   : False
1st quit on Ctrl+Q   : True
SIGKILL 後に新規起動  : True   (後始末コードなしで復帰)
```

修正前のバイナリで同じ手順を踏むと `HUNG` になることも確認済み。

自動テスト:

- `dropping_a_listener_whose_pipe_vanished_does_not_hang` — Ctrl+Q 退行の番人。`join_or_abandon` を素の `thread.join()` に戻すと落ちることを実測で確認
- `the_lock_does_not_survive_exec` — 更新後の再起動は `exec` でプロセスイメージを置き換えるため、ロックの fd がそこを生き延びると新しいイメージが自分自身のロックに弾かれて起動できなくなる。close-on-exec を固定する
- `a_second_acquire_is_refused_until_the_first_is_dropped` / `different_repositories_do_not_block_each_other`
- `cargo test --workspace` 1125 passed / 0 failed
- `cargo clippy --workspace` 新規警告なし
