### PR TITLE
feat: Viewer で複数ファイルをタブとして同時に開けるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,13 @@ Status bar
 - The main area is a three-column accordion (`ui/layout.rs`): Explorer | Viewer |
   Terminal, with focus-driven widths. Any panel can be maximized (`Ctrl+Alt+Z`),
   and resized tmux-style with `Ctrl+Alt+Arrow` (ratios persist to config.toml).
+- The Viewer keeps several files open at once. `ViewerState` owns a `tabs` list
+  plus an active index; only the active tab's state lives in the flat
+  `content`/`search`/`diff_view`/`selection` fields, and the rest is stashed on
+  the tab it belongs to (`viewer/tabs.rs`) — one copy, never two. `open_file`
+  is the single entry point and reuses an existing tab. The strip is drawn on
+  the block's first inner row (`ui/viewer_panel/tab_row.rs`), the same slot the
+  breadcrumb uses, so `screen_row_map` gets a placeholder for it.
 - Explorer column is split 50/50 (file tree top, diff/comment list bottom).
 - The revidere review view (`Focus::Revidere`, `w`) is *not* part of the
   accordion: it takes `main_area` whole as two columns (reading order | diff)
@@ -134,7 +141,7 @@ Status bar
 | `menu/` | Menu bar model (`model.rs` — which command sits under which menu), interaction state (`state.rs`), and availability predicates for the greyed-out rows (`enabled.rs`) |
 | `git_engine.rs` | All git operations via `git2` (no shell-out) — worktrees, diffs, branches, cherry-pick, merge |
 | `diff_state.rs` | Diff data model (file diffs, hunks, lines) using `similar` crate |
-| `viewer/` | File tree model (`file_tree.rs`) and file content buffer (`file_view.rs`) |
+| `viewer/` | File tree model (`file_tree.rs`), file content buffer (`file_view.rs`), and the open-file tabs (`tabs.rs`) |
 | `review_store.rs` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
 | `pty_manager.rs` | PTY session management — spawn, read/write, resize; vt100 parser for rendering; output scanner for Claude Code |
 | `file_watcher.rs` | Filesystem change detection via `notify` crate, debounced at 500ms |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures"]
 
 [package]
 name = "conductor"
-version = "0.110.0"
+version = "0.111.0"
 edition = "2024"
 
 [dependencies]

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -204,6 +204,50 @@ impl App {
         self.set_status(msg.to_string(), StatusLevel::Info);
     }
 
+    /// Viewer の次のタブへ切り替える。
+    pub fn next_viewer_tab(&mut self) {
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.next_tab(tab_width);
+        self.after_viewer_tab_change();
+    }
+
+    /// Viewer の前のタブへ切り替える。
+    pub fn prev_viewer_tab(&mut self) {
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.prev_tab(tab_width);
+        self.after_viewer_tab_change();
+    }
+
+    /// idx のタブをアクティブにする（タブ行のクリック）。
+    pub fn focus_viewer_tab(&mut self, idx: usize) {
+        let tab_width = self.config.viewer.tab_width;
+        self.viewer_state.focus_tab(idx, tab_width);
+        self.after_viewer_tab_change();
+    }
+
+    /// idx のタブを閉じる。省略時はアクティブなタブ。
+    pub fn close_viewer_tab(&mut self, idx: Option<usize>) {
+        let tab_width = self.config.viewer.tab_width;
+        let idx = idx.unwrap_or(self.viewer_state.active_tab);
+        let Some(closed) = self.viewer_state.tabs.get(idx).map(|t| t.path.clone()) else {
+            return;
+        };
+        self.viewer_state.close_tab(idx, tab_width);
+        self.after_viewer_tab_change();
+        self.set_status(format!("Closed {closed}"), StatusLevel::Info);
+    }
+
+    /// タブが切り替わったあと、ファイルに紐づくキャッシュを新しいファイルへ貼り直す。
+    /// ハイライトもコメントも「今開いているファイル」が前提なので、貼り直しを
+    /// 忘れると前のタブの色とコメントがそのまま残る。
+    fn after_viewer_tab_change(&mut self) {
+        self.rehighlight_viewer();
+        if let Some(path) = self.viewer_state.content.current_file.clone() {
+            self.review_state.build_file_comment_cache(&path);
+            self.viewer_state.reveal_file_in_tree(&path);
+        }
+    }
+
     /// ファイルパス（現在のworktreeからの相対パス）をViewerパネルで開く。
     ///
     /// 指定があれば line（1始まり）へジャンプする。Explorerツリー内で

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -284,7 +284,8 @@ impl App {
         if let Some((root, entries, git_status)) = self.bg.file_tree.poll() {
             // 3 つまとめて差し替える。根だけ先に新しくなると、まだ古いエントリ
             // を指しているクリックが別ブランチの同名ファイルを黙って開く。
-            self.viewer_state.replace_tree(root, entries, git_status);
+            self.viewer_state
+                .replace_tree(root, entries, git_status, self.config.viewer.tab_width);
             // このワークツリーのファイルツリーが揃ったので、以前見ていたファイルと
             // スクロール位置を復元する（一度だけ）。
             self.consume_pending_view_restore();

--- a/src/default_keybinds.toml
+++ b/src/default_keybinds.toml
@@ -264,6 +264,12 @@
 # rendered prose. Bound in this layer only — the rendered view resolves its keys
 # against it too, so one binding covers both directions.
 "m" = "toggle_markdown_render"
+# File tabs — several files stay open at once in the Viewer; t/T walk them and
+# x closes the current one. Vim leaves t/T/x free in a read-only pane, and the
+# same three work in diff mode so the strip behaves identically in both.
+"t" = "next_viewer_tab"
+"T" = "prev_viewer_tab"
+"x" = "close_viewer_tab"
 # 'z' opens the Vim fold chord: za toggles, zc closes, zo opens, zR opens every
 # fold, zM closes every fold. Only the prefix is bound — the second key is read
 # by the viewer handler, exactly like the g-prefixed jumps (gd/gi/gr).
@@ -312,6 +318,12 @@
 "K" = "prev_changed_file"
 "c" = "add_comment"
 "v" = "toggle_viewed"
+# File tabs — several files stay open at once in the Viewer; t/T walk them and
+# x closes the current one. Vim leaves t/T/x free in a read-only pane, and the
+# same three work in diff mode so the strip behaves identically in both.
+"t" = "next_viewer_tab"
+"T" = "prev_viewer_tab"
+"x" = "close_viewer_tab"
 # 'e' for "edit": open the file under review in $VISUAL/$EDITOR for a quick
 # manual fix without leaving the diff workflow (reloads on return).
 "e" = "open_in_editor"

--- a/src/event/mouse/viewer_panel.rs
+++ b/src/event/mouse/viewer_panel.rs
@@ -100,6 +100,20 @@ pub(super) fn handle_viewer_column_click(
 
     let inner_x = explorer_end + 1; // 左枠の内側
     let inner_y = main_area.y + 1; // 上枠の内側
+
+    // タブ行は内側の先頭行。判定は描画が記録したクリック領域だけで行う —
+    // タブ行を描かないモード（メディア/SUMMARY など）ではこれが空になるので、
+    // その行のクリックを飲み込まずに通常の処理へ落ちる。
+    if row == inner_y
+        && let Some(action) = crate::ui::tab_bar::hit_at(&app.viewer_state.tab_row_hits, col)
+    {
+        match action {
+            crate::ui::tab_bar::TabAction::Select(idx) => app.focus_viewer_tab(idx),
+            crate::ui::tab_bar::TabAction::Close(idx) => app.close_viewer_tab(Some(idx)),
+            _ => {}
+        }
+        return;
+    }
     let marker_w = crate::viewer::COMMENT_MARKER_W;
     let gutter_w = app.viewer_state.gutter_total_width();
     let on_gutter = col >= inner_x && col < inner_x + marker_w + gutter_w;

--- a/src/event/viewer/mod.rs
+++ b/src/event/viewer/mod.rs
@@ -36,6 +36,18 @@ fn enter_g_prefix_mode(app: &mut App) {
     app.code_nav.symbol_hint.input.clear();
 }
 
+/// タブの切り替え/クローズ。素のファイル表示・diff 表示・レンダリング済み
+/// markdown のどれでも同じ意味なので、3 つの分岐で共有する。
+fn handle_tab_action(app: &mut App, action: Option<Action>) -> bool {
+    match action {
+        Some(Action::NextViewerTab) => app.next_viewer_tab(),
+        Some(Action::PrevViewerTab) => app.prev_viewer_tab(),
+        Some(Action::CloseViewerTab) => app.close_viewer_tab(None),
+        _ => return false,
+    }
+    true
+}
+
 /// Viewer パネルがフォーカスされているときのキーを処理する。
 pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
     // インライン返信の入力モード
@@ -158,6 +170,12 @@ pub(super) fn handle_viewer_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // タブ操作も空バッファのガードより前へ。読めなかったファイルのタブが
+    // 閉じられなくなるのを避ける。
+    if handle_tab_action(app, action) {
+        return;
+    }
+
     if total == 0 {
         return;
     }
@@ -253,6 +271,10 @@ pub(super) fn handle_viewer_markdown_mode_key(app: &mut App, key: KeyEvent) {
     let total = app.viewer_state.md_total_lines;
     let action = app.keymap.resolve(&key, KeyContext::Viewer);
 
+    if handle_tab_action(app, action) {
+        return;
+    }
+
     match action {
         Some(Action::ToggleMarkdownRender) => app.cmd_toggle_markdown_render(),
         Some(Action::ExitToExplorer) => app.set_focus(crate::app::Focus::Explorer),
@@ -333,6 +355,10 @@ pub(super) fn handle_viewer_diff_mode_key(app: &mut App, key: KeyEvent) {
     // ファジーなファイル名ジャンプ — 最大化された diff ビューアからも到達できる。
     if let Some(Action::SearchFilename) = action {
         super::open_filename_search(app);
+        return;
+    }
+
+    if handle_tab_action(app, action) {
         return;
     }
 

--- a/src/keymap/action.rs
+++ b/src/keymap/action.rs
@@ -96,6 +96,12 @@ keymap_suite::actions! {
         /// Viewer に表示中のファイルを外部エディタ（$VISUAL / $EDITOR）で開く:
         /// TUI を一時停止し、エディタを実行してから、復帰して再読み込みする。
         OpenInEditor => "open_in_editor",
+        /// Viewer で開いているファイルのタブを次/前へ切り替える。閉じるのは
+        /// CloseViewerTab。ターミナルのセッションタブ (NextSession) とは
+        /// 別の列に並ぶ別物なので、アクションも分けている。
+        NextViewerTab => "next_viewer_tab",
+        PrevViewerTab => "prev_viewer_tab",
+        CloseViewerTab => "close_viewer_tab",
         /// Viewer 内の markdown ファイルを raw ソースとレンダリング済みの
         /// プロースの間で切り替える。他のファイル（および diff モード）では
         /// 何もしない。両方のビューが異なるのは markdown だけだから。
@@ -278,6 +284,9 @@ impl Action {
             Action::AddComment => "Add comment on line",
             Action::ExitToExplorer => "Back to Explorer",
             Action::OpenInEditor => "Open in $EDITOR",
+            Action::NextViewerTab => "Next file tab",
+            Action::PrevViewerTab => "Previous file tab",
+            Action::CloseViewerTab => "Close file tab",
             Action::ToggleMarkdownRender => "Toggle markdown Raw / Rendered",
             Action::LeaveTerminal => "Leave terminal (keep session)",
             Action::ScrollbackUp => "Scrollback up",

--- a/src/ui/common/status_bar.rs
+++ b/src/ui/common/status_bar.rs
@@ -97,6 +97,7 @@ pub(super) fn status_bar_hint(focus: crate::app::Focus, keymap: &crate::keymap::
             ("scroll", &[Action::NavigateDown, Action::NavigateUp]),
             ("panel", &[Action::CycleFocusForward]),
             ("search", &[Action::SearchInFile]),
+            ("tab", &[Action::NextViewerTab, Action::CloseViewerTab]),
             ("thread", &[Action::ToggleInlineThread]),
             ("back", &[Action::ExitToExplorer]),
         ],

--- a/src/ui/viewer_panel/diff_view.rs
+++ b/src/ui/viewer_panel/diff_view.rs
@@ -91,7 +91,13 @@ fn render_expandable_context(
 
 /// unified diff ビュー（GitHub 風）を描画する。
 pub(super) fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, block: Block<'_>) {
-    let inner_height = area.height.saturating_sub(2) as usize;
+    // タブ行は素のファイル表示と同じくブロック内側の先頭行に重ねる。
+    let tab_row_height: u16 = if super::tab_row::is_visible(&app.viewer_state) {
+        1
+    } else {
+        0
+    };
+    let inner_height = area.height.saturating_sub(2 + tab_row_height) as usize;
 
     // 表示行と、画面行→コメント/エントリのマップを組み立てる。インライン
     // コメントスレッドは、コメントされた各範囲の最終行の後に挿入される
@@ -227,12 +233,23 @@ pub(super) fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, blo
         (lines, srm, entry_map)
     };
 
+    // タブ行は描画上も画面行マップ上も先頭を 1 行占める。マップがずれると
+    // クリックとホバーが 1 行ずれて着地する。
+    let mut screen_row_map = screen_row_map;
+    let mut screen_entry_map = screen_entry_map;
+    let mut lines = lines;
+    if tab_row_height > 0 {
+        lines.insert(0, Line::default());
+        screen_row_map.insert(0, crate::viewer::ScreenRow::ThreadContent);
+        screen_entry_map.insert(0, None);
+    }
     app.viewer_state.content.screen_row_map = screen_row_map;
     app.viewer_state.diff_view.screen_entry_map = screen_entry_map;
 
     frame.render_widget(ratatui::widgets::Clear, area);
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+    super::file_view::render_tab_row(frame, area, app);
 
     // 選択ヒントのオーバーレイを表示する。
     let theme = &app.theme;
@@ -241,10 +258,12 @@ pub(super) fn render_diff_view(frame: &mut Frame, area: Rect, app: &mut App, blo
     // diff の行数がパネルに収まりきらない場合にスクロールバーを描画する —
     // トリガーも見た目も Explorer のファイルツリーと同じ。
     if vs.diff_view.diff_view_lines.len() > inner_height {
-        let scrollbar_area = area.inner(Margin {
+        let mut scrollbar_area = area.inner(Margin {
             horizontal: 0,
             vertical: 1,
         });
+        scrollbar_area.y += tab_row_height;
+        scrollbar_area.height = scrollbar_area.height.saturating_sub(tab_row_height);
         let mut scrollbar_state = ScrollbarState::new(
             vs.diff_view
                 .diff_view_lines

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -22,6 +22,7 @@ use super::media_view::render_media_view;
 use super::search_box::render_search_box;
 use super::span_utils::digit_count;
 use super::summary_view::render_summary_view;
+use super::tab_row;
 use super::syntax::ensure_diff_annotations_cached;
 
 /// 与えられた area に Viewer（ファイル内容）パネルを描画する。
@@ -31,6 +32,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
     // 画面行マップをクリアし、diff/media モードで古いデータが使われないようにする。
     app.viewer_state.content.screen_row_map.clear();
+    app.viewer_state.tab_row_hits.clear();
 
     // Summary 疑似ファイル: ブランチの変更サマリーがパネル全体を占める。
     // 描画関数が &mut App を取れるよう、共有借用の前にチェックする。
@@ -164,17 +166,26 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(theme.muted),
             ),
         };
-        let placeholder = Paragraph::new(text).style(style).block(block);
+        let mut body = String::new();
+        if tab_row::is_visible(vs) {
+            // タブ行のぶんだけ本文を下げる。
+            body.push('\n');
+        }
+        body.push_str(&text);
+        let placeholder = Paragraph::new(body).style(style).block(block);
         frame.render_widget(placeholder, area);
+        render_tab_row(frame, area, app);
         return;
     }
 
     // ジャンプ履歴からパンくずリストを組み立てる。
     let breadcrumb_visible = build_breadcrumb_line(app);
 
-    // パンくずバーの高さぶんを見込む（表示されているときは1行）。
+    // パンくずバーとタブ行の高さぶんを見込む（表示されているときは各1行）。
     let breadcrumb_height: u16 = if breadcrumb_visible.is_some() { 1 } else { 0 };
-    let inner_height = (area.height.saturating_sub(2 + breadcrumb_height)) as usize;
+    let tab_row_height: u16 = if tab_row::is_visible(vs) { 1 } else { 0 };
+    let inner_height =
+        (area.height.saturating_sub(2 + breadcrumb_height + tab_row_height)) as usize;
     let gutter_width = digit_count(vs.content.file_content.len());
 
     // diff 注釈は ViewerState にキャッシュされている（関数の入口で埋めた）。
@@ -254,6 +265,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // パンくずバーをブロック内の先頭行として先頭に追加する。
     let mut all_lines = Vec::new();
+    if tab_row_height > 0 {
+        // タブ行は別ウィジェットとして重ねるので、ここでは場所だけ空ける。
+        all_lines.push(Line::default());
+    }
     if let Some(crumb_line) = breadcrumb_visible {
         all_lines.push(crumb_line);
     }
@@ -276,8 +291,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             vertical: 1,
         });
         // トラックをパンくず行より下に置き、コード領域だけをカバーするようにする。
-        scrollbar_area.y += breadcrumb_height;
-        scrollbar_area.height = scrollbar_area.height.saturating_sub(breadcrumb_height);
+        let head_rows = breadcrumb_height + tab_row_height;
+        scrollbar_area.y += head_rows;
+        scrollbar_area.height = scrollbar_area.height.saturating_sub(head_rows);
         let mut scrollbar_state = ScrollbarState::new(visible_total.saturating_sub(inner_height))
             .position(vs.cursor_visible_index());
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -327,7 +343,22 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     if breadcrumb_height > 0 {
         screen_row_map.insert(0, crate::viewer::ScreenRow::ThreadContent);
     }
+    if tab_row_height > 0 {
+        screen_row_map.insert(0, crate::viewer::ScreenRow::ThreadContent);
+    }
     app.viewer_state.content.screen_row_map = screen_row_map;
+
+    render_tab_row(frame, area, app);
+}
+
+/// ブロック内側の先頭行にタブ行を重ね、クリック領域を記録する。
+pub(super) fn render_tab_row(frame: &mut Frame, area: Rect, app: &mut App) {
+    if !tab_row::is_visible(&app.viewer_state) || area.width < 3 || area.height < 3 {
+        return;
+    }
+    let row = Rect::new(area.x + 1, area.y + 1, area.width - 2, 1);
+    app.viewer_state.tab_row_hits =
+        tab_row::render(frame, row, &app.theme, &app.viewer_state);
 }
 
 /// Viewer のタイトルを max_w **表示カラム数**に収める。左側から省略し

--- a/src/ui/viewer_panel/mod.rs
+++ b/src/ui/viewer_panel/mod.rs
@@ -9,7 +9,7 @@
 //! 描画する（Raw/Rendered ヘッダー切り替えも含む）、[media_view] は画像/動画、
 //! [comment_thread] はインラインのレビューコメントスレッドと新規コメント作成ボックス、
 //! [syntax] は syntax/diff の注釈ヘルパー、[span_utils] は汎用の Span 操作、
-//! [search_box] はパネル内検索入力。
+//! [search_box] はパネル内検索入力、[tab_row] は開いているファイルのタブ行。
 
 mod code_line;
 mod comment_thread;
@@ -22,6 +22,7 @@ mod search_box;
 mod span_utils;
 mod summary_view;
 mod syntax;
+mod tab_row;
 
 pub use file_view::render;
 pub(crate) use markdown_view::toggle_segments;

--- a/src/ui/viewer_panel/tab_row.rs
+++ b/src/ui/viewer_panel/tab_row.rs
@@ -1,0 +1,248 @@
+//! Viewer で開いているファイルのタブ行。
+//!
+//! ブロック内側の先頭行に描く。パンくずと同じ扱いで、コード行がその分だけ
+//! 下がる（[super::file_view] が screen_row_map にプレースホルダを詰める）。
+//!
+//! タブが 1 枚だけのときは描かない — パスはタイトルに出ているので、1 行を
+//! 消費するだけの価値が無い。
+//!
+//! クリック領域はターミナルのタブバーと同じ [TabHit] で表すので、マウス処理は
+//! 幅を計算し直さずこの描画結果をそのまま引ける。
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::theme::Theme;
+use crate::ui::tab_bar::{TabAction, TabHit};
+use crate::ui::worktree_bar::visible_window;
+use crate::viewer::ViewerState;
+
+const CLOSE: &str = " [x]";
+const SEP: &str = " ";
+
+fn w(s: &str) -> u16 {
+    UnicodeWidthStr::width(s) as u16
+}
+
+/// パスを max_w 表示カラムに収める。前を削って末尾（ファイル名）を残す。
+fn elide_head(path: &str, max_w: u16) -> String {
+    let max_w = max_w as usize;
+    if UnicodeWidthStr::width(path) <= max_w {
+        return path.to_string();
+    }
+    if max_w <= 1 {
+        return "\u{2026}".to_string();
+    }
+    let budget = max_w - 1;
+    let mut tail: Vec<char> = Vec::new();
+    let mut used = 0usize;
+    for ch in path.chars().rev() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + cw > budget {
+            break;
+        }
+        tail.push(ch);
+        used += cw;
+    }
+    tail.push('\u{2026}');
+    tail.reverse();
+    tail.into_iter().collect()
+}
+
+/// タブ行を描くかどうか。描かないなら Viewer は 1 行も失わない。
+pub(crate) fn is_visible(vs: &ViewerState) -> bool {
+    vs.tabs.len() >= 2
+}
+
+/// タブ行を area（高さ 1）に描き、クリック領域を返す。
+pub(crate) fn render(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    vs: &ViewerState,
+) -> Vec<TabHit> {
+    let mut hits: Vec<TabHit> = Vec::new();
+    if area.width == 0 || area.height == 0 || !is_visible(vs) {
+        return hits;
+    }
+
+    let close_w = w(CLOSE);
+    let sep_w = w(SEP);
+    let hint_reserve = 4u16; // "\u{2039}NN " / " NN\u{203a}"
+
+    // 1 枚の長いパスが行を占有しないよう、ラベル幅に上限を設ける。
+    let max_label_w = area
+        .width
+        .saturating_sub(close_w + sep_w + hint_reserve * 2)
+        .clamp(6, 32);
+    let labels: Vec<String> = vs
+        .tabs
+        .iter()
+        .map(|t| elide_head(&t.path, max_label_w))
+        .collect();
+    let slots: Vec<u16> = labels.iter().map(|l| w(l) + close_w).collect();
+
+    let total = vs.tabs.len();
+    let all_fit = visible_window(&slots, sep_w, area.width, 0, 0, false).1 == total;
+    let avail = if all_fit {
+        area.width
+    } else {
+        area.width.saturating_sub(hint_reserve * 2)
+    };
+    // アクティブなタブは常に見えていなければならないので、窓はそこを基準に開く。
+    let (start, end) = if all_fit {
+        (0, total)
+    } else {
+        visible_window(&slots, sep_w, avail, vs.active_tab, vs.active_tab, true)
+    };
+
+    let mut spans: Vec<Span> = Vec::new();
+    let mut x = area.x;
+
+    if start > 0 {
+        let hint = format!("\u{2039}{start} ");
+        x += w(&hint);
+        spans.push(Span::styled(hint, Style::default().fg(theme.hint)));
+    }
+
+    for (idx, label) in labels.iter().enumerate().take(end).skip(start) {
+        if idx > start {
+            spans.push(Span::styled(
+                SEP,
+                Style::default().fg(theme.border_unfocused),
+            ));
+            x += sep_w;
+        }
+        let label_w = w(label);
+        let style = if idx == vs.active_tab {
+            Style::default()
+                .fg(theme.selected_fg)
+                .bg(theme.selected_bg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        spans.push(Span::styled(label.clone(), style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled("[x]", Style::default().fg(theme.error)));
+        hits.push(TabHit {
+            x0: x,
+            x1: x + label_w + 1,
+            action: TabAction::Select(idx),
+        });
+        hits.push(TabHit {
+            x0: x + label_w + 1,
+            x1: x + label_w + close_w,
+            action: TabAction::Close(idx),
+        });
+        x += label_w + close_w;
+    }
+
+    if end < total {
+        spans.push(Span::styled(
+            format!(" {}\u{203a}", total - end),
+            Style::default().fg(theme.hint),
+        ));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::tab_bar::hit_at;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn state(paths: &[&str], active: usize) -> ViewerState {
+        let mut vs = ViewerState::default();
+        for path in paths {
+            vs.tabs.push(crate::viewer::ViewerTab::for_test(path));
+        }
+        vs.active_tab = active;
+        vs
+    }
+
+    fn draw(width: u16, vs: &ViewerState) -> (ratatui::buffer::Buffer, Vec<TabHit>) {
+        let theme = Theme::default();
+        let mut terminal = Terminal::new(TestBackend::new(width, 1)).unwrap();
+        let mut hits = Vec::new();
+        terminal
+            .draw(|f| {
+                hits = render(f, f.area(), &theme, vs);
+            })
+            .unwrap();
+        (terminal.backend().buffer().clone(), hits)
+    }
+
+    fn text(buf: &ratatui::buffer::Buffer, width: u16) -> String {
+        (0..width).map(|x| buf[(x, 0)].symbol()).collect()
+    }
+
+    /// タブが 1 枚だけならタブ行は出ない。パスはタイトルに出ているので、
+    /// 1 行を使う理由が無い。
+    #[test]
+    fn a_single_tab_does_not_take_a_row() {
+        let vs = state(&["src/main.rs"], 0);
+        assert!(!is_visible(&vs));
+        let (_, hits) = draw(40, &vs);
+        assert!(hits.is_empty());
+    }
+
+    /// 長いパスは前を削ってファイル名を残す。頭から切ると、どのタブも
+    /// "src/ui/vie…" のように見分けが付かなくなる。
+    #[test]
+    fn long_paths_keep_their_tail() {
+        assert_eq!(
+            elide_head("src/ui/viewer_panel/tab_row.rs", 12),
+            "\u{2026}/tab_row.rs"
+        );
+        assert_eq!(elide_head("a.rs", 12), "a.rs");
+    }
+
+    #[test]
+    fn every_visible_tab_is_selectable_and_closable() {
+        let vs = state(&["a.rs", "b.rs"], 0);
+        let (_, hits) = draw(60, &vs);
+        for idx in 0..2 {
+            assert!(hits.iter().any(|h| h.action == TabAction::Select(idx)));
+            assert!(hits.iter().any(|h| h.action == TabAction::Close(idx)));
+        }
+        // Select 領域のクリックはそのタブに当たる。
+        let sel = hits
+            .iter()
+            .find(|h| h.action == TabAction::Select(1))
+            .unwrap();
+        assert_eq!(hit_at(&hits, sel.x0), Some(TabAction::Select(1)));
+    }
+
+    /// アクティブなタブは、はみ出していても必ず見えていなければならない —
+    /// 今どのファイルを読んでいるのかが分からなくなる。
+    #[test]
+    fn the_active_tab_stays_visible_when_tabs_overflow() {
+        let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let vs = state(&refs, 11);
+        let (buf, hits) = draw(40, &vs);
+        assert!(hits.iter().any(|h| h.action == TabAction::Select(11)));
+        assert!(text(&buf, 40).contains("file11.rs"));
+    }
+
+    /// はみ出した分は左右のヒントで数が分かる。
+    #[test]
+    fn overflow_is_announced_on_both_sides() {
+        let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let vs = state(&refs, 6);
+        let (buf, _) = draw(40, &vs);
+        let rendered = text(&buf, 40);
+        assert!(rendered.contains('\u{2039}'), "left hint: {rendered}");
+        assert!(rendered.contains('\u{203a}'), "right hint: {rendered}");
+    }
+}

--- a/src/viewer/content.rs
+++ b/src/viewer/content.rs
@@ -15,11 +15,53 @@ impl ViewerState {
         self.content.cached_diff_annotations_file = None;
     }
 
-    /// ファイルを開いて（読み込んで）、その行を file_content に格納する。
+    /// ファイルを開く。既に開いているファイルなら新しいタブを増やさず、その
+    /// タブをアクティブにして読んでいた位置へ戻る。
     ///
     /// relative_path は表示中のツリーの根からの相対。絶対パスに戻すのは
     /// [ViewerState::root] だけで、呼び出し側は根を知らなくてよい。
     pub fn open_file(&mut self, relative_path: &str, tab_width: usize) {
+        if self.activate_tab_for(relative_path) {
+            self.load_active_file(relative_path, tab_width);
+        } else {
+            self.reload_active_file(relative_path, tab_width);
+        }
+    }
+
+    /// アクティブなタブの中身をディスクから読み直し、読んでいた位置と表示モード
+    /// （diff / SUMMARY / markdown のスクロール）を保つ。
+    ///
+    /// [ViewerState::load_active_file] は表示モードを畳んでしまうので、退避と
+    /// 復元をここ 1 か所に閉じ込めている。ファイルウォッチャーの再読み込みも
+    /// タブ切り替えも同じ要求なので、別々に書くと片方だけ直る。
+    pub(in crate::viewer) fn reload_active_file(&mut self, relative_path: &str, tab_width: usize) {
+        let file_scroll = self.content.file_scroll;
+        let h_scroll = self.content.h_scroll;
+        let md_scroll = self.md_scroll;
+        let diff = self
+            .diff_view
+            .diff_mode
+            .then(|| std::mem::take(&mut self.diff_view));
+        let summary = self.show_summary.then_some(self.summary_scroll);
+
+        self.load_active_file(relative_path, tab_width);
+
+        let last_line = self.content.file_content.len().saturating_sub(1);
+        self.content.file_scroll = file_scroll.min(last_line);
+        self.content.h_scroll = h_scroll;
+        self.md_scroll = md_scroll;
+        if let Some(diff) = diff {
+            self.diff_view = diff;
+        }
+        if let Some(scroll) = summary {
+            self.show_summary = true;
+            self.summary_scroll = scroll;
+        }
+    }
+
+    /// アクティブなタブの中身を読み込んで file_content に格納する。タブの
+    /// 出し入れには関知しない — 入口は [ViewerState::open_file] の側。
+    pub(in crate::viewer) fn load_active_file(&mut self, relative_path: &str, tab_width: usize) {
         self.exit_diff_mode();
         // md_rendered は意図的に維持する（このモードはファイルをまたいで持続する）。
         // スクロール位置は維持しない — 古いドキュメントを指す値になるため。

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -7,7 +7,8 @@
 //! 他のサブモジュールへ分割されている（[content] はファイルを開く処理、
 //! [tree] はファイルツリーの走査・展開、[search] はファイル内検索とファイル名検索、
 //! [diff_view] は unified diff 表示、[highlight] は syntect によるシンタックスハイライト、
-//! [selection] はガター行選択、[fold] はコードブロックの折りたたみ）。
+//! [selection] はガター行選択、[fold] はコードブロックの折りたたみ、
+//! [tabs] は複数ファイルを同時に開くためのタブ）。
 
 mod content;
 mod diff_view;
@@ -18,6 +19,7 @@ mod highlight;
 mod search;
 mod selection;
 mod state;
+mod tabs;
 mod tree;
 
 pub use file_tree::{FileTreeEntry, file_icon};

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -320,6 +320,27 @@ impl Default for ClickTracker {
 
 // メイン構造体
 
+/// Viewer で開いているファイル 1 つ分のタブ。
+pub struct ViewerTab {
+    /// 表示中のツリーの根からの相対パス。
+    pub path: String,
+    /// 非アクティブな間の退避先。アクティブなタブの状態は ViewerState 側の
+    /// content/search/diff_view/selection が実体を持つので None になる。
+    /// 実体を 2 か所に置かないことで、どちらが本物かを迷う余地を無くしている。
+    pub(in crate::viewer) stashed: Option<TabView>,
+}
+
+/// タブ 1 つ分の、ファイルに紐づく状態のまとまり。
+#[derive(Default)]
+pub(in crate::viewer) struct TabView {
+    pub(in crate::viewer) content: FileContentState,
+    pub(in crate::viewer) search: SearchState,
+    pub(in crate::viewer) diff_view: DiffViewState,
+    pub(in crate::viewer) selection: LineSelection,
+    pub(in crate::viewer) md_scroll: usize,
+}
+
+
 /// Viewer の最も左にあるコメントマーカー列の幅（列数） — 💬/│ の
 /// スレッドマーカーが存在する場所で、行番号の左側にある。「+」バッジ列
 /// （行番号の右側）とは別に保つことで、既存スレッドの開閉と新規コメントの
@@ -340,7 +361,11 @@ pub const GUTTER_FIXED_W: usize = 6;
 pub struct ViewerState {
     /// ファイルツリー管理。
     pub tree: FileTreeState,
-    /// ファイル内容表示。
+    /// 開いているファイルのタブ。開いた順に並ぶ。
+    pub tabs: Vec<ViewerTab>,
+    /// tabs 内のアクティブなタブの位置。tabs が空のときは意味を持たない。
+    pub active_tab: usize,
+    /// ファイル内容表示 — アクティブなタブの実体。
     pub content: FileContentState,
     /// ファイル内検索。
     pub search: SearchState,
@@ -356,6 +381,9 @@ pub struct ViewerState {
     pub media_state: MediaState,
     /// ダブルクリック追跡。
     pub click: ClickTracker,
+    /// タブ行のクリック領域（render 中に更新される）。マウス処理が幅を
+    /// 計算し直さず、描画とまったく同じジオメトリを引けるようにする。
+    pub tab_row_hits: Vec<crate::ui::tab_bar::TabHit>,
     /// 'g' が押されて2つ目のキー（gd, gi, gr）待ちかどうか。
     pub pending_g_key: bool,
     /// 'z' が押されて2つ目のキー（za, zc, zo, zR, zM）待ちかどうか。

--- a/src/viewer/tabs.rs
+++ b/src/viewer/tabs.rs
@@ -1,0 +1,302 @@
+//! 開いているファイルのタブ — 追加・切り替え・クローズと、根が変わったときの整理。
+//!
+//! アクティブなタブの状態は [ViewerState] の content/search/diff_view/selection
+//! が実体を持ち、非アクティブなタブの分だけ [ViewerTab::stashed] に退避される。
+//! 実体を 1 つに保つのは、アクティブなタブの状態が「タブの中」と「ViewerState
+//! の直下」の 2 か所に現れると、どちらを書いたかで表示がずれるため。
+
+use super::state::{TabView, ViewerState, ViewerTab};
+
+impl ViewerTab {
+    /// 描画テスト用に、中身を持たないタブを作る。
+    #[cfg(test)]
+    pub fn for_test(path: &str) -> Self {
+        Self {
+            path: path.to_string(),
+            stashed: None,
+        }
+    }
+}
+
+impl ViewerState {
+    /// アクティブなタブのパス（タブが 1 つも無ければ None）。
+    pub fn active_tab_path(&self) -> Option<&str> {
+        self.tabs.get(self.active_tab).map(|t| t.path.as_str())
+    }
+
+    /// idx のタブへ切り替える。中身はディスクから読み直すので、裏で編集された
+    /// ファイルが古いまま表示されることはない。
+    pub fn focus_tab(&mut self, idx: usize, tab_width: usize) {
+        let Some(path) = self.tabs.get(idx).map(|t| t.path.clone()) else {
+            return;
+        };
+        if idx != self.active_tab {
+            self.stash_active_view();
+            self.active_tab = idx;
+            if let Some(view) = self.tabs[idx].stashed.take() {
+                self.restore_view(view);
+            }
+        }
+        self.reload_active_file(&path, tab_width);
+    }
+
+    /// 次のタブへ（末尾からは先頭へ回り込む）。
+    pub fn next_tab(&mut self, tab_width: usize) {
+        if self.tabs.len() < 2 {
+            return;
+        }
+        self.focus_tab((self.active_tab + 1) % self.tabs.len(), tab_width);
+    }
+
+    /// 前のタブへ（先頭からは末尾へ回り込む）。
+    pub fn prev_tab(&mut self, tab_width: usize) {
+        if self.tabs.len() < 2 {
+            return;
+        }
+        let last = self.tabs.len() - 1;
+        let prev = if self.active_tab == 0 {
+            last
+        } else {
+            self.active_tab - 1
+        };
+        self.focus_tab(prev, tab_width);
+    }
+
+    /// idx のタブを閉じる。アクティブなタブを閉じたときは右隣（無ければ左隣）へ
+    /// 移り、最後の 1 枚を閉じたときはファイル未選択の状態へ戻る。
+    pub fn close_tab(&mut self, idx: usize, tab_width: usize) {
+        if idx >= self.tabs.len() {
+            return;
+        }
+        if idx != self.active_tab {
+            self.tabs.remove(idx);
+            if idx < self.active_tab {
+                self.active_tab -= 1;
+            }
+            return;
+        }
+
+        self.tabs.remove(idx);
+        self.clear_active_view();
+        if self.tabs.is_empty() {
+            self.active_tab = 0;
+            return;
+        }
+        let next = idx.min(self.tabs.len() - 1);
+        self.active_tab = next;
+        if let Some(view) = self.tabs[next].stashed.take() {
+            self.restore_view(view);
+        }
+        let path = self.tabs[next].path.clone();
+        self.reload_active_file(&path, tab_width);
+    }
+
+    /// 根が変わったあと、新しい根に無いファイルのタブを閉じる。
+    ///
+    /// 相対パスは根が変わると別のファイルを指すので、残しておくと切り替え前の
+    /// worktree のファイルを開いたままに見える。
+    pub fn prune_tabs_to_root(&mut self, tab_width: usize) {
+        let root = self.tree.root.clone();
+        let before = self.tabs.len();
+        let active_path = self.active_tab_path().map(str::to_string);
+        self.tabs.retain(|t| root.join(&t.path).is_file());
+        if self.tabs.len() == before {
+            return;
+        }
+        match active_path.and_then(|p| self.tabs.iter().position(|t| t.path == p)) {
+            Some(idx) => self.active_tab = idx,
+            None => {
+                self.clear_active_view();
+                self.active_tab = 0;
+                if let Some(tab) = self.tabs.first_mut() {
+                    // 別の根で溜めた状態は捨て、新しい根のファイルとして開き直す。
+                    tab.stashed = None;
+                    let path = tab.path.clone();
+                    self.load_active_file(&path, tab_width);
+                }
+            }
+        }
+    }
+
+    /// relative_path のタブを用意してアクティブにする。既に開いていればそれを使う。
+    /// 新しく作った場合だけ true を返す。
+    pub(in crate::viewer) fn activate_tab_for(&mut self, relative_path: &str) -> bool {
+        if let Some(idx) = self.tabs.iter().position(|t| t.path == relative_path) {
+            if idx != self.active_tab {
+                self.stash_active_view();
+                self.active_tab = idx;
+                if let Some(view) = self.tabs[idx].stashed.take() {
+                    self.restore_view(view);
+                }
+            }
+            return false;
+        }
+        self.stash_active_view();
+        self.tabs.push(ViewerTab {
+            path: relative_path.to_string(),
+            stashed: None,
+        });
+        self.active_tab = self.tabs.len() - 1;
+        true
+    }
+
+    /// アクティブなタブの状態をタブ側へ退避する。
+    fn stash_active_view(&mut self) {
+        let view = self.take_active_view();
+        if let Some(tab) = self.tabs.get_mut(self.active_tab) {
+            tab.stashed = Some(view);
+        }
+    }
+
+    fn take_active_view(&mut self) -> TabView {
+        TabView {
+            content: std::mem::take(&mut self.content),
+            search: std::mem::take(&mut self.search),
+            diff_view: std::mem::take(&mut self.diff_view),
+            selection: std::mem::take(&mut self.selection),
+            md_scroll: std::mem::take(&mut self.md_scroll),
+        }
+    }
+
+    fn restore_view(&mut self, view: TabView) {
+        self.content = view.content;
+        self.search = view.search;
+        self.diff_view = view.diff_view;
+        self.selection = view.selection;
+        self.md_scroll = view.md_scroll;
+    }
+
+    /// アクティブなタブの状態を捨て、ファイル未選択の表示へ戻す。
+    fn clear_active_view(&mut self) {
+        self.take_active_view();
+        self.show_summary = false;
+        self.summary_scroll = 0;
+        self.media_state.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tabs_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        for (path, body) in files {
+            std::fs::write(dir.join(path), body).unwrap();
+        }
+        dir
+    }
+
+    /// 別のファイルを開いても前のファイルは閉じない — これが複数タブの本題。
+    /// 同じファイルをもう一度開いたときはタブを増やさず、既にあるタブへ戻る。
+    #[test]
+    fn opening_files_accumulates_tabs_and_reopening_reuses_one() {
+        let dir = fixture("reuse", &[("a.txt", "A\n"), ("b.txt", "B\n")]);
+        let mut vs = ViewerState::default();
+        vs.set_root(dir.clone());
+
+        vs.open_file("a.txt", 4);
+        vs.open_file("b.txt", 4);
+        assert_eq!(vs.tabs.len(), 2);
+        assert_eq!(vs.active_tab_path(), Some("b.txt"));
+
+        vs.open_file("a.txt", 4);
+        assert_eq!(vs.tabs.len(), 2, "既に開いているファイルはタブを増やさない");
+        assert_eq!(vs.active_tab_path(), Some("a.txt"));
+        assert_eq!(vs.content.file_content, vec!["A"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// タブごとに読んでいた位置を持つ。戻ったときに先頭へ巻き戻されると、
+    /// 差分レビュー中に行き来する用途では複数タブの意味が無くなる。
+    #[test]
+    fn switching_tabs_restores_where_each_file_was_left() {
+        let long: String = (0..50).map(|i| format!("line{i}\n")).collect();
+        let dir = fixture("scroll", &[("a.txt", &long), ("b.txt", &long)]);
+        let mut vs = ViewerState::default();
+        vs.set_root(dir.clone());
+
+        vs.open_file("a.txt", 4);
+        vs.content.file_scroll = 30;
+        vs.open_file("b.txt", 4);
+        assert_eq!(vs.content.file_scroll, 0, "新しいタブは先頭から");
+        vs.content.file_scroll = 10;
+
+        vs.prev_tab(4);
+        assert_eq!(vs.active_tab_path(), Some("a.txt"));
+        assert_eq!(vs.content.file_scroll, 30);
+
+        vs.next_tab(4);
+        assert_eq!(vs.active_tab_path(), Some("b.txt"));
+        assert_eq!(vs.content.file_scroll, 10);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 非アクティブな間にディスク上で書き換えられたタブは、戻った時点の中身を出す。
+    /// Claude Code が裏でファイルを直すのが日常なので、古い本文が残ると実害が出る。
+    #[test]
+    fn returning_to_a_tab_rereads_it_from_disk() {
+        let dir = fixture("stale", &[("a.txt", "OLD\n"), ("b.txt", "B\n")]);
+        let mut vs = ViewerState::default();
+        vs.set_root(dir.clone());
+
+        vs.open_file("a.txt", 4);
+        vs.open_file("b.txt", 4);
+        std::fs::write(dir.join("a.txt"), "NEW\n").unwrap();
+        vs.prev_tab(4);
+
+        assert_eq!(vs.content.file_content, vec!["NEW"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// タブを閉じたら隣へ移る。最後の 1 枚を閉じたらファイル未選択に戻る。
+    #[test]
+    fn closing_a_tab_falls_back_to_a_neighbour_then_to_nothing() {
+        let dir = fixture("close", &[("a.txt", "A\n"), ("b.txt", "B\n")]);
+        let mut vs = ViewerState::default();
+        vs.set_root(dir.clone());
+
+        vs.open_file("a.txt", 4);
+        vs.open_file("b.txt", 4);
+        vs.close_tab(vs.active_tab, 4);
+        assert_eq!(vs.tabs.len(), 1);
+        assert_eq!(vs.active_tab_path(), Some("a.txt"));
+        assert_eq!(vs.content.file_content, vec!["A"]);
+
+        vs.close_tab(0, 4);
+        assert!(vs.tabs.is_empty());
+        assert_eq!(vs.content.current_file, None);
+        assert!(vs.content.file_content.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// worktree を切り替えたら、切り替え先に無いファイルのタブは残らない。
+    /// 相対パスは根が変わると別のファイルを指すので、残すと別ブランチの中身を
+    /// 開いたままに見える。
+    #[test]
+    fn switching_root_drops_tabs_that_do_not_exist_there() {
+        let a = fixture("root_a", &[("both.txt", "A\n"), ("only_a.txt", "A\n")]);
+        let b = fixture("root_b", &[("both.txt", "B\n")]);
+        let mut vs = ViewerState::default();
+        vs.set_root(a.clone());
+
+        vs.open_file("both.txt", 4);
+        vs.open_file("only_a.txt", 4);
+        assert_eq!(vs.tabs.len(), 2);
+
+        vs.load_file_tree(&b, 4);
+
+        assert_eq!(vs.tabs.len(), 1);
+        assert_eq!(vs.active_tab_path(), Some("both.txt"));
+        assert_eq!(vs.content.file_content, vec!["B"], "新しい根の中身を読む");
+
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
+    }
+}

--- a/src/viewer/tree.rs
+++ b/src/viewer/tree.rs
@@ -36,11 +36,19 @@ impl ViewerState {
         root: PathBuf,
         entries: Vec<FileTreeEntry>,
         git_status: GitStatusMap,
+        tab_width: usize,
     ) {
+        let root_changed = self.tree.root != root;
         self.tree.root = root;
         self.tree.file_tree = entries;
         self.tree.git_status = git_status;
         self.invalidate_visible_cache();
+        // 相対パスの指す先が変わるので、新しい根に無いファイルのタブは閉じる。
+        // 同じ根への再走査では触らない — 一時的に消えたファイルのタブまで
+        // 勝手に閉じてしまう。
+        if root_changed {
+            self.prune_tabs_to_root(tab_width);
+        }
     }
 
     /// worktree_path 以下のファイルシステムを歩いてファイルツリーを構築する。
@@ -58,12 +66,14 @@ impl ViewerState {
     /// 根を受け取る唯一の入口。ここで [ViewerState::root] を確定させ、以降
     /// ファイルを開く・子を読む・検索候補を集めるのはすべてこの根に対して行う。
     pub fn load_file_tree(&mut self, worktree_path: &Path, tab_width: usize) -> bool {
+        let root_changed = self.tree.root != worktree_path;
         self.tree.root = worktree_path.to_path_buf();
+        if root_changed {
+            self.prune_tabs_to_root(tab_width);
+        }
 
         // クリアする前に状態を退避しておく。
         let prev_file = self.content.current_file.clone();
-        let prev_file_scroll = self.content.file_scroll;
-        let prev_h_scroll = self.content.h_scroll;
         let expanded_dirs: Vec<String> = self
             .tree
             .file_tree
@@ -127,55 +137,18 @@ impl ViewerState {
             idx += 1;
         }
 
-        // 以前開いていたファイルがまだ存在するなら再度開く。
-        if let Some(ref rel_path) = prev_file {
-            let full = worktree_path.join(rel_path);
-            if full.is_file() {
-                // ツリーのリフレッシュをまたいで viewer の「モード」を保持し、
-                // ファイルウォッチャーや定期リフレッシュが unified diff 表示や
-                // SUMMARY 疑似ファイルからユーザーを追い出さないようにする。
-                // 以下の open_file は exit_diff_mode を経由し両方をクリアしてしまうので、
-                // 全てのモードフラグをここで退避し、後で戻す必要がある。
-                let was_diff_mode = self.diff_view.diff_mode;
-                let prev_diff_lines = if was_diff_mode {
-                    std::mem::take(&mut self.diff_view.diff_view_lines)
-                } else {
-                    Vec::new()
-                };
-                let prev_diff_scroll = self.diff_view.diff_view_scroll;
-                let prev_diff_max_line_no = self.diff_view.diff_view_max_line_no;
-                let was_summary = self.show_summary;
-                let prev_summary_scroll = self.summary_scroll;
-                // open_file はレンダリング済み markdown のスクロールをリセットする
-                // （特定のドキュメントに紐づくインデックスだから）。これはユーザー自身が
-                // ファイルを開いた場合には正しい挙動だが、ここでは不適切 — ウォッチャーや
-                // 3秒ポーリングが、読んでいる途中の読者を文章の先頭に引き戻してしまう。
-                let prev_md_scroll = self.md_scroll;
-
-                self.open_file(rel_path, tab_width);
-                self.content.file_scroll = prev_file_scroll;
-                self.content.h_scroll = prev_h_scroll;
-                self.md_scroll = prev_md_scroll;
-
-                if was_diff_mode {
-                    self.diff_view.diff_mode = true;
-                    self.diff_view.diff_view_lines = prev_diff_lines;
-                    self.diff_view.diff_view_scroll = prev_diff_scroll;
-                    self.diff_view.diff_view_max_line_no = prev_diff_max_line_no;
-                }
-                // diff モードとは排他（enter_summary_view を参照）なので、
-                // 上のブロックと競合することはない。
-                if was_summary {
-                    self.show_summary = true;
-                    self.summary_scroll = prev_summary_scroll;
-                }
-
-                // tree_selected をファイルエントリに合わせて復元しようとする。
-                if let Some(idx) = self.tree.file_tree.iter().position(|e| e.path == *rel_path) {
-                    self.tree.tree_selected = idx;
-                }
+        // 以前開いていたファイルがまだ存在するなら、読んでいた位置と表示モード
+        // （unified diff / SUMMARY / markdown）を保ったまま読み直す。ウォッチャー
+        // や3秒ポーリングが読者を追い出さないようにするのが要点。
+        // ファイルが削除されていた場合は、自然に「ファイル未選択」のまま留まる。
+        if let Some(ref rel_path) = prev_file
+            && worktree_path.join(rel_path).is_file()
+        {
+            self.reload_active_file(rel_path, tab_width);
+            // tree_selected をファイルエントリに合わせて復元しようとする。
+            if let Some(idx) = self.tree.file_tree.iter().position(|e| e.path == *rel_path) {
+                self.tree.tree_selected = idx;
             }
-            // ファイルが削除されていた場合は、自然に「ファイル未選択」のまま留まる。
         }
 
         // 再構築をまたいでツリーのカーソルを固定する。ファイルが開いている場合は

--- a/src/viewer/tree/tests.rs
+++ b/src/viewer/tree/tests.rs
@@ -100,7 +100,7 @@ fn tree_root_and_entries_switch_together() {
         &mut entries,
         &GitStatusMap::default(),
     );
-    vs.replace_tree(b.path().to_path_buf(), entries, GitStatusMap::default());
+    vs.replace_tree(b.path().to_path_buf(), entries, GitStatusMap::default(), 4);
 
     // 相対パスは同じでも、読むのは差し替え後の根の下のファイル。
     vs.open_file("shared.txt", 4);


### PR DESCRIPTION
## Summary

Viewer が単一ファイルしか保持できず、別のファイルを開くと前のファイルが閉じてしまうため、差分レビュー中にファイル間を行き来するのが不便だった。Viewer に開いているファイルのタブを持たせ、複数ファイルを同時に開けるようにする。

### 状態の持ち方

`ViewerState` に `tabs: Vec<ViewerTab>` と `active_tab` を追加した。ただし状態の実体はひとつに保っている — アクティブなタブの状態は従来どおり `content` / `search` / `diff_view` / `selection` / `md_scroll` が持ち、非アクティブなタブの分だけ `ViewerTab::stashed` へ退避する。アクティブなタブの状態が「タブの中」と「ViewerState の直下」の二か所に現れると、どちらを書いたかで表示がずれるため。この形にしたことで、既存の `viewer_state.content.*` の参照は一切変更していない。

`open_file` は引き続き唯一の入口で、既に開いているファイルならタブを増やさずそのタブをアクティブにする。revidere・定義ジャンプ・grep・ファイル名検索・ターミナルの `file:line` はいずれも元から `open_file` を経由しているため、そのままタブを再利用する。

タブへ戻るときはディスクから読み直したうえで、読んでいた位置と表示モード（unified diff / SUMMARY / markdown）を復元する。非アクティブな間にファイルが書き換えられていても古い本文を表示しない。この「モードを退避して読み直して復元する」処理は `load_file_tree` にベタ書きされていたものを `reload_active_file` へ括り出し、タブ切り替えと共有している。

### UI

タブ行はブロック内側の先頭行、パンくずリストと同じスロットに描画する（`ui/viewer_panel/tab_row.rs`）。`screen_row_map` へプレースホルダを挿入するので、クリックとホバーの行がずれることはない。素のファイル表示と unified diff 表示の両方に出る。

- 色はすべて `theme` 由来（アクティブは `selected_bg` の塗りつぶし + BOLD、`[x]` は `error`）
- パスは前を削って末尾を残す省略（`…/tab_row.rs`）
- アクティブなタブははみ出していても必ず見える位置に窓を開き、隠れた分は左右にヒントを出す
- タブが1枚のときは描画しない。パスはパネルタイトルに出ているため

### 操作

| キー | 動作 |
|---|---|
| `t` | 次のタブ |
| `T` | 前のタブ |
| `x` | 現在のタブを閉じる |

viewer レイヤーと viewer_diff_mode レイヤーの両方に割り当てた。空バッファのガードより前で処理しているので、読み込みに失敗したファイルのタブも閉じられる。マウスではタブ本体のクリックで切り替え、`[x]` のクリックで閉じる。チートシートは `Action::ALL` から自動生成されるため追記は不要で、ステータスバーには `tab` の項目を追加した。

### worktree の切り替え

相対パスは根が変わると別のファイルを指すため、`replace_tree` / `load_file_tree` で根が変わったときに、新しい根に存在しないファイルのタブを閉じる。同じ根への再走査では走らせない — 定期リフレッシュのたびに、一時的に消えていただけのファイルのタブまで閉じてしまうため。

## Test plan

- `cargo check --workspace` / `cargo clippy --workspace` / `cargo test --workspace` がいずれも通ること（clippy の残存 2 件は本 PR で触れていないファイルの既存警告）
- `viewer::tabs` に追加したテスト
  - 別のファイルを開いても前のタブが残り、同じファイルを開き直してもタブが増えない
  - タブを切り替えると、それぞれのファイルで読んでいた位置に戻る
  - 非アクティブな間に書き換えられたファイルは、戻ったときに新しい内容を表示する
  - タブを閉じると隣のタブへ移り、最後の1枚を閉じるとファイル未選択に戻る
  - worktree を切り替えると、切り替え先に存在しないファイルのタブが残らない
- `ui::viewer_panel::tab_row` に追加したテスト
  - タブが1枚のときはタブ行を描画しない
  - 長いパスは末尾（ファイル名）を残して省略する
  - 表示されているタブがすべて選択・クローズ可能である
  - はみ出していてもアクティブなタブは必ず見えており、隠れた件数が左右に出る

## 補足

- メディア / SUMMARY / レンダリング済み markdown の表示中はタブ行を出していない。いずれもペイン全体を占有する専用レンダラで、行数の見積もりを個別に扱う必要があるため。マウス側は描画が記録したヒット領域だけで判定しているので、タブ行を描いていないモードでその行のクリックを飲み込むことはない
- `Cargo.toml` は後方互換の機能追加として `0.110.0` → `0.111.0`
