### PR TITLE
feat: SCIP 索引の読み取りを producer 非依存にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,13 +132,23 @@ Where the index lives and who builds it:
   `git2::Repository::commondir()` to the main one — the same move
   `mcp_serve::resolve` makes for the review DB. The lock is per repository on
   purpose: one producer peaks at 2.36GB, so the cap must not split per worktree.
-- **Rust only.** `RustAnalyzer` is the sole producer, gated on a `Cargo.toml` at
-  the tree root; Go and TypeScript keep going through the tree-sitter fallback
-  unchanged. sheaf has `ScipGo` / `ScipTypescript` ready when we want them.
+- **Generation is Rust only; reading is not.** `RustAnalyzer` is the sole producer
+  conductor runs, gated on a `Cargo.toml` at the tree root, so a Go or TypeScript
+  repository opened in conductor still answers entirely through tree-sitter.
+  sheaf-core itself is producer-independent and verified against real `scip-go` and
+  `scip-typescript` indexes (kind, declaration, doc, container, and implementations
+  all resolve); `ScipGo` / `ScipTypescript` are ready. What is missing is the host
+  side: choosing a producer per tree, and holding several index roots at once
+  (`go.mod` ×8 and `tsconfig.json` ×9 in one repository are the known real cases).
 - `conductor index` builds the first one (~14s here). After that `Regenerator`
   rebuilds whenever edits go quiet for 3s. It ignores gitignored paths — without
   that, `target/` churn would reset the quiescence timer forever and the index
   would never be rebuilt. That is why `FsEvent::Changed` carries a path.
+- Booting without an index does not wait for an edit: a load that finds nothing
+  calls `Regenerator::request`, and the status bar reports the result once.
+  Routine rebuilds stay silent. Note that `Lock::acquire` distinguishes "someone
+  else is generating" from "the directory is not there yet" — collapsing the two
+  made every first-ever `conductor index` answer `Busy`.
 - The index producers are external tools. sheaf's `tests/go_definition.rs` and
   `tests/ts_definition.rs` really launch `scip-go` / `npx` and **fail rather than
   skip** where they are absent. `#[ignore]`d tests need a real index; see
@@ -153,12 +163,51 @@ the UI thread, and `references_at` may fall through to a full tree walk (measure
 `hover_info::DefSite` is the seam: whoever resolved the position, the popup is
 built the same way, and a site the index found needs no tree-sitter definition at
 all (that absence is why hover used to stay silent on locals, fields and module
-names). The popup's header line is the **container** (`app::types::App`), built
-from the SCIP symbol by `semantic_index::container_path` — sheaf exposes the raw
-symbol string through `symbols_at`, deliberately outside `Definition` because it
-is not a claim about a location. The formatter returns `None` rather than guess
-on impl blocks, type parameters and locals, so it covers 99 of 217 `Exact`
-answers measured here.
+names).
+
+Its **declaration and kind** come from the index too, through `describe_at`.
+`SymbolInformation` carries both for every symbol rust-analyzer emits (measured:
+656 of 656 own-crate positions across three files), and the declaration is the
+producer's resolved type, not the source text — `let message: String` where the
+line reads `let message = who.greet();`. Scraping the definition line is the
+fallback, not the default. Two things make this harder than reading a field:
+
+- **`signature_documentation` is not what the scip crate says it is.** scip 0.9
+  generates a `Signature` with the text at field 2; rust-analyzer and scip-go both
+  write the older spelling, a `Document` with the text at field 5. Typed access
+  compiles and returns an empty string forever, so `store::signature_text` reads
+  both. **scip-typescript writes no `signature_documentation` at all** — its
+  declaration is a ```` ```ts ```` fence at `documentation[0]`, which
+  `store::fenced_declaration` lifts out (the remaining entries stay as doc).
+- **`kind`'s numbers are not the crate's.** The SCIP enum was renumbered, and the
+  producers' numbers do not line up with scip 0.9's (function is 17 there and 24
+  here). They do line up with **each other** — rust-analyzer and scip-go write the
+  same older numbering, verified against both indexes — so `store/kind.rs` is one
+  table with no tool name in it. Do not route these through `scip::types::Kind`,
+  and do not reintroduce a per-tool table: scip-typescript writes no `kind`, and a
+  table keyed on the tool would have silently answered `Unknown` for everything a
+  given tool had not been observed writing. Producers that omit `kind` fall to
+  `kind::from_declaration`, which reads the declaration's leading word (or
+  TypeScript's `(method)` / `(property)` prefix).
+
+The popup keeps one fixed shape so the reading order does not move per kind:
+container on the left of the header, kind on the right, declaration under it, doc
+under that, then the clickable location and "N refs". The container
+(`app::types::App`) arrives as `SymbolDetail.container` — sheaf-core builds it, so
+conductor never parses a SCIP symbol string. Three things it has to get right:
+
+- **A local has no spelling of its own.** `local 3` carries the enclosing function
+  in `SymbolInformation.enclosing_symbol` instead, and that is where the container
+  comes from. Adding it took the measured coverage from 99 to 193 of the `Exact`
+  answers in this repository — locals and parameters are most of the positions a
+  reader hovers.
+- **The separator comes from the file extension**, not the producer: `::` for
+  `.rs`, `.` for everything else.
+- **A backticked descriptor is a file for TypeScript and a generic type for
+  Rust.** ``src/`greet.tsx`/Loud#`` should drop the file (the popup shows the
+  location anyway); `` `Bridge<'a>`#`` must not be dropped, because the result
+  would name a different type. So it is dropped only in namespace position, and
+  anywhere else the formatter returns `None` rather than guess.
 
 Pressing a jump key **on** a definition shows its references instead. That test is
 `answer_points_at`: the index's own answer must name the position that was asked
@@ -166,10 +215,28 @@ about. It used to compare the top visible line against a tree-sitter name lookup
 with a ±2-line tolerance, which meant it never fired for fields or locals and
 misfired whenever the viewport had scrolled.
 
-Still on tree-sitter, deliberately: go-to-implementation (sheaf keeps
-`implements`/`implementers` internal and only counts implementers), and the
-symbol-action overlay (it shows definitions, implementations and references
-together, so it moves when implementations do).
+Go-to-implementation answers at two different strengths, and the variant says
+which. **rust-analyzer emits no SCIP `relationships` at all** (measured: 0 of
+22,434 `SymbolInformation` in this repository's index); scip-go and
+scip-typescript both do. Where they exist, the reverse of `implementers` *is* the
+answer and it comes back as `Implementations::Exact`. Where they do not, all that
+is left is the spelling of the symbols themselves: `impl#[Loud][Greeter]` names
+both sides, `store::impl_pair` reads the pair off it, and the answer is
+`Implementations::Derived`. The two are never mixed into one list — merging them
+would drag a producer-declared answer down to the weaker claim. Two consequences
+worth knowing before touching the derived path:
+
+- **The key is a bare spelling, not a symbol.** Two same-named traits in one
+  repository would merge. That is why the answer is not `Exact`.
+- **A generic impl has no block symbol.** `impl<'a> SyntacticLayer for Bridge<'a>`
+  puts nothing but its methods in the index, so the landing point is the earliest
+  definition under that `(trait, type, file)` — the `impl` line when the block
+  symbol exists, the first method inside it otherwise. Both land in the right
+  block; only the former lands on the right line.
+
+Still on tree-sitter, deliberately: the symbol-action overlay (it shows
+definitions, implementations and references together by name, so it moves when
+that overlay moves), and `gi` itself whenever the index stays silent.
 
 ## Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.111.0"
+version = "0.112.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/sheaf-core/src/lib.rs
+++ b/crates/sheaf-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use regenerate::{
     Outcome, Producer, Regenerator, RustAnalyzer, ScipGo, ScipTypescript, Target, generate_once,
     read_provenance, write_provenance,
 };
-pub use resolve::{definition_at, references_at, symbols_at};
+pub use resolve::{definition_at, describe_at, implementations_at, references_at};
 pub use store::{IndexSource, Slot, Store};
 pub use syntactic::{SyntacticAnswer, SyntacticLayer, Token};
 
@@ -181,6 +181,86 @@ pub struct ViaInterface {
     /// 1 なら、その参照が届く先はこの実装しかない。多いほど、この実装に届く見込みは薄い
     /// （実測で 51 実装が 1 箇所の呼び出しを共有している例がある）。
     pub implementations: u32,
+}
+
+/// trait / interface の実装先の答え。
+///
+/// producer によって根拠の強さが違うので variant を分けてある。scip-go と
+/// scip-typescript は SCIP の `relationships` に実装関係を書くので、それを
+/// そのまま返せる。rust-analyzer は 1 件も書かない (実測: このリポジトリの索引で
+/// SymbolInformation 22,434 件すべてが空) ので、符号の綴りから導出するしかない。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Implementations {
+    /// 索引が `relationships` に書いている実装先。0 件は「探したが無い」。
+    Exact(Vec<Implementation>),
+    /// 符号の綴りから導出した。0 件は「探したが無い」。
+    ///
+    /// 同名の trait がリポジトリに 2 つあると混ざる。飛び先は正しい impl ブロック
+    /// だが、その trait が聞かれたものと同じとは限らない。
+    Derived(Vec<Implementation>),
+    /// 索引が答えられない。索引が無い、聞かれたファイルが索引生成時と違う、
+    /// その位置に occurrence が無い、のいずれか。
+    ///
+    /// `Derived(vec![])` (探したが無い) とは別物として持つ。
+    Unknown,
+    /// その位置に識別子が無い。
+    NotCode,
+}
+
+/// trait を実装している impl ブロック 1 つ。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Implementation {
+    /// impl ブロックの位置。型の定義ではなく `impl X for T` の行を指す。
+    pub site: Location,
+    /// 実装している型の綴り。符号の断片であって完全な符号ではない。
+    pub ty: String,
+}
+
+/// 索引がそのシンボルについて書いている説明。
+///
+/// 位置についての主張ではないので [`Definition`] とは別の口にしてある。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolDetail {
+    pub symbol: SymbolId,
+    pub kind: SymbolKind,
+    /// その語を囲んでいるものの綴り (`app::types::App`)。組み立てられない形では None。
+    pub container: Option<String>,
+    /// 索引が書いた宣言 (`fn token_at(&self, path: &Path) -> Token`)。
+    /// 型は producer が解決したもので、ソースの字面ではない。
+    pub signature: Option<String>,
+    /// doc コメント。索引が持っていなければ空。
+    pub documentation: Vec<String>,
+}
+
+/// シンボルの種別。
+///
+/// 言語をまたいで名前が要るので、綴りは Rust に寄せていない。Go の interface と
+/// Rust の trait は分けてある — 実装を持てるかどうかが違い、ジャンプの意味も違う。
+/// 読み取れなかった種別は [`Unknown`](SymbolKind::Unknown) にする。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    AssociatedType,
+    Constant,
+    Enum,
+    EnumMember,
+    Class,
+    Field,
+    Function,
+    ImplBlock,
+    Interface,
+    Method,
+    Module,
+    Package,
+    Parameter,
+    SelfParameter,
+    Static,
+    Struct,
+    Trait,
+    TypeAlias,
+    TypeParameter,
+    Variable,
+    /// 索引が種別を書いていないか、書いた番号が表に無かった。
+    Unknown,
 }
 
 /// シンボルの識別子。中身の構造は後で決めるので、いまは SCIP のシンボル文字列を

--- a/crates/sheaf-core/src/regenerate.rs
+++ b/crates/sheaf-core/src/regenerate.rs
@@ -126,6 +126,21 @@ impl Regenerator {
         matches!(self.state, State::Pending { .. })
     }
 
+    /// 変更を待たずに 1 本作らせる。索引がまだ 1 本も無いときの口。
+    ///
+    /// 静穏時間は変更のときと同じに置く。組み込む側が起動直後にこれを呼ぶので、
+    /// すぐ始めると起動と生成 (実測 2.3GiB) が重なる。
+    ///
+    /// 走っている最中と、producer を起動できないと分かったあとは何もしない。
+    pub fn request(&mut self) {
+        if self.disabled || matches!(self.state, State::Running) {
+            return;
+        }
+        self.state = State::Pending {
+            last_change: Instant::now(),
+        };
+    }
+
     /// `root` のツリーの中でファイルが変わった。
     ///
     /// 索引に載らないファイルは数えない。ビルド成果物は数秒おきに書き換わるので、

--- a/crates/sheaf-core/src/regenerate/job.rs
+++ b/crates/sheaf-core/src/regenerate/job.rs
@@ -39,8 +39,14 @@ pub(super) struct Job {
 impl Job {
     pub(super) fn run(self) -> Outcome {
         let _lock = match Lock::acquire(&self.target.lock) {
-            Some(lock) => lock,
-            None => return Outcome::Busy,
+            Ok(Some(lock)) => lock,
+            Ok(None) => return Outcome::Busy,
+            Err(e) => {
+                return Outcome::Failed(format!(
+                    "ロックを置けない ({}): {e}",
+                    self.target.lock.display()
+                ));
+            }
         };
 
         // 索引の置き場所は、同じリポジトリを開いた別のプロセスと共有していることがある。
@@ -223,10 +229,18 @@ pub(super) struct Lock(std::fs::File);
 impl Lock {
     /// 取れなければ諦める。待たないのは、待っている間に対象のツリーが
     /// 変わってしまい、待った先で作るものが古くなるため。次の変更で作り直す。
-    pub(super) fn acquire(path: &Path) -> Option<Self> {
-        let file = std::fs::File::create(path).ok()?;
+    ///
+    /// **「ほかが持っている」と「置き場所が使えない」を分ける。** 混ぜると、
+    /// 置き場所のディレクトリがまだ無いだけのときに「ほかのプロセスが索引を
+    /// 作っている」と報告することになる (索引を一度も作っていないリポジトリが
+    /// まさにその状態で、`conductor index` が必ずそう答えていた)。
+    pub(super) fn acquire(path: &Path) -> std::io::Result<Option<Self>> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let file = std::fs::File::create(path)?;
         let fd = std::os::unix::io::AsRawFd::as_raw_fd(&file);
-        (unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } == 0).then_some(Lock(file))
+        Ok((unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } == 0).then_some(Lock(file)))
     }
 }
 

--- a/crates/sheaf-core/src/regenerate/tests.rs
+++ b/crates/sheaf-core/src/regenerate/tests.rs
@@ -210,7 +210,9 @@ fn ロックを取れなかったら待機に戻って編集を待たずにや�
     let mut regen = Regenerator::new(h.script(&format!("echo x >> {}", counter.display())));
     let target = h.target();
 
-    let held = Lock::acquire(&target.lock).expect("検査側がロックを取れない");
+    let held = Lock::acquire(&target.lock)
+        .expect("ロックを置けない")
+        .expect("検査側がロックを取れない");
 
     make_due(&mut regen, &h);
     let outcome = drive(&mut regen, &target);
@@ -658,4 +660,28 @@ fn 本物の_rust_analyzer_で_ready_に到達する() {
     );
     assert!(target.index.is_file());
     assert!(target.hashes.is_file());
+}
+
+#[test]
+fn 置き場所がまだ無いだけならビジーにしない() {
+    // 索引を一度も作っていないリポジトリは `.conductor/` を持たない。ここを
+    // ロックの取得失敗と同じ扱いにすると、初回の生成が必ず「ほかのプロセスが
+    // 索引を作っている」で終わる。
+    let h = Harness::new();
+    let counter = h.dir.path().join("runs");
+    let mut regen = Regenerator::new(h.script(&format!("echo x >> {}", counter.display())));
+    let mut target = h.target();
+    let fresh = h.dir.path().join("never-made/.conductor");
+    target.lock = fresh.join("generate.lock");
+    target.index = fresh.join("index.scip");
+    target.hashes = fresh.join("index.hashes");
+    target.log = fresh.join("index.log");
+
+    make_due(&mut regen, &h);
+    let outcome = drive(&mut regen, &target);
+    assert!(
+        !matches!(outcome, Outcome::Busy),
+        "置き場所が無いだけなのに Busy を返した"
+    );
+    assert!(counter.exists(), "producer が走っていない");
 }

--- a/crates/sheaf-core/src/resolve.rs
+++ b/crates/sheaf-core/src/resolve.rs
@@ -4,9 +4,9 @@
 //! インライン引数がそれで、実測でひとつも occurrence が無い一方、rust-analyzer は
 //! 同じ位置で定義を返す）。したがって切り替えの判定は位置ごとに行う。
 
-use crate::store::Resolved;
+use crate::store::{Implemented, Resolved};
 use crate::syntactic::{SyntacticAnswer, SyntacticLayer, Token};
-use crate::{Definition, References, Store, SymbolId};
+use crate::{Definition, Implementations, References, Store, SymbolDetail};
 use std::path::Path;
 
 /// その位置にある語の定義を答える。
@@ -32,24 +32,48 @@ pub fn definition_at(
     }
 }
 
-/// その位置の語が指しているシンボル。所属や綴りを見せるためのもので、
-/// どこにあるかの主張ではない。
+/// その位置の語について、索引が書いている説明。所属・種別・宣言を見せるための
+/// もので、どこにあるかの主張ではない。
 ///
 /// 索引が最新でない、その位置に occurrence が無い、識別子ではない、のいずれでも
-/// 空を返す。[`definition_at`] が [`Definition::Exact`] を返した位置でだけ使うこと —
+/// 空を返す。[`definition_at`] が [`Definition::Exact`] を返した位置でだけ使うこと --
 /// 構文層に落ちた答えの横に索引由来の綴りを並べると、出どころの違う 2 つが
 /// 1 つの説明に見える。
-pub fn symbols_at(
+pub fn describe_at(
     store: &Store,
     syntactic: &dyn SyntacticLayer,
     rel: &Path,
     line: u32,
     col: u32,
-) -> Vec<SymbolId> {
+) -> Vec<SymbolDetail> {
     let abs = store.root().join(rel);
     match syntactic.token_at(&abs, line, col) {
-        Token::Word(span) => store.symbols_in(rel, span).unwrap_or_default(),
+        Token::Word(span) => store.describe_in(rel, span).unwrap_or_default(),
         Token::NotWord | Token::Unknown => Vec::new(),
+    }
+}
+
+/// その位置の語が trait なら、それを実装している impl ブロック。
+///
+/// 索引が答えられなければ [`Implementations::Unknown`] を返す。ここだけは構文層に
+/// 落とさない -- 実装の探索は名前の一致で当てにいく作業で、位置から始まる問いの
+/// 答えとしては別物になる。落とすかどうかは呼び出し側が決める。
+pub fn implementations_at(
+    store: &Store,
+    syntactic: &dyn SyntacticLayer,
+    rel: &Path,
+    line: u32,
+    col: u32,
+) -> Implementations {
+    let abs = store.root().join(rel);
+    match syntactic.token_at(&abs, line, col) {
+        Token::NotWord => Implementations::NotCode,
+        Token::Word(span) => match store.implementations_in(rel, span) {
+            Some(Implemented::Declared(found)) => Implementations::Exact(found),
+            Some(Implemented::Derived(found)) => Implementations::Derived(found),
+            None => Implementations::Unknown,
+        },
+        Token::Unknown => Implementations::Unknown,
     }
 }
 

--- a/crates/sheaf-core/src/store.rs
+++ b/crates/sheaf-core/src/store.rs
@@ -4,8 +4,10 @@
 //! デコードしたまま持つと常駐がファイルの 7 倍になる。
 
 mod column;
+mod container;
 #[cfg(test)]
 mod fixture;
+mod kind;
 mod load;
 mod scip_split;
 mod slot;
@@ -17,16 +19,33 @@ pub use slot::Slot;
 
 use self::column::{Lines, contained_in, location_of, usable_range};
 use crate::{
-    Enclosing, Found, Location, Result, SheafError, Span, SymbolId, ViaInterface, blob_hash,
+    Enclosing, Found, Implementation, Location, Result, SheafError, Span, SymbolDetail, SymbolId,
+    ViaInterface, blob_hash,
 };
 use protobuf::Message;
-use scip::types::{Document, SymbolRole};
+use scip::types::{Document, SymbolInformation, SymbolRole};
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 /// 実装しているシンボル -> それが実装しているインタフェース側のシンボル。索引 1 本ぶん。
 type Implements = HashMap<Box<str>, Box<[Box<str>]>>;
+
+/// インタフェース側のシンボル -> それを実装しているシンボル。索引 1 本ぶん。
+type Implementers = HashMap<Box<str>, Box<[Box<str>]>>;
+
+/// trait の綴り -> その trait を実装している impl ブロック。索引 1 本ぶん。
+///
+/// 鍵が完全な符号ではなく綴りなのは、聞かれた位置から引けるようにするため。
+/// 同名の trait があると混ざるので、答えは `Derived` として返す。
+type TraitImpls = HashMap<Box<str>, Vec<Implementation>>;
+
+/// 実装先クエリに索引が返せるもの。索引が書いた関係と、符号の綴りからの導出は
+/// 強さが違うので分けて返す。
+pub(crate) enum Implemented {
+    Declared(Vec<Implementation>),
+    Derived(Vec<Implementation>),
+}
 
 /// 定義クエリに索引が返せるもの。
 pub(crate) enum Resolved {
@@ -58,6 +77,114 @@ fn enclosing_type(symbol: &str) -> Option<String> {
         return None;
     }
     Some(format!("{coordinate}{}{name}#", &descriptors[..at]))
+}
+
+/// 符号の中の型・trait の綴りを、照合できる形に均す。
+///
+/// rust-analyzer はジェネリックな綴りをバッククォートで括る (`` `Bridge<'a>` ``) ので、
+/// 括りを外して型引数の手前までを取る。impl 側と定義側で綴りが違うと、実装を
+/// 持つ trait が 1 件も引けなくなる。
+fn descriptor_name(spelled: &str) -> &str {
+    let plain = spelled.trim_matches('`');
+    match plain.split_once('<') {
+        Some((head, _)) => head,
+        None => plain,
+    }
+}
+
+/// 型を指す符号から、その型の綴りを取る。`syntactic/SyntacticLayer#` から
+/// `SyntacticLayer`。
+///
+/// trait かどうかはここでは判らない。struct の綴りで実装の表を引いても、表に
+/// 無いので空振りするだけで、誤った実装先は出ない。
+fn trait_name(symbol: &str) -> Option<&str> {
+    let descriptors = symbol.split(' ').nth(4)?;
+    let name = descriptors.strip_suffix('#')?;
+    let name = descriptor_name(name.rsplit(['/', '#']).next()?);
+    (!name.is_empty()).then_some(name)
+}
+
+/// 実装側の符号から、実装している型の綴りを取る。
+/// `demo/Loud#` から `Loud`、`demo/Loud#Greet().` から `Loud`。
+///
+/// 型を指す descriptor (`#` で終わる) のうち末尾のものを採る。無い符号は末尾の
+/// descriptor そのものを綴りとする。
+fn implementing_type(symbol: &str) -> Option<&str> {
+    let descriptors = symbol.split(' ').nth(4)?;
+    let mut last_type = None;
+    let mut start = 0;
+    for (at, c) in descriptors.char_indices() {
+        match c {
+            '#' => {
+                last_type = Some(&descriptors[start..at]);
+                start = at + 1;
+            }
+            '/' | '.' => start = at + 1,
+            _ => {}
+        }
+    }
+    let name = last_type.unwrap_or(&descriptors[start..]);
+    let name = descriptor_name(name.split('(').next().unwrap_or(name));
+    (!name.is_empty()).then_some(name)
+}
+
+/// impl の符号から (実装している型, 実装している trait) の綴りを取る。
+/// `.../impl#[Rough][SyntacticLayer]` から `("Rough", "SyntacticLayer")`。
+///
+/// **ブロック自身の符号だけでは足りない。** ジェネリックな impl は索引にブロックの
+/// 符号を持たず (`impl<'a> SyntacticLayer for Bridge<'a>` が実際にそう)、中の
+/// メソッドの符号しか出ない。だからメソッドの符号も同じ形として受ける。
+/// trait を実装していない impl は 2 つめの角括弧を持たないので None。
+fn impl_pair(symbol: &str) -> Option<(&str, &str)> {
+    let descriptors = symbol.split(' ').nth(4)?;
+    let at = descriptors.rfind("impl#[")?;
+    let (ty, rest) = descriptors[at + "impl#[".len()..].split_once(']')?;
+    let (implemented, _) = rest.strip_prefix('[')?.split_once(']')?;
+    let ty = ty.trim_matches('`');
+    let implemented = descriptor_name(implemented);
+    (!ty.is_empty() && !implemented.is_empty()).then_some((ty, implemented))
+}
+
+/// 宣言の本文。`SymbolInformation.signature_documentation` の中身。
+///
+/// **型付きで読むだけでは足りない。** scip crate が生成する `Signature` は本文を
+/// 2 番に置くが、rust-analyzer が書くのは旧仕様の `Document` で、本文は 5 番にある。
+/// フィールド番号が違うので `Signature::text` は必ず空文字列になり、実際の本文は
+/// 未知フィールドに落ちる。両方の綴りから読む。
+fn signature_text(signature: &scip::types::Signature) -> Option<String> {
+    const DOCUMENT_TEXT: u32 = 5;
+    if !signature.text.is_empty() {
+        return Some(signature.text.clone());
+    }
+    let unknown = signature.special_fields.unknown_fields();
+    let protobuf::UnknownValueRef::LengthDelimited(bytes) = unknown.get(DOCUMENT_TEXT)? else {
+        return None;
+    };
+    let text = String::from_utf8(bytes.to_vec()).ok()?;
+    (!text.is_empty()).then_some(text)
+}
+
+/// `documentation` の先頭に置かれた宣言と、残りの doc。
+///
+/// `signature_documentation` を書かない producer がある。scip-typescript は宣言を
+/// ```` ```ts ```` で括って `documentation` の先頭に入れるので、そこから取る。
+/// 括りが無ければ宣言ではないので、全部 doc のまま返す。
+fn fenced_declaration(documentation: &[String]) -> (Option<String>, Vec<String>) {
+    let Some(first) = documentation.first() else {
+        return (None, Vec::new());
+    };
+    let Some(body) = first
+        .strip_prefix("```")
+        .and_then(|rest| rest.split_once('\n'))
+        .and_then(|(_, body)| body.trim_end().strip_suffix("```"))
+    else {
+        return (None, documentation.to_vec());
+    };
+    let body = body.trim_end().to_string();
+    if body.is_empty() {
+        return (None, documentation.to_vec());
+    }
+    (Some(body), documentation[1..].to_vec())
 }
 
 struct DocEntry {
@@ -94,9 +221,15 @@ pub struct Store {
     /// 辿るのは上向き 1 ホップだけなので、逆向きの表は持たない
     /// （`docs/spec-interface-references.md`）。definitions と同じ理由で索引ごとに分ける。
     implements: Vec<Implements>,
-    /// インタフェース側のシンボル -> それを実装している型の数。
-    /// 参照が届く見込みを利用側が判断するのに要る。
-    implementers: Vec<HashMap<Box<str>, u32>>,
+    /// インタフェース側のシンボル -> それを実装しているシンボル。
+    /// 参照が届く見込み (数) と、実装先へのジャンプ (符号) の両方に要る。
+    implementers: Vec<Implementers>,
+    /// trait の綴り -> それを実装している impl ブロック。
+    ///
+    /// `implements` とは出どころが違う。あちらは索引が書いた `relationships` で、
+    /// こちらは impl ブロックの符号の綴りから導出したもの。rust-analyzer は
+    /// `relationships` を出さないので、Rust ではこちらだけが埋まる。
+    trait_impls: Vec<TraitImpls>,
     /// Document 番号からパスを引く表。references の値を照合先に戻すためだけに使う。
     doc_paths: Vec<PathBuf>,
     /// ルートの外を指していて投入しなかった Document の数。
@@ -188,12 +321,116 @@ impl Store {
         self.bytes.iter().map(Vec::len).sum::<usize>() + defs + refs + paths + doc_paths
     }
 
-    /// その位置の occurrence が指しているシンボル。
+    /// その位置の語について、索引が書いている説明。
     ///
-    /// 位置についての主張ではないので [`crate::Definition`] とは別の口にしてある。
-    /// 索引が最新でなければ None — 古い索引の綴りを最新のコードの説明として
+    /// [`symbols_in`](Self::symbols_in) と同じく位置の主張ではないので、鮮度の
+    /// 扱いも同じ。聞かれたファイルと、説明の出どころになった Document の両方が
+    /// 索引生成時のままでなければ答えない — 古い綴りを最新のコードの説明として
     /// 見せると、名前だけそれらしい別物になる。
-    pub(crate) fn symbols_in(&self, rel: &Path, span: Span) -> Option<Vec<SymbolId>> {
+    pub(crate) fn describe_in(&self, rel: &Path, span: Span) -> Option<Vec<SymbolDetail>> {
+        if !self.is_current(rel) {
+            return None;
+        }
+        let entry = self.docs.get(rel)?;
+        let doc = parse_document(&self.bytes[entry.index][entry.span.clone()]).ok()?;
+        let content = (entry.column_encoding != scip_split::ColumnEncoding::Utf8)
+            .then(|| std::fs::read(self.root.join(rel)))
+            .transpose()
+            .ok()?;
+        let lines = content.as_deref().map(Lines::of);
+        let at = InDocument {
+            doc: &doc,
+            rel,
+            encoding: entry.column_encoding,
+            lines: lines.as_ref(),
+        };
+
+        let mut out: Vec<SymbolDetail> = Vec::new();
+        for occ in &doc.occurrences {
+            let Some(range) = usable_range(&occ.range, entry.column_encoding, lines.as_ref())
+            else {
+                continue;
+            };
+            if !contained_in(&range, span) {
+                continue;
+            }
+            if out.iter().any(|d| d.symbol.as_str() == occ.symbol) {
+                continue;
+            }
+            out.push(self.detail_of(&occ.symbol, entry.index, &doc, &at));
+        }
+        Some(out)
+    }
+
+    /// その符号の説明を組み立てる。
+    ///
+    /// 説明はその符号の**定義がある Document** に載る。ローカル束縛は定義も参照も
+    /// 同じ Document なので、まず手元を見るだけで当たる。説明が見つからなくても
+    /// 符号は答えになる (何を指しているかは分かる) ので、中身が空のまま返す。
+    fn detail_of(
+        &self,
+        symbol: &str,
+        index: usize,
+        doc: &Document,
+        at: &InDocument<'_>,
+    ) -> SymbolDetail {
+        if let Some(info) = doc.symbols.iter().find(|i| i.symbol == symbol) {
+            return self.to_detail(info, at.rel);
+        }
+        for loc in self.definitions_of(symbol, index, at) {
+            if !self.is_current(&loc.path) {
+                continue;
+            }
+            let Some(entry) = self.docs.get(&loc.path) else {
+                continue;
+            };
+            let Ok(defining) = parse_document(&self.bytes[entry.index][entry.span.clone()]) else {
+                continue;
+            };
+            if let Some(info) = defining.symbols.iter().find(|i| i.symbol == symbol) {
+                return self.to_detail(info, &loc.path);
+            }
+        }
+        SymbolDetail {
+            symbol: SymbolId(symbol.into()),
+            kind: crate::SymbolKind::Unknown,
+            container: None,
+            signature: None,
+            documentation: Vec::new(),
+        }
+    }
+
+    fn to_detail(&self, info: &SymbolInformation, at: &Path) -> SymbolDetail {
+        let (signature, documentation) = match info
+            .signature_documentation
+            .as_ref()
+            .and_then(signature_text)
+        {
+            Some(text) => (Some(text), info.documentation.clone()),
+            None => fenced_declaration(&info.documentation),
+        };
+        let kind = match kind::of(info.kind.value(), &info.symbol) {
+            crate::SymbolKind::Unknown => signature
+                .as_deref()
+                .map_or(crate::SymbolKind::Unknown, kind::from_declaration),
+            known => known,
+        };
+        let enclosing = (!info.enclosing_symbol.is_empty()).then_some(&*info.enclosing_symbol);
+        SymbolDetail {
+            symbol: SymbolId(info.symbol.as_str().into()),
+            kind,
+            container: container::of(&info.symbol, enclosing, at),
+            signature,
+            documentation,
+        }
+    }
+
+    /// その位置の語が trait なら、それを実装している impl ブロック。
+    ///
+    /// 索引が最新でなければ None。飛び先の impl ブロックがあるファイルが変わって
+    /// いれば、その 1 件を落とすのではなく答えを丸ごと捨てる — 残りだけを返すと
+    /// 消えた実装があることが呼び出し側に見えない。
+    pub(crate) fn implementations_in(&self, rel: &Path, span: Span) -> Option<Implemented> {
         if !self.is_current(rel) {
             return None;
         }
@@ -205,7 +442,9 @@ impl Store {
             .ok()?;
         let lines = content.as_deref().map(Lines::of);
 
-        let mut out: Vec<SymbolId> = Vec::new();
+        let mut declared: Vec<Implementation> = Vec::new();
+        let mut derived: Vec<Implementation> = Vec::new();
+        let mut fresh = Freshness::starting_at(self, rel);
         for occ in &doc.occurrences {
             let Some(range) = usable_range(&occ.range, entry.column_encoding, lines.as_ref())
             else {
@@ -214,9 +453,66 @@ impl Store {
             if !contained_in(&range, span) {
                 continue;
             }
-            let id = SymbolId(occ.symbol.as_str().into());
-            if !out.contains(&id) {
-                out.push(id);
+            for found in self.declared_implementations(&occ.symbol, entry.index, &mut fresh)? {
+                if !declared.contains(&found) {
+                    declared.push(found);
+                }
+            }
+            let Some(name) = trait_name(&occ.symbol) else {
+                continue;
+            };
+            let Some(found) = self.trait_impls[entry.index].get(name) else {
+                continue;
+            };
+            for imp in found {
+                if !fresh.allows(&imp.site.path) {
+                    return None;
+                }
+                if !derived.contains(imp) {
+                    derived.push(imp.clone());
+                }
+            }
+        }
+        // 索引が書いた関係があるなら綴りからの導出は要らない。両方を混ぜると、
+        // 弱いほうに引きずられて答え全体が Derived になる。
+        let (mut out, declared) = if declared.is_empty() {
+            (derived, false)
+        } else {
+            (declared, true)
+        };
+        out.sort_by(|a, b| position_key(&a.site).cmp(&position_key(&b.site)));
+        Some(if declared {
+            Implemented::Declared(out)
+        } else {
+            Implemented::Derived(out)
+        })
+    }
+
+    /// 索引が `relationships` に書いている実装先。rust-analyzer は 1 件も書かないが、
+    /// scip-go と scip-typescript は書く。
+    fn declared_implementations(
+        &self,
+        symbol: &str,
+        index: usize,
+        fresh: &mut Freshness<'_>,
+    ) -> Option<Vec<Implementation>> {
+        let mut out = Vec::new();
+        for implementor in self.implementers[index].get(symbol).into_iter().flatten() {
+            let Some(ty) = implementing_type(implementor) else {
+                continue;
+            };
+            for site in self.definitions[index]
+                .get(&**implementor)
+                .into_iter()
+                .flatten()
+            {
+                if !fresh.allows(&site.path) {
+                    return None;
+                }
+                out.push(Implementation {
+                    site: site.clone(),
+                    ty: ty.to_string(),
+                });
             }
         }
         Some(out)
@@ -353,8 +649,7 @@ impl Store {
             for interface in self.interfaces_of(symbol, entry.index) {
                 let implementations = self.implementers[entry.index]
                     .get(interface)
-                    .copied()
-                    .unwrap_or(0);
+                    .map_or(0, |found| found.len() as u32);
                 for reference in self.references_of_symbol(interface, entry.index, &mut fresh)? {
                     if !fresh.allows(&reference.path) {
                         return None;

--- a/crates/sheaf-core/src/store/container.rs
+++ b/crates/sheaf-core/src/store/container.rs
@@ -1,0 +1,164 @@
+//! 符号から「それを囲んでいるもの」の綴りを組み立てる。
+//!
+//! 所属が分かると、ホバーが説明しているのがどの型のフィールドなのかが名前だけで
+//! 判る。組み立てられない形では None にする — 当てにいくと別物の名前を出す。
+
+/// `app/types/App#theme_sel.` から `app::types::App` を作る。
+///
+/// `enclosing` はローカル束縛のように符号そのものが綴りを持たないときに使う。
+/// そちらは「囲んでいるもの」がそのまま答えなので、末尾を落とさない。
+pub(crate) fn of(symbol: &str, enclosing: Option<&str>, path: &std::path::Path) -> Option<String> {
+    let sep = separator(path);
+    match parts(symbol) {
+        Some(mut parts) if parts.len() > 1 => {
+            parts.pop();
+            Some(parts.join(sep))
+        }
+        // 綴りを持つのに囲むものが無い (トップレベル) なら、囲みも無い。
+        Some(_) => None,
+        None => Some(parts(enclosing?)?.join(sep)),
+    }
+}
+
+/// Rust だけが `::` で、ほかは `.`。索引を作ったツールではなくソースの綴りで決める。
+fn separator(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rs") => "::",
+        _ => ".",
+    }
+}
+
+/// 符号の descriptor を 1 つずつに分ける。
+///
+/// 逆クォートで括られた名前空間は落とす。TypeScript はファイルを
+/// ``src/`greet.tsx`/`` という名前空間として符号に含めるが、位置はホバーが別に
+/// 出しているので綴りには要らない。名前空間以外の逆クォート (ジェネリックな
+/// 型の綴り) は落とすと別物になるので、そこでは組み立てを諦める。
+fn parts(symbol: &str) -> Option<Vec<String>> {
+    // シンボルは `<scheme> <manager> <package> <version> <descriptors>`。
+    let descriptors = symbol.split(' ').nth(4)?;
+    let mut parts = Vec::new();
+    let mut name = String::new();
+    let mut chars = descriptors.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // 逆クォートで括られた名前。中の区切りは字面なので、閉じまで読み切る。
+            '`' => {
+                let escaped: String = std::iter::from_fn(|| chars.next())
+                    .take_while(|&c| c != '`')
+                    .collect();
+                // 名前空間なら落とす。ほかの位置に来たものは落とすと別物になる。
+                if chars.peek() != Some(&'/') {
+                    return None;
+                }
+                chars.next();
+                let _ = escaped;
+            }
+            // 名前空間・型・項の区切り。ここまでが 1 つの descriptor。
+            '/' | '#' | '.' => {
+                if name.is_empty() {
+                    return None;
+                }
+                parts.push(std::mem::take(&mut name));
+            }
+            // 名前が確定していれば、メソッドの曖昧さ回避 `name(1).`。読み飛ばす。
+            // 確定していなければ引数の descriptor `(name)` で、括弧の中が名前。
+            '(' => {
+                let inner: String = std::iter::from_fn(|| chars.next())
+                    .take_while(|&c| c != ')')
+                    .collect();
+                if name.is_empty() {
+                    parts.push(inner);
+                }
+            }
+            // 型引数、マクロ、メタ。綴りを組み立てる規則を持っていない。
+            '[' | ']' | '!' | ':' => return None,
+            _ => name.push(c),
+        }
+    }
+    (!parts.is_empty()).then_some(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn rust(symbol: &str) -> Option<String> {
+        of(symbol, None, Path::new("a.rs"))
+    }
+
+    #[test]
+    fn 囲んでいる型と名前空間を綴る() {
+        assert_eq!(
+            rust("rust-analyzer cargo conductor 0.1.0 app/types/App#theme_sel."),
+            Some("app::types::App".to_string())
+        );
+        assert_eq!(
+            rust("rust-analyzer cargo conductor 0.1.0 app/types/App#"),
+            Some("app::types".to_string())
+        );
+        assert_eq!(
+            rust("rust-analyzer cargo conductor 0.1.0 app/App#set_focus()."),
+            Some("app::App".to_string())
+        );
+    }
+
+    #[test]
+    fn 綴りを持たない符号は囲んでいる符号から組み立てる() {
+        let encl = "rust-analyzer cargo conductor 0.1.0 app/types/App#theme_sel().";
+        assert_eq!(
+            of("local 3", Some(encl), Path::new("a.rs")),
+            Some("app::types::App::theme_sel".to_string())
+        );
+        assert_eq!(of("local 3", None, Path::new("a.rs")), None);
+    }
+
+    #[test]
+    fn 区切りは拡張子で決まる() {
+        assert_eq!(
+            of(
+                "scip-go gomod demo . demo/Loud#Greet().",
+                None,
+                Path::new("greet.go")
+            ),
+            Some("demo.Loud".to_string())
+        );
+    }
+
+    #[test]
+    fn 引数の所属は囲んでいる関数まで綴る() {
+        assert_eq!(
+            of(
+                "scip-typescript npm tsdemo 1.0.0 src/`greet.tsx`/run().(g)",
+                None,
+                Path::new("src/greet.tsx")
+            ),
+            Some("src.run".to_string())
+        );
+    }
+
+    #[test]
+    fn ファイルの名前空間は綴りに入れない() {
+        assert_eq!(
+            of(
+                "scip-typescript npm tsdemo 1.0.0 src/`greet.tsx`/Loud#greet().",
+                None,
+                Path::new("src/greet.tsx")
+            ),
+            Some("src.Loud".to_string())
+        );
+    }
+
+    #[test]
+    fn 組み立てられない綴りでは黙る() {
+        for symbol in [
+            "rust-analyzer cargo conductor 0.1.0 app/focus/impl#[Focus][Eq]eq().",
+            "rust-analyzer cargo conductor 0.1.0 ui/`PanelChrome<'a>`#draw().",
+            "rust-analyzer cargo conductor 0.1.0 macros/log!",
+            "local 3",
+        ] {
+            assert_eq!(rust(symbol), None, "{symbol}");
+        }
+    }
+}

--- a/crates/sheaf-core/src/store/kind.rs
+++ b/crates/sheaf-core/src/store/kind.rs
@@ -1,0 +1,165 @@
+//! `SymbolInformation.kind` の番号を意味に直す。
+//!
+//! 番号は scip crate が生成する enum とずれている。SCIP の Kind は途中で項目が
+//! 挿入されて番号が振り直されており、scip 0.9 では関数が 24 だが、索引に書いて
+//! あるのは 17 である。**これは producer の癖ではなく、producer が揃って古い
+//! 番号を書いている**ことによる (rust-analyzer と scip-go の索引を実際に読んで、
+//! 両方が同じ体系であることを確かめた)。だから表は 1 つでよく、ツール名で
+//! 分けない。載っていない番号は [`SymbolKind::Unknown`] にする — 当てにいって
+//! 別の名前を出すより黙るほうがよい。
+//!
+//! 番号を書かない producer もある (scip-typescript は `kind` も
+//! `signature_documentation` も出さず、宣言を `documentation` のコードブロックに
+//! 入れる)。そちらは [`from_declaration`] で宣言の綴りから読む。
+
+use crate::SymbolKind;
+
+/// 索引が書いた番号を種別に直す。
+///
+/// `symbol` も見るのは、型を指す番号が型別名と impl ブロックの両方に付くため
+/// (実測 109 件のうち 105 件が impl ブロック)。番号だけでは分けられない。
+pub(crate) fn of(raw: i32, symbol: &str) -> SymbolKind {
+    match raw {
+        3 => SymbolKind::AssociatedType,
+        8 => SymbolKind::Constant,
+        11 => SymbolKind::Enum,
+        12 => SymbolKind::EnumMember,
+        15 => SymbolKind::Field,
+        17 => SymbolKind::Function,
+        21 => SymbolKind::Interface,
+        // 26 は本体を持つメソッド、67 と 70 は interface / trait 側の宣言。
+        // 呼ぶ側から見れば同じものなので分けない。
+        26 | 67 | 70 => SymbolKind::Method,
+        29 => SymbolKind::Module,
+        35 => SymbolKind::Package,
+        37 => SymbolKind::Parameter,
+        44 => SymbolKind::SelfParameter,
+        49 => SymbolKind::Struct,
+        53 => SymbolKind::Trait,
+        55 if is_impl_block(symbol) => SymbolKind::ImplBlock,
+        55 => SymbolKind::TypeAlias,
+        58 => SymbolKind::TypeParameter,
+        61 => SymbolKind::Variable,
+        // self を取らない関連関数。呼び出し側から見れば関数なので分けない。
+        80 => SymbolKind::Function,
+        82 => SymbolKind::Static,
+        _ => SymbolKind::Unknown,
+    }
+}
+
+/// 宣言の綴りから種別を読む。番号を書かない producer 用。
+///
+/// scip-typescript が `documentation` に入れる宣言は TypeScript の quickinfo
+/// そのままで、`(method) greet(): string` のように種別が前置される。前置の無い
+/// ものは宣言の先頭語で判る。**先頭語だけを見る。** 綴りの途中に現れる語
+/// (`function` を返す型など) を拾うと、別の種別に化ける。
+pub(crate) fn from_declaration(declaration: &str) -> SymbolKind {
+    let head = declaration.trim_start();
+    // TypeScript の quickinfo は種別を括弧で前置する。
+    if let Some(rest) = head.strip_prefix('(') {
+        let (marker, _) = rest.split_once(')').unwrap_or((rest, ""));
+        return match marker {
+            "method" => SymbolKind::Method,
+            "property" => SymbolKind::Field,
+            "parameter" => SymbolKind::Parameter,
+            "local var" | "local function" => SymbolKind::Variable,
+            "getter" | "setter" => SymbolKind::Method,
+            "alias" => SymbolKind::TypeAlias,
+            "enum member" => SymbolKind::EnumMember,
+            _ => SymbolKind::Unknown,
+        };
+    }
+    match head.split_whitespace().next().unwrap_or("") {
+        "function" => SymbolKind::Function,
+        "class" => SymbolKind::Class,
+        "struct" => SymbolKind::Struct,
+        "interface" => SymbolKind::Interface,
+        "enum" => SymbolKind::Enum,
+        "type" => SymbolKind::TypeAlias,
+        "namespace" | "module" | "package" => SymbolKind::Module,
+        "const" => SymbolKind::Constant,
+        "var" | "let" => SymbolKind::Variable,
+        _ => SymbolKind::Unknown,
+    }
+}
+
+/// impl ブロックの符号か。`impl#[Rough][SyntacticLayer]` のように角括弧で終わる。
+/// 型別名は `store/Implements#` のように `#` で終わる。
+fn is_impl_block(symbol: &str) -> bool {
+    symbol.ends_with(']')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn 番号の表はproducerをまたいで同じ() {
+        // rust-analyzer と scip-go の実索引で確かめた対応。ツール名で分けると、
+        // 片方でしか観測していない番号がもう片方で黙って Unknown になる。
+        assert_eq!(of(17, "demo/Run()."), SymbolKind::Function);
+        assert_eq!(of(15, "demo/Loud#Volume."), SymbolKind::Field);
+        assert_eq!(of(61, "0"), SymbolKind::Variable);
+        // Go にしか出ないもの。
+        assert_eq!(of(21, "demo/Greeter#"), SymbolKind::Interface);
+        assert_eq!(of(35, "demo/"), SymbolKind::Package);
+        assert_eq!(of(67, "demo/Greeter#Greet."), SymbolKind::Method);
+    }
+
+    #[test]
+    fn 型を指す番号は符号で型別名とimplブロックに分かれる() {
+        assert_eq!(of(55, "store/Implements#"), SymbolKind::TypeAlias);
+        assert_eq!(
+            of(55, "worktree_ops/impl#[WorktreeManager][Default]"),
+            SymbolKind::ImplBlock
+        );
+    }
+
+    #[test]
+    fn 表に無い番号は種別なしとして読む() {
+        assert_eq!(of(9999, "x"), SymbolKind::Unknown);
+        assert_eq!(of(0, "x"), SymbolKind::Unknown);
+    }
+
+    #[test]
+    fn 番号を書かない索引は宣言の綴りから読む() {
+        // scip-typescript が実際に書く形。
+        assert_eq!(
+            from_declaration("(method) greet(): string"),
+            SymbolKind::Method
+        );
+        assert_eq!(
+            from_declaration("(property) volume: number"),
+            SymbolKind::Field
+        );
+        assert_eq!(
+            from_declaration("(parameter) g: Greeter"),
+            SymbolKind::Parameter
+        );
+        assert_eq!(from_declaration("interface Greeter"), SymbolKind::Interface);
+        assert_eq!(from_declaration("class Loud"), SymbolKind::Class);
+        assert_eq!(
+            from_declaration("function run(g: Greeter): number"),
+            SymbolKind::Function
+        );
+        assert_eq!(
+            from_declaration("var message: string"),
+            SymbolKind::Variable
+        );
+        assert_eq!(
+            from_declaration(r#"module "greet.tsx""#),
+            SymbolKind::Module
+        );
+    }
+
+    #[test]
+    fn 綴りの途中に現れる語は種別にしない() {
+        // 戻り値の型が function でも、その宣言はプロパティである。
+        assert_eq!(
+            from_declaration("(property) handler: function"),
+            SymbolKind::Field
+        );
+        assert_eq!(from_declaration(""), SymbolKind::Unknown);
+        assert_eq!(from_declaration("なにか"), SymbolKind::Unknown);
+    }
+}

--- a/crates/sheaf-core/src/store/load.rs
+++ b/crates/sheaf-core/src/store/load.rs
@@ -6,8 +6,14 @@
 
 use super::column::{Lines, location_of, usable_range};
 use super::scip_split::{self, Split};
-use super::{DocEntry, Implements, Store, is_definition, is_local, parse_document};
-use crate::Result;
+use super::{
+    DocEntry, Implementation, Implements, Store, TraitImpls, impl_pair, is_definition, is_local,
+    parse_document,
+};
+use crate::{Location, Result};
+
+/// (trait の綴り, 型の綴り, ファイル) -> いちばん上の定義位置。投入中だけ使う。
+type ImplSites = HashMap<(Box<str>, Box<str>, PathBuf), Location>;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -97,6 +103,10 @@ impl Store {
         let mut implements: Vec<Implements> = vec![HashMap::new(); sources.len()];
         let mut implementers: Vec<HashMap<Box<str>, HashSet<Box<str>>>> =
             vec![HashMap::new(); sources.len()];
+        // (trait の綴り, 型の綴り, ファイル) -> いちばん上の定義位置。
+        // ブロックの符号とメソッドの符号の両方が来るので、いちばん上を採ると
+        // ブロックがあれば impl の行に、無ければその中の最初のメソッドに落ちる。
+        let mut impl_sites: Vec<ImplSites> = vec![HashMap::new(); sources.len()];
         let mut doc_paths: Vec<PathBuf> = Vec::with_capacity(owners.len());
         let mut missing_provenance = 0;
         for (path, owner) in owners {
@@ -137,6 +147,19 @@ impl Store {
                     let Some(loc) = location_of(&range, &path) else {
                         continue;
                     };
+                    // rust-analyzer は relationships を出さないので、trait と実装の
+                    // 対応はこの符号の綴りからしか取れない。
+                    if let Some((ty, implemented)) = impl_pair(&occ.symbol) {
+                        let key = (implemented.into(), ty.into(), path.clone());
+                        impl_sites[index]
+                            .entry(key)
+                            .and_modify(|held| {
+                                if (loc.line, loc.col) < (held.line, held.col) {
+                                    *held = loc.clone();
+                                }
+                            })
+                            .or_insert_with(|| loc.clone());
+                    }
                     definitions[index]
                         .entry(occ.symbol.as_str().into())
                         .or_insert_with(Vec::new)
@@ -189,10 +212,26 @@ impl Store {
             definitions,
             references,
             implements,
-            // 実装の集合はここまでで確定するので、数だけ残して符号は捨てる。
             implementers: implementers
                 .into_iter()
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.len() as u32)).collect())
+                .map(|m| {
+                    m.into_iter()
+                        .map(|(k, v)| (k, v.into_iter().collect()))
+                        .collect()
+                })
+                .collect(),
+            trait_impls: impl_sites
+                .into_iter()
+                .map(|sites| {
+                    let mut out: TraitImpls = HashMap::new();
+                    for ((implemented, ty, _), site) in sites {
+                        out.entry(implemented).or_default().push(Implementation {
+                            site,
+                            ty: ty.into_string(),
+                        });
+                    }
+                    out
+                })
                 .collect(),
             doc_paths,
             outside_root,

--- a/crates/sheaf-core/tests/describe.rs
+++ b/crates/sheaf-core/tests/describe.rs
@@ -1,0 +1,593 @@
+//! 索引が書いている説明 (種別・宣言・doc・所属) と、実装先の検査。
+//!
+//! producer によって書きぶりが違うので、2 通りの索引を組み立てる。
+//! rust-analyzer の形 (種別の番号と `signature_documentation` を書き、
+//! `relationships` を書かない) と、scip-typescript の形 (種別も
+//! `signature_documentation` も書かず、宣言を `documentation` のコードブロックに
+//! 入れ、`relationships` を書く)。
+
+use protobuf::SpecialFields;
+use protobuf::{EnumOrUnknown, Message, MessageField};
+use scip::types::{
+    Document, Index, Metadata, Occurrence, Relationship, Signature, SymbolInformation,
+    TextEncoding, ToolInfo,
+};
+use sheaf_core::{
+    Implementations, IndexSource, Span, Store, SymbolKind, SyntacticAnswer, SyntacticLayer, Token,
+    describe_at, implementations_at,
+};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// `impl Rough for SyntacticLayer` の形と、自由関数を 1 つ持つソース。
+const SOURCE: &str = "\
+pub fn greet(name: &str) {}
+struct Rough;
+impl SyntacticLayer for Rough {}
+";
+
+const COORDINATE: &str = "rust-analyzer cargo demo 0.1.0 ";
+
+/// scip-typescript の形の索引を組み立てるソース。ファイルを名前空間として符号に
+/// 含める綴りなので、所属の組み立てもここで検査できる。
+const TS_SOURCE: &str = "\
+interface Greeter {}
+class Loud implements Greeter {}
+";
+
+const TS_COORDINATE: &str = "scip-typescript npm demo 1.0.0 src/`lib.tsx`/";
+
+fn ts_symbol(descriptors: &str) -> String {
+    format!("{TS_COORDINATE}{descriptors}")
+}
+
+fn symbol(descriptors: &str) -> String {
+    format!("{COORDINATE}{descriptors}")
+}
+
+/// 語の切り出しだけを持つ構文層。定義も参照も答えない。
+struct Words;
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+}
+
+impl SyntacticLayer for Words {
+    fn token_at(&self, path: &Path, line: u32, col: u32) -> Token {
+        let Ok(src) = std::fs::read(path) else {
+            return Token::Unknown;
+        };
+        let Some(text) = src.split(|b| *b == b'\n').nth(line as usize) else {
+            return Token::NotWord;
+        };
+        let col = col as usize;
+        if col >= text.len() || !is_word_byte(text[col]) {
+            return Token::NotWord;
+        }
+        let mut start = col;
+        while start > 0 && is_word_byte(text[start - 1]) {
+            start -= 1;
+        }
+        let mut end = col + 1;
+        while end < text.len() && is_word_byte(text[end]) {
+            end += 1;
+        }
+        Token::Word(Span {
+            start_line: line,
+            start_col: start as u32,
+            end_line: line,
+            end_col: end as u32,
+        })
+    }
+
+    fn definition_at(&self, _: &Path, _: u32, _: u32) -> SyntacticAnswer {
+        SyntacticAnswer::NotCode
+    }
+
+    fn references_at(&self, _: &Path, _: u32, _: u32) -> SyntacticAnswer {
+        SyntacticAnswer::NotCode
+    }
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "sheaf-describe-{}-{}-{:?}",
+        tag,
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    dir
+}
+
+fn occurrence(range: Vec<i32>, symbol: &str, roles: i32) -> Occurrence {
+    Occurrence {
+        range,
+        symbol: symbol.to_string(),
+        symbol_roles: roles,
+        ..Default::default()
+    }
+}
+
+/// rust-analyzer が書く形の宣言。
+///
+/// scip crate が生成する `Signature` は本文を 2 番に置くが、rust-analyzer が書くのは
+/// 旧仕様の `Document` で本文は 5 番にある。実索引に合わせてこちらを組み立てる
+/// (型付きの綴りで作ると、読めなくなっていることに検査が気づけない)。
+fn document_signature(text: &str) -> Signature {
+    let mut fields = SpecialFields::new();
+    fields
+        .mut_unknown_fields()
+        .add_length_delimited(5, text.as_bytes().to_vec());
+    Signature {
+        special_fields: fields,
+        ..Default::default()
+    }
+}
+
+/// 種別の番号と宣言を持つ SymbolInformation。番号は rust-analyzer が実際に書くもの。
+fn information(symbol: &str, kind: i32, signature: &str, doc: &[&str]) -> SymbolInformation {
+    SymbolInformation {
+        symbol: symbol.to_string(),
+        kind: EnumOrUnknown::from_i32(kind),
+        signature_documentation: MessageField::some(document_signature(signature)),
+        documentation: doc.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    }
+}
+
+/// 種別も宣言も書かず、宣言を doc のコードブロックに入れる形。scip-typescript がこれ。
+fn fenced(symbol: &str, declaration: &str, doc: &[&str]) -> SymbolInformation {
+    let mut documentation = vec![format!("```ts\n{declaration}\n```")];
+    documentation.extend(doc.iter().map(|s| s.to_string()));
+    SymbolInformation {
+        symbol: symbol.to_string(),
+        documentation,
+        ..Default::default()
+    }
+}
+
+fn implements(mut info: SymbolInformation, interface: &str) -> SymbolInformation {
+    info.relationships.push(Relationship {
+        symbol: interface.to_string(),
+        is_implementation: true,
+        ..Default::default()
+    });
+    info
+}
+
+/// 索引を 1 本書き出してルートとともに返す。`tool` が None ならツール名を名乗らない。
+fn build(tag: &str, tool: Option<&str>) -> (PathBuf, PathBuf) {
+    let root = workdir(tag);
+    std::fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
+
+    let greet = symbol("greet().");
+    let rough = symbol("Rough#");
+    let impl_block = symbol("impl#[Rough][SyntacticLayer]");
+
+    let doc = Document {
+        relative_path: "src/lib.rs".to_string(),
+        language: "rust".to_string(),
+        occurrences: vec![
+            // pub fn greet(name: &str) {}  -> greet は 7..12、name は 13..17
+            occurrence(vec![0, 7, 12], &greet, 1),
+            occurrence(vec![0, 13, 17], "local 0", 1),
+            // struct Rough;                -> Rough は 7..12
+            occurrence(vec![1, 7, 12], &rough, 1),
+            // impl SyntacticLayer for Rough {} -> impl ブロックの定義は行頭から
+            occurrence(vec![2, 0, 4], &impl_block, 1),
+            // 同じ行の SyntacticLayer は trait への参照 -> 5..19
+            occurrence(vec![2, 5, 19], &symbol("SyntacticLayer#"), 0),
+        ],
+        symbols: vec![
+            information(
+                &greet,
+                17,
+                "pub fn greet(name: &str)",
+                &["名前を呼ぶ。", "2 行目。"],
+            ),
+            SymbolInformation {
+                enclosing_symbol: greet.clone(),
+                ..information("local 0", 37, "name: &str", &[])
+            },
+            information(&rough, 49, "struct Rough", &[]),
+            information(&impl_block, 55, "struct Rough", &[]),
+        ],
+        ..Default::default()
+    };
+    let index = Index {
+        metadata: MessageField::some(Metadata {
+            project_root: format!("file://{}", root.display()),
+            text_document_encoding: EnumOrUnknown::from(TextEncoding::UTF8),
+            tool_info: tool.map_or(MessageField::none(), |name| {
+                MessageField::some(ToolInfo {
+                    name: name.to_string(),
+                    ..Default::default()
+                })
+            }),
+            ..Default::default()
+        }),
+        documents: vec![doc],
+        ..Default::default()
+    };
+
+    let index_path = root.join("index.scip");
+    std::fs::write(&index_path, index.write_to_bytes().unwrap()).unwrap();
+    (index_path, root)
+}
+
+fn load(index_path: &Path, root: &Path) -> Store {
+    let bytes = std::fs::read(root.join("src/lib.rs")).unwrap();
+    let expected = HashMap::from([(PathBuf::from("src/lib.rs"), sheaf_core::blob_hash(&bytes))]);
+    Store::load(
+        &[IndexSource {
+            index: index_path.to_path_buf(),
+            subroot: PathBuf::new(),
+            expected,
+        }],
+        root,
+    )
+    .unwrap()
+}
+
+#[test]
+fn 索引が書いた宣言と種別を答える() {
+    let (index_path, root) = build("signature", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 0, 8);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].kind, SymbolKind::Function);
+    assert_eq!(
+        found[0].signature.as_deref(),
+        Some("pub fn greet(name: &str)")
+    );
+    assert_eq!(found[0].documentation, vec!["名前を呼ぶ。", "2 行目。"]);
+}
+
+#[test]
+fn 番号の意味はツール名に依らない() {
+    // 番号の体系は producer をまたいで同じ (rust-analyzer と scip-go の実索引で
+    // 確認済み)。ツール名で表を切り替えると、名乗らない索引で全部が種別なしになる。
+    let (index_path, root) = build("no-tool", None);
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 0, 8);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].kind, SymbolKind::Function);
+}
+
+#[test]
+fn ローカル束縛の所属は囲んでいる符号から出す() {
+    // ローカルの符号は `local 0` で、綴りを持たない。囲んでいる符号を見ないと
+    // どの関数の引数なのかがホバーから消える。
+    let (index_path, root) = build("enclosing", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 0, 14);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].kind, SymbolKind::Parameter);
+    assert_eq!(found[0].container.as_deref(), Some("greet"));
+}
+
+#[test]
+fn 型を指す番号は_impl_ブロックと型別名に分かれる() {
+    let (index_path, root) = build("impl-kind", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 2, 1);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].kind, SymbolKind::ImplBlock);
+}
+
+#[test]
+fn 説明の無い符号でも符号自身は答えになる() {
+    // SymbolInformation を持たない符号 (SyntacticLayer 自身の定義は別クレート)
+    // でも、何を指しているかは答えられる。所属の綴りを組み立てるのに要る。
+    let (index_path, root) = build("bare", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 2, 8);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].symbol.as_str(), symbol("SyntacticLayer#"));
+    assert_eq!(found[0].kind, SymbolKind::Unknown);
+    assert_eq!(found[0].signature, None);
+}
+
+#[test]
+fn 索引が古ければ説明を出さない() {
+    let (index_path, root) = build("stale", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+    std::fs::write(root.join("src/lib.rs"), format!("// 追記\n{SOURCE}")).unwrap();
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 0, 8);
+    assert!(found.is_empty(), "{found:?}");
+}
+
+#[test]
+fn trait_の位置から実装している_impl_ブロックに届く() {
+    let (index_path, root) = build("impls", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let answer = implementations_at(&store, &Words, Path::new("src/lib.rs"), 2, 8);
+    let Implementations::Derived(found) = answer else {
+        panic!("{answer:?}");
+    };
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].ty, "Rough");
+    assert_eq!(found[0].site.line, 2);
+    assert_eq!(found[0].site.col, 0);
+}
+
+#[test]
+fn 実装を持たない語は探した結果として_0_件を返す() {
+    // 「索引が答えられない」(Unknown) と「探したが無い」(Derived が空) は別物。
+    let (index_path, root) = build("none", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    let answer = implementations_at(&store, &Words, Path::new("src/lib.rs"), 0, 8);
+    assert_eq!(answer, Implementations::Derived(Vec::new()), "{answer:?}");
+}
+
+#[test]
+fn 識別子でない位置と索引が古い位置は区別される() {
+    let (index_path, root) = build("notcode", Some("rust-analyzer"));
+    let store = load(&index_path, &root);
+
+    // 行頭の空白でも記号でもよい。ここでは 1 行目の空白位置。
+    let space = implementations_at(&store, &Words, Path::new("src/lib.rs"), 0, 3);
+    assert_eq!(space, Implementations::NotCode, "{space:?}");
+
+    std::fs::write(root.join("src/lib.rs"), format!("// 追記\n{SOURCE}")).unwrap();
+    let stale = implementations_at(&store, &Words, Path::new("src/lib.rs"), 2, 8);
+    assert_eq!(stale, Implementations::Unknown, "{stale:?}");
+}
+
+#[test]
+fn 新しい綴りの宣言も読める() {
+    // scip の現行仕様どおり Signature.text に本文を置く producer もあり得る。
+    // 旧仕様への対応が新仕様を潰していないことを見る。
+    let root = workdir("new-signature");
+    std::fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
+    let greet = symbol("greet().");
+    let index = Index {
+        metadata: MessageField::some(Metadata {
+            project_root: format!("file://{}", root.display()),
+            text_document_encoding: EnumOrUnknown::from(TextEncoding::UTF8),
+            tool_info: MessageField::some(ToolInfo {
+                name: "rust-analyzer".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        documents: vec![Document {
+            relative_path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            occurrences: vec![occurrence(vec![0, 7, 12], &greet, 1)],
+            symbols: vec![SymbolInformation {
+                symbol: greet.clone(),
+                kind: EnumOrUnknown::from_i32(17),
+                signature_documentation: MessageField::some(Signature {
+                    text: "pub fn greet(name: &str)".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let index_path = root.join("index.scip");
+    std::fs::write(&index_path, index.write_to_bytes().unwrap()).unwrap();
+    let store = load(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.rs"), 0, 8);
+    assert_eq!(
+        found[0].signature.as_deref(),
+        Some("pub fn greet(name: &str)")
+    );
+}
+
+// ここから先は実索引が要る。SHEAF_TEST_INDEX と SHEAF_TEST_ROOT で場所を渡す。
+//   cargo test -p sheaf-core --test describe -- --ignored
+
+fn real_store() -> (Store, PathBuf) {
+    let index =
+        std::env::var("SHEAF_TEST_INDEX").expect("SHEAF_TEST_INDEX に .scip のパスを渡すこと");
+    let root =
+        std::env::var("SHEAF_TEST_ROOT").expect("SHEAF_TEST_ROOT にソースツリーのルートを渡すこと");
+    let index = PathBuf::from(index);
+    let root = PathBuf::from(root);
+    let expected = sheaf_core::read_provenance(
+        &index.with_file_name("index.hashes"),
+        &sheaf_core::RustAnalyzer,
+    )
+    .expect("index.hashes が要る");
+    let store = Store::load(
+        &[IndexSource {
+            index,
+            subroot: PathBuf::new(),
+            expected,
+        }],
+        &root,
+    )
+    .unwrap();
+    (store, root)
+}
+
+/// ソースの `line_1` 行目にある `needle` の位置で答えを引く。行がずれていたら失敗させる。
+fn at<T>(
+    root: &Path,
+    rel: &str,
+    line_1: usize,
+    needle: &str,
+    query: impl Fn(&Path, u32, u32) -> T,
+) -> T {
+    let src = std::fs::read_to_string(root.join(rel)).unwrap();
+    let line = src.lines().nth(line_1 - 1).expect("行が無い");
+    let col = line
+        .find(needle)
+        .unwrap_or_else(|| panic!("{rel}:{line_1} に {needle} が無い: {line}"));
+    query(Path::new(rel), line_1 as u32 - 1, col as u32)
+}
+
+#[test]
+#[ignore = "実索引が要る"]
+fn 実索引_宣言と種別が読める() {
+    let (store, root) = real_store();
+    let rel = "src/hover_info.rs";
+
+    // 定数の宣言。索引が書いた型が出る。
+    let found = at(&root, rel, 13, "MAX_SIGNATURE_LINES", |p, l, c| {
+        describe_at(&store, &Words, p, l, c)
+    });
+    assert!(!found.is_empty(), "索引が答えていない (索引が古い?)");
+    assert_eq!(found[0].kind, SymbolKind::Constant, "{found:?}");
+    assert_eq!(
+        found[0].signature.as_deref(),
+        Some("const MAX_SIGNATURE_LINES: usize"),
+        "宣言が読めていない。Signature の綴り違いを疑うこと"
+    );
+}
+
+#[test]
+#[ignore = "実索引が要る"]
+fn 実索引_ローカル束縛の推論後の型が出る() {
+    // tree-sitter は名前でも引けず、字面には型が書かれていない位置。索引に
+    // 推論結果があることがこの機能の一番の効きどころなので、実索引で押さえる。
+    let (store, root) = real_store();
+    let found = at(&root, "src/hover_info.rs", 89, "source", |p, l, c| {
+        describe_at(&store, &Words, p, l, c)
+    });
+    let signature = found
+        .iter()
+        .find_map(|d| d.signature.as_deref())
+        .expect("宣言が引けない");
+    assert!(
+        signature.starts_with("let source: ") && signature.contains("String"),
+        "推論後の型が出ていない: {signature}"
+    );
+}
+
+#[test]
+#[ignore = "実索引が要る"]
+fn 実索引_trait_から実装先が引ける() {
+    let (store, root) = real_store();
+    // sheaf の SyntacticLayer を conductor 側で実装しているのは Bridge。
+    let answer = at(
+        &root,
+        "src/semantic_index/bridge.rs",
+        65,
+        "SyntacticLayer",
+        |p, l, c| implementations_at(&store, &Words, p, l, c),
+    );
+    let Implementations::Derived(found) = &answer else {
+        panic!("{answer:?}");
+    };
+    // 綴りはバッククォートを外した実物。型引数は落とさない (どの実装かの区別に要る)。
+    let bridge = found
+        .iter()
+        .find(|i| i.ty == "Bridge<'a>")
+        .unwrap_or_else(|| panic!("Bridge への実装が出ない: {found:?}"));
+    assert_eq!(bridge.site.path, Path::new("src/semantic_index/bridge.rs"));
+
+    // ジェネリックな impl は索引にブロックの符号が無いので、着地はその中の
+    // 最初のメソッドになる。impl の行そのものではないが、同じブロックの中に入る。
+    let src = std::fs::read_to_string(root.join(&bridge.site.path)).unwrap();
+    let landed = src.lines().nth(bridge.site.line as usize).unwrap();
+    assert!(landed.contains("fn token_at"), "着地点が動いた: {landed}");
+
+    // 同名の trait を 1 つも持たないので、実装の数は手書きのものと一致する。
+    assert!(found.len() >= 2, "テスト側の実装も出るはず: {found:?}");
+}
+
+/// scip-typescript の形の索引を 1 本書き出す。
+fn build_fenced() -> (PathBuf, PathBuf) {
+    let root = workdir("fenced");
+    std::fs::write(root.join("src/lib.tsx"), TS_SOURCE).unwrap();
+
+    let greeter = ts_symbol("Greeter#");
+    let loud = ts_symbol("Loud#");
+
+    let doc = Document {
+        relative_path: "src/lib.tsx".to_string(),
+        occurrences: vec![
+            // interface Greeter {}            -> Greeter は 10..17
+            occurrence(vec![0, 10, 17], &greeter, 1),
+            // class Loud implements Greeter {} -> Loud は 6..10、Greeter は 22..29
+            occurrence(vec![1, 6, 10], &loud, 1),
+            occurrence(vec![1, 22, 29], &greeter, 0),
+        ],
+        symbols: vec![
+            fenced(&greeter, "interface Greeter", &["挨拶できるもの。"]),
+            implements(fenced(&loud, "class Loud", &[]), &greeter),
+        ],
+        ..Default::default()
+    };
+    let index = Index {
+        metadata: MessageField::some(Metadata {
+            project_root: format!("file://{}", root.display()),
+            text_document_encoding: EnumOrUnknown::from(TextEncoding::UTF8),
+            ..Default::default()
+        }),
+        documents: vec![doc],
+        ..Default::default()
+    };
+
+    let index_path = root.join("index.scip");
+    std::fs::write(&index_path, index.write_to_bytes().unwrap()).unwrap();
+    (index_path, root)
+}
+
+fn load_ts(index_path: &Path, root: &Path) -> Store {
+    let bytes = std::fs::read(root.join("src/lib.tsx")).unwrap();
+    let expected = HashMap::from([(PathBuf::from("src/lib.tsx"), sheaf_core::blob_hash(&bytes))]);
+    Store::load(
+        &[IndexSource {
+            index: index_path.to_path_buf(),
+            subroot: PathBuf::new(),
+            expected,
+        }],
+        root,
+    )
+    .unwrap()
+}
+
+#[test]
+fn 宣言をコードブロックに入れる索引からも種別と宣言を出す() {
+    let (index_path, root) = build_fenced();
+    let store = load_ts(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.tsx"), 0, 12);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].signature.as_deref(), Some("interface Greeter"));
+    // 番号が無いので、種別は宣言の綴りから読む。
+    assert_eq!(found[0].kind, SymbolKind::Interface);
+    // 宣言に使ったぶんは doc から抜く。
+    assert_eq!(found[0].documentation, vec!["挨拶できるもの。"]);
+}
+
+#[test]
+fn ファイルの名前空間は所属の綴りに入れない() {
+    let (index_path, root) = build_fenced();
+    let store = load_ts(&index_path, &root);
+
+    let found = describe_at(&store, &Words, Path::new("src/lib.tsx"), 1, 7);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].container.as_deref(), Some("src"));
+}
+
+#[test]
+fn 索引が関係を書いていれば実装先はそのまま答えになる() {
+    let (index_path, root) = build_fenced();
+    let store = load_ts(&index_path, &root);
+
+    let found = implementations_at(&store, &Words, Path::new("src/lib.tsx"), 0, 12);
+    let Implementations::Exact(found) = found else {
+        panic!("索引の relationships から答えていない: {found:?}");
+    };
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].ty, "Loud");
+    assert_eq!((found[0].site.line, found[0].site.col), (1, 6));
+}

--- a/src/app/code_nav.rs
+++ b/src/app/code_nav.rs
@@ -39,6 +39,44 @@ impl AnsweredBy {
     }
 }
 
+/// 索引の宣言をポップアップに載せる最大行数。超えたら … で切り詰める。
+/// 索引の宣言は where 節を畳まずに書くので、長いものは実際に長い。
+const MAX_INDEX_SIGNATURE_LINES: usize = 8;
+
+/// 索引が答えた説明を、ホバーが受け取る形にする。
+///
+/// 同じ位置に複数の符号が乗ることがある (`Struct { file_path }` の省略記法だと
+/// フィールドとローカル束縛の両方) ので、説明を持っているものを先に採る。
+fn indexed_detail(described: &[sheaf_core::SymbolDetail]) -> crate::hover_info::IndexedDetail {
+    let detail = described
+        .iter()
+        .find(|d| d.signature.is_some())
+        .or_else(|| described.first());
+    let Some(detail) = detail else {
+        return Default::default();
+    };
+    let mut signature_lines: Vec<String> = detail
+        .signature
+        .iter()
+        .flat_map(|s| s.lines())
+        .map(str::to_string)
+        .collect();
+    if signature_lines.len() > MAX_INDEX_SIGNATURE_LINES {
+        signature_lines.truncate(MAX_INDEX_SIGNATURE_LINES);
+        signature_lines.push("…".to_string());
+    }
+    crate::hover_info::IndexedDetail {
+        kind: crate::semantic_index::kind_label(detail.kind).to_string(),
+        signature_lines,
+        doc_lines: detail
+            .documentation
+            .iter()
+            .flat_map(|d| d.lines())
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
 /// 意味索引への 1 回の問い合わせに要るもの。タブ展開前の座標で持つ。
 struct SemanticSite {
     rel: std::path::PathBuf,
@@ -57,8 +95,11 @@ impl App {
     /// 索引が答えた位置は gd の飛び先と同じなので、両者の説明がずれない。
     fn hover_info_at(&self, symbol: &str, line_1: usize, start_col: usize) -> Option<HoverInfo> {
         let current_file = self.viewer_state.content.current_file.clone();
+        // 索引への問い合わせは 1 回にまとめる。所属と説明で別々に聞くと、同じ位置に
+        // 2 回 Document をデコードすることになる。
+        let described = self.semantic_description(line_1, start_col);
         let site = self
-            .semantic_def_site(symbol, line_1, start_col)
+            .semantic_def_site(line_1, start_col, described.as_deref())
             .or_else(|| {
                 crate::hover_info::resolve_def_site(
                     &self.code_nav.index,
@@ -70,17 +111,36 @@ impl App {
             Some(site.file_path.as_str()) == current_file.as_deref() && site.line == line_1;
         let mut info = crate::hover_info::build_hover_info(&self.code_nav.index, symbol, site)?;
         info.on_definition_line = same_line;
-        info.container = self.semantic_container(line_1, start_col);
+        info.container = described
+            .as_ref()
+            .and_then(|d| d.iter().find_map(|s| s.container.clone()));
         Some(info)
+    }
+
+    /// 意味索引に、その位置の語について書いてあることを聞く。
+    fn semantic_description(
+        &self,
+        line_1: usize,
+        start_col: usize,
+    ) -> Option<Vec<sheaf_core::SymbolDetail>> {
+        let tree_root = self.selected_worktree_path();
+        let store = self.code_nav.semantic.store(&tree_root)?;
+        let line_idx = line_1.checked_sub(1)?;
+        let occurrence = self.occurrence_at_rendered_column(line_idx, start_col)?;
+        let site = self.semantic_site(&tree_root, line_idx, occurrence)?;
+        let bridge = self.bridge(&site);
+        Some(sheaf_core::describe_at(
+            store, &bridge, &site.rel, site.line, site.col,
+        ))
     }
 
     /// 意味索引に定義位置を聞く。Exact のときだけ採る -- Enclosing は「囲んでいる
     /// 型の定義」であって、聞かれた語の定義ではない。
     fn semantic_def_site(
         &self,
-        symbol: &str,
         line_1: usize,
         start_col: usize,
+        described: Option<&[sheaf_core::SymbolDetail]>,
     ) -> Option<crate::hover_info::DefSite> {
         let line_idx = line_1.checked_sub(1)?;
         let occurrence = self.occurrence_at_rendered_column(line_idx, start_col)?;
@@ -88,39 +148,14 @@ impl App {
             return None;
         };
         let first = locations.first()?;
-        let file_path = first.path.to_string_lossy().into_owned();
-        let line = first.line as usize + 1;
         Some(crate::hover_info::DefSite {
-            kind: self.definition_kind_at(symbol, &file_path, line),
-            file_path,
-            line,
+            file_path: first.path.to_string_lossy().into_owned(),
+            line: first.line as usize + 1,
+            // 索引が種別を答えるので、tree-sitter から借りるのはもうやめている。
+            kind: String::new(),
             def_count: locations.len(),
+            detail: described.map(indexed_detail),
         })
-    }
-
-    /// その位置の語を囲んでいるものの綴り。索引が答えられなければ None。
-    fn semantic_container(&self, line_1: usize, start_col: usize) -> Option<String> {
-        let tree_root = self.selected_worktree_path();
-        let store = self.code_nav.semantic.store(&tree_root)?;
-        let line_idx = line_1.checked_sub(1)?;
-        let occurrence = self.occurrence_at_rendered_column(line_idx, start_col)?;
-        let site = self.semantic_site(&tree_root, line_idx, occurrence)?;
-        let bridge = self.bridge(&site);
-        sheaf_core::symbols_at(store, &bridge, &site.rel, site.line, site.col)
-            .iter()
-            .find_map(|id| crate::semantic_index::container_path(id.as_str()))
-    }
-
-    /// 索引が返した位置に tree-sitter の定義が重なっていれば、その種別を借りる。
-    /// 見つからなくても答えは変わらず、種別の見出しが付かないだけ。
-    fn definition_kind_at(&self, symbol: &str, file_path: &str, line: usize) -> String {
-        self.code_nav
-            .index
-            .find_definitions(symbol)
-            .iter()
-            .find(|d| d.file_path == file_path && d.line == line)
-            .map(|d| format!("{:?}", d.kind))
-            .unwrap_or_default()
     }
 
     /// ビューアのカーソル行から選んだシンボルについて、ホバー情報のポップアップを
@@ -787,10 +822,7 @@ impl App {
 
     /// 一覧のポップアップを開き直す。
     fn show_reference_list(&mut self, title: String, results: Vec<crate::symbol_index::Reference>) {
-        self.code_nav.references.show(
-            title,
-            results,
-        );
+        self.code_nav.references.show(title, results);
     }
 
     /// 意味索引が返した定義を画面に反映する。
@@ -1071,6 +1103,23 @@ impl App {
         let site = self.semantic_site(&tree_root, line_idx, occurrence)?;
         let bridge = self.bridge(&site);
         Some(sheaf_core::references_at(
+            store, &bridge, &site.rel, site.line, site.col,
+        ))
+    }
+
+    /// 意味索引に、その位置の trait を実装しているものを聞く。返り値の読み方は
+    /// [`Self::semantic_definition`] と同じだが、こちらは構文層に落ちない
+    /// ([`sheaf_core::Implementations::Unknown`] が「索引が答えられない」)。
+    pub fn semantic_implementations(
+        &self,
+        line_idx: usize,
+        occurrence: usize,
+    ) -> Option<sheaf_core::Implementations> {
+        let tree_root = self.selected_worktree_path();
+        let store = self.code_nav.semantic.store(&tree_root)?;
+        let site = self.semantic_site(&tree_root, line_idx, occurrence)?;
+        let bridge = self.bridge(&site);
+        Some(sheaf_core::implementations_at(
             store, &bridge, &site.rel, site.line, site.col,
         ))
     }
@@ -1716,10 +1765,7 @@ pub struct Building {
         let src = "fn f() {\n    let value = 1; // build the index\n}\n";
         let mask = crate::symbol_index::CodeMask::compute(src, "lib.rs");
         let line = src.lines().nth(1).unwrap();
-        assert_eq!(
-            first_candidate(line, 2, &mask),
-            Some("value".to_string())
-        );
+        assert_eq!(first_candidate(line, 2, &mask), Some("value".to_string()));
 
         // 文字列リテラルも同様にその中身を隠す。
         let src = "fn f() {\n    let s = \"index\";\n}\n";

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -158,6 +158,11 @@ impl App {
                 self.start_semantic_index_load();
             } else if let Some(n) = documents {
                 log::info!("Semantic index loaded: {n} documents");
+            } else {
+                // 索引がまだ無い。作らせないと、何か編集するまで作り直しの
+                // 引き金が引かれないまま構文層に落ち続ける。
+                self.code_nav.semantic.request_build();
+                log::info!("No semantic index yet; requested a build");
             }
         }
 

--- a/src/event/viewer/code_nav.rs
+++ b/src/event/viewer/code_nav.rs
@@ -46,8 +46,7 @@ pub(in crate::event) fn run(
         HintAction::Definition => {
             go_to_definition_at(app, line_idx, occurrence, symbol, source_screen_row)
         }
-        // 実装ジャンプは索引に問い合わせ口が無いので位置を使わない。
-        HintAction::Implementation => go_to_implementation_at(app, symbol),
+        HintAction::Implementation => go_to_implementation_at(app, line_idx, occurrence, symbol),
         HintAction::References => find_references_at(app, line_idx, occurrence, symbol),
         HintAction::Hover => app.show_hover_info_at(line_idx, symbol),
     }
@@ -138,7 +137,18 @@ fn go_to_definition_at(
     }
 }
 
-fn go_to_implementation_at(app: &mut App, symbol: &str) {
+fn go_to_implementation_at(app: &mut App, line_idx: usize, occurrence: usize, symbol: &str) {
+    // 索引が答えるのは「この trait を実装しているもの」で、名前の一致ではない。
+    // 索引が黙ったときだけ下の名前ベースの経路へ落ちる。
+    if let Some(
+        sheaf_core::Implementations::Exact(impls) | sheaf_core::Implementations::Derived(impls),
+    ) = app.semantic_implementations(line_idx, occurrence)
+        && !impls.is_empty()
+    {
+        apply_semantic_implementations(app, symbol, impls);
+        return;
+    }
+
     if !app.code_nav.index.is_available() {
         app.set_status(
             "Symbol index not ready yet".to_string(),
@@ -183,6 +193,46 @@ fn go_to_implementation_at(app: &mut App, symbol: &str) {
             );
         }
     }
+}
+
+/// 索引が導出した実装先を、ジャンプか一覧にする。
+///
+/// 索引に impl ブロックの符号が無い形 (ジェネリックな impl) では、着地点はその
+/// ブロックの最初のメソッドになる。飛び先の行そのものより「どの型の実装か」が
+/// 要る情報なので、一覧にはその型を並べる。
+fn apply_semantic_implementations(
+    app: &mut App,
+    symbol: &str,
+    impls: Vec<sheaf_core::Implementation>,
+) {
+    if let [only] = impls.as_slice() {
+        let file = only.site.path.to_string_lossy().into_owned();
+        let line = only.site.line as usize + 1;
+        let ty = only.ty.clone();
+        app.jump_to_location(&file, line, 0);
+        app.set_status(
+            format!("Jumped to {ty}'s impl of '{symbol}' [index] {file}:{line}"),
+            StatusLevel::Success,
+        );
+        return;
+    }
+
+    let n = impls.len();
+    app.code_nav.references.show(
+        format!("{symbol} (implementations, index)"),
+        impls
+            .iter()
+            .map(|imp| crate::symbol_index::Reference {
+                file_path: imp.site.path.to_string_lossy().into_owned(),
+                line: imp.site.line as usize + 1,
+                content: format!("impl {symbol} for {}", imp.ty),
+            })
+            .collect(),
+    );
+    app.set_status(
+        format!("{n} implementations found for '{symbol}' [index]"),
+        StatusLevel::Info,
+    );
 }
 
 fn find_references_at(app: &mut App, line_idx: usize, occurrence: usize, symbol: &str) {

--- a/src/event_loop_timers.rs
+++ b/src/event_loop_timers.rs
@@ -89,9 +89,8 @@ pub(crate) fn run_due_timers(
                 // 新規作成されたファイルが現れるようにする。安い処理 (子は遅延読み込み)
                 // で、変化があったときだけ再描画する。
                 if app.refresh_viewer() {
-                    app.dirty.mark(
-                        crate::app::DirtyPanels::EXPLORER | crate::app::DirtyPanels::VIEWER,
-                    );
+                    app.dirty
+                        .mark(crate::app::DirtyPanels::EXPLORER | crate::app::DirtyPanels::VIEWER);
                 }
                 app.check_diff_viewer_staleness();
             }
@@ -253,8 +252,18 @@ fn tick_semantic_regeneration(app: &mut App) {
         // そのときだけ正しい向きで読み直す。
         crate::semantic_index::Regenerated::Ready { root, store } => {
             log::info!("semantic index regenerated: {} documents", store.len());
+            // 索引が無い状態から埋まったときだけ知らせる。作り直しは編集が
+            // 収まるたびに走るので、毎回出すと status がそれで埋まる。
+            let was_absent = app.code_nav.semantic.store(&tree_root).is_none();
+            let documents = store.len();
             if !app.code_nav.semantic.accept(&root, &tree_root, Some(store)) {
                 app.start_semantic_index_load();
+            } else if was_absent {
+                let unit = if documents == 1 { "file" } else { "files" };
+                app.set_status(
+                    format!("Code index ready ({documents} {unit})"),
+                    crate::app::StatusLevel::Success,
+                );
             }
         }
         // 待機に戻すのは sheaf 側がやる。ここで作り直しを起こすと二重に走る。

--- a/src/hover_info.rs
+++ b/src/hover_info.rs
@@ -21,7 +21,8 @@ const REF_COUNT_CAP: usize = 50;
 pub struct HoverInfo {
     /// シンボル名 (ポップアップのタイトル)。
     pub symbol_name: String,
-    /// 定義の種別 (例: "Function", "Struct")。シンボルインデックス由来。
+    /// 定義の種別 (例: "fn", "struct")。索引が答えていればそちら、
+    /// 無ければシンボルインデックス由来。どちらも無ければ空。
     pub kind: String,
     /// 定義があるファイルのパス (リポジトリルートからの相対)。
     pub file_path: String,
@@ -45,6 +46,30 @@ pub struct HoverInfo {
     /// 聞かれた位置がその定義そのものだったか。シグネチャを出しても画面に見えて
     /// いるものの写しにしかならないので、描画側はそれを省く。
     pub on_definition_line: bool,
+    /// シグネチャが索引由来か。索引のシグネチャは型が解決済みで、字面とは違うものを
+    /// 見せている (`let source: String` に対して字面は `let source = read(..)?`)ので、
+    /// 定義行の上でも省かない。
+    pub signature_from_index: bool,
+}
+
+/// 索引がその語について書いていた説明。
+///
+/// 組み立ては呼び出し側 ([`crate::app::App`]) の仕事で、ここは受け取るだけ。
+/// ホバーの組み立てを意味索引に依存させないため。
+#[derive(Default)]
+pub struct IndexedDetail {
+    /// 種別のラベル ("fn", "struct")。読めなければ空。
+    pub kind: String,
+    /// 索引が書いた宣言。行に割ってある。
+    pub signature_lines: Vec<String>,
+    /// 索引が持っている doc コメント。
+    pub doc_lines: Vec<String>,
+}
+
+impl IndexedDetail {
+    fn is_empty(&self) -> bool {
+        self.kind.is_empty() && self.signature_lines.is_empty() && self.doc_lines.is_empty()
+    }
 }
 
 /// ホバーが説明する定義の位置。意味索引が位置で答えたものでも、
@@ -57,6 +82,8 @@ pub struct DefSite {
     pub kind: String,
     /// 候補の総数。2 以上なら、表示しているのはそのうちの 1 つ。
     pub def_count: usize,
+    /// 索引がその語について書いていた説明。無ければソースから読み取る。
+    pub detail: Option<IndexedDetail>,
 }
 
 /// シンボルインデックスを名前で引いて定義位置を決める。複数箇所で定義されて
@@ -79,11 +106,17 @@ pub fn resolve_def_site(
         line: def.line,
         kind: format!("{:?}", def.kind),
         def_count: defs.len(),
+        detail: None,
     })
 }
 
 /// 定義位置からホバー情報を組み立てる。ファイルが読めない、行がファイルの外、
 /// のいずれかなら (黙って) None を返す。
+///
+/// 索引が説明を持っていればそちらを使う。索引の宣言は producer が型を解決した
+/// もので、定義行を読み直して作る写しより中身が濃い (`let source: String` に対して
+/// 字面は `let source = std::fs::read_to_string(..)?`)。doc だけは索引が持たない
+/// ことが多い (doc コメントのある項目に限られる) ので、無ければソースから拾う。
 pub fn build_hover_info(index: &SymbolIndex, symbol: &str, def: DefSite) -> Option<HoverInfo> {
     let root = index.root();
     let source = std::fs::read_to_string(root.join(&def.file_path)).ok()?;
@@ -92,6 +125,22 @@ pub fn build_hover_info(index: &SymbolIndex, symbol: &str, def: DefSite) -> Opti
     if def_idx >= lines.len() {
         return None;
     }
+    let indexed = def.detail.filter(|d| !d.is_empty());
+    let signature_from_index = indexed
+        .as_ref()
+        .is_some_and(|d| !d.signature_lines.is_empty());
+    let kind = match indexed.as_ref().map(|d| d.kind.as_str()) {
+        Some(k) if !k.is_empty() => k.to_string(),
+        _ => def.kind,
+    };
+    let doc_lines = match indexed.as_ref().filter(|d| !d.doc_lines.is_empty()) {
+        Some(d) => d.doc_lines.clone(),
+        None => extract_doc_comment(&lines, def_idx),
+    };
+    let signature_lines = match indexed.filter(|d| !d.signature_lines.is_empty()) {
+        Some(d) => d.signature_lines,
+        None => extract_signature(&lines, def_idx),
+    };
 
     // 正確な数ではなく上限付き。これはポインタがシンボル上で止まるたびに UI
     // スレッドで走るが、ありふれた名前の正確な数を出すにはその名前が現れる全ファイルを
@@ -101,16 +150,17 @@ pub fn build_hover_info(index: &SymbolIndex, symbol: &str, def: DefSite) -> Opti
 
     Some(HoverInfo {
         symbol_name: symbol.to_string(),
-        kind: def.kind,
+        kind,
         file_path: def.file_path,
         line: def.line,
-        doc_lines: extract_doc_comment(&lines, def_idx),
-        signature_lines: extract_signature(&lines, def_idx),
+        doc_lines,
+        signature_lines,
         def_count: def.def_count,
         ref_count,
         ref_count_capped,
         on_definition_line: false,
         container: None,
+        signature_from_index,
     })
 }
 
@@ -230,6 +280,7 @@ fn extract_doc_comment(lines: &[&str], def_idx: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
 
     fn sig(src: &str, def_line_1: usize) -> Vec<String> {
         let lines: Vec<&str> = src.lines().collect();
@@ -241,6 +292,89 @@ mod tests {
         extract_doc_comment(&lines, def_line_1 - 1)
     }
 
+    /// 索引が説明を持っていたことにして、その位置のホバーを組み立てる。
+    fn with_index(dir: &Path, symbol: &str, line: usize, detail: IndexedDetail) -> HoverInfo {
+        let index = SymbolIndex::new(dir.to_path_buf());
+        index.build().unwrap();
+        build_hover_info(
+            &index,
+            symbol,
+            DefSite {
+                file_path: "lib.rs".to_string(),
+                line,
+                kind: String::new(),
+                def_count: 1,
+                detail: Some(detail),
+            },
+        )
+        .expect("hover info")
+    }
+
+    fn scratch(tag: &str, src: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("hover_idx_{tag}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("lib.rs"), src).unwrap();
+        dir
+    }
+
+    #[test]
+    fn 索引の宣言は字面の写しより優先される() {
+        // 索引は型を解決済みで、字面には型が書かれていない。ここを字面から
+        // 読み直すと、この機能でいちばん効く位置が一番貧しくなる。
+        let dir = scratch("prefer", "fn caller() {\n    let total = 1 + 2;\n}\n");
+        let info = with_index(
+            &dir,
+            "total",
+            2,
+            IndexedDetail {
+                kind: "let".to_string(),
+                signature_lines: vec!["let total: i32".to_string()],
+                doc_lines: Vec::new(),
+            },
+        );
+        assert_eq!(info.signature_lines, vec!["let total: i32"]);
+        assert_eq!(info.kind, "let");
+        assert!(info.signature_from_index);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn 索引が_doc_を持たなければソースから拾う() {
+        // 索引の documentation は doc コメントのある項目にしか付かない。
+        // 種別と宣言だけ索引から採り、doc は今までどおり読み取る。
+        let dir = scratch("doc", "/// 足し算。\npub fn add(a: i64) -> i64 { a }\n");
+        let info = with_index(
+            &dir,
+            "add",
+            2,
+            IndexedDetail {
+                kind: "fn".to_string(),
+                signature_lines: vec!["pub fn add(a: i64) -> i64".to_string()],
+                doc_lines: Vec::new(),
+            },
+        );
+        assert_eq!(info.doc_lines, vec!["足し算。"]);
+        assert_eq!(info.signature_lines, vec!["pub fn add(a: i64) -> i64"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn 索引が答えなければ従来どおり字面から組み立てる() {
+        let dir = scratch(
+            "fallback",
+            "/// 足し算。\npub fn add(a: i64) -> i64 {\n    a\n}\n",
+        );
+        let index = SymbolIndex::new(dir.clone());
+        index.build().unwrap();
+        let site = resolve_def_site(&index, "add", Some("lib.rs")).expect("定義位置");
+        let info = build_hover_info(&index, "add", site).expect("hover info");
+        assert_eq!(info.signature_lines, vec!["pub fn add(a: i64) -> i64"]);
+        assert_eq!(info.kind, "Function");
+        assert!(!info.signature_from_index);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn signature_single_line_fn() {
         let src = "pub fn foo(a: usize) -> bool {\n    true\n}\n";
@@ -250,7 +384,10 @@ mod tests {
     #[test]
     fn signature_multi_line_fn() {
         let src = "fn foo(\n    a: usize,\n    b: &str,\n) -> bool {\n    true\n}\n";
-        assert_eq!(sig(src, 1), vec!["fn foo(", "    a: usize,", "    b: &str,", ") -> bool"]);
+        assert_eq!(
+            sig(src, 1),
+            vec!["fn foo(", "    a: usize,", "    b: &str,", ") -> bool"]
+        );
     }
 
     #[test]
@@ -362,6 +499,7 @@ fn caller() {
                 line: 3,
                 kind: String::new(),
                 def_count: 1,
+                detail: None,
             },
         )
         .expect("位置から組み立てられる");
@@ -404,7 +542,10 @@ fn caller() {
             info.doc_lines,
             vec!["Adds two numbers together.", "Returns their sum."]
         );
-        assert_eq!(info.signature_lines, vec!["pub fn add(a: i64, b: i64) -> i64"]);
+        assert_eq!(
+            info.signature_lines,
+            vec!["pub fn add(a: i64, b: i64) -> i64"]
+        );
         // "add" は定義箇所と呼び出し箇所の 2 つに現れる。
         assert!(info.ref_count >= 2, "ref_count = {}", info.ref_count);
 

--- a/src/semantic_index/mod.rs
+++ b/src/semantic_index/mod.rs
@@ -55,6 +55,15 @@ impl SemanticIndex {
         self.slot.get(tree_root)
     }
 
+    /// 索引がまだ無いので 1 本作ってほしい、と伝える。
+    ///
+    /// 生成が起きるのは編集が収束したときだけなので、これが無いと索引の無い
+    /// リポジトリでは何か 1 ファイル編集するまで全部が構文層に落ち続ける。
+    /// その差は画面に出ないので、ユーザからは「ジャンプが甘い」としか見えない。
+    pub fn request_build(&mut self) {
+        self.regenerator.request();
+    }
+
     /// ファイルが変わったことを伝える。どのツリーの変更を数えるかは sheaf 側が決める。
     pub fn note_change(&mut self, changed: &Path, tree_root: &Path) {
         self.regenerator.note_change(changed, tree_root);
@@ -175,43 +184,36 @@ fn main_conductor_dir(repo_root: &Path) -> Option<PathBuf> {
     Some(repo.commondir().parent()?.join(".conductor"))
 }
 
-/// SCIP のシンボル文字列から、その語を囲んでいるものの綴りを組み立てる。
+/// 種別を、ホバーの見出しに置く 1 語にする。
 ///
-/// `rust-analyzer cargo conductor 0.1.0 app/types/App#theme_sel.` から
-/// `app::types::App` を作る。所属が分かると、ホバーが説明しているのがどの型の
-/// フィールドなのかが名前だけで判る。
-///
-/// 綴りを組み立てられない形 (ローカル変数の `local 3`、型引数、逆クォートで
-/// 括られた名前) では None。当てにいくと別物の名前を出すことになる。
-pub fn container_path(symbol: &str) -> Option<String> {
-    // シンボルは `<scheme> <manager> <package> <version> <descriptors>`。
-    let descriptors = symbol.split(' ').nth(4)?;
-    let mut parts = Vec::new();
-    let mut name = String::new();
-    let mut chars = descriptors.chars();
-    while let Some(c) = chars.next() {
-        match c {
-            // 名前空間・型・項の区切り。ここまでが 1 つの descriptor。
-            '/' | '#' | '.' => {
-                if name.is_empty() {
-                    return None;
-                }
-                parts.push(std::mem::take(&mut name));
-            }
-            // メソッドの曖昧さ回避 `name(1).`。名前は括弧の前で確定しているので読み飛ばす。
-            '(' => {
-                if !chars.by_ref().any(|c| c == ')') {
-                    return None;
-                }
-            }
-            // 型引数、マクロ、メタ、逆クォート。綴りを組み立てる規則を持っていない。
-            ')' | '[' | ']' | '!' | ':' | '`' => return None,
-            _ => name.push(c),
-        }
+/// 綴りは Rust の宣言キーワードに寄せてある。ホバーの本文には索引が書いた宣言が
+/// そのまま並ぶので、見出しだけ英語の分類名 (`Function`) にすると 2 つの語彙が
+/// 混ざる。読めない種別は空にして、見出しごと出さない。
+pub fn kind_label(kind: sheaf_core::SymbolKind) -> &'static str {
+    use sheaf_core::SymbolKind::*;
+    match kind {
+        Function => "fn",
+        Method => "method",
+        Struct => "struct",
+        Class => "class",
+        Enum => "enum",
+        EnumMember => "variant",
+        Field => "field",
+        Trait => "trait",
+        Interface => "interface",
+        Package => "package",
+        TypeAlias => "type",
+        AssociatedType => "assoc type",
+        ImplBlock => "impl",
+        Module => "mod",
+        Constant => "const",
+        Static => "static",
+        Variable => "let",
+        Parameter => "param",
+        SelfParameter => "self",
+        TypeParameter => "type param",
+        Unknown => "",
     }
-    // 末尾の descriptor は聞かれた語そのもの。囲んでいるものだけを返す。
-    parts.pop()?;
-    (!parts.is_empty()).then(|| parts.join("::"))
 }
 
 #[cfg(test)]
@@ -565,6 +567,106 @@ mod tests {
         assert_eq!(store.outside_root(), 0, "ツリー外を指す Document がある");
     }
 
+    /// 索引が説明を答える割合を、実リポジトリの実 Bridge (tree-sitter) 越しに測る。
+    ///
+    /// 合成した索引では、rust-analyzer が実際に何を書くかを検査できない。ここが
+    /// 落ちるのは、宣言の綴りが変わって読めなくなったとき (`Signature` の
+    /// フィールド番号がまさにそれ) と、種別の番号が変わったとき。
+    #[test]
+    #[ignore = ".conductor/index.scip を置いたリポジトリが要る"]
+    fn real_index_describes_what_it_answers() {
+        use crate::app::{code_identifiers_on_line, occurrence_span_in_source};
+
+        let repo_root = std::env::var("CONDUCTOR_TEST_REPO").expect("CONDUCTOR_TEST_REPO");
+        let repo_root = Path::new(&repo_root);
+        let store = load(repo_root, repo_root).expect("索引と出自の申告が揃っている");
+
+        // 索引はこのワークスペースのシンボルしか説明を持たない (rust-analyzer は
+        // SCIP の external_symbols を書かないので、std や ratatui の語は符号だけ)。
+        // 全体の割合で見ると、その欠落と自前の欠落が混ざって回帰に気づけない。
+        let own = |symbol: &str| {
+            symbol.starts_with("local ")
+                || matches!(
+                    symbol.split(' ').nth(2),
+                    Some("conductor" | "sheaf-core" | "revidere" | "revidere-fixtures")
+                )
+        };
+
+        let (mut asked, mut described, mut own_described, mut own_signature) = (0, 0, 0, 0);
+        let mut kinds: std::collections::BTreeMap<&str, usize> = Default::default();
+        for rel in [
+            "src/repo_path.rs",
+            "src/jump_history.rs",
+            "src/hover_info.rs",
+        ] {
+            let abs = repo_root.join(rel);
+            let source = std::fs::read_to_string(&abs).unwrap();
+            let mask = crate::symbol_index::CodeMask::compute(&source, rel);
+            let index = crate::symbol_index::SymbolIndex::new(repo_root.to_path_buf());
+            let bridge = Bridge {
+                abs_path: &abs,
+                source: &source,
+                mask: &mask,
+                index: &index,
+            };
+            for (line, text) in source.lines().enumerate() {
+                for (k, _, word) in code_identifiers_on_line(text, line + 1, &mask) {
+                    let Some((start, end)) = occurrence_span_in_source(text, k) else {
+                        continue;
+                    };
+                    if text.get(start..end) != Some(word.as_str()) {
+                        continue;
+                    }
+                    asked += 1;
+                    let answer = sheaf_core::describe_at(
+                        &store,
+                        &bridge,
+                        Path::new(rel),
+                        line as u32,
+                        start as u32,
+                    );
+                    let Some(detail) = answer.first() else {
+                        continue;
+                    };
+                    described += 1;
+                    if !own(detail.symbol.as_str()) {
+                        continue;
+                    }
+                    own_described += 1;
+                    if detail.signature.is_some() {
+                        own_signature += 1;
+                    }
+                    let label = kind_label(detail.kind);
+                    if !label.is_empty() {
+                        *kinds.entry(label).or_default() += 1;
+                    }
+                }
+            }
+        }
+
+        println!(
+            "聞いた {asked} / 符号が付いた {described} / うち自前 {own_described} / 宣言 {own_signature}"
+        );
+        println!("種別の内訳: {kinds:?}");
+        assert!(
+            own_described > 100,
+            "索引がほとんど答えていない: {own_described}"
+        );
+        // 自前のシンボルには索引が必ず SymbolInformation を書く。ここが落ちるのは
+        // 宣言の綴りか種別の番号が変わったとき。
+        assert!(
+            own_signature * 20 >= own_described * 19,
+            "自前のシンボルの宣言が読めていない: {own_signature}/{own_described}"
+        );
+        let with_kind: usize = kinds.values().sum();
+        assert!(
+            with_kind * 20 >= own_described * 19,
+            "自前のシンボルの種別が読めていない: {with_kind}/{own_described}"
+        );
+        // 分類が 1 種類に潰れていたら、番号の対応表が壊れている。
+        assert!(kinds.len() >= 5, "種別が偏りすぎ: {kinds:?}");
+    }
+
     /// 呼び出し口(`App::pick_line_identifier`)が選ばせうる位置を、リポジトリの
     /// 実ファイルで全部叩く。索引が実際にどれだけ答えるかと、飛び先が
     /// リポジトリ内の実在する位置であることを見る。
@@ -574,7 +676,6 @@ mod tests {
     #[test]
     #[ignore = ".conductor/index.scip を置いたリポジトリが要る"]
     fn real_index_answers_across_the_repository() {
-        use super::container_path;
         use crate::app::{code_identifiers_on_line, occurrence_span_in_source};
 
         let repo_root = std::env::var("CONDUCTOR_TEST_REPO").expect("CONDUCTOR_TEST_REPO");
@@ -634,7 +735,7 @@ mod tests {
                     slowest = slowest.max(at.elapsed());
                     if let sheaf_core::Definition::Exact(locations) = answer {
                         exact += 1;
-                        if let Some(path) = sheaf_core::symbols_at(
+                        if let Some(path) = sheaf_core::describe_at(
                             &store,
                             &bridge,
                             Path::new(rel),
@@ -642,7 +743,7 @@ mod tests {
                             start as u32,
                         )
                         .iter()
-                        .find_map(|id| container_path(id.as_str()))
+                        .find_map(|d| d.container.clone())
                         {
                             containers += 1;
                             if named.len() < 5 {
@@ -690,33 +791,11 @@ mod tests {
     // 判定そのものがあちらにあるので、こちらに写しを置くと片方だけが古くなる。
 
     #[test]
-    fn 符号から所属の綴りを組み立てる() {
-        assert_eq!(
-            container_path("rust-analyzer cargo conductor 0.1.0 app/types/App#theme_sel."),
-            Some("app::types::App".to_string())
-        );
-        // 末尾の descriptor は聞かれた語そのもの。型そのものを聞いたらモジュールが残る。
-        assert_eq!(
-            container_path("rust-analyzer cargo conductor 0.1.0 app/types/App#"),
-            Some("app::types".to_string())
-        );
-        // メソッドの曖昧さ回避は名前の後ろに付くだけなので、綴りは組み立てられる。
-        assert_eq!(
-            container_path("rust-analyzer cargo conductor 0.1.0 app/App#set_focus()."),
-            Some("app::App".to_string())
-        );
-    }
-
-    #[test]
-    fn 綴りを組み立てられない符号では黙る() {
-        // メソッドの曖昧さ回避、型引数、逆クォート、ローカル。当てにいくと別物の名前になる。
-        for symbol in [
-            "rust-analyzer cargo conductor 0.1.0 app/impl#[Focus]next().",
-            "rust-analyzer cargo conductor 0.1.0 app/`weird name`#",
-            "local 3",
-        ] {
-            assert_eq!(container_path(symbol), None, "{symbol}");
-        }
+    fn 読めない種別は見出しごと出さない() {
+        // 種別を読めなかったときにそれらしい名前を返すと、ホバーが自信を持って嘘を出す。
+        assert_eq!(kind_label(sheaf_core::SymbolKind::Unknown), "");
+        assert_eq!(kind_label(sheaf_core::SymbolKind::Function), "fn");
+        assert_eq!(kind_label(sheaf_core::SymbolKind::Variable), "let");
     }
 
     #[test]

--- a/src/ui/hover_info.rs
+++ b/src/ui/hover_info.rs
@@ -23,14 +23,19 @@ pub fn render_hover_info_overlay(frame: &mut Frame, area: Rect, app: &mut App) {
     }
     let host = {
         let vr = app.layout.cache.columns[2];
-        if vr.width > 0 && vr.height > 0 { vr } else { area }
+        if vr.width > 0 && vr.height > 0 {
+            vr
+        } else {
+            area
+        }
     };
     render_base_popup(frame, host, app);
     // レベル1: 参照一覧（ピン留め）。レベル2: プレビュー。
     if app.code_nav.hover_info.refs.is_some() {
         render_refs_list(frame, host, app);
         if app
-            .code_nav.hover_info
+            .code_nav
+            .hover_info
             .refs
             .as_ref()
             .is_some_and(|r| r.preview.is_some())
@@ -45,29 +50,22 @@ fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
     let theme = app.theme.clone();
     // info への不変借用を先に終わらせてから app.code_nav.hover_info に
     // ヒットテスト用の Rect を書き戻せるよう、所有データとして取り出しておく。
-    let (symbol_name, mut body, def_label, ref_count, ref_count_capped) = {
+    // 見出しは 1 行に固定する。所属を左、種別を右に置き、種別ごとに行の並びは
+    // 変えない。並びが種別で動くと、次にどこを見ればよいかが毎回変わる。
+    let (symbol_name, mut body, container, kind, def_label, ref_count, ref_count_capped) = {
         let info = app.code_nav.hover_info.info.as_ref().unwrap();
         let mut def_label = format!("▸ {}:{}", info.file_path, info.line);
-        if !info.kind.is_empty() {
-            def_label.push_str(&format!("  {}", info.kind));
-        }
         if info.def_count > 1 {
             def_label.push_str(&format!("  (+{} defs)", info.def_count - 1));
         }
         def_label.push_str(" — click to jump");
 
-        // 本文の行: シグネチャ、doc。場所と参照はクリックできるフッターに置く。
+        // 本文の行: シグネチャ、doc。見出しは幅が決まってから足す。場所と参照は
+        // クリックできるフッターに置く。
         let mut body: Vec<Line> = Vec::new();
-        if let Some(container) = &info.container {
-            body.push(Line::from(Span::styled(
-                container.clone(),
-                Style::default()
-                    .fg(theme.info)
-                    .add_modifier(Modifier::ITALIC),
-            )));
-        }
-        // 聞かれた位置がその定義そのものなら、シグネチャは画面に見えているものの写し。
-        if !info.on_definition_line {
+        // 索引の宣言は型が解決済みで、画面の字面とは違うものを見せている。
+        // 字面の写しにしかならない tree-sitter 由来のときだけ、定義行の上で省く。
+        if info.signature_from_index || !info.on_definition_line {
             body.extend(highlighted_signature(app, info));
         }
         if !info.doc_lines.is_empty() {
@@ -84,6 +82,8 @@ fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
         (
             info.symbol_name.clone(),
             body,
+            info.container.clone().unwrap_or_default(),
+            info.kind.clone(),
             def_label,
             info.ref_count,
             info.ref_count_capped,
@@ -93,6 +93,7 @@ fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
     if !body.is_empty() {
         body.push(Line::from(""));
     }
+    let header_w = header_width(&container, &kind);
 
     // クリック可能な refs 行（専用に確保した最下行に描画する）。+ は件数が
     // 上限で打ち切られたことを示す印で、ありふれた名前の場合に、数え終えて
@@ -103,28 +104,49 @@ fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
         format!("▸ {ref_count} refs — click to list")
     };
 
-    // 幅は本文 + フッター 2 行のうち最も広いものに合わせる。
+    // 幅は見出し + 本文 + フッター 2 行のうち最も広いものに合わせる。
     let content_w = body
         .iter()
         .map(|l| l.width())
-        .chain([refs_label.chars().count(), def_label.chars().count()])
+        .chain([
+            refs_label.chars().count(),
+            def_label.chars().count(),
+            header_w,
+        ])
         .max()
         .unwrap_or(20)
         .clamp(20, 100) as u16;
     let popup_width = (content_w + 4).min(host.width.saturating_sub(2)).max(4);
-    let inner_w = popup_width.saturating_sub(4).max(1) as usize;
+    // 本文を描くのは枠の内側ちょうど。ここを狭く見積もると、折り返さない行を
+    // 折り返す前提で高さを取って、本文の下に空行が残る。
+    let inner_w = popup_width.saturating_sub(2).max(1) as usize;
+    if header_w > 0 {
+        body.insert(0, header_line(&container, &kind, inner_w, &theme));
+    }
     let body_h: usize = body
         .iter()
         .map(|l| {
             let w = l.width();
-            if w == 0 { 1 } else { w.div_ceil(inner_w).max(1) }
+            if w == 0 {
+                1
+            } else {
+                w.div_ceil(inner_w).max(1)
+            }
         })
         .sum();
     let footer_h = 1 + usize::from(refs_present);
     let inner_h = (body_h + footer_h).max(1);
-    let popup_height = (inner_h as u16 + 2).min(host.height.saturating_sub(2)).max(3);
+    let popup_height = (inner_h as u16 + 2)
+        .min(host.height.saturating_sub(2))
+        .max(3);
 
-    let popup_area = place(host, app.code_nav.hover_info.anchor_row, app.code_nav.hover_info.anchor_col, popup_width, popup_height);
+    let popup_area = place(
+        host,
+        app.code_nav.hover_info.anchor_row,
+        app.code_nav.hover_info.anchor_col,
+        popup_width,
+        popup_height,
+    );
 
     frame.render_widget(Clear, popup_area);
     let block = Block::default()
@@ -160,7 +182,9 @@ fn render_base_popup(frame: &mut Frame, host: Rect, app: &mut App) {
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 refs_label,
-                Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
             ))),
             refs_hit,
         );
@@ -273,7 +297,10 @@ fn render_refs_list(frame: &mut Frame, host: Rect, app: &mut App) {
             Style::default().fg(theme.fg)
         };
         let row_area = Rect::new(inner.x, inner.y + row as u16, inner.width, 1);
-        frame.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), row_area);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(text, style))),
+            row_area,
+        );
         row_hits.push((idx, row_area));
     }
     refs.rect = popup_area;
@@ -285,13 +312,15 @@ fn render_refs_list(frame: &mut Frame, host: Rect, app: &mut App) {
 fn render_preview(frame: &mut Frame, host: Rect, app: &mut App) {
     let theme = app.theme.clone();
     let list_rect = app
-        .code_nav.hover_info
+        .code_nav
+        .hover_info
         .refs
         .as_ref()
         .map(|r| r.rect)
         .unwrap_or_default();
     let Some(preview) = app
-        .code_nav.hover_info
+        .code_nav
+        .hover_info
         .refs
         .as_mut()
         .and_then(|r| r.preview.as_mut())
@@ -308,7 +337,9 @@ fn render_preview(frame: &mut Frame, host: Rect, app: &mut App) {
         .max()
         .unwrap_or(30) as u16;
     let popup_width = (content_w + 2).min(host.width.saturating_sub(2)).max(10);
-    let popup_height = (preview.lines.len() as u16 + 2).min(host.height.saturating_sub(2)).max(3);
+    let popup_height = (preview.lines.len() as u16 + 2)
+        .min(host.height.saturating_sub(2))
+        .max(3);
 
     // 一覧の右側に収まればそこ、収まらなければ下、host 内にクランプする。
     let right_x = list_rect.x + list_rect.width;
@@ -319,7 +350,9 @@ fn render_preview(frame: &mut Frame, host: Rect, app: &mut App) {
         let y = if below + popup_height <= host.y + host.height {
             below
         } else {
-            (host.y + host.height).saturating_sub(popup_height).max(host.y)
+            (host.y + host.height)
+                .saturating_sub(popup_height)
+                .max(host.y)
         };
         let x = list_rect
             .x
@@ -344,7 +377,10 @@ fn render_preview(frame: &mut Frame, host: Rect, app: &mut App) {
             let is_center = *n == preview.center_line;
             let num_style = Style::default().fg(theme.muted);
             let text_style = if is_center {
-                Style::default().fg(theme.fg).bg(theme.selected_bg).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(theme.fg)
+                    .bg(theme.selected_bg)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme.fg)
             };
@@ -373,4 +409,52 @@ fn place(host: Rect, anchor_row: u16, anchor_col: u16, w: u16, h: u16) -> Rect {
     let max_x = (host.x + host.width).saturating_sub(w);
     let x = anchor_col.clamp(host.x, max_x.max(host.x));
     Rect::new(x, y, w, h)
+}
+
+/// 見出し行が要る幅。所属も種別も無ければ 0 で、行そのものを出さない。
+fn header_width(container: &str, kind: &str) -> usize {
+    let (left, right) = (container.chars().count(), kind.chars().count());
+    match (left, right) {
+        (0, 0) => 0,
+        (0, r) => r,
+        (l, 0) => l,
+        // あいだは最低 2 文字空ける。詰まると 1 つの語に見える。
+        (l, r) => l + 2 + r,
+    }
+}
+
+/// 所属を左、種別を右に置いた見出し行。幅が足りなければ右寄せをやめて詰める。
+fn header_line(
+    container: &str,
+    kind: &str,
+    inner_w: usize,
+    theme: &crate::theme::Theme,
+) -> Line<'static> {
+    let mut spans = Vec::new();
+    if !container.is_empty() {
+        spans.push(Span::styled(
+            container.to_string(),
+            Style::default()
+                .fg(theme.info)
+                .add_modifier(Modifier::ITALIC),
+        ));
+    }
+    if !kind.is_empty() {
+        // 所属が無くても右端に置く。左に寄せると、すぐ下に並ぶ宣言の先頭と
+        // 同じ列から始まって、種別が宣言の一部に見える。
+        let used = container.chars().count() + kind.chars().count();
+        let gap = inner_w
+            .saturating_sub(used)
+            .max(usize::from(!container.is_empty()) * 2);
+        if gap > 0 {
+            spans.push(Span::raw(" ".repeat(gap)));
+        }
+        spans.push(Span::styled(
+            kind.to_string(),
+            Style::default()
+                .fg(theme.hint)
+                .add_modifier(Modifier::ITALIC),
+        ));
+    }
+    Line::from(spans)
 }


### PR DESCRIPTION
## 何を変えたか

SCIP 索引の読み取りから producer 固有の前提を外し、rust-analyzer / scip-go / scip-typescript の
3 つを同じ経路で扱えるようにした。あわせて、ホバーの所属 (container) をローカル束縛にも出す。

### 種別の表からツール名を消した

`SymbolInformation.kind` の番号は scip crate が生成する enum とずれているが、**そのずれは
producer 固有ではない** — rust-analyzer と scip-go の実索引を読んで、両方が同じ (古い) 番号体系を
書いていることを確かめた。ツール名で表を切り替える設計は、観測していないツールの索引で全部が
`Unknown` に落ちるだけの害だったので、表を 1 つにまとめた。

番号を書かない producer (scip-typescript) は `kind::from_declaration` で宣言の綴りから読む。

### 宣言をコードブロックから取れるようにした

scip-typescript は `signature_documentation` を書かず、宣言を ```` ```ts ```` フェンスとして
`documentation[0]` に入れる。`store::fenced_declaration` がそれを剥がし、残りを doc に回す。

### 実装先ジャンプに `Implementations::Exact` を足した

scip-go と scip-typescript は `relationships.is_implementation` を書く (rust-analyzer は 0 件)。
索引が書いているならそれがそのまま答えなので、符号の綴りからの導出 (`Derived`) と型で分けた。
両者は 1 つのリストに混ぜない — 混ぜると producer が申告した答えが弱いほうの主張に落ちる。

### 所属を sheaf-core に移し、`enclosing_symbol` を使う

ローカル束縛の符号は `local 3` で綴りを持たないので、囲んでいる関数を
`SymbolInformation.enclosing_symbol` から取る。**実索引での所属の被覆が 99 → 193 箇所**に増えた
(ローカルと引数は、読む人がホバーする位置の大半を占める)。

区切りはツールではなくファイルの拡張子で決める (`.rs` は `::`、他は `.`)。TypeScript が符号に
含めるファイルの名前空間 (``src/`greet.tsx`/``) は落とし、それ以外の位置の逆クォート
(ジェネリックな型の綴り) では組み立てを諦める。

conductor 側の `semantic_index::container_path` は削除した。conductor が SCIP の符号文字列を
読む場所はもう無い。

## 検証

- `cargo test --workspace` 全 18 スイート green / `cargo clippy --workspace --all-targets` 追加警告なし
- scip-go と scip-typescript の実索引に対して end-to-end で確認 (種別・所属・宣言・doc・実装先)
- TUI 実機 (pty): `let message` と `who: &dyn Greeter` のホバーに所属 `run` が出ることを確認

## 残っている作業 (このPRの範囲外)

conductor は依然として Rust の索引しか**生成**しない (`semantic_index::target()` が `Cargo.toml`
を見ている)。Go / TypeScript のリポジトリを開いても索引は 1 本も作られず、tree-sitter の名前一致に
落ちる。生成側の対応は別 PR で行う。
