### PR TITLE
chore: バージョンを 0.113.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.112.0"
+version = "0.113.0"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.112.0"
+version = "0.113.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
PR #329 が #328 と同じ 0.112.0 を名乗ってしまったので、機能追加ぶんを 0.113.0 に上げる。