### PR TITLE
chore: リポジトリ全体を rustfmt clean にして pre-commit で担保する

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# make hooks (git config core.hooksPath .githooks) で有効化する
+set -e
+
+if ! cargo fmt --all -- --check; then
+	echo "" >&2
+	echo "pre-commit: rustfmt 未適用のファイルがあります。'cargo fmt --all' を実行してから commit してください。" >&2
+	exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,311 +8,205 @@ Conductor is a terminal-based Git workspace and code review TUI written in Rust.
 
 ## Commands
 
-- **Build:** `cargo build`
-- **Run:** `cargo run` or `cargo run -- <repo-path>` (defaults to current directory)
-- **Test:** `cargo test --workspace` (tests are inline `#[cfg(test)]` modules in `git_engine.rs`, `config.rs`, `review_store.rs`)
-- **Run single test:** `cargo test <test_name>` (e.g., `cargo test test_parse_full_config`)
-- **Lint:** `cargo clippy --workspace`
-- **Check:** `cargo check --workspace`
+`cargo build` · `cargo run [-- <repo-path>]` · `cargo test --workspace` ·
+`cargo clippy --workspace` · `cargo check --workspace` · `make fmt`.
+Set `RUST_LOG=debug` for logging.
 
-Bare `cargo test` / `cargo clippy` only cover the `conductor` package — the
-`crates/revidere*` and `crates/sheaf-core` members need `--workspace`.
+**Always pass `--workspace`** — bare `cargo test` / `cargo clippy` only cover the
+`conductor` package, not `crates/revidere*` or `crates/sheaf-core`.
 `default-members` is deliberately left alone so `cargo run` stays unambiguous.
-- **Logging:** Set `RUST_LOG=debug` (or `info`, `warn`) before running
+
+A pre-commit hook (`make hooks`, once per clone) runs `cargo fmt --all -- --check`.
 
 ### MCP Server (`conductor mcp-serve`, `src/mcp_serve/`)
 
 The review DB tools are served by the conductor binary itself over stdio — no
 separate build step, no Node. `cargo install --path .` updates the binary and its
 MCP tools together, which is the point: they used to be two artifacts on two
-release channels and drifted apart.
+release channels and drifted apart. `plugins/conductor/.mcp.json` starts it for
+the Claude Code sessions inside the TUI, resolving the DB from
+`$CONDUCTOR_DB_PATH` (injected by `pty_manager/spawn.rs`). The AI review does
+*not* go through MCP — its artifact is a JSON file written by `revidere`.
 
-- **Run by hand:** `conductor mcp-serve --db <path>` (speaks JSON-RPC on stdout)
-- **Who starts it:** `plugins/conductor/.mcp.json`, for the interactive Claude Code
-  sessions inside the TUI (it resolves the DB from `$CONDUCTOR_DB_PATH`, injected by
-  `pty_manager/spawn.rs`). The AI review does *not* go through MCP — its
-  artifact is a JSON file written by `revidere` (see `revidere.rs` below)
-- **Tool contract:** the 7 `#[tool]` handlers in `src/mcp_serve/tools.rs`. Their doc
+- **Tool contract:** the `#[tool]` handlers in `src/mcp_serve/tools.rs`. Their doc
   comments become the JSON Schema descriptions the model reads, so changing one
   changes the tool's public contract — treat them as API, not commentary.
-
-Never print to stdout from anything reachable by `mcp-serve`; it would corrupt the
-protocol. Logging goes to stderr (env_logger's default).
+- **Never print to stdout** from anything reachable by `mcp-serve`; it would
+  corrupt the protocol. Logging goes to stderr.
 
 ### Session hook (`conductor cc-hook`, `src/cc_hook.rs`)
 
-`/clear` rotates Claude Code's log to a **new session id**, and nothing on disk
-links the old file to the new one — so a panel pinned to its spawn-time
-`--session-id` would keep showing the pre-clear transcript forever. The fix is a
-`SessionStart` hook that runs inside the panel's own Claude process and reports
-its current session id back.
-
-- **Who installs it:** `pty_manager/spawn.rs` writes `.conductor/claude-hooks.json`
-  and passes it as `--settings` on every Claude spawn, plus `CONDUCTOR_PANEL_ID`
-  and `CONDUCTOR_NOTIFY_SOCK` in the environment. `--settings` *adds a layer* —
-  the user's own settings and the project's `.claude/settings.json` keep working.
-- **Why the binary and not `plugins/`:** same reason `mcp-serve` lives here — a
-  separately released plugin drifts, and the failure is silent (scrollback just
-  shows stale history). `cargo install --path .` ships the binary and the hook
-  together.
-- **Fallback:** when the hook stays silent (hooks disabled, older CLI),
-  `claude_sessions/rotation.rs` infers the rotation from the logs instead. It is
-  deliberately conservative — see its module docs for what it refuses to guess.
+`/clear` rotates Claude Code's log to a **new session id** and nothing on disk
+links the old file to the new one, so a panel pinned to its spawn-time
+`--session-id` would show the pre-clear transcript forever. A `SessionStart` hook
+runs inside the panel's own Claude process and reports the current id back.
+`pty_manager/spawn.rs` writes `.conductor/claude-hooks.json` and passes it as
+`--settings` on every spawn (that *adds a layer*, so the user's own settings keep
+working), plus `CONDUCTOR_PANEL_ID` and `CONDUCTOR_NOTIFY_SOCK`. It lives in the
+binary rather than `plugins/` for the same reason `mcp-serve` does: a separately
+released plugin drifts, and the failure is silent. When the hook stays quiet
+(hooks disabled, older CLI), `claude_sessions/rotation.rs` infers the rotation
+from the logs — deliberately conservative, see its module docs.
 
 ### Review analyser (`crates/revidere`)
 
 revidere turns a git diff into `<worktree>/.conductor/review.json`: every changed
 line sorted into sections by importance, plus a coverage check that no changed
-line is left unexplained. It lives in this repo as workspace members:
-`crates/revidere` (the whole analyser plus the artifact types and `ReadingOrder`)
-and `crates/revidere-fixtures` (shared test scaffolding).
+line is left unexplained. `crates/revidere-fixtures` is shared test scaffolding.
 
-- **One entry point:** `revidere::analyze(&Options, &dyn Ai)`. It has no binary and
-  no CLI — conductor is the only caller (`app/revidere.rs`, on a worker thread).
+- **One entry point:** `revidere::analyze(&Options, &dyn Ai)`. No binary, no CLI —
+  conductor is the only caller (`app/revidere.rs`, on a worker thread).
 - **The AI is injected.** revidere never spawns anything; conductor implements
-  `revidere::Ai` over `ai_caller`, so the review runs on the same `[api]` config as
-  every other AI feature. `provider = "gemini"` will *not* work: the prompt hands
-  over the ledger only, and the model is expected to read the repository itself, so
-  it needs an agentic CLI under `provider = "command"`.
-- **Cache identity:** the stored-answer key includes `Ai::identity()`. If that ever
-  goes constant, changing models silently returns the old model's answer.
-- **Failing coverage is not a failure.** `analyze` returns the artifact either way;
-  `review.coverage.is_complete()` is what distinguishes them. Treating an
-  incomplete review as an error throws away a readable one.
-- revidere writes nothing to stdout/stderr (the host owns a TUI) — progress goes
-  through `log`.
+  `revidere::Ai` over `ai_caller`, so the review runs on the same `[api]` config
+  as every other AI feature. `provider = "gemini"` will *not* work: the prompt
+  hands over the ledger only and the model must read the repository itself, so it
+  needs an agentic CLI under `provider = "command"`.
+- **Cache identity** includes `Ai::identity()`. If that goes constant, changing
+  models silently returns the old model's answer.
+- **Failing coverage is not a failure.** `analyze` returns the artifact either
+  way; `review.coverage.is_complete()` distinguishes them.
+- revidere writes nothing to stdout/stderr (the host owns a TUI) — use `log`.
 
 ### Code index (`crates/sheaf-core`, `src/semantic_index/`)
 
 sheaf-core holds a SCIP index split per file, keyed by content hash, and answers
-position queries (go-to-definition, find-references) **with a confidence level
-attached**. It was developed in its own repository (`../sheaf`) and vendored here
-as a workspace member. `src/semantic_index/` is conductor's side of the seam.
+position queries (go-to-definition, find-references, go-to-implementation)
+**with a confidence level attached**. It was developed in its own repository
+(`../sheaf`) and vendored here as a workspace member; `src/semantic_index/` is
+conductor's side of the seam. An LSP was evaluated and rejected — conductor's
+jumps run at review time, so an LSP's residency buys nothing it needs.
 
 **tree-sitter is not replaced — it is the layer underneath.** sheaf-core defines
-the syntactic layer as a trait and ships no implementation, and it will not even
-consult the index unless `token_at` answers. `semantic_index::bridge::Bridge`
-implements that trait over the existing `CodeMask` + `SymbolIndex`, so every
-position where the index has nothing to say lands on today's answer, marked
-`Definition::Syntactic` rather than `Exact`.
+the syntactic layer as a trait and ships no implementation, and will not consult
+the index unless `token_at` answers. `semantic_index::bridge::Bridge` implements
+that trait over `CodeMask` + `SymbolIndex`, so every position the index cannot
+answer lands on today's answer, marked `Definition::Syntactic` rather than
+`Exact`. Deliberately still tree-sitter-only: the symbol-action overlay, `gi`
+when the index is silent, and the hover popup's reference count
+(`count_references_upto`, capped at 50 — it runs on the UI thread).
 
-Why an index and not a language server: conductor's jumps only run at review
-time, after the implementation is finished, so the thing an LSP's residency buys
-— incremental re-analysis on every keystroke — is a requirement conductor does
-not have. Measured on this repository, rust-analyzer peaks at 3.70GB
-(`analysis-stats`) and does not persist its analysis, so a per-worktree or
-per-focus server re-pays ~13s on every switch. The index is 14.5MB on disk and
-1.10x that resident, and **one index serves every worktree** — freshness is
-per-file by content hash, so a worktree on the same branch answers `Exact` and
-only its edited files fall through.
+Invariants. Breaking any of these turns a weak answer into a confident one:
 
 - **The confidence cannot be bypassed.** `Definition` / `References` keep the
   positions inside their variants, so there is no way to get a `Location` without
-  deciding which variant you got. Claims of different strength live in different
-  types (`Exact` vs `Enclosing`, `Found::direct` vs `Found::via_interface`), and
-  `Syntactic(vec![])` ("looked, found nothing") is distinct from `NotCode`
-  ("not an identifier"). `lib.rs` pins this with ```compile_fail``` doctests —
-  if you touch the public API, check they still fail to compile.
-- **Provenance is all-or-nothing.** If any file an answer depended on differs from
-  its state at index time, the whole answer is dropped and the query falls through
-  to the syntactic layer. Returning the surviving subset would silently hide the
-  missing candidates behind an `Exact`.
-- **The syntactic layer cannot fake an `Exact`.** `SyntacticAnswer` has no variant
-  that reaches it. A fallback answer stays visibly a fallback.
-- **Design tie-breakers, in order:** (1) N worktrees must not multiply memory,
-  (2) keep the producer's accuracy, (3) never answer wrongly — no answer is better.
-- Comments, test names, and error messages are Japanese, and the public API
-  deliberately exposes no `protobuf` / `scip` types (conductor pulls them in as
-  dev-dependencies only, to fabricate index fixtures in tests).
+  deciding which variant you got, and `Syntactic(vec![])` ("looked, found
+  nothing") is distinct from `NotCode`. `lib.rs` pins this with
+  ```compile_fail``` doctests — check they still fail to compile.
+- **Provenance is all-or-nothing.** If any file an answer depended on changed
+  since index time, the whole answer is dropped and the query falls through.
+  Returning the surviving subset would hide the missing candidates behind an
+  `Exact`.
+- **Exact and Derived are never merged.** Go-to-implementation answers `Exact`
+  from SCIP `relationships` where the producer emits them (scip-go,
+  scip-typescript) and `Derived` from the symbol spelling where it does not
+  (rust-analyzer emits none) — `store::impl_pair`. Merging would drag a
+  producer-declared answer down to the weaker claim. The derived key is a bare
+  spelling, so two same-named traits collide; that is why it is not `Exact`.
+- When in doubt: never answer wrongly — no answer is better — and never let N
+  worktrees multiply memory.
 
-Where the index lives and who builds it:
-
-- `<main worktree>/.conductor/{index.scip,index.hashes,index.log,generate.lock}`.
-  Linked worktrees have no `.conductor/` of their own, so `semantic_index` walks
-  `git2::Repository::commondir()` to the main one — the same move
-  `mcp_serve::resolve` makes for the review DB. The lock is per repository on
-  purpose: one producer peaks at 2.36GB, so the cap must not split per worktree.
-- **Generation is Rust only; reading is not.** `RustAnalyzer` is the sole producer
-  conductor runs, gated on a `Cargo.toml` at the tree root, so a Go or TypeScript
-  repository opened in conductor still answers entirely through tree-sitter.
-  sheaf-core itself is producer-independent and verified against real `scip-go` and
-  `scip-typescript` indexes (kind, declaration, doc, container, and implementations
-  all resolve); `ScipGo` / `ScipTypescript` are ready. What is missing is the host
-  side: choosing a producer per tree, and holding several index roots at once
-  (`go.mod` ×8 and `tsconfig.json` ×9 in one repository are the known real cases).
-- `conductor index` builds the first one (~14s here). After that `Regenerator`
-  rebuilds whenever edits go quiet for 3s. It ignores gitignored paths — without
-  that, `target/` churn would reset the quiescence timer forever and the index
-  would never be rebuilt. That is why `FsEvent::Changed` carries a path.
-- Booting without an index does not wait for an edit: a load that finds nothing
-  calls `Regenerator::request`, and the status bar reports the result once.
-  Routine rebuilds stay silent. Note that `Lock::acquire` distinguishes "someone
-  else is generating" from "the directory is not there yet" — collapsing the two
-  made every first-ever `conductor index` answer `Busy`.
-- The index producers are external tools. sheaf's `tests/go_definition.rs` and
-  `tests/ts_definition.rs` really launch `scip-go` / `npx` and **fail rather than
-  skip** where they are absent. `#[ignore]`d tests need a real index; see
-  `SHEAF_TEST_INDEX` / `SHEAF_TEST_ROOT`, and `CONDUCTOR_TEST_REPO` for
-  `src/semantic_index/`'s own.
-
-The hover popup resolves its **definition** through the index like `gd` does, so
-the two never disagree about where a symbol lives. Its **reference count** stays
-on tree-sitter's capped counter (`count_references_upto`, 50) — that one runs on
-the UI thread, and `references_at` may fall through to a full tree walk (measured
-157ms). The list behind "N refs" is a click, which already pays that walk today.
-`hover_info::DefSite` is the seam: whoever resolved the position, the popup is
-built the same way, and a site the index found needs no tree-sitter definition at
-all (that absence is why hover used to stay silent on locals, fields and module
-names).
-
-Its **declaration and kind** come from the index too, through `describe_at`.
-`SymbolInformation` carries both for every symbol rust-analyzer emits (measured:
-656 of 656 own-crate positions across three files), and the declaration is the
-producer's resolved type, not the source text — `let message: String` where the
-line reads `let message = who.greet();`. Scraping the definition line is the
-fallback, not the default. Two things make this harder than reading a field:
+Two SCIP traps that typed access will not save you from:
 
 - **`signature_documentation` is not what the scip crate says it is.** scip 0.9
-  generates a `Signature` with the text at field 2; rust-analyzer and scip-go both
+  generates a `Signature` with the text at field 2; rust-analyzer and scip-go
   write the older spelling, a `Document` with the text at field 5. Typed access
   compiles and returns an empty string forever, so `store::signature_text` reads
-  both. **scip-typescript writes no `signature_documentation` at all** — its
-  declaration is a ```` ```ts ```` fence at `documentation[0]`, which
-  `store::fenced_declaration` lifts out (the remaining entries stay as doc).
-- **`kind`'s numbers are not the crate's.** The SCIP enum was renumbered, and the
-  producers' numbers do not line up with scip 0.9's (function is 17 there and 24
-  here). They do line up with **each other** — rust-analyzer and scip-go write the
-  same older numbering, verified against both indexes — so `store/kind.rs` is one
-  table with no tool name in it. Do not route these through `scip::types::Kind`,
-  and do not reintroduce a per-tool table: scip-typescript writes no `kind`, and a
-  table keyed on the tool would have silently answered `Unknown` for everything a
-  given tool had not been observed writing. Producers that omit `kind` fall to
-  `kind::from_declaration`, which reads the declaration's leading word (or
-  TypeScript's `(method)` / `(property)` prefix).
+  both. scip-typescript writes none — its declaration is a ```` ```ts ```` fence
+  at `documentation[0]`, lifted out by `store::fenced_declaration`.
+- **`kind`'s numbers are not the crate's.** The enum was renumbered (function is
+  17 in scip 0.9, 24 in what the producers write), but the producers agree with
+  *each other*, so `store/kind.rs` is one table with no tool name in it. Do not
+  route these through `scip::types::Kind`, and do not reintroduce a per-tool
+  table: scip-typescript writes no `kind` at all, and a tool-keyed table would
+  silently answer `Unknown`. Producers that omit it fall to
+  `kind::from_declaration`.
 
-The popup keeps one fixed shape so the reading order does not move per kind:
-container on the left of the header, kind on the right, declaration under it, doc
-under that, then the clickable location and "N refs". The container
-(`app::types::App`) arrives as `SymbolDetail.container` — sheaf-core builds it, so
-conductor never parses a SCIP symbol string. Three things it has to get right:
+Where it lives: `<main worktree>/.conductor/{index.scip,index.hashes,index.log,
+generate.lock}`. Linked worktrees have no `.conductor/`, so `semantic_index`
+walks `git2::Repository::commondir()` to the main one — the same move
+`mcp_serve::resolve` makes for the review DB. The lock is per repository on
+purpose: one producer peaks at 2.36GB, so the cap must not split per worktree.
 
-- **A local has no spelling of its own.** `local 3` carries the enclosing function
-  in `SymbolInformation.enclosing_symbol` instead, and that is where the container
-  comes from. Adding it took the measured coverage from 99 to 193 of the `Exact`
-  answers in this repository — locals and parameters are most of the positions a
-  reader hovers.
-- **The separator comes from the file extension**, not the producer: `::` for
-  `.rs`, `.` for everything else.
-- **A backticked descriptor is a file for TypeScript and a generic type for
-  Rust.** ``src/`greet.tsx`/Loud#`` should drop the file (the popup shows the
-  location anyway); `` `Bridge<'a>`#`` must not be dropped, because the result
-  would name a different type. So it is dropped only in namespace position, and
-  anywhere else the formatter returns `None` rather than guess.
+- **Generation is Rust only; reading is not.** `RustAnalyzer` is the sole
+  producer conductor runs, gated on a root `Cargo.toml`, so a Go or TypeScript
+  repository still answers entirely through tree-sitter. sheaf-core itself is
+  producer-independent and verified against real `scip-go` / `scip-typescript`
+  indexes; what is missing is the host side — choosing a producer per tree and
+  holding several index roots at once.
+- `Regenerator` rebuilds when edits go quiet for 3s, **ignoring gitignored
+  paths** — without that, `target/` churn would reset the quiescence timer
+  forever. That is why `FsEvent::Changed` carries a path. `Lock::acquire`
+  distinguishes "someone else is generating" from "the directory is not there
+  yet"; collapsing the two made every first-ever `conductor index` answer `Busy`.
+- sheaf's `tests/{go,ts}_definition.rs` really launch `scip-go` / `npx` and
+  **fail rather than skip** where absent. `#[ignore]`d tests need a real index —
+  see `SHEAF_TEST_INDEX` / `SHEAF_TEST_ROOT`, and `CONDUCTOR_TEST_REPO` for
+  `src/semantic_index/`'s own.
 
-Pressing a jump key **on** a definition shows its references instead. That test is
-`answer_points_at`: the index's own answer must name the position that was asked
-about. It used to compare the top visible line against a tree-sitter name lookup
-with a ±2-line tolerance, which meant it never fired for fields or locals and
-misfired whenever the viewport had scrolled.
-
-Go-to-implementation answers at two different strengths, and the variant says
-which. **rust-analyzer emits no SCIP `relationships` at all** (measured: 0 of
-22,434 `SymbolInformation` in this repository's index); scip-go and
-scip-typescript both do. Where they exist, the reverse of `implementers` *is* the
-answer and it comes back as `Implementations::Exact`. Where they do not, all that
-is left is the spelling of the symbols themselves: `impl#[Loud][Greeter]` names
-both sides, `store::impl_pair` reads the pair off it, and the answer is
-`Implementations::Derived`. The two are never mixed into one list — merging them
-would drag a producer-declared answer down to the weaker claim. Two consequences
-worth knowing before touching the derived path:
-
-- **The key is a bare spelling, not a symbol.** Two same-named traits in one
-  repository would merge. That is why the answer is not `Exact`.
-- **A generic impl has no block symbol.** `impl<'a> SyntacticLayer for Bridge<'a>`
-  puts nothing but its methods in the index, so the landing point is the earliest
-  definition under that `(trait, type, file)` — the `impl` line when the block
-  symbol exists, the first method inside it otherwise. Both land in the right
-  block; only the former lands on the right line.
-
-Still on tree-sitter, deliberately: the symbol-action overlay (it shows
-definitions, implementations and references together by name, so it moves when
-that overlay moves), and `gi` itself whenever the index stays silent.
+sheaf-core's comments, test names, and error messages are Japanese, and its
+public API deliberately exposes no `protobuf` / `scip` types.
 
 ## Architecture
 
 ### Application Structure
 
-Single-struct state model: `App` in `app/` (`app/mod.rs`, with logic split across `app/review.rs`, `app/terminal.rs`, `app/worktree.rs`) holds all application state as flat fields. No ECS or component architecture.
-
-**Main loop** (`main.rs`): 60fps event loop — polls crossterm events at 16ms, handles keys/mouse, checks file watcher, refreshes worktrees periodically (3s), scans Claude Code PTY output for file-change patterns.
-
-**Event dispatch** (`event/`, dispatched from `event/mod.rs` into per-context submodules `global`/`explorer`/`viewer`/`terminal`/`worktree`/`overlay`/`mouse`): Overlay modes (worktree input, cherry-pick, branch switch, review input, etc.) take absolute priority and consume all keys. Otherwise, the `Focus` enum routes input to the focused panel. Terminal panels forward all keys except Esc directly to PTY.
+`App` in `app/` holds all state as flat fields — no ECS, no components. `main.rs`
+runs a 60fps loop: crossterm events at 16ms, file watcher, a worktree refresh
+every 3s, and a scan of Claude Code's PTY output for file-change patterns.
+`event/` dispatches per context: overlay modes (worktree input, cherry-pick,
+branch switch, …) take absolute priority and consume all keys; otherwise `Focus`
+routes to the focused panel, and terminal panels forward everything but Esc
+straight to the PTY.
 
 ### Layout
 
 ```
-Title bar
-Menu bar (full width)
-Worktree monitor strip (full width)
+Title bar / Menu bar / Worktree monitor strip   (all full width)
 Explorer | Viewer | Terminal (Claude Code / Shell)
 Status bar
 ```
 
-- The **menu bar** (`ui/menu_bar.rs`, `menu/`) is a permanent one-row strip of
-  dropdown menus directly under the title bar — the browsable route to the same
-  commands the palette and the keybindings run. `f10` focuses it. Unlike the
-  worktree strip it stays visible while a panel is maximized. Menu rows carry a
-  `CommandId` and go through `App::execute_palette_command`, so the menu holds
-  no command logic of its own; `menu/model.rs` is taxonomy and labels only.
+A three-column accordion (`ui/layout.rs`) with focus-driven widths: Explorer
+(50/50 tree over diff/comment list), Viewer, Terminal (80/20 Claude Code over
+shell). `Ctrl+Alt+Z` maximizes, `Ctrl+Alt+Arrow` resizes tmux-style (ratios
+persist), `Focus::Editor` merges Explorer+Viewer into one PTY panel. The menu bar
+(`ui/menu_bar.rs`, `menu/`, `f10`) and the worktree strip (`ui/worktree_bar.rs`)
+are full-width rows, not columns; only the menu bar survives a maximize. Menu
+rows carry a `CommandId` and go through `App::execute_palette_command`, so
+`menu/model.rs` is taxonomy and labels only, with no command logic.
 
-- The worktree list is **not** a column: it lives in a full-width monitor strip
-  along the top (`ui/worktree_bar.rs`), showing every worktree's branch, dirty
-  count, ahead/behind, and Claude Code waiting/active state. Hidden while a panel
-  is maximized.
-- The main area is a three-column accordion (`ui/layout.rs`): Explorer | Viewer |
-  Terminal, with focus-driven widths. Any panel can be maximized (`Ctrl+Alt+Z`),
-  and resized tmux-style with `Ctrl+Alt+Arrow` (ratios persist to config.toml).
-- The Viewer keeps several files open at once. `ViewerState` owns a `tabs` list
-  plus an active index; only the active tab's state lives in the flat
+- **The Viewer keeps several files open at once.** `ViewerState` owns a `tabs`
+  list plus an active index; only the active tab's state lives in the flat
   `content`/`search`/`diff_view`/`selection` fields, and the rest is stashed on
-  the tab it belongs to (`viewer/tabs.rs`) — one copy, never two. `open_file`
-  is the single entry point and reuses an existing tab. The strip is drawn on
-  the block's first inner row (`ui/viewer_panel/tab_row.rs`), the same slot the
-  breadcrumb uses, so `screen_row_map` gets a placeholder for it.
-- Explorer column is split 50/50 (file tree top, diff/comment list bottom).
+  the tab it belongs to (`viewer/tabs.rs`) — one copy, never two. `open_file` is
+  the single entry point and reuses an existing tab. The strip draws on the
+  block's first inner row (`ui/viewer_panel/tab_row.rs`), the same slot the
+  breadcrumb uses, so `screen_row_map` needs a placeholder for it.
 - The revidere review view (`Focus::Revidere`, `w`) is *not* part of the
-  accordion: it takes `main_area` whole as two columns (reading order | diff)
-  and hides the terminal column. `ui/layout/render.rs` short-circuits there.
-- Terminal column is split 80/20 vertically (Claude Code top, Shell bottom).
-- When the embedded editor is active (`Focus::Editor`), it merges the
-  Explorer+Viewer columns into one PTY panel.
-- Tab cycles focus; panel-specific vim-style keys (j/k, h/l, g/G, /)
+  accordion: it takes `main_area` whole as two columns (reading order | diff) and
+  hides the terminal column. `ui/layout/render.rs` short-circuits there.
 
 ### Key Modules
 
 | Module | Role |
 |--------|------|
-| `app/` | All application state and business logic methods (`mod.rs` + `review.rs`, `terminal.rs`, `worktree.rs`, `review_publish.rs`, `revidere.rs`) |
-| `event/` | Keyboard/mouse event dispatch based on Focus and overlay state (per-context submodules) |
-| `menu/` | Menu bar model (`model.rs` — which command sits under which menu), interaction state (`state.rs`), and availability predicates for the greyed-out rows (`enabled.rs`) |
-| `git_engine.rs` | All git operations via `git2` (no shell-out) — worktrees, diffs, branches, cherry-pick, merge |
-| `diff_state.rs` | Diff data model (file diffs, hunks, lines) using `similar` crate |
-| `viewer/` | File tree model (`file_tree.rs`), file content buffer (`file_view.rs`), and the open-file tabs (`tabs.rs`) |
-| `review_store.rs` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
-| `pty_manager.rs` | PTY session management — spawn, read/write, resize; vt100 parser for rendering; output scanner for Claude Code |
-| `file_watcher.rs` | Filesystem change detection via `notify` crate, debounced at 500ms |
+| `app/` | All application state and business logic (`mod.rs` plus `review.rs`, `terminal.rs`, `worktree.rs`, `review_publish.rs`, `revidere.rs`) |
+| `event/` | Keyboard/mouse dispatch by Focus and overlay state (per-context submodules) |
+| `menu/` | Menu taxonomy (`model.rs`), interaction state (`state.rs`), greyed-out predicates (`enabled.rs`) |
+| `git_engine/` | All git operations via `git2`, no shell-out — worktrees, diffs, branches, cherry-pick, merge |
+| `diff_state/` | Diff data model (file diffs, hunks, lines) over the `similar` crate |
+| `viewer/` | File tree (`file_tree.rs`), content buffer (`file_view.rs`), open-file tabs (`tabs.rs`) |
+| `review_store/` | SQLite persistence (`.conductor/conductor.db`) for reviews, sessions, templates, history |
+| `pty_manager/` | PTY spawn/read/write/resize, vt100 parsing for rendering, output scanner for Claude Code |
+| `claude_sessions/` | Which `.jsonl` transcript backs a panel (`rotation.rs` is the hook-less `/clear` fallback) |
+| `cc_notify.rs` / `cc_hook.rs` | Unix-socket channel from Claude Code hooks — waiting/active state and the `SessionStart` session-id report |
+| `semantic_index/` | conductor's side of sheaf-core (`mod.rs`) and the `SyntacticLayer` over tree-sitter (`bridge.rs`) |
+| `revidere.rs` / `app/revidere.rs` | Loading the review artifact and building its `ReadingOrder` (read-only) / running `analyze` on a worker thread |
+| `file_watcher.rs` | Filesystem changes via `notify`, debounced at 500ms |
 | `instance_lock.rs` | `.conductor/conductor.lock` の flock による単独起動の担保 — リポジトリ (全 worktree 込み) につき 1 ウィンドウ。ロックは fd の寿命に紐づくので、クラッシュ後の後始末は要らない |
-| `cc_notify.rs` / `cc_hook.rs` | Unix-socket channel from Claude Code hooks — waiting/active state, and the `SessionStart` report that keeps a panel's session id correct across `/clear` |
-| `claude_sessions/` | Resolving which `.jsonl` transcript backs a panel (`rotation.rs` is the hook-less fallback for `/clear`) |
-| `config.rs` | Config loading from `~/.config/conductor/config.toml` |
-| `theme.rs` | Color themes (catppuccin-mocha default, dracula, nord, solarized-dark) |
-| `term_caps.rs` | Terminal capability probing — OSC 11 background-colour query driving light/dark theme auto-selection |
-| `pr_intake.rs` | Fetches a PR via `gh` and prepares its worktree for review (re-entrant: reuses an existing valid worktree) |
-| `semantic_index/` | conductor's side of sheaf-core: where the index lives (`mod.rs`) and the `SyntacticLayer` implementation over tree-sitter (`bridge.rs`) |
-| `revidere.rs` | Loads the review artifact (`<worktree>/.conductor/review.json`) via the `revidere` library and builds its `ReadingOrder` — read-only, no AI |
-| `app/revidere.rs` | Runs `revidere::analyze` on a worker thread (one per branch, cancellable), wires `ai_caller` into its `Ai` seam, and jumps from a section into the Viewer |
-| `ui/revidere_view.rs` | The full-screen two-column review view (reading order \| diff) |
-| `app/review_publish.rs` | Publishes review comments to GitHub via `gh`, tracking which comments are already posted |
+| `term_caps.rs` | OSC 11 background-colour probe driving light/dark theme auto-selection |
+| `pr_intake.rs` | Fetches a PR via `gh` and prepares its worktree (re-entrant: reuses a valid one) |
+| `config/` · `theme/` | Config loading from `~/.config/conductor/config.toml` · colour themes |
 
 ### UI Modules (`src/ui/`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.114.0"
+version = "0.114.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -36,9 +36,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -106,17 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "async-trait"
-version = "0.1.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.2",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +119,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -140,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -159,9 +148,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bincode"
@@ -219,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -293,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -348,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -358,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -370,14 +359,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -451,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.113.2"
+version = "0.113.3"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -486,7 +475,7 @@ dependencies = [
  "syntect-tui",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-rust",
@@ -548,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -629,20 +618,31 @@ checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -651,14 +651,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.23.0"
+name = "darling_core"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
- "darling_core",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -689,7 +713,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -697,6 +721,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -731,13 +758,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -769,9 +796,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "env_filter"
@@ -814,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "fallible-iterator"
@@ -869,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -927,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -942,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -952,15 +979,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -969,38 +996,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1147,9 +1174,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1167,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1186,9 +1213,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1268,13 +1295,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1282,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1295,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1309,15 +1335,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1329,15 +1355,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1367,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1393,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1427,6 +1453,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1440,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -1460,11 +1488,11 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1473,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -1519,9 +1547,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1543,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1565,7 +1593,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1614,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1666,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1692,15 +1720,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
@@ -1722,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -1786,9 +1814,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1801,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -1859,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1908,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -2065,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2162,19 +2190,19 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
- "quick-xml 0.41.0",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2208,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2244,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2300,9 +2328,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -2330,7 +2358,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2338,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2353,7 +2381,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2453,27 +2481,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2490,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2577,21 +2605,21 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.1"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2600,15 +2628,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.1"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2618,7 +2646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2679,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2705,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2742,9 +2770,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2805,7 +2833,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2885,7 +2913,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2896,7 +2924,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2933,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2973,7 +3001,7 @@ dependencies = [
  "scip",
  "sha1",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3073,7 +3101,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 1.1.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3184,9 +3212,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3230,7 +3258,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "yaml-rust",
 ]
@@ -3270,11 +3298,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3290,22 +3318,23 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3317,15 +3346,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3333,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3358,9 +3387,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3379,7 +3408,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3420,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3467,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -3565,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",
@@ -3621,9 +3650,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "two-face"
-version = "0.5.1"
+version = "0.5.2+bat-0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+checksum = "915be7adc2ff6f4338acbf71f3eda0a146f46003b992a1669c674308610efdac"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3703,9 +3732,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3784,9 +3813,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3797,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3807,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3817,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3830,18 +3859,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -3853,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
  "bitflags 2.13.1",
  "rustix 1.1.4",
@@ -3887,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.13"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.13.1",
  "wayland-backend",
@@ -3938,12 +3967,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "quote",
 ]
 
@@ -3961,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4275,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x11-clipboard"
@@ -4308,9 +4337,9 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcursor"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
 
 [[package]]
 name = "xkeysym"
@@ -4379,9 +4408,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4390,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4401,13 +4430,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4418,9 +4447,9 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.113.3"
+version = "0.113.4"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -1150,14 +1150,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1759,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2651,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
@@ -3071,9 +3074,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.113.1"
+version = "0.113.2"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.113.4"
+version = "0.114.0"
 dependencies = [
  "aa-media",
  "anyhow",
@@ -618,36 +618,12 @@ checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.1",
- "darling_macro 0.24.1",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -665,22 +641,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.1",
+ "darling_core",
  "quote",
  "syn 3.0.4",
 ]
@@ -721,9 +686,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -1114,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1298,12 +1260,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1311,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1324,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1338,16 +1301,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1358,15 +1322,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1396,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1406,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1422,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1491,15 +1455,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1890,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1939,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2199,13 +2163,13 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -2328,15 +2292,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -2635,7 +2590,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling 0.24.1",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3335,12 +3290,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3352,15 +3306,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3922,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.13.1",
  "wayland-backend",
@@ -3978,7 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.41.0",
+ "quick-xml",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.113.4"
+version = "0.114.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.114.0"
+version = "0.114.1"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.113.2"
+version = "0.113.3"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.113.1"
+version = "0.113.2"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.113.3"
+version = "0.113.4"
 edition = "2024"
 
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"
 git2 = { version = "0.20", features = ["vendored-openssl"] }
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 syntect-tui = "3.0.6"
-similar = { version = "2", features = ["inline"] }
+similar = { version = "3", features = ["inline"] }
 toml = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build dev clean
+.PHONY: install build dev clean hooks fmt
 
 install:
 	cargo install --path .
@@ -11,3 +11,9 @@ dev:
 
 clean:
 	cargo clean
+
+fmt:
+	cargo fmt --all
+
+hooks:
+	git config core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -4,25 +4,18 @@ Terminal-based Git workspace and code review TUI written in Rust. Manages multip
 
 ## Prerequisites
 
-### Required
-
 | Dependency | Version | Notes |
 |---|---|---|
 | **Rust toolchain** | 1.88+ | Edition 2024. Install via [rustup](https://rustup.rs/) |
-| **Git** | 2.x | Used for worktree operations (`git worktree add`, `git fetch`, etc.) |
-| **Claude Code** | latest | `claude` CLI must be in `$PATH`. Install via `npm install -g @anthropic-ai/claude-code` |
-| **Node.js + npm** | 20+ | Required for Claude Code installation |
+| **Git** | 2.x | Worktree operations (`git worktree add`, `git fetch`, …) |
+| **Claude Code** | latest | `claude` must be in `$PATH` (`npm install -g @anthropic-ai/claude-code`) |
+| **Node.js + npm** | 20+ | Required to install Claude Code |
 
-### Optional
-
-| Dependency | Purpose | How to enable |
-|---|---|---|
-| **ccusage** (via npx) | Token usage / cost display in title bar | Set `ccusage.enabled = true` in config |
-| **GitHub CLI** (`gh`) | Pulling in a PR for review, and publishing review comments to GitHub | [Install](https://cli.github.com/) and run `gh auth login` |
+Optional: **`gh`** ([install](https://cli.github.com/), then `gh auth login`) for
+pulling a PR in and publishing review comments, and **ccusage** (via npx) for the
+title bar's token/cost display (`ccusage.enabled = true`).
 
 ## Installation
-
-### 1. Install the binary
 
 ```sh
 git clone https://github.com/S-Nakamur-a/conductor.git
@@ -30,33 +23,27 @@ cd conductor
 make install
 ```
 
-`make install` installs the `conductor` binary to `~/.cargo/bin/` (`cargo install --path .`). The MCP server and the revidere review analyser ship inside this same binary, so there's nothing else to install for them.
+`make install` puts the `conductor` binary in `~/.cargo/bin/`. The MCP server and
+the revidere review analyser ship inside that same binary, so there is nothing
+else to install for them.
 
-### 2. Install the Claude Code plugin
-
-In a Claude Code session, run:
+Then, in a Claude Code session:
 
 ```
 /plugin marketplace add S-Nakamur-a/conductor
 /plugin install conductor@conductor-marketplace
 ```
 
-This sets up:
-- **MCP server** — review comment DB integration and change summaries
-- **Hooks** — waiting-state detection for Claude Code sessions
-- **Skills** — `/address-conductor-comment` (resolve review comments), `/explain-comment` (annotate hard-to-understand code with inline comments)
+That sets up the MCP server (review comment DB and change summaries), the hooks
+that detect a waiting Claude Code session, and the `/address-conductor-comment`
+and `/explain-comment` skills.
 
 ## Usage
 
 ```sh
-# Run against the current directory
-conductor
-
-# Run against a specific repo
-conductor /path/to/repo
-
-# Or use make for development
-make dev
+conductor                 # the current directory
+conductor /path/to/repo   # a specific repo
+make dev                  # cargo run, for development
 ```
 
 ## Layout
@@ -76,184 +63,89 @@ make dev
 ```
 
 The main area is a three-column accordion — **Explorer | Viewer | Terminal** —
-with focus-driven widths. The worktree list is no longer a column: every
-worktree (branch, dirty count, ahead/behind, and Claude Code waiting/active
-state) is shown in the full-width **worktree monitor strip** along the top, so
-multiple parallel sessions can be watched at a glance. Click a worktree to jump
-to it, `[+]` to create one, or open the switcher modal for the full list/detail
-view.
+with focus-driven widths. Explorer is split 50/50 (file tree / diff / comment
+list) and Terminal 80/20 (Claude Code / shell). Any panel maximizes with
+`Ctrl+Alt+Z` and resizes tmux-style with `Ctrl+Alt+Arrow`, and the ratios
+persist to `config.toml`.
 
-- **Explorer** column is split 50/50: file tree (top) and diff / comment list (bottom).
-- **Terminal** column is split 80/20: Claude Code (top) and Shell (bottom).
-- Any panel can be maximized (`Ctrl+Alt+Z`) to take the full main area, or resized
-  tmux-style with `Ctrl+Alt+Arrow` (the new ratios persist to `config.toml`).
+The worktree list is not a column. Every worktree — branch, dirty count,
+ahead/behind, and Claude Code waiting/active state — sits in the full-width
+monitor strip along the top, so parallel sessions can be watched at a glance.
+Click one to jump to it, or `[+]` to create one.
 
 ### Keybindings
 
-- **Tab / Shift+Tab** — cycle panel focus (non-terminal panels)
-- **Alt+h / Alt+l** — cycle panel focus from anywhere, including terminals
-- **Alt+1…6** (or **⌘+1…6**) — focus a specific panel
-- **Ctrl+Alt+Z** — maximize / restore (zoom) the focused panel
-- **Ctrl+Alt+Arrow** — resize the focused panel tmux-style (ratios persist)
-- **Ctrl+Tab / Ctrl+Shift+Tab** (or **Alt+] / Alt+[**) — switch the selected worktree
-- **Ctrl+n** — new Claude Code session · **Ctrl+t** — new shell
-- **j/k** — navigate up/down · **h/l** — collapse/expand · **g/G** — top/bottom
-- **/** — search · **Ctrl+g** — full-text (grep) search
-- **?** — show help · **Esc** — back / close overlay · **Ctrl+q** — quit
+Press **?** in the app for the full list; **Ctrl+p** (or **:** outside a
+terminal) opens the fuzzy-searchable command palette, which reaches every
+command by name.
 
-### Command Palette
-
-**Ctrl+p** (any panel, including terminals) or **:** (non-terminal panels) opens the command palette. All available commands are listed and fuzzy-searchable — worktree operations, terminal management, diff toggles, review comments, etc.
+| | |
+|---|---|
+| **Tab / Shift+Tab** | cycle panel focus (non-terminal panels) |
+| **Alt+h / Alt+l** | cycle panel focus from anywhere, terminals included |
+| **Alt+1…6** (or **⌘+1…6**) | focus a specific panel |
+| **Ctrl+Alt+Z** / **Ctrl+Alt+Arrow** | maximize / resize the focused panel |
+| **Ctrl+Tab / Ctrl+Shift+Tab** (or **Alt+] / Alt+[**) | switch worktree |
+| **Ctrl+n** / **Ctrl+t** | new Claude Code session / new shell |
+| **j/k** · **h/l** · **g/G** | up/down · collapse/expand · top/bottom |
+| **/** · **Ctrl+g** | search · full-text (grep) search |
+| **Esc** · **Ctrl+q** | back / close overlay · quit |
 
 ## Reviewing a Pull Request
 
-PR review is built into the normal Explorer/Viewer/Terminal accordion — there's
-no separate full-screen mode to enter or exit, so all the usual navigation and
-terminal keybindings keep working while you review:
+PR review runs inside the normal Explorer/Viewer/Terminal accordion — there is
+no separate mode to enter or leave, so every navigation and terminal keybinding
+keeps working while you review.
 
-1. **Pull Request → local worktree** — menu: *Review ▸ Review Pull Request…*,
-   enter a PR number or URL. Conductor fetches it (via `gh`) into a worktree,
-   focuses the Explorer's changed-files list, and offers to run the AI review
-   below on it.
-2. **Changed files and comments** — the Explorer's bottom pane cycles between
-   the changed-files diff list and the review comment list.
-3. **Jump into the code** — the diff pane supports the Viewer's `gd`/`gi`/`gr`
-   symbol-jump hints (go to definition / implementation / references). **Symbol
-   jumps only work for Rust, Go, and TypeScript** — other languages show no
-   hints.
-4. **AI review** — `W` (menu: *Review ▸ Review current branch*) asks first, then
-   runs **revidere** over the worktree's
-   diff. It sorts every changed line into sections by importance
-   (core / ripple / follow / minor) and checks that **no changed line is left
-   unexplained**. `w` then opens the result as a full-screen two-column view:
-   the reading order on the left, the diff in that order on the right. `j`/`k`
-   scroll, `n`/`N` move between sections, `Enter` opens the section's location
-   in the Viewer (where you can leave a comment), `q` closes it.
+*Review ▸ Review Pull Request…* fetches a PR (via `gh`) into a worktree and
+focuses the changed-files list. `W` then runs **revidere**, the AI reviewer that
+ships inside the binary: it sorts every changed line into sections by importance
+and checks that no changed line is left unexplained. `w` opens the result as a
+two-column reading-order view, and *Review: Publish Comments to GitHub* posts
+your inline comments back to the PR.
 
-   revidere lives in this repository (`crates/revidere`) and ships inside the
-   `conductor` binary, so there is nothing extra to install. It calls the AI
-   through the same `[api]` section as every other AI feature here — but note
-   that this one needs `provider = "command"` pointing at an agentic CLI: the
-   model is expected to read the repository itself, which a plain HTTP
-   completion cannot do. Replies are cached on the diff itself, so re-running on
-   an unchanged diff returns instantly — the confirmation offers a re-analysis
-   that ignores the cache when a review for this commit already exists, and
-   `alt+w` skips both the question and the cache.
-5. **Publish comments** — palette: *Review: Publish Comments to GitHub* posts
-   your inline review comments (and replies) back to the PR via `gh`.
-
-Requires the `gh` CLI (see Prerequisites) to be installed and authenticated.
-
-> **Breaking change:** diff mode's "jump to top" moved from `g` to `gg` (vim-style),
-> since `g` is now a prefix for symbol-jump hints (`gd`/`gi`/`gr`/`gg`).
-
+Full walkthrough, including the symbol-jump keys and revidere's `[api]`
+requirements: [docs/reviewing-a-pr.md](docs/reviewing-a-pr.md).
 ## MCP Server
 
-The MCP server that exposes the review database to Claude Code sessions running inside the terminal is the `conductor` binary itself, via `conductor mcp-serve` — there's no separate package to build or keep in sync with the TUI's version.
-
-The MCP server is automatically configured when you install the Claude Code plugin (see Installation step 2). **`conductor` must be on `$PATH`** for this to work — the plugin's `.mcp.json` invokes it by name, not by absolute path.
-
-To run it manually (e.g. for development):
+The MCP server that exposes the review database to the Claude Code sessions
+running inside the terminal is the `conductor` binary itself, via
+`conductor mcp-serve` — there is no separate package to keep in sync with the
+TUI's version. Installing the plugin configures it, but **`conductor` must be on
+`$PATH`**: the plugin's `.mcp.json` invokes it by name, not by absolute path.
 
 ```sh
-conductor mcp-serve --db /path/to/repo/.conductor/conductor.db
+conductor mcp-serve --db /path/to/repo/.conductor/conductor.db   # run it by hand
 ```
 
 ## Configuration
 
 Config file: `~/.config/conductor/config.toml`
 
-All fields are optional with sensible defaults. Full example:
+All fields are optional with sensible defaults, so an absent config file is a
+valid one. The full set of keys — with every field commented out at its default
+— is in [docs/configuration.md](docs/configuration.md).
 
-```toml
-[general]
-# repo = "/path/to/default/repo"       # default repository to open on startup
-main_branch = "main"                    # main/trunk branch name (default: "main")
-# shell = "/bin/zsh"                    # shell for PTY sessions (default: $SHELL)
-# repos = ["/path/to/repo1", "/path/to/repo2"]  # additional repos for multi-repo support
-# worktree_dir = "~/worktrees"          # custom worktree base directory
-                                        #   (default: <repo-parent>/<repo-name>-worktrees/)
-decoration = "aquarium"                 # worktree panel decoration
-                                        #   aquarium | space | garden | city | none
-# auto_resume = true                    # automatically resume Claude Code sessions on startup
-# auto_resume_main = false              # also resume the session on the main worktree
-                                        #   (grabbed sessions are always resumed regardless)
-
-[terminal]
-# inactive_scrollback = 1000            # scrollback lines for background sessions
-# active_scrollback = 10000             # scrollback lines for foreground session
-
-[viewer]
-theme = "catppuccin-mocha"              # syntax highlighting theme
-                                        #   catppuccin-mocha | dracula | nord | solarized-dark
-# syntax_theme_file = "~/.config/conductor/custom.tmTheme"  # custom .tmTheme file path
-# tab_width = 2                         # spaces per tab stop
-# word_wrap = false                     # soft-wrap long lines (未実装)
-
-[diff]
-# default_view = "unified"              # unified | side-by-side
-# word_diff = true                      # highlight intra-line word changes
-
-[review]
-# レビュー機能はMCPプラグイン (conductor plugin) に移行済みです。
-# 以下の設定は互換性のため残されていますが、通常は変更不要です。
-# prompt_template = "以下のレビューコメントに対応してください。\n\n{comments}"
-                                        # template for review prompts ({comments} is replaced)
-# prompt_action = "clipboard"           # clipboard | send_to_session
-
-[keybinds]
-# Key-bind overrides, in key->action form (powered by keymap-rs). Each entry
-# maps a key chord to an action name and LAYERS OVER the built-in defaults
-# per-chord. [keybinds.keys] is the global layer; each [keybinds.layers.<name>]
-# is a per-panel layer (worktree, explorer, explorer_diff_list,
-# explorer_comment_list, viewer, viewer_diff_mode, terminal, editor, overlay).
-#
-# [keybinds.keys]
-# "ctrl+q" = "quit"
-#
-# [keybinds.layers.worktree]
-# "j" = "navigate_down"
-# "down" = "navigate_down"
-# "w" = "create_worktree"
-
-[ccusage]
-# enabled = false                       # token usage display in the title bar (requires ccusage)
-# poll_interval_secs = 120              # polling interval in seconds
-
-[updates]
-# check_on_startup = true               # check for new versions on startup
-# check_interval_secs = 3600            # minimum interval between checks (default: 1h)
-
-[api]
-# LLM provider for smart-worktree generation (turn a task description into a
-# branch name + initial Claude Code prompt). Each provider stands alone — a
-# failure surfaces to the user rather than falling back to another.
-# provider = "gemini"                   # "gemini" (Gemini API) | "claude" (claude -p CLI) | "command" (external)
-# model = "gemini-2.5-flash"            # model used by the "gemini" provider
-# command = ["ollama", "run", "llama3"] # external command for provider = "command"
-                                        #   (prompt on stdin, completion on stdout)
-# command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
-```
+The sections are `[general]` (repo, main branch, shell, worktree directory,
+Claude Code auto-resume), `[terminal]` (scrollback limits), `[viewer]` (syntax
+theme, tab width), `[diff]` (unified / side-by-side, word diff), `[keybinds]`
+(per-chord overrides layered over the defaults, globally or per panel),
+`[ccusage]`, `[updates]`, and `[api]` (the LLM provider shared by every AI
+feature).
 
 ## Development
 
 ```sh
-cargo build              # build
-cargo test --workspace   # test (crates/ のワークスペースメンバーも含む)
-cargo clippy --workspace # lint
-make fmt                 # cargo fmt --all
+cargo build               # build
+cargo test --workspace    # test — bare `cargo test` skips the crates/ members
+cargo clippy --workspace  # lint
+make fmt                  # cargo fmt --all
+make hooks                # enable the pre-commit hook (once per clone)
 ```
 
-### Git hooks
-
-Commit 時に `cargo fmt --all -- --check` を走らせる pre-commit フックが
-`.githooks/pre-commit` にあります。clone 後に一度だけ有効化してください。
-
-```sh
-make hooks   # git config core.hooksPath .githooks
-```
-
-フックが落ちた場合は `make fmt` (= `cargo fmt --all`) を実行してから commit し直します。
+`make hooks` points `core.hooksPath` at `.githooks/`, whose `pre-commit` runs
+`cargo fmt --all -- --check`. If it rejects a commit, run `make fmt` and commit
+again.
 
 ## Data Paths
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,26 @@ theme = "catppuccin-mocha"              # syntax highlighting theme
 # command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
 ```
 
+## Development
+
+```sh
+cargo build              # build
+cargo test --workspace   # test (crates/ のワークスペースメンバーも含む)
+cargo clippy --workspace # lint
+make fmt                 # cargo fmt --all
+```
+
+### Git hooks
+
+Commit 時に `cargo fmt --all -- --check` を走らせる pre-commit フックが
+`.githooks/pre-commit` にあります。clone 後に一度だけ有効化してください。
+
+```sh
+make hooks   # git config core.hooksPath .githooks
+```
+
+フックが落ちた場合は `make fmt` (= `cargo fmt --all`) を実行してから commit し直します。
+
 ## Data Paths
 
 | Path | Description |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terminal-based Git workspace and code review TUI written in Rust. Manages multip
 
 | Dependency | Version | Notes |
 |---|---|---|
-| **Rust toolchain** | 1.85+ | Edition 2024. Install via [rustup](https://rustup.rs/) |
+| **Rust toolchain** | 1.88+ | Edition 2024. Install via [rustup](https://rustup.rs/) |
 | **Git** | 2.x | Used for worktree operations (`git worktree add`, `git fetch`, etc.) |
 | **Claude Code** | latest | `claude` CLI must be in `$PATH`. Install via `npm install -g @anthropic-ai/claude-code` |
 | **Node.js + npm** | 20+ | Required for Claude Code installation |

--- a/crates/sheaf-core/Cargo.toml
+++ b/crates/sheaf-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sheaf-core"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 publish = false
 
 [dependencies]

--- a/crates/sheaf-core/tests/dispatch.rs
+++ b/crates/sheaf-core/tests/dispatch.rs
@@ -442,9 +442,7 @@ fn 実リポジトリ_インタフェース経由の参照が位置ごと一致�
     assert_eq!(
         places,
         [75, 121, 129, 137, 144, 187, 233, 241, 263, 269, 276]
-            .map(|l| format!(
-                "pkg/prospects/internal/domainservice/role_reconciliation.go:{l}"
-            ))
+            .map(|l| format!("pkg/prospects/internal/domainservice/role_reconciliation.go:{l}"))
             .to_vec()
     );
 

--- a/crates/sheaf-core/tests/enclosing.rs
+++ b/crates/sheaf-core/tests/enclosing.rs
@@ -17,7 +17,8 @@ use std::path::{Path, PathBuf};
 
 const PKG: &str = "rust-analyzer cargo demo 0.1.0";
 /// derive が作った impl。定義 occurrence を持たない。
-const DERIVED: &str = "rust-analyzer cargo demo 0.1.0 app/focus/impl#[Focus][`PartialEq<Self>`]eq().";
+const DERIVED: &str =
+    "rust-analyzer cargo demo 0.1.0 app/focus/impl#[Focus][`PartialEq<Self>`]eq().";
 /// その型。定義 occurrence を持つ。
 const TYPE: &str = "rust-analyzer cargo demo 0.1.0 app/focus/Focus#";
 
@@ -274,7 +275,10 @@ fn 実索引_derive_の_default_は型の定義に落ちる() {
         }
     );
     assert!(
-        found[0].ty.as_str().ends_with("git_engine/status_map/GitStatusMap#"),
+        found[0]
+            .ty
+            .as_str()
+            .ends_with("git_engine/status_map/GitStatusMap#"),
         "{}",
         found[0].ty.as_str()
     );

--- a/crates/sheaf-core/tests/layout.rs
+++ b/crates/sheaf-core/tests/layout.rs
@@ -5,7 +5,10 @@
 //! 答えの対象に入ってくる」という形で誤答の経路を作るので、そこを重点的に見る。
 
 use scip::types::{Document, Index, Metadata, Occurrence, SymbolRole, ToolInfo};
-use sheaf_core::{Definition, IndexSource, Location, Span, Store, SyntacticAnswer, SyntacticLayer, Token, blob_hash, definition_at};
+use sheaf_core::{
+    Definition, IndexSource, Location, Span, Store, SyntacticAnswer, SyntacticLayer, Token,
+    blob_hash, definition_at,
+};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -130,7 +133,11 @@ fn 索引ルートが2つあっても同じstoreから両方引ける() {
     // api/ と api/nested/ が別々の索引ルート。入れ子は実在する形で、
     // 実測した対象では go.mod が 8 個あり、うち 1 つが別の索引ルートの下にいた。
     let outer_hash = put(&root, "api/main.go", "package main\n\nfunc Outer() {}\n");
-    let inner_hash = put(&root, "api/nested/lib.go", "package nested\n\nfunc Inner() {}\n");
+    let inner_hash = put(
+        &root,
+        "api/nested/lib.go",
+        "package nested\n\nfunc Inner() {}\n",
+    );
 
     let outer_index = root.join("outer.scip");
     write_index(
@@ -152,7 +159,11 @@ fn 索引ルートが2つあっても同じstoreから両方引ける() {
     let store = Store::load(
         &[
             source(&outer_index, "api", vec![provenance("main.go", outer_hash)]),
-            source(&inner_index, "api/nested", vec![provenance("lib.go", inner_hash)]),
+            source(
+                &inner_index,
+                "api/nested",
+                vec![provenance("lib.go", inner_hash)],
+            ),
         ],
         &root,
     )
@@ -189,8 +200,16 @@ fn 同じ符号が別の索引にあっても混ざらない() {
     // 座標に索引ルートの情報が入らないので、別の索引ルートの同じ相対パスの
     // ファイルが同じ符号を持つ。またいで突き合わせると誤った定義を Exact で返す。
     let root = workdir("same-symbol");
-    let a_hash = put(&root, "appA/types/routes.d.ts", "export const marker = 1;\n");
-    let b_hash = put(&root, "appB/types/routes.d.ts", "export const marker = 2;\n");
+    let a_hash = put(
+        &root,
+        "appA/types/routes.d.ts",
+        "export const marker = 1;\n",
+    );
+    let b_hash = put(
+        &root,
+        "appB/types/routes.d.ts",
+        "export const marker = 2;\n",
+    );
 
     const SHARED: &str = "scip-typescript npm . . types/`routes.d.ts`/marker.";
 
@@ -213,8 +232,16 @@ fn 同じ符号が別の索引にあっても混ざらない() {
 
     let store = Store::load(
         &[
-            source(&a_index, "appA", vec![provenance("types/routes.d.ts", a_hash)]),
-            source(&b_index, "appB", vec![provenance("types/routes.d.ts", b_hash)]),
+            source(
+                &a_index,
+                "appA",
+                vec![provenance("types/routes.d.ts", a_hash)],
+            ),
+            source(
+                &b_index,
+                "appB",
+                vec![provenance("types/routes.d.ts", b_hash)],
+            ),
         ],
         &root,
     )
@@ -243,7 +270,10 @@ fn 接ぎ木してもルートの外に出るdocumentは捨てる() {
     write_index(
         &index,
         vec![
-            doc("main.go", vec![occurrence(vec![0, 8, 12], "m/Main().", DEF)]),
+            doc(
+                "main.go",
+                vec![occurrence(vec![0, 8, 12], "m/Main().", DEF)],
+            ),
             // api/ から見て 2 つ上がるとリポジトリルートの外。
             doc(
                 "../../outside.go",
@@ -338,10 +368,7 @@ fn パスが衝突したらいちばん深い索引ルートが勝つ() {
     write_index(
         &front_index,
         vec![
-            doc(
-                "app.ts",
-                vec![occurrence(vec![0, 13, 14], "front/a.", DEF)],
-            ),
+            doc("app.ts", vec![occurrence(vec![0, 13, 14], "front/a.", DEF)]),
             // front から見た ../common/tokens/src/mui.d.ts。所有者は common/tokens。
             doc(
                 "../common/tokens/src/mui.d.ts",
@@ -371,7 +398,11 @@ fn パスが衝突したらいちばん深い索引ルートが勝つ() {
                     provenance("../common/tokens/src/mui.d.ts", own_hash.clone()),
                 ],
             ),
-            source(&tokens_index, "common/tokens", vec![provenance("src/mui.d.ts", own_hash)]),
+            source(
+                &tokens_index,
+                "common/tokens",
+                vec![provenance("src/mui.d.ts", own_hash)],
+            ),
         ],
         &root,
     )

--- a/crates/sheaf-core/tests/ts_definition.rs
+++ b/crates/sheaf-core/tests/ts_definition.rs
@@ -119,7 +119,9 @@ fn hash_tree(root: &Path) -> BTreeMap<PathBuf, String> {
             continue;
         };
         for entry in entries.flatten() {
-            let Ok(kind) = entry.file_type() else { continue };
+            let Ok(kind) = entry.file_type() else {
+                continue;
+            };
             if kind.is_dir() {
                 stack.push(entry.path());
             } else if kind.is_file()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,82 @@
+# Configuration
+
+Config file: `~/.config/conductor/config.toml`
+
+All fields are optional with sensible defaults. This is the full set, with
+every optional field commented out at its default.
+
+```toml
+[general]
+# repo = "/path/to/default/repo"       # default repository to open on startup
+main_branch = "main"                    # main/trunk branch name (default: "main")
+# shell = "/bin/zsh"                    # shell for PTY sessions (default: $SHELL)
+# repos = ["/path/to/repo1", "/path/to/repo2"]  # additional repos for multi-repo support
+# worktree_dir = "~/worktrees"          # custom worktree base directory
+                                        #   (default: <repo-parent>/<repo-name>-worktrees/)
+decoration = "aquarium"                 # worktree panel decoration
+                                        #   aquarium | space | garden | city | none
+# auto_resume = true                    # automatically resume Claude Code sessions on startup
+# auto_resume_main = false              # also resume the session on the main worktree
+                                        #   (grabbed sessions are always resumed regardless)
+
+[terminal]
+# inactive_scrollback = 1000            # scrollback lines for background sessions
+# active_scrollback = 10000             # scrollback lines for foreground session
+
+[viewer]
+theme = "catppuccin-mocha"              # syntax highlighting theme
+                                        #   catppuccin-mocha | dracula | nord | solarized-dark
+# syntax_theme_file = "~/.config/conductor/custom.tmTheme"  # custom .tmTheme file path
+# tab_width = 2                         # spaces per tab stop
+# word_wrap = false                     # soft-wrap long lines (未実装)
+
+[diff]
+# default_view = "unified"              # unified | side-by-side
+# word_diff = true                      # highlight intra-line word changes
+
+[review]
+# レビュー機能はMCPプラグイン (conductor plugin) に移行済みです。
+# 以下の設定は互換性のため残されていますが、通常は変更不要です。
+# prompt_template = "以下のレビューコメントに対応してください。\n\n{comments}"
+                                        # template for review prompts ({comments} is replaced)
+# prompt_action = "clipboard"           # clipboard | send_to_session
+
+[keybinds]
+# Key-bind overrides, in key->action form (powered by keymap-rs). Each entry
+# maps a key chord to an action name and LAYERS OVER the built-in defaults
+# per-chord. [keybinds.keys] is the global layer; each [keybinds.layers.<name>]
+# is a per-panel layer (worktree, explorer, explorer_diff_list,
+# explorer_comment_list, viewer, viewer_diff_mode, terminal, editor, overlay).
+#
+# [keybinds.keys]
+# "ctrl+q" = "quit"
+#
+# [keybinds.layers.worktree]
+# "j" = "navigate_down"
+# "down" = "navigate_down"
+# "w" = "create_worktree"
+
+[ccusage]
+# enabled = false                       # token usage display in the title bar (requires ccusage)
+# poll_interval_secs = 120              # polling interval in seconds
+
+[updates]
+# check_on_startup = true               # check for new versions on startup
+# check_interval_secs = 3600            # minimum interval between checks (default: 1h)
+
+[api]
+# LLM provider for smart-worktree generation (turn a task description into a
+# branch name + initial Claude Code prompt). Each provider stands alone — a
+# failure surfaces to the user rather than falling back to another.
+# provider = "gemini"                   # "gemini" (Gemini API) | "claude" (claude -p CLI) | "command" (external)
+# model = "gemini-2.5-flash"            # model used by the "gemini" provider
+# command = ["ollama", "run", "llama3"] # external command for provider = "command"
+                                        #   (prompt on stdin, completion on stdout)
+# command_timeout_secs = 60             # wall-clock timeout for the command provider (0 = no timeout)
+```
+
+## Key-bind action names
+
+`[keybinds]` entries map a key chord to an *action name*. The authoritative list
+of action names is `src/keymap/action.rs`; the layer names accepted under
+`[keybinds.layers.<name>]` are listed in the `[keybinds]` comment above.

--- a/docs/reviewing-a-pr.md
+++ b/docs/reviewing-a-pr.md
@@ -1,0 +1,43 @@
+# Reviewing a Pull Request
+
+PR review is built into the normal Explorer/Viewer/Terminal accordion — there's
+no separate full-screen mode to enter or exit, so all the usual navigation and
+terminal keybindings keep working while you review:
+
+1. **Pull Request → local worktree** — menu: *Review ▸ Review Pull Request…*,
+   enter a PR number or URL. Conductor fetches it (via `gh`) into a worktree,
+   focuses the Explorer's changed-files list, and offers to run the AI review
+   below on it.
+2. **Changed files and comments** — the Explorer's bottom pane cycles between
+   the changed-files diff list and the review comment list.
+3. **Jump into the code** — the diff pane supports the Viewer's `gd`/`gi`/`gr`
+   symbol-jump hints (go to definition / implementation / references). **Symbol
+   jumps only work for Rust, Go, and TypeScript** — other languages show no
+   hints.
+4. **AI review** — `W` (menu: *Review ▸ Review current branch*) asks first, then
+   runs **revidere** over the worktree's
+   diff. It sorts every changed line into sections by importance
+   (core / ripple / follow / minor) and checks that **no changed line is left
+   unexplained**. `w` then opens the result as a full-screen two-column view:
+   the reading order on the left, the diff in that order on the right. `j`/`k`
+   scroll, `n`/`N` move between sections, `Enter` opens the section's location
+   in the Viewer (where you can leave a comment), `q` closes it.
+
+   revidere lives in this repository (`crates/revidere`) and ships inside the
+   `conductor` binary, so there is nothing extra to install. It calls the AI
+   through the same `[api]` section as every other AI feature here — but note
+   that this one needs `provider = "command"` pointing at an agentic CLI: the
+   model is expected to read the repository itself, which a plain HTTP
+   completion cannot do. Replies are cached on the diff itself, so re-running on
+   an unchanged diff returns instantly — the confirmation offers a re-analysis
+   that ignores the cache when a review for this commit already exists, and
+   `alt+w` skips both the question and the cache.
+5. **Publish comments** — palette: *Review: Publish Comments to GitHub* posts
+   your inline review comments (and replies) back to the PR via `gh`.
+
+Requires the `gh` CLI (see Prerequisites) to be installed and authenticated.
+
+> **Breaking change:** diff mode's "jump to top" moved from `g` to `gg` (vim-style),
+> since `g` is now a prefix for symbol-jump hints (`gd`/`gi`/`gr`/`gg`).
+
+

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -114,7 +114,11 @@ impl App {
         if let Err(e) = crate::config::persist_ui_high_contrast(self.theme_sel.high_contrast) {
             log::warn!("failed to persist high_contrast: {e}");
         }
-        let state = if self.theme_sel.high_contrast { "on" } else { "off" };
+        let state = if self.theme_sel.high_contrast {
+            "on"
+        } else {
+            "off"
+        };
         self.set_status_info(format!("High contrast {state}"));
     }
 
@@ -206,7 +210,8 @@ impl App {
     }
 
     fn cmd_show_diff_list(&mut self) {
-        self.viewer_state.explorer.explorer_bottom_view = crate::viewer::ExplorerBottomView::DiffList;
+        self.viewer_state.explorer.explorer_bottom_view =
+            crate::viewer::ExplorerBottomView::DiffList;
         self.viewer_state.explorer.explorer_focus_on_diff_list = true;
         self.set_focus(Focus::Explorer);
     }
@@ -217,5 +222,4 @@ impl App {
         self.viewer_state.explorer.explorer_focus_on_diff_list = true;
         self.set_focus(Focus::Explorer);
     }
-
 }

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -46,9 +46,10 @@ impl App {
             return;
         }
         let (worktree_name, working_dir) = self.selected_worktree_info();
-        let Some(path) =
-            editor_target(self.viewer_state.content.current_file.as_deref(), &working_dir)
-        else {
+        let Some(path) = editor_target(
+            self.viewer_state.content.current_file.as_deref(),
+            &working_dir,
+        ) else {
             self.set_status("No file open to edit".to_string(), StatusLevel::Warning);
             return;
         };
@@ -255,7 +256,10 @@ mod tests {
 
     #[test]
     fn editor_target_is_none_for_empty_path() {
-        assert_eq!(editor_target(Some(""), std::path::Path::new("/repo/wt")), None);
+        assert_eq!(
+            editor_target(Some(""), std::path::Path::new("/repo/wt")),
+            None
+        );
     }
 
     #[test]
@@ -273,7 +277,10 @@ mod tests {
 
     #[test]
     fn resolve_editor_uses_editor_when_visual_unset() {
-        assert_eq!(resolve_editor_command(None, Some("nano"), "vi"), vec!["nano"]);
+        assert_eq!(
+            resolve_editor_command(None, Some("nano"), "vi"),
+            vec!["nano"]
+        );
     }
 
     #[test]
@@ -298,7 +305,10 @@ mod tests {
             resolve_editor_command(Some(""), Some("nano"), "vi"),
             vec!["nano"]
         );
-        assert_eq!(resolve_editor_command(Some("  vim  "), None, "vi"), vec!["vim"]);
+        assert_eq!(
+            resolve_editor_command(Some("  vim  "), None, "vi"),
+            vec!["vim"]
+        );
     }
 
     #[test]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -4,7 +4,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-
 use crate::config;
 use crate::diff_state::{DiffState, DiffViewMode};
 use crate::git_engine;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,12 +12,12 @@ mod lifecycle;
 mod panel_resize;
 mod reflow;
 mod repo;
+mod revidere;
 mod review;
 mod review_commands;
 mod review_edit;
 mod review_history;
 mod review_publish;
-mod revidere;
 pub use revidere::RevidereRuns;
 mod state;
 pub use state::{
@@ -42,7 +42,6 @@ mod worktree_smart;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-
 use crate::config;
 use crate::diff_state::DiffState;
 use crate::git_engine;
@@ -65,9 +64,9 @@ pub use focus::Focus;
 pub use panel_resize::{Divider, ResizeDir};
 pub use reflow::ReflowView;
 pub use types::{
-    BackgroundOps, BgDiffResult, CcusageInfo, DirtyPanels, GrabbedBranch, Notice, PendingViewRestore,
-    PendingWorktree, PendingWorktreeOp, SmartGenResult, StatusLevel, StatusMessage,
-    WorktreeInputMode, WorktreeListRow, WorktreeOpResult,
+    BackgroundOps, BgDiffResult, CcusageInfo, DirtyPanels, GrabbedBranch, Notice,
+    PendingViewRestore, PendingWorktree, PendingWorktreeOp, SmartGenResult, StatusLevel,
+    StatusMessage, WorktreeInputMode, WorktreeListRow, WorktreeOpResult,
 };
 pub use update::UpdateState;
 
@@ -196,7 +195,6 @@ pub struct App {
 
     /// Alt+/ で出す、各パネル上の番号バッジ (2 秒で自動的に消える)。
     pub panel_number_overlay: PanelNumberOverlay,
-
 
     // リフロー・トランスクリプトビュー
     /// 無限スクロールバックモード中にClaude PTYパネルへオーバーレイされる、

--- a/src/app/panel_resize.rs
+++ b/src/app/panel_resize.rs
@@ -226,7 +226,9 @@ impl App {
         let e = self.config.layout.explorer_width_pct;
         let v = self.config.layout.viewer_width_pct;
         let t = 100u16.saturating_sub(e.saturating_add(v));
-        self.set_status_info(format!("Layout: Explorer {e}% / Viewer {v}% / Terminal {t}%"));
+        self.set_status_info(format!(
+            "Layout: Explorer {e}% / Viewer {v}% / Terminal {t}%"
+        ));
     }
 
     /// 実行時のClaude領域高さパーセントを delta ポイント分調整する。
@@ -235,9 +237,10 @@ impl App {
     /// 広げる。結果の分割をフラッシュ表示する。比率が変わったかを返す。
     /// 永続化は呼び出し側が行う。
     fn adjust_terminal_split(&mut self, delta: i16) -> bool {
-        let next = (self.layout.terminal_split_pct as i16 + delta)
-            .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
-            as u16;
+        let next = (self.layout.terminal_split_pct as i16 + delta).clamp(
+            Self::TERMINAL_SPLIT_MIN as i16,
+            Self::TERMINAL_SPLIT_MAX as i16,
+        ) as u16;
         if next == self.layout.terminal_split_pct {
             return false;
         }
@@ -259,9 +262,10 @@ impl App {
     /// パネルが使える最低限を保つようクランプされる。フラッシュ表示する。
     /// 比率が変わったかを返す。永続化は呼び出し側が行う。
     fn adjust_explorer_split(&mut self, delta: i16) -> bool {
-        let next = (self.config.layout.explorer_split_pct as i16 + delta)
-            .clamp(Self::TERMINAL_SPLIT_MIN as i16, Self::TERMINAL_SPLIT_MAX as i16)
-            as u16;
+        let next = (self.config.layout.explorer_split_pct as i16 + delta).clamp(
+            Self::TERMINAL_SPLIT_MIN as i16,
+            Self::TERMINAL_SPLIT_MAX as i16,
+        ) as u16;
         if next == self.config.layout.explorer_split_pct {
             return false;
         }
@@ -359,7 +363,10 @@ mod tests {
         for delta in [-50i16, -20, -5, 5, 20, 50] {
             let (e, v) = clamp_ev_divider(24, 38, delta, MIN);
             let t = 100u16.saturating_sub(e + v);
-            assert!(e >= MIN && v >= MIN && t >= MIN, "ev delta={delta}: {e}/{v}/{t}");
+            assert!(
+                e >= MIN && v >= MIN && t >= MIN,
+                "ev delta={delta}: {e}/{v}/{t}"
+            );
 
             let v2 = clamp_vt_divider(24, 38, delta, MIN);
             let t2 = 100u16.saturating_sub(24 + v2);

--- a/src/app/review.rs
+++ b/src/app/review.rs
@@ -125,8 +125,7 @@ impl App {
             .comments
             .iter()
             .filter(|c| {
-                c.file_path == file_path
-                    && c.status != crate::review_store::CommentStatus::Resolved
+                c.file_path == file_path && c.status != crate::review_store::CommentStatus::Resolved
             })
             .map(|c| c.line_end.unwrap_or(c.line_start) as usize)
             .collect();

--- a/src/app/review_commands.rs
+++ b/src/app/review_commands.rs
@@ -12,7 +12,10 @@ impl App {
             // 本文だけを入力するインラインの作成ボックスを開く — GitHub 風に
             // file:line のプレフィックスは入力させない。
             let (start, end) = if let Some((start, end)) = self.viewer_state.selected_range() {
-                (start as u32, if start == end { None } else { Some(end as u32) })
+                (
+                    start as u32,
+                    if start == end { None } else { Some(end as u32) },
+                )
             } else {
                 ((self.viewer_state.content.file_scroll + 1) as u32, None)
             };
@@ -69,7 +72,8 @@ impl App {
     }
 
     pub(super) fn cmd_delete_comment(&mut self) {
-        if self.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
+        if self.viewer_state.explorer.explorer_bottom_view
+            == crate::viewer::ExplorerBottomView::Comments
             && self.viewer_state.explorer.explorer_focus_on_diff_list
             && !self.review_state.comment_list_rows.is_empty()
         {
@@ -80,7 +84,8 @@ impl App {
     }
 
     pub(super) fn cmd_toggle_comment_resolve(&mut self) {
-        if self.viewer_state.explorer.explorer_bottom_view == crate::viewer::ExplorerBottomView::Comments
+        if self.viewer_state.explorer.explorer_bottom_view
+            == crate::viewer::ExplorerBottomView::Comments
             && self.viewer_state.explorer.explorer_focus_on_diff_list
             && !self.review_state.comment_list_rows.is_empty()
         {

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -51,7 +51,8 @@ impl App {
         self.rebuild_worktree_list_rows();
         let sel = self.worktrees.selected_index();
         if let Some(pos) = self
-            .worktrees.rows
+            .worktrees
+            .rows
             .iter()
             .position(|r| matches!(r, super::WorktreeListRow::Worktree(i) if *i == sel))
         {
@@ -133,7 +134,12 @@ impl App {
         }
         let tab_width = self.config.viewer.tab_width;
         self.viewer_state.open_file(&restore.file, tab_width);
-        let max = self.viewer_state.content.file_content.len().saturating_sub(1);
+        let max = self
+            .viewer_state
+            .content
+            .file_content
+            .len()
+            .saturating_sub(1);
         self.viewer_state.content.file_scroll = restore.scroll.min(max);
     }
 

--- a/src/app/worktree.rs
+++ b/src/app/worktree.rs
@@ -40,7 +40,8 @@ impl App {
         if n <= 1 {
             return;
         }
-        self.worktrees.select((self.worktrees.selected_index() + 1) % n);
+        self.worktrees
+            .select((self.worktrees.selected_index() + 1) % n);
         self.on_worktree_changed();
     }
 
@@ -51,7 +52,8 @@ impl App {
         if n <= 1 {
             return;
         }
-        self.worktrees.select((self.worktrees.selected_index() + n - 1) % n);
+        self.worktrees
+            .select((self.worktrees.selected_index() + n - 1) % n);
         self.on_worktree_changed();
     }
 
@@ -490,10 +492,17 @@ mod tests {
 
         let result = compute_bg_diff(dir.path(), "no-such-base", false, 4);
 
-        let err = result.error.as_deref().expect("base failure must be recorded");
+        let err = result
+            .error
+            .as_deref()
+            .expect("base failure must be recorded");
         assert!(err.contains("no-such-base"), "error was: {err}");
         assert_eq!(
-            result.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            result
+                .files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
             vec!["dirty.txt"],
         );
     }
@@ -507,7 +516,11 @@ mod tests {
 
         assert_eq!(result.error, None);
         assert_eq!(
-            result.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            result
+                .files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
             vec!["dirty.txt"],
         );
     }

--- a/src/app/worktree_pr.rs
+++ b/src/app/worktree_pr.rs
@@ -69,9 +69,7 @@ impl App {
                 self.viewer_state.explorer.explorer_focus_on_diff_list = true;
                 self.set_focus(Focus::Explorer);
                 self.set_status(
-                    format!(
-                        "PR #{pr_number} ready for review."
-                    ),
+                    format!("PR #{pr_number} ready for review."),
                     StatusLevel::Success,
                 );
                 // 取り込んだだけでは読む順が無い。「Review Pull Request」は

--- a/src/app/worktree_smart.rs
+++ b/src/app/worktree_smart.rs
@@ -155,17 +155,16 @@ impl App {
             let desc_panic = desc.clone();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 // フェーズ1: LLM生成。
-                let gen_result =
-                    match run_smart_generation(&desc, &cancel, &api, &repo_path) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            let _ = tx.send(WorktreeOpResult::SmartFailed {
-                                description: desc,
-                                error: e,
-                            });
-                            return;
-                        }
-                    };
+                let gen_result = match run_smart_generation(&desc, &cancel, &api, &repo_path) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx.send(WorktreeOpResult::SmartFailed {
+                            description: desc,
+                            error: e,
+                        });
+                        return;
+                    }
+                };
 
                 if gen_result.branch.is_empty() {
                     let _ = tx.send(WorktreeOpResult::SmartFailed {

--- a/src/claude_log/convert.rs
+++ b/src/claude_log/convert.rs
@@ -269,7 +269,11 @@ pub(super) fn content_to_display_blocks(
                     if !id.is_empty() {
                         tool_kinds.insert(id, result_kind(&name, &input));
                     }
-                    Some(DisplayBlock::ToolUse { name, input, errored })
+                    Some(DisplayBlock::ToolUse {
+                        name,
+                        input,
+                        errored,
+                    })
                 }
                 Block::ToolResult {
                     tool_use_id,

--- a/src/claude_log/mod.rs
+++ b/src/claude_log/mod.rs
@@ -14,9 +14,9 @@ mod convert;
 mod model;
 mod schema;
 mod session;
-mod tool_class;
 #[cfg(test)]
 mod tests;
+mod tool_class;
 
 pub use session::load_session;
 

--- a/src/claude_log/session.rs
+++ b/src/claude_log/session.rs
@@ -132,7 +132,8 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
             _ => continue,
         };
 
-        let duration_secs = thinking_duration_secs(prev_displayed_ts.as_deref(), this_ts.as_deref());
+        let duration_secs =
+            thinking_duration_secs(prev_displayed_ts.as_deref(), this_ts.as_deref());
 
         let blocks = content_to_display_blocks(
             msg.content,
@@ -145,10 +146,7 @@ pub fn load_session(path: &Path) -> Vec<LogEntry> {
             continue;
         }
 
-        entries.push(LogEntry {
-            role,
-            blocks,
-        });
+        entries.push(LogEntry { role, blocks });
         prev_displayed_ts = this_ts;
     }
     entries

--- a/src/claude_log/tests.rs
+++ b/src/claude_log/tests.rs
@@ -16,7 +16,13 @@ fn parse_msg_content(json: &str) -> Vec<DisplayBlock> {
     // このヘルパを使うテストのうち duration の値が問題になるものは無い。
     // 例外は thinking_text_is_captured だが、それも duration ではなく
     // text フィールドを見ている — 1 は適当なプレースホルダ。
-    content_to_display_blocks(msg.content, is_user, &mut HashMap::new(), &HashSet::new(), 1)
+    content_to_display_blocks(
+        msg.content,
+        is_user,
+        &mut HashMap::new(),
+        &HashSet::new(),
+        1,
+    )
 }
 
 // 隠しコンテキストの正規化 (isMeta / ラッパー)
@@ -72,7 +78,10 @@ fn task_notification_collapses_to_its_summary() {
     );
     match &blocks[0] {
         DisplayBlock::Notice(t) => {
-            assert_eq!(t, "Background command \"Run brew audit\" completed (exit code 0)");
+            assert_eq!(
+                t,
+                "Background command \"Run brew audit\" completed (exit code 0)"
+            );
         }
         other => panic!("expected Notice, got {other:?}"),
     }
@@ -257,9 +266,8 @@ fn assistant_text_quoting_wrapper_tags_is_untouched() {
 
 #[test]
 fn string_content_becomes_single_text_block() {
-    let blocks = parse_msg_content(
-        r#"{"type":"user","message":{"role":"user","content":"hello world"}}"#,
-    );
+    let blocks =
+        parse_msg_content(r#"{"type":"user","message":{"role":"user","content":"hello world"}}"#);
     assert_eq!(blocks.len(), 1);
     assert!(matches!(blocks[0], DisplayBlock::Text(_)));
 }
@@ -361,7 +369,9 @@ fn tool_result_keeps_all_lines_no_cap() {
     );
     let blocks = parse_msg_content(&json);
     match &blocks[0] {
-        DisplayBlock::ToolResult { lines, is_error, .. } => {
+        DisplayBlock::ToolResult {
+            lines, is_error, ..
+        } => {
             assert_eq!(lines.len(), 10);
             assert_eq!(lines[0], "line0");
             assert_eq!(lines[9], "line9");
@@ -384,7 +394,13 @@ fn tool_result_id_resolves_across_records_in_one_session() {
     assert_eq!(entries.len(), 2);
     assert!(matches!(
         &entries[1].blocks[0],
-        DisplayBlock::ToolResult { kind: ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, .. }
+        DisplayBlock::ToolResult {
+            kind: ResultKind::Counted {
+                bucket: CountedBucket::Read,
+                from_bash: false
+            },
+            ..
+        }
     ));
 }
 
@@ -400,7 +416,10 @@ fn tool_result_with_unknown_tool_use_id_is_hidden() {
     );
     assert!(matches!(
         &blocks[0],
-        DisplayBlock::ToolResult { kind: ResultKind::Hidden, .. }
+        DisplayBlock::ToolResult {
+            kind: ResultKind::Hidden,
+            ..
+        }
     ));
 }
 
@@ -676,7 +695,11 @@ fn load_session_thinking_duration_ignores_skipped_meta_record_as_previous() {
         r#"{"type":"assistant","timestamp":"2026-07-31T00:00:05Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning","signature":"x"}]}}"#,
     ]);
     let entries = load_session(f.path());
-    assert_eq!(entries.len(), 2, "the isMeta record must not produce an entry");
+    assert_eq!(
+        entries.len(),
+        2,
+        "the isMeta record must not produce an entry"
+    );
     match &entries[1].blocks[0] {
         DisplayBlock::Thinking { duration_secs, .. } => assert_eq!(*duration_secs, 5),
         other => panic!("expected Thinking, got {other:?}"),
@@ -726,18 +749,12 @@ fn compact_sequence_produces_the_measured_blocks() {
     assert_eq!(blocks.len(), 5, "got {blocks:?}");
     assert!(matches!(blocks[0], DisplayBlock::CompactBoundary));
     assert!(matches!(blocks[1], DisplayBlock::Text(t) if t == "/compact"));
-    assert!(
-        matches!(blocks[2], DisplayBlock::Annotation { lines }
-            if lines == &["Compacted (ctrl+o to see full summary)".to_string()])
-    );
-    assert!(
-        matches!(blocks[3], DisplayBlock::Annotation { lines }
-            if lines == &["Read alpha.rs (42 lines)".to_string()])
-    );
-    assert!(
-        matches!(blocks[4], DisplayBlock::Annotation { lines }
-            if lines == &["Referenced file beta.yml".to_string()])
-    );
+    assert!(matches!(blocks[2], DisplayBlock::Annotation { lines }
+            if lines == &["Compacted (ctrl+o to see full summary)".to_string()]));
+    assert!(matches!(blocks[3], DisplayBlock::Annotation { lines }
+            if lines == &["Read alpha.rs (42 lines)".to_string()]));
+    assert!(matches!(blocks[4], DisplayBlock::Annotation { lines }
+            if lines == &["Referenced file beta.yml".to_string()]));
 }
 
 #[test]

--- a/src/claude_log/tool_class.rs
+++ b/src/claude_log/tool_class.rs
@@ -186,20 +186,32 @@ mod tests {
     #[test]
     fn read_is_counted_bucket_read() {
         let input = json!({"file_path": "/a.txt"});
-        assert_eq!(classify("Read", &input), ToolCategory::Counted(CountedBucket::Read));
+        assert_eq!(
+            classify("Read", &input),
+            ToolCategory::Counted(CountedBucket::Read)
+        );
     }
 
     #[test]
     fn grep_and_glob_are_counted_bucket_search() {
         let input = json!({"pattern": "foo"});
-        assert_eq!(classify("Grep", &input), ToolCategory::Counted(CountedBucket::Search));
-        assert_eq!(classify("Glob", &input), ToolCategory::Counted(CountedBucket::Search));
+        assert_eq!(
+            classify("Grep", &input),
+            ToolCategory::Counted(CountedBucket::Search)
+        );
+        assert_eq!(
+            classify("Glob", &input),
+            ToolCategory::Counted(CountedBucket::Search)
+        );
     }
 
     #[test]
     fn bash_ls_is_counted_bucket_list() {
         let input = json!({"command": "ls -la /tmp"});
-        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::List));
+        assert_eq!(
+            classify("Bash", &input),
+            ToolCategory::Counted(CountedBucket::List)
+        );
     }
 
     #[test]
@@ -207,7 +219,10 @@ mod tests {
         // 元のテーブルでは cat のシェル呼び出しは Read ツール自身の bucket
         // に合流する — どちらも1つの "Read N files" 行にカウントされる。
         let input = json!({"command": "cat foo.txt"});
-        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::Read));
+        assert_eq!(
+            classify("Bash", &input),
+            ToolCategory::Counted(CountedBucket::Read)
+        );
     }
 
     #[test]
@@ -225,7 +240,10 @@ mod tests {
     #[test]
     fn bash_leading_whitespace_still_dispatches_on_first_word() {
         let input = json!({"command": "   ls /tmp"});
-        assert_eq!(classify("Bash", &input), ToolCategory::Counted(CountedBucket::List));
+        assert_eq!(
+            classify("Bash", &input),
+            ToolCategory::Counted(CountedBucket::List)
+        );
     }
 
     #[test]
@@ -330,5 +348,4 @@ mod tests {
         let input = json!({"unrelated": "x"});
         assert_eq!(unknown_tool_arg(&input), None);
     }
-
 }

--- a/src/command_palette/tests.rs
+++ b/src/command_palette/tests.rs
@@ -75,7 +75,10 @@ fn scope_splits_global_from_current_layer() {
             .find(|s| COMMANDS[s.index].action == Some(action))
             .map(|s| s.scope)
     };
-    assert_eq!(scope_of(Action::CreateWorktree), Some(CommandScope::Current));
+    assert_eq!(
+        scope_of(Action::CreateWorktree),
+        Some(CommandScope::Current)
+    );
     assert_eq!(scope_of(Action::Quit), Some(CommandScope::Global));
     // viewer 専用のアクションはグローバルでも worktree レイヤーでもない。
     assert_eq!(scope_of(Action::SearchInFile), Some(CommandScope::Other));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,8 +35,8 @@ pub use persist::{
 // crate::config::* 配下で re-export し続ける。
 #[allow(unused_imports)]
 pub use sections::{
-    ApiConfig, CcusageConfig, DiffConfig, DiffView, GeneralConfig, LayoutConfig,
-    ReviewConfig, TerminalConfig, UiConfig, UpdatesConfig, ViewerConfig,
+    ApiConfig, CcusageConfig, DiffConfig, DiffView, GeneralConfig, LayoutConfig, ReviewConfig,
+    TerminalConfig, UiConfig, UpdatesConfig, ViewerConfig,
 };
 #[allow(unused_imports)]
 pub use snapshot::{AppearanceSnapshot, has_restart_changes};

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -346,7 +346,12 @@ pub fn persist_layout_proportions(
         "explorer_width_pct",
         &explorer_width_pct.to_string(),
     );
-    let updated = upsert_section_kv(&updated, "layout", "viewer_width_pct", &viewer_width_pct.to_string());
+    let updated = upsert_section_kv(
+        &updated,
+        "layout",
+        "viewer_width_pct",
+        &viewer_width_pct.to_string(),
+    );
     let updated = upsert_section_kv(
         &updated,
         "layout",

--- a/src/config/sections.rs
+++ b/src/config/sections.rs
@@ -274,4 +274,3 @@ impl UiConfig {
         self.icons.unwrap_or(IconSet::Unicode)
     }
 }
-

--- a/src/config/tests_config.rs
+++ b/src/config/tests_config.rs
@@ -55,10 +55,9 @@ fn removed_review_prompt_keys_are_ignored() {
 /// 廃止しても既存インストールの起動を壊してはならない。
 #[test]
 fn removed_rich_section_is_ignored() {
-    let cfg: Config = toml::from_str(
-        "[general]\nmain_branch = \"develop\"\n\n[rich]\nmode = \"force\"\n",
-    )
-    .expect("stale [rich] section should be ignored, not rejected");
+    let cfg: Config =
+        toml::from_str("[general]\nmain_branch = \"develop\"\n\n[rich]\nmode = \"force\"\n")
+            .expect("stale [rich] section should be ignored, not rejected");
     // 同じファイル内の他のセクションは通常どおり読めていること。
     assert_eq!(cfg.general.main_branch, "develop");
 }

--- a/src/config/tests_persist.rs
+++ b/src/config/tests_persist.rs
@@ -1,8 +1,8 @@
 //! コメントを保持したまま編集する upsert_section_kv/upsert_ui_theme と
 //! is_section_header のテスト。
 
-use super::*;
 use super::persist::{is_section_header, upsert_section_kv, upsert_ui_theme};
+use super::*;
 
 #[test]
 fn upsert_high_contrast_inserts_into_ui_section() {
@@ -38,7 +38,10 @@ fn upsert_section_kv_inserts_layout_value_over_commented_default() {
 fn upsert_section_kv_replaces_existing_layout_value() {
     let contents = "[layout]\nexplorer_width_pct = 24\nviewer_width_pct = 38\n";
     let result = upsert_section_kv(contents, "layout", "viewer_width_pct", "42");
-    assert_eq!(result, "[layout]\nexplorer_width_pct = 24\nviewer_width_pct = 42\n");
+    assert_eq!(
+        result,
+        "[layout]\nexplorer_width_pct = 24\nviewer_width_pct = 42\n"
+    );
 }
 
 #[test]
@@ -67,8 +70,7 @@ fn upsert_ui_theme_replaces_existing_theme_line() {
     let contents = "[ui]\ntheme = \"dracula\"\n";
     let result = upsert_ui_theme(contents, "github-light");
     assert_eq!(
-        result,
-        "[ui]\ntheme = \"github-light\"\n",
+        result, "[ui]\ntheme = \"github-light\"\n",
         "existing theme line must be replaced in place"
     );
 }

--- a/src/config/tests_snapshot.rs
+++ b/src/config/tests_snapshot.rs
@@ -61,11 +61,19 @@ fn appearance_snapshot_detects_each_live_field_change() {
 
     let mut c = base.clone();
     c.ui.theme = Some(String::from("dracula"));
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "ui.theme");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "ui.theme"
+    );
 
     let mut c = base.clone();
     c.viewer.theme = String::from("nord");
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "viewer.theme");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "viewer.theme"
+    );
 
     let mut c = base.clone();
     c.viewer.syntax_theme_file = Some(String::from("/custom.tmTheme"));
@@ -77,31 +85,59 @@ fn appearance_snapshot_detects_each_live_field_change() {
 
     let mut c = base.clone();
     c.viewer.tab_width = 4; // デフォルトは2
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "viewer.tab_width");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "viewer.tab_width"
+    );
 
     let mut c = base.clone();
     c.diff.word_diff = false; // デフォルトは true
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "diff.word_diff");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "diff.word_diff"
+    );
 
     let mut c = base.clone();
     c.diff.default_view = DiffView::SideBySide; // デフォルトは Unified
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "diff.default_view");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "diff.default_view"
+    );
 
     let mut c = base.clone();
     c.general.decoration = String::from("space");
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "general.decoration");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "general.decoration"
+    );
 
     let mut c = base.clone();
     c.layout.explorer_width_pct = 30;
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.explorer_width_pct");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "layout.explorer_width_pct"
+    );
 
     let mut c = base.clone();
     c.layout.viewer_width_pct = 42;
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.viewer_width_pct");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "layout.viewer_width_pct"
+    );
 
     let mut c = base.clone();
     c.layout.terminal_split_pct = 70;
-    assert_ne!(c.appearance_snapshot(), base.appearance_snapshot(), "layout.terminal_split_pct");
+    assert_ne!(
+        c.appearance_snapshot(),
+        base.appearance_snapshot(),
+        "layout.terminal_split_pct"
+    );
 }
 
 /// has_restart_changes: live フィールドのみ変えたら false。
@@ -166,82 +202,127 @@ fn every_field_is_either_live_or_restart() {
     {
         let mut c = base.clone();
         c.general.repo = Some(PathBuf::from("/p"));
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.repo");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.repo"
+        );
     }
     {
         let mut c = base.clone();
         c.general.main_branch = String::from("master");
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.main_branch");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.main_branch"
+        );
     }
     {
         let mut c = base.clone();
         c.general.shell = String::from("/bin/fish");
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.shell");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.shell"
+        );
     }
     {
         let mut c = base.clone();
         c.general.repos = vec![PathBuf::from("/p")];
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.repos");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.repos"
+        );
     }
     {
         let mut c = base.clone();
         c.general.worktree_dir = Some(PathBuf::from("/wt"));
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.worktree_dir");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.worktree_dir"
+        );
     }
     {
         let mut c = base.clone();
         c.general.decoration = String::from("space");
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.decoration");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.decoration"
+        );
     }
     {
         let mut c = base.clone();
         c.general.auto_resume = false; // デフォルトは true
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.auto_resume");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.auto_resume"
+        );
     }
     {
         let mut c = base.clone();
         c.general.auto_resume_main = true;
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "general.auto_resume_main");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "general.auto_resume_main"
+        );
     }
     // terminal
     {
         let mut c = base.clone();
         c.terminal.active_scrollback = 9999;
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "terminal.active_scrollback");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "terminal.active_scrollback"
+        );
     }
     // viewer (live)
     {
         let mut c = base.clone();
         c.viewer.theme = String::from("nord");
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "viewer.theme");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "viewer.theme"
+        );
     }
     {
         let mut c = base.clone();
         c.viewer.tab_width = 4; // デフォルトは2
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "viewer.tab_width");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "viewer.tab_width"
+        );
     }
     // diff (live)
     {
         let mut c = base.clone();
         c.diff.word_diff = false; // デフォルトは true
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "diff.word_diff");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "diff.word_diff"
+        );
     }
     // api
     {
         let mut c = base.clone();
         c.api.provider = String::from("claude"); // デフォルトは "gemini"
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "api.provider");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "api.provider"
+        );
     }
     // ccusage
     {
         let mut c = base.clone();
         c.ccusage.enabled = true;
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "ccusage.enabled");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "ccusage.enabled"
+        );
     }
     // layout (live)
     {
         let mut c = base.clone();
         c.layout.explorer_width_pct = 30;
-        assert!(c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c), "layout.explorer_width_pct");
+        assert!(
+            c.appearance_snapshot() != base.appearance_snapshot() || has_restart_changes(&base, &c),
+            "layout.explorer_width_pct"
+        );
     }
 }

--- a/src/diff_state/display_list.rs
+++ b/src/diff_state/display_list.rs
@@ -138,7 +138,14 @@ impl DiffState {
             }
             if let Some(node) = nodes.get(dir_path) {
                 for child_dir in &node.child_dirs {
-                    emit_dir(child_dir, depth + 1, leaves, nodes, collapsed_dirs, display_list);
+                    emit_dir(
+                        child_dir,
+                        depth + 1,
+                        leaves,
+                        nodes,
+                        collapsed_dirs,
+                        display_list,
+                    );
                 }
                 for &li in &node.leaves {
                     display_list.push(DiffListEntry::File {
@@ -278,8 +285,9 @@ impl DiffState {
 
     /// 指定した表示インデックスのディレクトリを折りたたむ(他の行では何もしない)。
     pub fn collapse_section(&mut self, display_idx: usize) {
-        if let Some(DiffListEntry::Directory { path, collapsed, .. }) =
-            self.display_list.get(display_idx)
+        if let Some(DiffListEntry::Directory {
+            path, collapsed, ..
+        }) = self.display_list.get(display_idx)
             && !collapsed
         {
             let key = path.clone();
@@ -290,8 +298,9 @@ impl DiffState {
 
     /// 指定した表示インデックスのディレクトリを展開する(他の行では何もしない)。
     pub fn expand_section(&mut self, display_idx: usize) {
-        if let Some(DiffListEntry::Directory { path, collapsed, .. }) =
-            self.display_list.get(display_idx)
+        if let Some(DiffListEntry::Directory {
+            path, collapsed, ..
+        }) = self.display_list.get(display_idx)
             && *collapsed
         {
             let key = path.clone();

--- a/src/diff_state/tests.rs
+++ b/src/diff_state/tests.rs
@@ -289,7 +289,13 @@ fn diff_state_with(paths: &[&str]) -> super::DiffState {
 fn resolve_changed_path_accepts_alternate_spellings() {
     let ds = diff_state_with(&["src/a.rs", "src/deep/c.rs", "top.txt"]);
 
-    for spelling in ["src/a.rs", "./src/a.rs", "src//a.rs", "  src/a.rs  ", "src/a.rs/"] {
+    for spelling in [
+        "src/a.rs",
+        "./src/a.rs",
+        "src//a.rs",
+        "  src/a.rs  ",
+        "src/a.rs/",
+    ] {
         assert_eq!(
             ds.resolve_changed_path(spelling).as_deref(),
             Some("src/a.rs"),
@@ -297,10 +303,19 @@ fn resolve_changed_path_accepts_alternate_spellings() {
         );
     }
     // git diff の a/ と b/ プレフィックス。生成側がパスに残したもの。
-    assert_eq!(ds.resolve_changed_path("b/src/a.rs").as_deref(), Some("src/a.rs"));
-    assert_eq!(ds.resolve_changed_path("a/top.txt").as_deref(), Some("top.txt"));
+    assert_eq!(
+        ds.resolve_changed_path("b/src/a.rs").as_deref(),
+        Some("src/a.rs")
+    );
+    assert_eq!(
+        ds.resolve_changed_path("a/top.txt").as_deref(),
+        Some("top.txt")
+    );
     // リポジトリルートではなくサブディレクトリからの相対パスで書かれたもの。
-    assert_eq!(ds.resolve_changed_path("deep/c.rs").as_deref(), Some("src/deep/c.rs"));
+    assert_eq!(
+        ds.resolve_changed_path("deep/c.rs").as_deref(),
+        Some("src/deep/c.rs")
+    );
 }
 
 /// 本当に diff に含まれないファイルは未解決のままでなければならない。
@@ -322,7 +337,10 @@ fn resolve_changed_path_refuses_an_ambiguous_suffix() {
     let ds = diff_state_with(&["src/app/mod.rs", "src/ui/mod.rs"]);
     assert_eq!(ds.resolve_changed_path("mod.rs"), None);
     // 曖昧さを解消するのに十分なコンテキストがあれば問題なく解決する。
-    assert_eq!(ds.resolve_changed_path("ui/mod.rs").as_deref(), Some("src/ui/mod.rs"));
+    assert_eq!(
+        ds.resolve_changed_path("ui/mod.rs").as_deref(),
+        Some("src/ui/mod.rs")
+    );
 }
 
 /// リポジトリに実在するトップレベルの b/ は、b/ を diff プレフィックスとして
@@ -330,8 +348,14 @@ fn resolve_changed_path_refuses_an_ambiguous_suffix() {
 #[test]
 fn resolve_changed_path_prefers_an_exact_match_over_prefix_stripping() {
     let ds = diff_state_with(&["b/src/a.rs", "src/a.rs"]);
-    assert_eq!(ds.resolve_changed_path("b/src/a.rs").as_deref(), Some("b/src/a.rs"));
-    assert_eq!(ds.resolve_changed_path("src/a.rs").as_deref(), Some("src/a.rs"));
+    assert_eq!(
+        ds.resolve_changed_path("b/src/a.rs").as_deref(),
+        Some("b/src/a.rs")
+    );
+    assert_eq!(
+        ds.resolve_changed_path("src/a.rs").as_deref(),
+        Some("src/a.rs")
+    );
 }
 
 /// レビュアーが折りたたんだディレクトリの中にあるファイルには表示行が存在しない。
@@ -350,7 +374,9 @@ fn reveal_path_expands_collapsed_ancestors() {
         "precondition: a collapsed ancestor hides the file's row"
     );
 
-    let idx = ds.reveal_path("src/deep/nested/c.rs").expect("row after reveal");
+    let idx = ds
+        .reveal_path("src/deep/nested/c.rs")
+        .expect("row after reveal");
     assert_eq!(
         ds.resolve_file(idx).map(|f| f.path.as_str()),
         Some("src/deep/nested/c.rs")
@@ -692,9 +718,19 @@ fn load_diff_reproduces_the_silent_zero_files_report() {
     let paths: Vec<&str> = ds.files.iter().map(|f| f.path.as_str()).collect();
     assert_eq!(
         paths,
-        vec!["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"]
+        vec![
+            "tracked1.txt",
+            "tracked2.txt",
+            "untracked1.txt",
+            "untracked2.txt"
+        ]
     );
-    for path in ["tracked1.txt", "tracked2.txt", "untracked1.txt", "untracked2.txt"] {
+    for path in [
+        "tracked1.txt",
+        "tracked2.txt",
+        "untracked1.txt",
+        "untracked2.txt",
+    ] {
         assert!(
             ds.display_index_for_path(path).is_some(),
             "display_list should include '{path}'"
@@ -838,7 +874,11 @@ fn a_file_edited_after_commit_stays_one_entry() {
     let base_commit = repo.find_commit(base_oid).unwrap();
 
     // ブランチ側で1行追加してコミット。
-    let head_oid = commit_files(&repo, Some(&base_commit), &[("a.txt", b"base\ncommitted\n")]);
+    let head_oid = commit_files(
+        &repo,
+        Some(&base_commit),
+        &[("a.txt", b"base\ncommitted\n")],
+    );
     checkout_branch(&repo, "feature", head_oid);
 
     // コミット済みのファイルをさらに編集する。

--- a/src/event/explorer/comment_list.rs
+++ b/src/event/explorer/comment_list.rs
@@ -22,26 +22,24 @@ pub(in crate::event) fn handle_explorer_comment_list_key(app: &mut App, key: Key
     // Select が実際に位置へジャンプしたときだけモーダルを閉じる — 返信を持つ
     // コメントへの Select はその場でスレッドを開くだけなので、その場合は
     // モーダルを開いたままにしておく必要がある。
-    let close_after = in_modal
-        && matches!(action, Some(Action::Select))
-        && {
-            let visual = app.viewer_state.explorer.comment_list_selected;
-            match app.review_state.comment_list_rows.get(visual) {
-                Some(CommentListRow::Comment { comment_idx }) => {
-                    let has_replies = app
-                        .review_state
-                        .comments
-                        .get(*comment_idx)
-                        .and_then(|c| app.review_state.reply_counts.get(&c.id))
-                        .copied()
-                        .unwrap_or(0)
-                        > 0;
-                    !has_replies
-                }
-                Some(CommentListRow::Reply { .. }) => true,
-                None => false,
+    let close_after = in_modal && matches!(action, Some(Action::Select)) && {
+        let visual = app.viewer_state.explorer.comment_list_selected;
+        match app.review_state.comment_list_rows.get(visual) {
+            Some(CommentListRow::Comment { comment_idx }) => {
+                let has_replies = app
+                    .review_state
+                    .comments
+                    .get(*comment_idx)
+                    .and_then(|c| app.review_state.reply_counts.get(&c.id))
+                    .copied()
+                    .unwrap_or(0)
+                    > 0;
+                !has_replies
             }
-        };
+            Some(CommentListRow::Reply { .. }) => true,
+            None => false,
+        }
+    };
 
     match action {
         Some(Action::ExitSubPanel) => {

--- a/src/event/explorer/mod.rs
+++ b/src/event/explorer/mod.rs
@@ -16,6 +16,10 @@ mod viewer_actions;
 // これらのアイテムが1階層深いディレクトリに移動した後も、event の兄弟サブモジュール
 // (mouse, viewer, overlay, event::mod 自身) が既存の super::explorer::X /
 // crate::event::explorer::X という参照をそのまま解決できるよう再エクスポートする。
-pub(in crate::event) use comment_list::{handle_explorer_comment_list_key, navigate_to_comment_with_focus};
+pub(in crate::event) use comment_list::{
+    handle_explorer_comment_list_key, navigate_to_comment_with_focus,
+};
 pub(in crate::event) use tree::handle_explorer_key;
-pub(in crate::event) use viewer_actions::{open_viewer_comment, open_viewer_comment_detail, submit_new_comment};
+pub(in crate::event) use viewer_actions::{
+    open_viewer_comment, open_viewer_comment_detail, submit_new_comment,
+};

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -10,7 +10,6 @@
 mod clipboard;
 mod dialogs;
 mod explorer;
-mod revidere;
 mod global;
 mod menu;
 mod mouse;
@@ -19,6 +18,7 @@ mod overlay_helpers;
 mod paste;
 pub mod reflow;
 mod reflow_key;
+mod revidere;
 mod scroll;
 mod terminal;
 mod viewer;
@@ -354,15 +354,14 @@ fn handle_hover_modal_key(app: &mut App, key: KeyEvent) {
         KeyCode::Down | KeyCode::Char('j') => app.hover_refs_move(1),
         KeyCode::Enter => {
             let has_preview = app
-                .code_nav.hover_info
+                .code_nav
+                .hover_info
                 .refs
                 .as_ref()
                 .is_some_and(|r| r.preview.is_some());
             if has_preview {
                 app.hover_jump_to_preview();
-            } else if let Some(sel) =
-                app.code_nav.hover_info.refs.as_ref().map(|r| r.selected)
-            {
+            } else if let Some(sel) = app.code_nav.hover_info.refs.as_ref().map(|r| r.selected) {
                 app.open_hover_preview(sel);
             } else {
                 // 参照一覧を開いていないときの Enter は、説明している定義へ飛ぶ。
@@ -437,7 +436,9 @@ fn dispatch_pty_key(app: &mut App, key: KeyEvent) {
     // 押しても終了しない。実際の終了方法をフラッシュ表示してから、通常
     // どおり転送する。
     if key.code == KeyCode::Char('q')
-        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+        && key
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL)
     {
         app.set_status_info(
             "Ctrl+Q is sent to the terminal here. To quit Conductor: Ctrl+Esc to leave, then Ctrl+Q.".to_string(),

--- a/src/event/mouse/tests.rs
+++ b/src/event/mouse/tests.rs
@@ -537,7 +537,10 @@ fn the_fold_marker_claims_the_gutter_right_of_the_line_number() {
     // ガターは [10, 20)。隙間が 15、マーカーが 16、隙間が 17、区切り線が 18、
     // 空白が 19。
     let gutter_end = 20;
-    assert!(!in_fold_zone(14, gutter_end), "行番号の最終桁はコメント側の担当");
+    assert!(
+        !in_fold_zone(14, gutter_end),
+        "行番号の最終桁はコメント側の担当"
+    );
     assert!(in_fold_zone(15, gutter_end));
     assert!(in_fold_zone(16, gutter_end));
     assert!(in_fold_zone(17, gutter_end));

--- a/src/event/overlay/misc.rs
+++ b/src/event/overlay/misc.rs
@@ -93,7 +93,12 @@ pub(in crate::event) fn handle_command_palette_key(app: &mut App, key: KeyEvent)
 pub(in crate::event) fn handle_theme_picker_key(app: &mut App, key: KeyEvent) {
     let count = app.overlays.theme_picker.themes.len();
 
-    if overlay_list_nav(&app.keymap, &key, &mut app.overlays.theme_picker.selected, count) {
+    if overlay_list_nav(
+        &app.keymap,
+        &key,
+        &mut app.overlays.theme_picker.selected,
+        count,
+    ) {
         // ライブプレビュー: 永続化せずに新しくハイライトされたテーマを適用する。
         let name = app
             .overlays

--- a/src/event/overlay/mod.rs
+++ b/src/event/overlay/mod.rs
@@ -30,9 +30,7 @@ pub(super) use search::{
     handle_filename_search_key, handle_grep_search_key, handle_viewer_search_key,
 };
 pub(super) use session::{handle_history_key, handle_resume_session_key};
-pub(super) use symbol::{
-    handle_references_key, handle_symbol_action_key, handle_symbol_hint_key,
-};
+pub(super) use symbol::{handle_references_key, handle_symbol_action_key, handle_symbol_hint_key};
 pub(super) use vcs::{
     handle_cherry_pick_key, handle_grab_key, handle_prune_key, handle_switch_branch_key,
 };

--- a/src/event/overlay/symbol.rs
+++ b/src/event/overlay/symbol.rs
@@ -102,7 +102,8 @@ pub(in crate::event) fn handle_symbol_hint_key(app: &mut App, key: KeyEvent) {
             let input = app.code_nav.symbol_hint.input.clone();
             // 入力に一致するヒントを探す。
             let matched = app
-                .code_nav.symbol_hint
+                .code_nav
+                .symbol_hint
                 .hints
                 .iter()
                 .find(|h| h.label == input)

--- a/src/event/reflow.rs
+++ b/src/event/reflow.rs
@@ -277,8 +277,14 @@ mod tests {
         for i in 0..=100 {
             let p = i as f64 / 100.0;
             let v = transition_eased(p);
-            assert!((0.0..=1.0).contains(&v), "transition_eased({p}) = {v} out of range");
-            assert!(v >= prev - 1e-12, "transition_eased must be monotonic non-decreasing");
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "transition_eased({p}) = {v} out of range"
+            );
+            assert!(
+                v >= prev - 1e-12,
+                "transition_eased must be monotonic non-decreasing"
+            );
             prev = v;
         }
     }

--- a/src/event/reflow_key.rs
+++ b/src/event/reflow_key.rs
@@ -25,8 +25,8 @@ use crate::app::App;
 /// する際に参照するものなので、ここで古いままにしておくと、このビューが
 /// 避けようとしている最下部への強制スナップが復活してしまう。
 pub(super) fn handle_reflow_key(app: &mut App, key: KeyEvent) {
-    use crossterm::event::KeyModifiers;
     use crate::event::reflow::{at_bottom, clamp_scroll};
+    use crossterm::event::KeyModifiers;
 
     let inner = app.reflow.last_inner_height as usize;
     let total = app.reflow.total_lines;

--- a/src/event/terminal/ansi.rs
+++ b/src/event/terminal/ansi.rs
@@ -285,35 +285,77 @@ mod tests {
 
     #[test]
     fn arrows_use_csi_in_normal_cursor_mode() {
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Up), false), Some(b"\x1b[A".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Down), false), Some(b"\x1b[B".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Right), false), Some(b"\x1b[C".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Left), false), Some(b"\x1b[D".to_vec()));
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Up), false),
+            Some(b"\x1b[A".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Down), false),
+            Some(b"\x1b[B".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Right), false),
+            Some(b"\x1b[C".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Left), false),
+            Some(b"\x1b[D".to_vec())
+        );
     }
 
     #[test]
     fn arrows_use_ss3_in_application_cursor_mode() {
         // DECCKM が有効な場合、less/bat/vim などのページャやエディタは SS3 を
         // 期待する — bat で矢印キースクロールが効くのはこのためである。
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Up), true), Some(b"\x1bOA".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Down), true), Some(b"\x1bOB".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Right), true), Some(b"\x1bOC".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Left), true), Some(b"\x1bOD".to_vec()));
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Up), true),
+            Some(b"\x1bOA".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Down), true),
+            Some(b"\x1bOB".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Right), true),
+            Some(b"\x1bOC".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Left), true),
+            Some(b"\x1bOD".to_vec())
+        );
     }
 
     #[test]
     fn home_end_honor_application_cursor_mode() {
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Home), false), Some(b"\x1b[H".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::End), false), Some(b"\x1b[F".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::Home), true), Some(b"\x1bOH".to_vec()));
-        assert_eq!(key_event_to_ansi(&key(KeyCode::End), true), Some(b"\x1bOF".to_vec()));
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Home), false),
+            Some(b"\x1b[H".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::End), false),
+            Some(b"\x1b[F".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::Home), true),
+            Some(b"\x1bOH".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&key(KeyCode::End), true),
+            Some(b"\x1bOF".to_vec())
+        );
     }
 
     #[test]
     fn modified_arrows_stay_csi_regardless_of_cursor_mode() {
         // 修飾キーがある場合、DECCKM に関わらず xterm は CSI の 1;<param> 形式を使う。
         let shift_up = KeyEvent::new(KeyCode::Up, KeyModifiers::SHIFT);
-        assert_eq!(key_event_to_ansi(&shift_up, true), Some(b"\x1b[1;2A".to_vec()));
-        assert_eq!(key_event_to_ansi(&shift_up, false), Some(b"\x1b[1;2A".to_vec()));
+        assert_eq!(
+            key_event_to_ansi(&shift_up, true),
+            Some(b"\x1b[1;2A".to_vec())
+        );
+        assert_eq!(
+            key_event_to_ansi(&shift_up, false),
+            Some(b"\x1b[1;2A".to_vec())
+        );
     }
 }

--- a/src/event/viewer/inline_reply.rs
+++ b/src/event/viewer/inline_reply.rs
@@ -89,7 +89,10 @@ pub(super) fn handle_inline_reply_input(app: &mut App, key: KeyEvent) {
     // モーダルと同じ規約にすることで、インライン返信も本格的な複数行フォーム
     // になる。
     if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT) {
-        app.viewer_state.explorer.inline_reply_buffer.insert_char('\n');
+        app.viewer_state
+            .explorer
+            .inline_reply_buffer
+            .insert_char('\n');
         return;
     }
     match key.code {
@@ -171,7 +174,10 @@ pub(super) fn handle_inline_reply_input(app: &mut App, key: KeyEvent) {
         }
         _ => {
             // 通常の編集操作（文字入力、矢印、Home/End、単語単位移動、Backspace/Delete）。
-            app.viewer_state.explorer.inline_reply_buffer.handle_key(key);
+            app.viewer_state
+                .explorer
+                .inline_reply_buffer
+                .handle_key(key);
         }
     }
 }

--- a/src/event/worktree.rs
+++ b/src/event/worktree.rs
@@ -46,11 +46,7 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
         Some(Action::Select) => {
             // 選択を確定して切り替えモーダルを閉じる。
             app.overlays.active = ActiveOverlay::None;
-            match app
-                .worktrees.rows
-                .get(app.worktrees.row_selected)
-                .copied()
-            {
+            match app.worktrees.rows.get(app.worktrees.row_selected).copied() {
                 Some(WorktreeListRow::Session { pty_idx, .. }) => {
                     app.switch_claude_session(pty_idx);
                     app.set_focus(Focus::TerminalClaude);
@@ -98,13 +94,9 @@ pub(super) fn handle_worktree_key(app: &mut App, key: KeyEvent) {
 
                     let mut warnings: Vec<String> = Vec::new();
                     if !is_clean {
-                        warnings.push(format!(
-                            "{dirty_count} uncommitted change(s) will be LOST"
-                        ));
+                        warnings.push(format!("{dirty_count} uncommitted change(s) will be LOST"));
                     }
-                    if let Some(main_branch) =
-                        main_branch.filter(|m| *m != branch)
-                    {
+                    if let Some(main_branch) = main_branch.filter(|m| *m != branch) {
                         match git_engine::GitEngine::open(&app.repo.path)
                             .and_then(|e| e.is_branch_merged_into(&branch, &main_branch))
                         {

--- a/src/git_engine/mod.rs
+++ b/src/git_engine/mod.rs
@@ -6,17 +6,17 @@
 //! 機能は責務ごとに兄弟サブモジュールへ分割されており、いずれも共有の
 //! [GitEngine] ハンドルにメソッドを実装している:
 //!
-//! - [worktree_ops]: worktree/ブランチの列挙とステータススナップショット
-//! - [worktree_create]: worktree の作成(ベース ref、リモートブランチ、
+//! - `worktree_ops`: worktree/ブランチの列挙とステータススナップショット
+//! - `worktree_create`: worktree の作成(ベース ref、リモートブランチ、
 //!   または fetch 済みブランチから)とベース ref の鮮度確認
-//! - [worktree_delete]: ブランチ削除と worktree の削除/整理
-//! - [grab]: wt grab/wt ungrab のブランチ入れ替えワークフロー
-//! - [branch_lineage]: 親/派生ブランチの検出と PR URL の構築
-//! - [fetch]: git fetch へのシェルアウト
-//! - [merge]: pull、main へのマージ、origin へのハードリセット
-//! - [cherry_pick]: コミットの一覧取得と worktree への cherry-pick
-//! - [recently_modified]: worktree の最近変更されたファイルパス
-//! - [status_map]: Explorer のファイルツリー(薄暗い表示)と Changed
+//! - `worktree_delete`: ブランチ削除と worktree の削除/整理
+//! - `grab`: wt grab/wt ungrab のブランチ入れ替えワークフロー
+//! - `branch_lineage`: 親/派生ブランチの検出と PR URL の構築
+//! - `fetch`: git fetch へのシェルアウト
+//! - `merge`: pull、main へのマージ、origin へのハードリセット
+//! - `cherry_pick`: コミットの一覧取得と worktree への cherry-pick
+//! - `recently_modified`: worktree の最近変更されたファイルパス
+//! - `status_map`: Explorer のファイルツリー(薄暗い表示)と Changed
 //!   files 一覧(ステージ状態の色分け)で共有される、パス -> git status
 //!   のルックアップ
 

--- a/src/go_test.rs
+++ b/src/go_test.rs
@@ -22,8 +22,7 @@ use crate::test_run::{TestRun, TestRunKind, shell_single_quote};
 /// トップレベルのテスト関数: 0 桁目から始まる func TestXxx(。レシーバ付きの
 /// メソッド (func (s *Suite) TestX() はあえて対象外にしている。go test -run
 /// では直接指定できないため。
-static FUNC_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^func\s+(Test\w*)\s*\(").unwrap());
+static FUNC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^func\s+(Test\w*)\s*\(").unwrap());
 
 /// 名前が文字列リテラルのサブテスト呼び出し: x.Run("name"。テーブル駆動の
 /// t.Run(tt.name, …) のようなリテラルでないものは飛ばす。関数単位のボタンが
@@ -132,7 +131,10 @@ fn go_test_cmd(run_pattern: &str, target: &str) -> String {
     // run_pattern はリテラルのシングルクォートで囲んで安全: 関数名は \w のみで、
     // ' を含むサブテスト名はここへ来る前に弾かれているため、埋め込みの
     // シングルクォートは現れない。
-    format!("go test -run '{run_pattern}' {}", shell_single_quote(target))
+    format!(
+        "go test -run '{run_pattern}' {}",
+        shell_single_quote(target)
+    )
 }
 
 /// ファイルに対応する go test のパッケージ引数。入れ子のファイルなら ./dir、

--- a/src/keymap/tests/edge_cases.rs
+++ b/src/keymap/tests/edge_cases.rs
@@ -55,7 +55,11 @@ fn macos_unicode_fallback_chords_resolve() {
     ];
     for (glyph, action) in cases {
         let key = KeyEvent::new(KeyCode::Char(glyph), KeyModifiers::empty());
-        assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "glyph {glyph:?}");
+        assert_eq!(
+            km.resolve(&key, KeyContext::Global),
+            Some(action),
+            "glyph {glyph:?}"
+        );
     }
 }
 

--- a/src/keymap/tests/overrides.rs
+++ b/src/keymap/tests/overrides.rs
@@ -39,7 +39,10 @@ fn user_override_adds_a_chord() {
 fn user_override_shadows_a_default_chord() {
     // ワークツリーで "g" -> go_to_top に再バインドする（デフォルトは grab_branch）。
     let mut layer = toml::Table::new();
-    layer.insert("g".to_string(), toml::Value::String("go_to_top".to_string()));
+    layer.insert(
+        "g".to_string(),
+        toml::Value::String("go_to_top".to_string()),
+    );
     let mut layers = toml::Table::new();
     layers.insert("worktree".to_string(), toml::Value::Table(layer));
     let mut user = toml::Table::new();
@@ -140,7 +143,10 @@ fn in_layer_conflict_is_warned() {
     // 1つのレイヤー内で同じチョードの2通りの綴り: keymap-config が Conflict
     // を報告し、後の方のバインディングが勝つ。
     let mut keys = toml::Table::new();
-    keys.insert("ctrl+x".to_string(), toml::Value::String("quit".to_string()));
+    keys.insert(
+        "ctrl+x".to_string(),
+        toml::Value::String("quit".to_string()),
+    );
     keys.insert(
         "control+x".to_string(),
         toml::Value::String("show_help".to_string()),

--- a/src/keymap/tests/resolution.rs
+++ b/src/keymap/tests/resolution.rs
@@ -2,8 +2,8 @@
 //! どおりのアクションに解決されることのテスト。terminal/editor での横取りと、
 //! コンテキストからグローバルへのフォールバックを含む。
 
-use super::*;
 use super::super::map::DEFAULT_KEYBINDS;
+use super::*;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use keymap_suite::ActionName;
 
@@ -28,7 +28,10 @@ fn critical_defaults_resolve() {
     // Quit は ctrl+q に移動した。素の q は未バインド（そのまま通過）なので
     // うっかりアプリを終了させることはもうできない。
     let key_ctrl_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL);
-    assert_eq!(km.resolve(&key_ctrl_q, KeyContext::Global), Some(Action::Quit));
+    assert_eq!(
+        km.resolve(&key_ctrl_q, KeyContext::Global),
+        Some(Action::Quit)
+    );
     let key_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty());
     assert_eq!(km.resolve(&key_q, KeyContext::Global), None);
 
@@ -59,15 +62,28 @@ fn worktree_switch_and_zoom_aliases_resolve() {
     // prefix z）、ctrl+alt によるペインサイズ変更ファミリーに加わる。
     let km = default_keymap();
     let cases = [
-        (KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT), Action::NextWorktree),
-        (KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT), Action::PrevWorktree),
         (
-            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL | KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT),
+            Action::NextWorktree,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT),
+            Action::PrevWorktree,
+        ),
+        (
+            KeyEvent::new(
+                KeyCode::Char('z'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            ),
             Action::TogglePanelExpand,
         ),
     ];
     for (key, action) in cases {
-        assert_eq!(km.resolve(&key, KeyContext::Global), Some(action), "{key:?}");
+        assert_eq!(
+            km.resolve(&key, KeyContext::Global),
+            Some(action),
+            "{key:?}"
+        );
     }
 }
 
@@ -82,7 +98,10 @@ fn terminal_intercepts_only_firing_actions() {
     assert_eq!(km.resolve(&ctrl_q, KeyContext::Global), Some(Action::Quit));
     assert_eq!(km.resolve(&ctrl_q, KeyContext::Terminal), None);
     let ctrl_r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
-    assert_eq!(km.resolve(&ctrl_r, KeyContext::Global), Some(Action::SwitchRepo));
+    assert_eq!(
+        km.resolve(&ctrl_r, KeyContext::Global),
+        Some(Action::SwitchRepo)
+    );
     assert_eq!(km.resolve(&ctrl_r, KeyContext::Terminal), None);
 
     // フォーカス/ナビゲーションのチョードは PTY から奪い返される。
@@ -105,7 +124,10 @@ fn terminal_intercepts_only_firing_actions() {
     // レンダリングされるヘルプは解決結果と食い違わない: ターミナルでは Quit に
     // チョードは宣伝されないが、ターミナルで発火するアクションはそのチョードを
     // 保つ。
-    assert!(km.keys_for_action(KeyContext::Terminal, Action::Quit).is_empty());
+    assert!(
+        km.keys_for_action(KeyContext::Terminal, Action::Quit)
+            .is_empty()
+    );
     assert!(
         !km.keys_for_action(KeyContext::Terminal, Action::LeaveTerminal)
             .is_empty()
@@ -182,8 +204,10 @@ fn editor_context_steals_only_leave_and_globals() {
         km.resolve(&alt_l, KeyContext::Editor),
         Some(Action::CycleFocusForward)
     );
-    let ctrl_alt_z =
-        KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL | KeyModifiers::ALT);
+    let ctrl_alt_z = KeyEvent::new(
+        KeyCode::Char('z'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
     assert_eq!(
         km.resolve(&ctrl_alt_z, KeyContext::Editor),
         Some(Action::TogglePanelExpand)
@@ -251,22 +275,50 @@ fn worktree_git_action_keys_resolve() {
     // 0.67 の意図的な変更。新しいバインディングを静かな退行から守るために固定する。
     let km = default_keymap();
     let cases = [
-        (KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()), Action::PullWorktree),
-        (KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()), Action::CherryPick),
-        (KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()), Action::OpenPullRequest),
+        (
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()),
+            Action::PullWorktree,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()),
+            Action::CherryPick,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()),
+            Action::OpenPullRequest,
+        ),
         // 'X' は解決済みグリフ 'X' + 冗長な SHIFT として届き、keymap-core が
         // "X" のバインディングに合うよう畳み込む（shift_g のテストを参照）。
-        (KeyEvent::new(KeyCode::Char('X'), KeyModifiers::SHIFT), Action::PruneWorktrees),
+        (
+            KeyEvent::new(KeyCode::Char('X'), KeyModifiers::SHIFT),
+            Action::PruneWorktrees,
+        ),
         // g/G はここでも go_to_top/bottom になった（以前は grab/ungrab）。
         // 他のすべてのパネルと揃えるため; grab/ungrab は b/B（"branch"、do/undo）
         // に移動した。
-        (KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty()), Action::GoToTop),
-        (KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT), Action::GoToBottom),
-        (KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()), Action::GrabBranch),
-        (KeyEvent::new(KeyCode::Char('B'), KeyModifiers::SHIFT), Action::UngrabBranch),
+        (
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty()),
+            Action::GoToTop,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            Action::GoToBottom,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()),
+            Action::GrabBranch,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('B'), KeyModifiers::SHIFT),
+            Action::UngrabBranch,
+        ),
     ];
     for (key, action) in cases {
-        assert_eq!(km.resolve(&key, KeyContext::Worktree), Some(action), "{key:?}");
+        assert_eq!(
+            km.resolve(&key, KeyContext::Worktree),
+            Some(action),
+            "{key:?}"
+        );
     }
 
     // 付け替えで空いたキーは、ワークツリーパネルでは今は未バインドである
@@ -326,8 +378,7 @@ fn ctrl_tab_switches_worktree() {
         Some(Action::CycleFocusForward)
     );
     // Ctrl+Shift+Tab と Ctrl+BackTab はどちらも Ctrl+Shift+Tab に正規化される。
-    let ctrl_shift_tab =
-        KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+    let ctrl_shift_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
     assert_eq!(
         km.resolve(&ctrl_shift_tab, KeyContext::Explorer),
         Some(Action::PrevWorktree)
@@ -376,14 +427,20 @@ fn f10_opens_the_menu_bar_from_every_context() {
     let km = default_keymap();
     let f10 = KeyEvent::new(KeyCode::F(10), KeyModifiers::NONE);
 
-    assert_eq!(km.resolve(&f10, KeyContext::Global), Some(Action::FocusMenuBar));
+    assert_eq!(
+        km.resolve(&f10, KeyContext::Global),
+        Some(Action::FocusMenuBar)
+    );
     // 多くの時間が費やされる PTY 上でも含めて。
     assert_eq!(
         km.resolve(&f10, KeyContext::Terminal),
         Some(Action::FocusMenuBar),
         "must fire while a terminal panel is focused"
     );
-    assert_eq!(km.resolve(&f10, KeyContext::Explorer), Some(Action::FocusMenuBar));
+    assert_eq!(
+        km.resolve(&f10, KeyContext::Explorer),
+        Some(Action::FocusMenuBar)
+    );
 
     // そして生成されるチートシートにも宣伝されなければならない。
     assert_eq!(
@@ -397,18 +454,43 @@ fn f10_opens_the_menu_bar_from_every_context() {
 fn revidere_layer_resolves() {
     let km = default_keymap();
     let cases = [
-        (KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()), Action::NavigateDown),
-        (KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()), Action::RevidereNextSection),
-        (KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT), Action::RevidererPrevSection),
-        (KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()), Action::Select),
-        (KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()), Action::ExitSubPanel),
+        (
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()),
+            Action::NavigateDown,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()),
+            Action::RevidereNextSection,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT),
+            Action::RevidererPrevSection,
+        ),
+        (
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+            Action::Select,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()),
+            Action::ExitSubPanel,
+        ),
         // 画面の切り替えは行き先ごとに別のキー。1 つのキーで交互に切り替えると、
         // 押した結果がいまどちらを出しているかに依存する。
-        (KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()), Action::RevidereShowOverview),
-        (KeyEvent::new(KeyCode::Char('d'), KeyModifiers::empty()), Action::RevidereShowSections),
+        (
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()),
+            Action::RevidereShowOverview,
+        ),
+        (
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::empty()),
+            Action::RevidereShowSections,
+        ),
     ];
     for (key, action) in cases {
-        assert_eq!(km.resolve(&key, KeyContext::Revidere), Some(action), "{key:?}");
+        assert_eq!(
+            km.resolve(&key, KeyContext::Revidere),
+            Some(action),
+            "{key:?}"
+        );
     }
 }
 
@@ -416,15 +498,24 @@ fn revidere_layer_resolves() {
 fn explorer_show_and_analyze_keys_resolve() {
     let km = default_keymap();
     assert_eq!(
-        km.resolve(&KeyEvent::new(KeyCode::Char('w'), KeyModifiers::empty()), KeyContext::Explorer),
+        km.resolve(
+            &KeyEvent::new(KeyCode::Char('w'), KeyModifiers::empty()),
+            KeyContext::Explorer
+        ),
         Some(Action::ShowRevidere)
     );
     assert_eq!(
-        km.resolve(&KeyEvent::new(KeyCode::Char('W'), KeyModifiers::SHIFT), KeyContext::Explorer),
+        km.resolve(
+            &KeyEvent::new(KeyCode::Char('W'), KeyModifiers::SHIFT),
+            KeyContext::Explorer
+        ),
         Some(Action::AnalyzeRevidere)
     );
     assert_eq!(
-        km.resolve(&KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT), KeyContext::Explorer),
+        km.resolve(
+            &KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT),
+            KeyContext::Explorer
+        ),
         Some(Action::ForceAnalyzeRevidere)
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,10 @@ mod pr_intake;
 mod pty_manager;
 mod refresh_pipe;
 mod repo_path;
+mod revidere;
 mod review_publish;
 mod review_state;
 mod review_store;
-mod revidere;
 mod rust_test;
 mod search_result_tree;
 mod semantic_index;
@@ -60,14 +60,12 @@ use std::io;
 
 use anyhow::Result;
 use crossterm::event::{
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
-    DisableLineWrap, EnableLineWrap,
-    EnterAlternateScreen, LeaveAlternateScreen, SetTitle, disable_raw_mode, enable_raw_mode,
-    supports_keyboard_enhancement,
+    DisableLineWrap, EnableLineWrap, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
+    disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement,
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -109,7 +107,10 @@ fn main() -> Result<()> {
     enter_tui(terminal.backend_mut(), keyboard_enhanced)?;
 
     let mut app = App::new(repo_path);
-    execute!(io::stdout(), SetTitle(format!("conductor - {}", app.repo.main_name)))?;
+    execute!(
+        io::stdout(),
+        SetTitle(format!("conductor - {}", app.repo.main_name))
+    )?;
 
     // raw mode に入ったあと・イベントループが stdin を読み始める前でなければ
     // ならない。端末への問い合わせの応答を自分で stdin から読むため。

--- a/src/mcp_serve/tools.rs
+++ b/src/mcp_serve/tools.rs
@@ -27,8 +27,8 @@ use super::args::{
     SetChangeSummary,
 };
 use super::reply::{
-    ensure_not_blank, err_text, line_range, normalize_repo_relative, ok_text,
-    render_thread, short_id,
+    ensure_not_blank, err_text, line_range, normalize_repo_relative, ok_text, render_thread,
+    short_id,
 };
 use super::resolve;
 use crate::review_store::{Author, CommentKind, CommentStatus, ReviewStore};
@@ -374,7 +374,6 @@ impl McpServer {
             None => ok_text(format!("No change summary set for branch \"{target}\".")),
         }
     }
-
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -395,7 +394,7 @@ impl ServerHandler for McpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     // tools/list
 
     #[test]

--- a/src/menu/model.rs
+++ b/src/menu/model.rs
@@ -25,10 +25,7 @@ use crate::command_palette::CommandId;
 pub enum MenuItem {
     /// 実行可能なコマンド。label はドロップダウンに表示するテキスト、id が
     /// 実行される対象。
-    Command {
-        id: CommandId,
-        label: &'static str,
-    },
+    Command { id: CommandId, label: &'static str },
     /// 関連コマンド群の間に置く、選択不可の区切り。
     Separator,
 }

--- a/src/menu/state.rs
+++ b/src/menu/state.rs
@@ -186,10 +186,7 @@ pub fn first_selectable(items: &[MenuItem]) -> usize {
 
 /// items 内で最後に選択可能な行。なければ 0。
 pub fn last_selectable(items: &[MenuItem]) -> usize {
-    items
-        .iter()
-        .rposition(MenuItem::is_selectable)
-        .unwrap_or(0)
+    items.iter().rposition(MenuItem::is_selectable).unwrap_or(0)
 }
 
 /// from から dir 方向(+1 で下、-1 で上)へ1行選択を進める。区切りは

--- a/src/menu/tests.rs
+++ b/src/menu/tests.rs
@@ -138,7 +138,11 @@ fn step_selection_skips_separators() {
 #[test]
 fn step_selection_wraps_at_both_ends() {
     let items = sample();
-    assert_eq!(step_selection(&items, 3, 1), 0, "past the end wraps to first");
+    assert_eq!(
+        step_selection(&items, 3, 1),
+        0,
+        "past the end wraps to first"
+    );
     assert_eq!(
         step_selection(&items, 0, -1),
         3,

--- a/src/pr_intake.rs
+++ b/src/pr_intake.rs
@@ -57,7 +57,10 @@ impl std::fmt::Display for PrIntakeError {
                 "`gh` (GitHub CLI) is not installed. Install it from https://cli.github.com/ and retry."
             ),
             PrIntakeError::GhNotAuthenticated => {
-                write!(f, "Not logged in to GitHub CLI. Run `gh auth login` and retry.")
+                write!(
+                    f,
+                    "Not logged in to GitHub CLI. Run `gh auth login` and retry."
+                )
             }
             PrIntakeError::PrNotFound(n) => write!(f, "Pull request #{n} not found."),
             PrIntakeError::NetworkError => write!(
@@ -76,7 +79,10 @@ impl std::fmt::Display for PrIntakeError {
 /// 「見つからない」に該当したときに PR を名指しできるよう pr_number を持ち回る。
 fn classify_failure_text(pr_number: u64, text: &str) -> PrIntakeError {
     let lower = text.to_lowercase();
-    if lower.contains("gh auth login") || lower.contains("not logged in") || lower.contains("authentication") {
+    if lower.contains("gh auth login")
+        || lower.contains("not logged in")
+        || lower.contains("authentication")
+    {
         PrIntakeError::GhNotAuthenticated
     } else if lower.contains("could not resolve host")
         || lower.contains("connection timed out")
@@ -190,7 +196,9 @@ pub enum PrIntakeOutcome {
         worktree_path: PathBuf,
         meta: Option<FetchedPr>,
     },
-    Failed { error: PrIntakeError },
+    Failed {
+        error: PrIntakeError,
+    },
 }
 
 /// PR 取り込みの一連の流れを同期的に実行する。input を PR 番号へ解決し、
@@ -338,7 +346,10 @@ mod tests {
     #[test]
     fn classify_failure_text_detects_auth() {
         assert_eq!(
-            classify_failure_text(1, "To get started with GitHub CLI, please run:  gh auth login"),
+            classify_failure_text(
+                1,
+                "To get started with GitHub CLI, please run:  gh auth login"
+            ),
             PrIntakeError::GhNotAuthenticated
         );
     }
@@ -358,7 +369,10 @@ mod tests {
     #[test]
     fn classify_failure_text_detects_network_error() {
         assert_eq!(
-            classify_failure_text(1, "fatal: unable to access: Could not resolve host: github.com"),
+            classify_failure_text(
+                1,
+                "fatal: unable to access: Could not resolve host: github.com"
+            ),
             PrIntakeError::NetworkError
         );
     }
@@ -430,7 +444,11 @@ mod tests {
         let outcome = intake_pr(&repo_path, None, "42");
         match outcome {
             PrIntakeOutcome::Failed { error } => {
-                assert!(error.to_string().contains(&broken_dir.display().to_string()));
+                assert!(
+                    error
+                        .to_string()
+                        .contains(&broken_dir.display().to_string())
+                );
             }
             PrIntakeOutcome::Ready { .. } => panic!("expected Failed, got Ready"),
         }

--- a/src/pty_manager/io.rs
+++ b/src/pty_manager/io.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-use super::locale::utf8_chunks;
 use super::PtyManager;
+use super::locale::utf8_chunks;
 
 impl PtyManager {
     /// 指定セッションインデックスの PTY へ入力データを送る。
@@ -302,9 +302,7 @@ pub(super) fn encode_mouse_wheel(
     let col = col.max(1);
     let row = row.max(1);
     match encoding {
-        vt100::MouseProtocolEncoding::Sgr => {
-            format!("\x1b[<{button};{col};{row}M").into_bytes()
-        }
+        vt100::MouseProtocolEncoding::Sgr => format!("\x1b[<{button};{col};{row}M").into_bytes(),
         // デフォルト(X10)と Utf8: CSI M Cb Cx Cy、各バイトは 32 だけオフセットする。
         // 223 を超える値はレガシー形式では表現できないため、座標が
         // ラップしないようクランプする。

--- a/src/pty_manager/reader.rs
+++ b/src/pty_manager/reader.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use super::{PtyManager, MAX_RAW_HISTORY_BYTES};
+use super::{MAX_RAW_HISTORY_BYTES, PtyManager};
 
 impl PtyManager {
     /// バックグラウンド reader スレッドの本体。
@@ -76,8 +76,7 @@ impl PtyManager {
                         // 見える。内側のスコープは、以降の CPR / オルタネート
                         // 画面処理の前に履歴のガードを解放する。
                         if let Some(raw_history) = &raw_history {
-                            let mut history =
-                                raw_history.lock().unwrap_or_else(|e| e.into_inner());
+                            let mut history = raw_history.lock().unwrap_or_else(|e| e.into_inner());
                             history.extend(bytes.iter().copied());
                             Self::trim_raw_history(&mut history, MAX_RAW_HISTORY_BYTES);
                         }

--- a/src/pty_manager/spawn.rs
+++ b/src/pty_manager/spawn.rs
@@ -197,7 +197,15 @@ impl PtyManager {
             cmd.env_remove(key);
         }
 
-        self.finish_spawn(SessionKind::Editor, worktree, label, working_dir, rows, cols, cmd)
+        self.finish_spawn(
+            SessionKind::Editor,
+            worktree,
+            label,
+            working_dir,
+            rows,
+            cols,
+            cmd,
+        )
     }
 
     /// spawn 経路の共有末尾処理: PTY のペアを開き、reader スレッドと vt100
@@ -261,8 +269,8 @@ impl PtyManager {
         // 端末の自動折り返しに頼る通常のシェルに限って記録する。Claude と
         // 一時的なエディタは固定幅でその場描画するため、再生してもリフロー
         // されずメモリを消費するだけなので、記録をスキップする。
-        let raw_history: Option<Arc<Mutex<VecDeque<u8>>>> = matches!(kind, SessionKind::Shell)
-            .then(|| Arc::new(Mutex::new(VecDeque::new())));
+        let raw_history: Option<Arc<Mutex<VecDeque<u8>>>> =
+            matches!(kind, SessionKind::Shell).then(|| Arc::new(Mutex::new(VecDeque::new())));
 
         // 6. PTY 出力を継続的に読み取るバックグラウンドスレッドを起動する。
         let buffer_clone = Arc::clone(&output_buffer);

--- a/src/pty_manager/tests.rs
+++ b/src/pty_manager/tests.rs
@@ -4,9 +4,9 @@
 
 use std::collections::VecDeque;
 
+use super::PtyManager;
 use super::io::{encode_mouse_wheel, sanitize_pasted_text, scroll_arrow_sequence};
 use super::locale::{utf8_chunks, utf8_locale_overrides};
-use super::PtyManager;
 
 #[test]
 fn arrow_sequence_honors_decckm_and_direction() {

--- a/src/review_store/mod.rs
+++ b/src/review_store/mod.rs
@@ -36,8 +36,8 @@ use rusqlite::Connection;
 // match するだけ）ため、rustc には re-export 自体が使われていると見えない。
 #[allow(unused_imports)]
 pub use model::{
-    Author, CommentKind, CommentStatus, CommentTemplate, DailyStats, PrReviewMeta,
-    ReviewComment, ReviewReply, SessionHistory, SessionStatsSnapshot, StreakInfo,
+    Author, CommentKind, CommentStatus, CommentTemplate, DailyStats, PrReviewMeta, ReviewComment,
+    ReviewReply, SessionHistory, SessionStatsSnapshot, StreakInfo,
 };
 
 /// 指定したリポジトリルートに対する conductor データベースのパスを返す。

--- a/src/review_store/replies.rs
+++ b/src/review_store/replies.rs
@@ -209,7 +209,9 @@ mod tests {
                 None,
             )
             .unwrap();
-        store.add_reply(&review.id, "first", Author::Claude).unwrap();
+        store
+            .add_reply(&review.id, "first", Author::Claude)
+            .unwrap();
         store.add_reply(&review.id, "second", Author::User).unwrap();
 
         let replies = store.get_replies(&review.id).unwrap();

--- a/src/review_store/worktree_metadata.rs
+++ b/src/review_store/worktree_metadata.rs
@@ -97,7 +97,9 @@ impl ReviewStore {
                  base_ref  = excluded.base_ref,
                  head_ref  = excluded.head_ref,
                  author    = excluded.author",
-            params![branch, pr_number, pr_url, pr_title, base_ref, head_ref, author],
+            params![
+                branch, pr_number, pr_url, pr_title, base_ref, head_ref, author
+            ],
         )?;
         Ok(())
     }
@@ -177,7 +179,10 @@ mod tests {
 
         let meta = store.get_pr_review_meta("feat/x").unwrap().unwrap();
         assert_eq!(meta.pr_number, Some(42));
-        assert_eq!(meta.pr_url.as_deref(), Some("https://github.com/o/r/pull/42"));
+        assert_eq!(
+            meta.pr_url.as_deref(),
+            Some("https://github.com/o/r/pull/42")
+        );
 
         // upsert なので重複せず上書きされる。
         store

--- a/src/rust_test.rs
+++ b/src/rust_test.rs
@@ -39,7 +39,10 @@ enum FileTarget {
 ///
 /// relative_path が対応対象の .rs ファイルでない (src/ とトップレベルの
 /// tests/ の外にある) か、テストを含まない場合は空のマップを返す。
-pub fn scan_rust_test_runs(file_content: &[String], relative_path: &str) -> HashMap<usize, TestRun> {
+pub fn scan_rust_test_runs(
+    file_content: &[String],
+    relative_path: &str,
+) -> HashMap<usize, TestRun> {
     let mut runs = HashMap::new();
 
     let Some(target) = file_target(relative_path) else {
@@ -394,10 +397,7 @@ mod tests {
         let runs = scan_rust_test_runs(&src, "src/ai_caller.rs");
 
         // 内側のモジュールボタン (3 行目) は入れ子のモジュールに絞られる。
-        assert_eq!(
-            runs[&3].command,
-            "cargo test 'ai_caller::tests::command::'"
-        );
+        assert_eq!(runs[&3].command, "cargo test 'ai_caller::tests::command::'");
         // 外側のモジュールボタン (2 行目)。
         assert_eq!(runs[&2].command, "cargo test 'ai_caller::tests::'");
         // 関数は入れ子を含む完全なパスを持つ (5 行目)。

--- a/src/symbol_index/code_mask.rs
+++ b/src/symbol_index/code_mask.rs
@@ -226,7 +226,10 @@ fn subtract_format_args(source: &str, start: usize, end: usize) -> Vec<(usize, u
         }
         let name_start = i + 1;
         let mut j = name_start;
-        if bytes.get(j).is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_') {
+        if bytes
+            .get(j)
+            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        {
             j += 1;
             while bytes
                 .get(j)
@@ -440,7 +443,8 @@ fn real(x: i32) -> Foo {
 
     #[test]
     fn go_masks_comments_and_both_string_forms() {
-        let src = "package main\n// Foo does things\nfunc Bar() {\n\ts := \"Foo\"\n\tr := `Foo raw`\n}\n";
+        let src =
+            "package main\n// Foo does things\nfunc Bar() {\n\ts := \"Foo\"\n\tr := `Foo raw`\n}\n";
         let mask = CodeMask::compute(src, "main.go");
 
         assert_eq!(

--- a/src/symbol_index/mod.rs
+++ b/src/symbol_index/mod.rs
@@ -23,8 +23,8 @@ mod model;
 #[cfg(test)]
 mod tests;
 
-pub use code_mask::{CodeMask, identifier_occurrences};
 pub(crate) use code_mask::language_for_ext;
+pub use code_mask::{CodeMask, identifier_occurrences};
 pub use index::SymbolIndex;
 // Reference は現在 app/ から crate::symbol_index::Reference として外部利用されている。
 // Symbol/SymbolKind は今のところこのモジュールツリー内で super::model::X としてのみ

--- a/src/symbol_index/tests.rs
+++ b/src/symbol_index/tests.rs
@@ -176,7 +176,11 @@ fn find_references_skips_comment_and_string_hits() {
 
     // 実際にコード位置の参照なのは4行目の呼び出しだけである — 1行目の
     // コメントと3行目の文字列リテラルは返ってきてはならない。
-    assert_eq!(refs.len(), 1, "expected exactly one code-position hit: {refs:?}");
+    assert_eq!(
+        refs.len(),
+        1,
+        "expected exactly one code-position hit: {refs:?}"
+    );
     assert_eq!(refs[0].line, 4);
 
     let _ = std::fs::remove_dir_all(&dir);
@@ -206,7 +210,10 @@ fn hover_reference_count_stays_within_a_frame() {
     let elapsed = start.elapsed();
 
     assert!(count > 0, "sanity: `new` should be found at all");
-    assert!(capped, "sanity: `new` should exceed a cap of 50 in this repo");
+    assert!(
+        capped,
+        "sanity: `new` should exceed a cap of 50 in this repo"
+    );
     assert!(
         elapsed < std::time::Duration::from_millis(30),
         "hover reference count took {elapsed:?}; uncapped this measured ~157ms \
@@ -228,7 +235,10 @@ fn find_references_defers_parsing_to_files_that_match() {
     let refs = idx.find_references("count_references_upto", &root);
     let elapsed = start.elapsed();
 
-    assert!(!refs.is_empty(), "sanity: the symbol should be found at all");
+    assert!(
+        !refs.is_empty(),
+        "sanity: the symbol should be found at all"
+    );
     assert!(
         elapsed < std::time::Duration::from_millis(80),
         "took {elapsed:?}; parsing every visited file instead of only the \

--- a/src/term_caps.rs
+++ b/src/term_caps.rs
@@ -53,8 +53,7 @@ pub fn query_background_luminance() -> Option<f64> {
     // 応答はメインスレッドで libc::poll を使って読む。OSC 11 に対応しない端末でも
     // 期限より長くブロックしないようにするため。
     const TIMEOUT_MS: i32 = 150;
-    let deadline = std::time::Instant::now()
-        + std::time::Duration::from_millis(TIMEOUT_MS as u64);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(TIMEOUT_MS as u64);
 
     let mut buf: Vec<u8> = Vec::with_capacity(64);
     loop {
@@ -256,7 +255,10 @@ mod tests {
         // 一部の端末 (古い xterm など) は OSC の終端に BEL (0x07) を使う。
         let lum = super::parse_osc11_luminance("\x1b]11;rgb:ffff/ffff/ffff\x07");
         assert!(lum.is_some());
-        assert!((lum.unwrap() - 1.0).abs() < 0.01, "white bg via BEL terminator");
+        assert!(
+            (lum.unwrap() - 1.0).abs() < 0.01,
+            "white bg via BEL terminator"
+        );
     }
 
     #[test]
@@ -265,7 +267,10 @@ mod tests {
         // パーサは先頭 2 桁を読むので、これは自然に扱える。
         let lum = super::parse_osc11_luminance("\x1b]11;rgb:ff/ff/ff\x1b\\");
         assert!(lum.is_some());
-        assert!((lum.unwrap() - 1.0).abs() < 0.01, "white bg via 8-bit channels");
+        assert!(
+            (lum.unwrap() - 1.0).abs() < 0.01,
+            "white bg via 8-bit channels"
+        );
 
         let dark = super::parse_osc11_luminance("\x1b]11;rgb:1e/1e/2e\x1b\\");
         assert!(dark.is_some());

--- a/src/theme/catppuccin.rs
+++ b/src/theme/catppuccin.rs
@@ -68,9 +68,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(40, 56, 58),    // teal寄りの surface
             reply_text: Color::Rgb(166, 173, 200),      // Subtext0
 
-            code_bg: Color::Rgb(17, 17, 27), // Crust
+            code_bg: Color::Rgb(17, 17, 27),    // Crust
             code_fg: Color::Rgb(245, 194, 231), // Pink
-
         }
     }
 
@@ -108,7 +107,7 @@ impl Theme {
             selected_bg: Color::Rgb(136, 57, 239),  // Mauve
             selected_fg: Color::Rgb(239, 241, 245), // Base(白に近い)
             selected_bg_inactive: Color::Rgb(204, 208, 218), // Surface0
-            selected_fg_inactive: Color::Rgb(76, 79, 105),   // Text
+            selected_fg_inactive: Color::Rgb(76, 79, 105), // Text
 
             line_selected_bg: Color::Rgb(204, 208, 218), // Surface0
             line_selected_fg: Color::Rgb(76, 79, 105),   // Text
@@ -123,7 +122,7 @@ impl Theme {
             search_match_bg: Color::Rgb(252, 238, 190), // 明るい黄色
             search_current_fg: Color::Rgb(76, 79, 105), // Text
 
-            waiting_primary: Color::Rgb(254, 100, 11),  // Peach
+            waiting_primary: Color::Rgb(254, 100, 11), // Peach
             waiting_secondary: Color::Rgb(212, 82, 9),
 
             titlebar_bg: Color::Rgb(230, 233, 239), // Mantle
@@ -138,9 +137,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(196, 228, 220),    // teal がかった明るい色
             reply_text: Color::Rgb(108, 111, 133),         // Subtext0
 
-            code_bg: Color::Rgb(230, 233, 239),  // Mantle
-            code_fg: Color::Rgb(234, 118, 203),  // Pink
-
+            code_bg: Color::Rgb(230, 233, 239), // Mantle
+            code_fg: Color::Rgb(234, 118, 203), // Pink
         }
     }
 }

--- a/src/theme/github.rs
+++ b/src/theme/github.rs
@@ -13,45 +13,45 @@ impl Theme {
         Self {
             name: "github-light",
             light: true,
-            fg: Color::Rgb(36, 41, 47),         // fg.default
-            accent: Color::Rgb(9, 105, 218),    // accent.fg
-            muted: Color::Rgb(208, 215, 222),   // border.default — 白背景でも視認できる区切り線
-            success: Color::Rgb(26, 127, 55),   // success.fg
-            error: Color::Rgb(207, 34, 46),     // danger.fg
-            warning: Color::Rgb(154, 103, 0),   // attention.fg (amber)
-            info: Color::Rgb(9, 105, 218),      // accent.fg
+            fg: Color::Rgb(36, 41, 47),       // fg.default
+            accent: Color::Rgb(9, 105, 218),  // accent.fg
+            muted: Color::Rgb(208, 215, 222), // border.default — 白背景でも視認できる区切り線
+            success: Color::Rgb(26, 127, 55), // success.fg
+            error: Color::Rgb(207, 34, 46),   // danger.fg
+            warning: Color::Rgb(154, 103, 0), // attention.fg (amber)
+            info: Color::Rgb(9, 105, 218),    // accent.fg
 
             diff_add: Color::Rgb(26, 127, 55),
-            diff_add_bg: Color::Rgb(230, 255, 237),  // GitHub の追加行背景
+            diff_add_bg: Color::Rgb(230, 255, 237), // GitHub の追加行背景
             diff_del: Color::Rgb(207, 34, 46),
-            diff_del_bg: Color::Rgb(255, 235, 233),  // GitHub の削除行背景
+            diff_del_bg: Color::Rgb(255, 235, 233), // GitHub の削除行背景
             diff_add_bg_emphasis: Color::Rgb(204, 255, 220), // より強調した追加
             diff_del_bg_emphasis: Color::Rgb(255, 193, 186), // より強調した削除
-            diff_section_header: Color::Rgb(110, 119, 129),  // fg.muted
+            diff_section_header: Color::Rgb(110, 119, 129), // fg.muted
 
-            border_focused: Color::Rgb(9, 105, 218),    // accent.fg
+            border_focused: Color::Rgb(9, 105, 218), // accent.fg
             border_unfocused: Color::Rgb(208, 215, 222), // border.default
             border_secondary: Color::Rgb(175, 184, 193), // border.muted
 
-            selected_bg: Color::Rgb(9, 105, 218),    // accent.fg
-            selected_fg: Color::Rgb(255, 255, 255),  // white
+            selected_bg: Color::Rgb(9, 105, 218),   // accent.fg
+            selected_fg: Color::Rgb(255, 255, 255), // white
             selected_bg_inactive: Color::Rgb(234, 238, 242), // neutral.subtle
-            selected_fg_inactive: Color::Rgb(36, 41, 47),    // fg.default
+            selected_fg_inactive: Color::Rgb(36, 41, 47), // fg.default
 
             line_selected_bg: Color::Rgb(234, 238, 242), // neutral.subtle
             line_selected_fg: Color::Rgb(36, 41, 47),    // fg.default
 
-            gutter_selected_bg: Color::Rgb(9, 105, 218),  // accent.fg
+            gutter_selected_bg: Color::Rgb(9, 105, 218), // accent.fg
             gutter_selected_fg: Color::Rgb(255, 255, 255), // white
-            gutter_hover_fg: Color::Rgb(110, 119, 129),   // fg.muted
-            gutter_hover_bg: Color::Rgb(246, 248, 250),   // canvas.subtle
+            gutter_hover_fg: Color::Rgb(110, 119, 129),  // fg.muted
+            gutter_hover_bg: Color::Rgb(246, 248, 250),  // canvas.subtle
 
             hint: Color::Rgb(110, 119, 129),            // fg.muted
             search_match_fg: Color::Rgb(154, 103, 0),   // attention.fg
             search_match_bg: Color::Rgb(255, 248, 197), // attention.subtle
             search_current_fg: Color::Rgb(36, 41, 47),  // fg.default
 
-            waiting_primary: Color::Rgb(225, 111, 36),  // オレンジ
+            waiting_primary: Color::Rgb(225, 111, 36), // オレンジ
             waiting_secondary: Color::Rgb(184, 92, 30),
 
             titlebar_bg: Color::Rgb(246, 248, 250), // canvas.subtle
@@ -66,9 +66,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(232, 245, 241),    // ティールがかった淡色
             reply_text: Color::Rgb(110, 119, 129),         // fg.muted
 
-            code_bg: Color::Rgb(246, 248, 250),  // canvas.subtle — GitHub のインラインコード背景
-            code_fg: Color::Rgb(149, 56, 0),     // インラインコード用の褐色がかった赤
-
+            code_bg: Color::Rgb(246, 248, 250), // canvas.subtle — GitHub のインラインコード背景
+            code_fg: Color::Rgb(149, 56, 0),    // インラインコード用の褐色がかった赤
         }
     }
 }

--- a/src/theme/gruvbox.rs
+++ b/src/theme/gruvbox.rs
@@ -61,9 +61,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(52, 64, 54),
             reply_text: Color::Rgb(131, 165, 152),
 
-            code_bg: Color::Rgb(29, 32, 33), // bg0_h
+            code_bg: Color::Rgb(29, 32, 33),    // bg0_h
             code_fg: Color::Rgb(211, 134, 155), // 紫がかったピンク
-
         }
     }
 }

--- a/src/theme/hsl.rs
+++ b/src/theme/hsl.rs
@@ -38,7 +38,11 @@ pub(super) fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
         let v = (l * 255.0).round() as u8;
         return (v, v, v);
     }
-    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
     let p = 2.0 * l - q;
     let hue_to_rgb = |p: f64, q: f64, mut t: f64| -> f64 {
         if t < 0.0 {

--- a/src/theme/kanagawa.rs
+++ b/src/theme/kanagawa.rs
@@ -61,9 +61,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(38, 56, 56),
             reply_text: Color::Rgb(127, 180, 202),
 
-            code_bg: Color::Rgb(18, 18, 24), // sumiInk0
+            code_bg: Color::Rgb(18, 18, 24),    // sumiInk0
             code_fg: Color::Rgb(210, 126, 153), // 桜色のピンク
-
         }
     }
 }

--- a/src/theme/solarized.rs
+++ b/src/theme/solarized.rs
@@ -63,7 +63,6 @@ impl Theme {
 
             code_bg: Color::Rgb(0, 33, 42), // base03、base より一段暗い
             code_fg: Color::Rgb(211, 54, 130), // magenta
-
         }
     }
 
@@ -77,13 +76,13 @@ impl Theme {
         Self {
             name: "solarized-light",
             light: true,
-            fg: Color::Rgb(101, 123, 131),     // base00 — 本文テキスト
-            accent: Color::Rgb(38, 139, 210),  // blue
-            muted: Color::Rgb(147, 161, 161),  // base1 — 区切り線用の中間グレー
-            success: Color::Rgb(133, 153, 0),  // green
-            error: Color::Rgb(220, 50, 47),    // red
-            warning: Color::Rgb(181, 137, 0),  // yellow
-            info: Color::Rgb(42, 161, 152),    // cyan
+            fg: Color::Rgb(101, 123, 131),    // base00 — 本文テキスト
+            accent: Color::Rgb(38, 139, 210), // blue
+            muted: Color::Rgb(147, 161, 161), // base1 — 区切り線用の中間グレー
+            success: Color::Rgb(133, 153, 0), // green
+            error: Color::Rgb(220, 50, 47),   // red
+            warning: Color::Rgb(181, 137, 0), // yellow
+            info: Color::Rgb(42, 161, 152),   // cyan
 
             diff_add: Color::Rgb(133, 153, 0),
             diff_add_bg: Color::Rgb(232, 244, 210),
@@ -93,12 +92,12 @@ impl Theme {
             diff_del_bg_emphasis: Color::Rgb(248, 206, 200),
             diff_section_header: Color::Rgb(147, 161, 161), // base1
 
-            border_focused: Color::Rgb(38, 139, 210),  // blue
+            border_focused: Color::Rgb(38, 139, 210), // blue
             border_unfocused: Color::Rgb(147, 161, 161), // base1
             border_secondary: Color::Rgb(131, 148, 150), // base0
 
-            selected_bg: Color::Rgb(38, 139, 210),   // blue
-            selected_fg: Color::Rgb(253, 246, 227),  // base3(最も明るい)
+            selected_bg: Color::Rgb(38, 139, 210),  // blue
+            selected_fg: Color::Rgb(253, 246, 227), // base3(最も明るい)
             selected_bg_inactive: Color::Rgb(238, 232, 213), // base2
             selected_fg_inactive: Color::Rgb(101, 123, 131), // base00
 
@@ -110,12 +109,12 @@ impl Theme {
             gutter_hover_fg: Color::Rgb(131, 148, 150),   // base0
             gutter_hover_bg: Color::Rgb(245, 238, 218),   // base3 と base2 の中間
 
-            hint: Color::Rgb(131, 148, 150),             // base0
-            search_match_fg: Color::Rgb(181, 137, 0),    // yellow
-            search_match_bg: Color::Rgb(253, 240, 184),  // 明るい黄色
+            hint: Color::Rgb(131, 148, 150),              // base0
+            search_match_fg: Color::Rgb(181, 137, 0),     // yellow
+            search_match_bg: Color::Rgb(253, 240, 184),   // 明るい黄色
             search_current_fg: Color::Rgb(253, 246, 227), // base3
 
-            waiting_primary: Color::Rgb(203, 75, 22),   // orange
+            waiting_primary: Color::Rgb(203, 75, 22), // orange
             waiting_secondary: Color::Rgb(160, 60, 18),
 
             titlebar_bg: Color::Rgb(238, 232, 213), // base2
@@ -130,9 +129,8 @@ impl Theme {
             comment_user_bg: Color::Rgb(216, 236, 232),    // teal がかった明るい色
             reply_text: Color::Rgb(88, 110, 117),          // base01
 
-            code_bg: Color::Rgb(228, 222, 200),  // base2 よりわずかに暗い
-            code_fg: Color::Rgb(211, 54, 130),   // magenta
-
+            code_bg: Color::Rgb(228, 222, 200), // base2 よりわずかに暗い
+            code_fg: Color::Rgb(211, 54, 130),  // magenta
         }
     }
 }

--- a/src/theme/tests.rs
+++ b/src/theme/tests.rs
@@ -3,7 +3,10 @@ use super::*;
 #[test]
 fn complement_rotates_hue_180_and_round_trips() {
     // 純粋な赤(h=0) → 同じ彩度/明度のシアン(h=0.5)。
-    assert_eq!(Theme::complement(Color::Rgb(255, 0, 0)), Color::Rgb(0, 255, 255));
+    assert_eq!(
+        Theme::complement(Color::Rgb(255, 0, 0)),
+        Color::Rgb(0, 255, 255)
+    );
     // complement を2回適用すると(近似的に)元の色相に戻る。
     let original = Color::Rgb(203, 166, 247); // Catppuccin Mauve accent
     let twice = Theme::complement(Theme::complement(original));
@@ -157,7 +160,10 @@ fn all_names_dark_before_light() {
         .iter()
         .position(|n| Theme::from_name(n).light)
         .expect("at least one light theme");
-    assert!(last_dark < first_light, "dark themes must precede light themes");
+    assert!(
+        last_dark < first_light,
+        "dark themes must precede light themes"
+    );
 }
 
 #[test]

--- a/src/ui/common/list_row.rs
+++ b/src/ui/common/list_row.rs
@@ -455,8 +455,7 @@ mod tests {
     fn only_the_hovered_row_is_underlined() {
         let theme = test_theme();
         let base = theme.fg;
-        let underlined =
-            |style: Style| style.add_modifier.contains(Modifier::UNDERLINED);
+        let underlined = |style: Style| style.add_modifier.contains(Modifier::UNDERLINED);
 
         assert!(underlined(row_style(
             &theme,

--- a/src/ui/common/mod.rs
+++ b/src/ui/common/mod.rs
@@ -16,11 +16,11 @@ mod worktree_label;
 #[cfg(test)]
 mod tests;
 
+pub use panel_chrome::PanelChrome;
 pub use pty::{PtyRenderCache, build_pty_lines, render_pty_cached};
 pub use status_bar::render_status_bar;
 pub(crate) use status_bar::representative_chord;
 pub use title_bar::render_title_bar;
-pub use panel_chrome::PanelChrome;
 pub use worktree_label::render_worktree_label;
 
 /// 非同期処理中に使う点字スピナーのフレーム一覧。

--- a/src/ui/common/panel_chrome.rs
+++ b/src/ui/common/panel_chrome.rs
@@ -8,8 +8,8 @@
 use std::borrow::Cow;
 
 use ratatui::layout::Alignment;
-use ratatui::style::{Modifier, Style};
 use ratatui::style::Color;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders};
 

--- a/src/ui/dashboard/repo.rs
+++ b/src/ui/dashboard/repo.rs
@@ -39,7 +39,8 @@ pub fn render_repo_selector_overlay(frame: &mut Frame, area: Rect, app: &App) {
     }
 
     let items: Vec<ListItem> = app
-        .repo.known
+        .repo
+        .known
         .iter()
         .enumerate()
         .map(|(i, path)| {
@@ -161,7 +162,10 @@ pub fn render_pr_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         Style::default().fg(theme.fg)
     };
-    frame.render_widget(Paragraph::new(Span::styled(input_text, input_style)), chunks[0]);
+    frame.render_widget(
+        Paragraph::new(Span::styled(input_text, input_style)),
+        chunks[0],
+    );
     if !overlay.loading {
         set_cursor_for_input(frame, chunks[0], &overlay.buffer);
     }
@@ -169,15 +173,11 @@ pub fn render_pr_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
     let message = if overlay.loading {
         Some(("Fetching PR metadata via gh...".to_string(), theme.muted))
     } else {
-        overlay
-            .error
-            .as_ref()
-            .map(|e| (e.clone(), theme.error))
+        overlay.error.as_ref().map(|e| (e.clone(), theme.error))
     };
     if let Some((text, color)) = message {
-        let paragraph =
-            Paragraph::new(Span::styled(text, Style::default().fg(color)))
-                .wrap(ratatui::widgets::Wrap { trim: false });
+        let paragraph = Paragraph::new(Span::styled(text, Style::default().fg(color)))
+            .wrap(ratatui::widgets::Wrap { trim: false });
         frame.render_widget(paragraph, chunks[1]);
     }
 }

--- a/src/ui/dashboard/update.rs
+++ b/src/ui/dashboard/update.rs
@@ -28,7 +28,8 @@ pub fn render_update_confirm_overlay(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(block, popup_area);
 
     let version = app
-        .update.info
+        .update
+        .info
         .as_ref()
         .map(|u| u.latest_version.as_str())
         .unwrap_or("?");

--- a/src/ui/dashboard/worktree.rs
+++ b/src/ui/dashboard/worktree.rs
@@ -134,8 +134,7 @@ pub fn render_smart_description_overlay(frame: &mut Frame, area: Rect, app: &App
             .smart_description_buffer
             .text_after_cursor()
     );
-    let (rows, cur_row, cur_col) =
-        wrap_with_cursor(&display, text_width as usize, '\u{2588}');
+    let (rows, cur_row, cur_col) = wrap_with_cursor(&display, text_width as usize, '\u{2588}');
 
     // ポップアップは内容に合わせて拡張する: 枠線(2) + テキスト行 + ヒント(1)、
     // ただし画面に収まる範囲にクランプする。テキストが表示可能な高さを超えたら、

--- a/src/ui/explorer_panel/comment_list.rs
+++ b/src/ui/explorer_panel/comment_list.rs
@@ -97,8 +97,7 @@ pub(super) fn render_comment_list(frame: &mut Frame, area: Rect, app: &App, pane
             match row {
                 CommentListRow::Comment { comment_idx } => {
                     let comment = app.review_state.comments.get(*comment_idx)?;
-                    let resolved =
-                        comment.status == crate::review_store::CommentStatus::Resolved;
+                    let resolved = comment.status == crate::review_store::CommentStatus::Resolved;
 
                     let kind_badge = crate::ui::review::kind_icon(comment.kind, icon_set);
                     let status_marker = if resolved { "\u{2713}" } else { "\u{25cb}" };
@@ -260,9 +259,7 @@ pub(super) fn render_comment_list(frame: &mut Frame, area: Rect, app: &App, pane
                         ListItem::new(Line::from(vec![
                             Span::styled(
                                 format!("    \u{21b3} {author_label} "),
-                                Style::default()
-                                    .fg(theme.info)
-                                    .add_modifier(Modifier::BOLD),
+                                Style::default().fg(theme.info).add_modifier(Modifier::BOLD),
                             ),
                             Span::styled(body, Style::default().fg(theme.reply_text)),
                             Span::styled(more_suffix, Style::default().fg(theme.muted)),

--- a/src/ui/explorer_panel/file_tree.rs
+++ b/src/ui/explorer_panel/file_tree.rs
@@ -5,9 +5,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{
-    List, ListItem, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{List, ListItem, Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 /// 深さレベルごとのインデント文字列のキャッシュ。確保の繰り返しを避ける。
 const INDENT_CACHE: &[&str] = &[

--- a/src/ui/explorer_panel/mod.rs
+++ b/src/ui/explorer_panel/mod.rs
@@ -50,7 +50,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         == crate::viewer::ExplorerBottomView::DiffList
         && app.diff_state.error.is_some();
     let banner_rows = diff_list::diff_list_banner_rows(shows_error_banner);
-    let diff_inner_height = (chunks[1].height.saturating_sub(2) as usize).saturating_sub(banner_rows);
+    let diff_inner_height =
+        (chunks[1].height.saturating_sub(2) as usize).saturating_sub(banner_rows);
     app.viewer_state.explorer.explorer_tree_height = tree_inner_height.max(1);
     app.viewer_state.explorer.explorer_diff_list_height = diff_inner_height.max(1);
     app.viewer_state.explorer.explorer_diff_banner_rows = banner_rows;

--- a/src/ui/layout/cache.rs
+++ b/src/ui/layout/cache.rs
@@ -169,8 +169,7 @@ pub(crate) fn accordion_widths(
             // 移った）ので幅は0になり、空いたスペースは explorer と viewer の
             // レビューペインに回る。
             let min_col = 3_u16;
-            let explorer =
-                ((total_width as u32 * explorer_pct as u32 / 100) as u16).max(min_col);
+            let explorer = ((total_width as u32 * explorer_pct as u32 / 100) as u16).max(min_col);
             let viewer = ((total_width as u32 * viewer_pct as u32 / 100) as u16).max(min_col);
             (0, explorer, viewer)
         }

--- a/src/ui/layout/render.rs
+++ b/src/ui/layout/render.rs
@@ -162,9 +162,11 @@ fn highlight_active_divider(frame: &mut Frame, app: &App) {
             (true, edge.saturating_sub(1), lc.main_area)
         }
         Divider::ExplorerSplit => (false, lc.explorer_mid_y.saturating_sub(1), lc.columns[1]),
-        Divider::TerminalSplit => {
-            (false, lc.terminal_split[1].y.saturating_sub(1), lc.columns[3])
-        }
+        Divider::TerminalSplit => (
+            false,
+            lc.terminal_split[1].y.saturating_sub(1),
+            lc.columns[3],
+        ),
     };
 
     let buf = frame.buffer_mut();

--- a/src/ui/layout/tests.rs
+++ b/src/ui/layout/tests.rs
@@ -175,7 +175,10 @@ fn menu_bar_row_comes_out_of_the_main_area() {
     let cfg = layout(24, 38, 80);
     cache.update(rect(200, 50), None, false, &cfg, 80);
 
-    assert_eq!(cache.main_area.y, cache.wtbar_area.y + cache.wtbar_area.height);
+    assert_eq!(
+        cache.main_area.y,
+        cache.wtbar_area.y + cache.wtbar_area.height
+    );
     assert_eq!(
         cache.main_area.y + cache.main_area.height,
         cache.status_area.y,
@@ -197,6 +200,9 @@ fn every_vertical_row_is_accounted_for() {
             + cache.wtbar_area.height
             + cache.main_area.height
             + cache.status_area.height;
-        assert_eq!(total, h, "regions must tile the frame exactly at height {h}");
+        assert_eq!(
+            total, h,
+            "regions must tile the frame exactly at height {h}"
+        );
     }
 }

--- a/src/ui/markdown/code_colors.rs
+++ b/src/ui/markdown/code_colors.rs
@@ -95,7 +95,9 @@ impl StringState {
             self.interrupted = false;
         }
         let is_interpolation = scopes.iter().any(|s| {
-            s.contains("interpolation.") || s.contains("expansion") || s.contains("embedded")
+            s.contains("interpolation.")
+                || s.contains("expansion")
+                || s.contains("embedded")
                 || s.starts_with("variable.")
         });
         if self.in_string && is_interpolation {
@@ -180,7 +182,10 @@ fn classify(
             Category::Keyword
         };
     }
-    if scopes.iter().any(|s| s.starts_with("entity.name.function.")) {
+    if scopes
+        .iter()
+        .any(|s| s.starts_with("entity.name.function."))
+    {
         return Category::FunctionName;
     }
     // 文法が明示的にタグ付けするビルトイン関数（Python の range、Bash の echo）。
@@ -223,7 +228,10 @@ fn classify(
     // 使っているビルトインは object のみで、この位置で同様に読まれる Python の
     // 全ビルトイン（int、Exception、...）を網羅した検証済みリストではない。
     // 実際の実物キャプチャからのみ拡張すること。
-    if scopes.iter().any(|s| s.starts_with("entity.other.inherited-class.")) {
+    if scopes
+        .iter()
+        .any(|s| s.starts_with("entity.other.inherited-class."))
+    {
         return if text == "object" {
             Category::Keyword
         } else {

--- a/src/ui/markdown/parse.rs
+++ b/src/ui/markdown/parse.rs
@@ -161,7 +161,7 @@ fn parse_heading(s: &str) -> Option<(u8, String)> {
     Some((hashes as u8, rest.trim_start().to_string()))
 }
 
-/// - / * / +（箇条書き）、または N. / N)（順序付き）→ ListItem。項目テキスト先頭の
+/// 箇条書き（- / * / +）と順序付き（N. / N)）を ListItem にする。項目テキスト先頭の
 /// GFM タスクマーカー（[ ] / [x] ）は checked に切り出す。
 fn parse_list_item(line: &str) -> Option<MdBlock> {
     let indent = line.len() - line.trim_start().len();

--- a/src/ui/markdown/parse.rs
+++ b/src/ui/markdown/parse.rs
@@ -96,10 +96,7 @@ pub(crate) fn parse_blocks(text: &str) -> Vec<MdBlock> {
         } else if is_hr(trimmed) {
             blocks.push(MdBlock::Rule);
         } else if let Some((level, htext)) = parse_heading(trimmed) {
-            blocks.push(MdBlock::Heading {
-                level,
-                text: htext,
-            });
+            blocks.push(MdBlock::Heading { level, text: htext });
         } else if let Some(rest) = trimmed.strip_prefix('>') {
             blocks.push(MdBlock::Quote(
                 rest.strip_prefix(' ').unwrap_or(rest).to_string(),
@@ -187,7 +184,10 @@ fn parse_list_item(line: &str) -> Option<MdBlock> {
     let digits: String = s.chars().take_while(char::is_ascii_digit).collect();
     if !digits.is_empty() {
         let after = &s[digits.len()..];
-        if let Some(rest) = after.strip_prefix(". ").or_else(|| after.strip_prefix(") ")) {
+        if let Some(rest) = after
+            .strip_prefix(". ")
+            .or_else(|| after.strip_prefix(") "))
+        {
             let (checked, text) = split_task_marker(rest);
             return Some(MdBlock::ListItem {
                 ordered: Some(digits),

--- a/src/ui/markdown/render.rs
+++ b/src/ui/markdown/render.rs
@@ -76,8 +76,12 @@ pub(crate) fn render_block(
             out
         }
         MdBlock::Paragraph(text) => {
-            let cells =
-                spans_to_cells(&inline_spans(text, Style::default().fg(theme.fg), theme, flavor));
+            let cells = spans_to_cells(&inline_spans(
+                text,
+                Style::default().fg(theme.fg),
+                theme,
+                flavor,
+            ));
             wrap_cells(&cells, width, false)
         }
         // 実物の Claude Code は引用を dim な ▎ で示し、本文はターミナルのデフォルト色の
@@ -88,7 +92,10 @@ pub(crate) fn render_block(
             let inner = width.saturating_sub(2).max(1);
             let style = Style::default().fg(theme.fg).add_modifier(Modifier::ITALIC);
             let cells = spans_to_cells(&inline_spans(text, style, theme, flavor));
-            let bar = Span::styled("\u{258e} ".to_string(), Style::default().add_modifier(Modifier::DIM));
+            let bar = Span::styled(
+                "\u{258e} ".to_string(),
+                Style::default().add_modifier(Modifier::DIM),
+            );
             with_prefix(wrap_cells(&cells, inner, false), bar.clone(), bar)
         }
         MdBlock::Quote(text) => {
@@ -168,9 +175,14 @@ pub(crate) fn render_block(
             with_prefix(wrap_cells(&cells, inner, false), first, cont)
         }
         MdBlock::CodeBlock { lang, lines } => match flavor {
-            MarkdownFlavor::Rich => {
-                render_code_block(lang.as_deref(), lines, width, theme, syntax_set, syntect_theme)
-            }
+            MarkdownFlavor::Rich => render_code_block(
+                lang.as_deref(),
+                lines,
+                width,
+                theme,
+                syntax_set,
+                syntect_theme,
+            ),
             MarkdownFlavor::Transcript => {
                 render_code_block_transcript(lang.as_deref(), lines, width, syntax_set)
             }
@@ -209,7 +221,12 @@ fn render_code_block(
     let fallback = Style::default().fg(theme.fg).bg(code_bg);
 
     // カード色で塗った全幅の空行（上下のパディング）。
-    let pad_row = || Line::from(Span::styled(" ".repeat(width), Style::default().bg(code_bg)));
+    let pad_row = || {
+        Line::from(Span::styled(
+            " ".repeat(width),
+            Style::default().bg(code_bg),
+        ))
+    };
 
     let mut out = vec![pad_row()];
     for raw in lines {

--- a/src/ui/markdown/table.rs
+++ b/src/ui/markdown/table.rs
@@ -49,7 +49,9 @@ pub(crate) fn render_table(
 
     let widths = fit_col_widths(&natural_col_widths(headers, &rows, theme), width);
 
-    let header_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+    let header_style = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
     let body_style = Style::default().fg(theme.fg);
 
     let mut out = Vec::with_capacity(rows.len() + 2);
@@ -69,12 +71,7 @@ pub(crate) fn render_table(
     )));
     for row in &rows {
         out.extend(render_table_row(
-            row,
-            &widths,
-            &aligns,
-            body_style,
-            width,
-            theme,
+            row, &widths, &aligns, body_style, width, theme,
         ));
     }
     out
@@ -152,9 +149,7 @@ fn render_table_row(
         .collect();
 
     let height = cols.iter().map(Vec::len).max().unwrap_or(0);
-    let blank = |col_w: usize| -> Vec<Cell> {
-        (0..col_w).map(|_| Cell::new(' ', base)).collect()
-    };
+    let blank = |col_w: usize| -> Vec<Cell> { (0..col_w).map(|_| Cell::new(' ', base)).collect() };
 
     (0..height)
         .map(|row_line| {
@@ -178,13 +173,7 @@ fn render_table_row(
 /// 描画し、単語境界で折り返し、align に従って各行をパディングする。常に最低1行を
 /// 返す（空セルは空行1つになる）ので、行の高さはセルの最大値になり、決してゼロには
 /// ならない。
-fn wrap_cell(
-    text: &str,
-    col_w: usize,
-    align: Align,
-    base: Style,
-    theme: &Theme,
-) -> Vec<Vec<Cell>> {
+fn wrap_cell(text: &str, col_w: usize, align: Align, base: Style, theme: &Theme) -> Vec<Vec<Cell>> {
     if col_w == 0 {
         return vec![Vec::new()];
     }
@@ -198,9 +187,7 @@ fn wrap_cell(
 /// 折り返し済みの行1本を align に従って col_w 桁までパディングする。
 fn pad_cell_line(cells: Vec<Cell>, col_w: usize, align: Align, base: Style) -> Vec<Cell> {
     let pad = col_w.saturating_sub(cells_width(&cells));
-    let space = |n: usize| -> Vec<Cell> {
-        (0..n).map(|_| Cell::new(' ', base)).collect()
-    };
+    let space = |n: usize| -> Vec<Cell> { (0..n).map(|_| Cell::new(' ', base)).collect() };
     match align {
         Align::Left => {
             let mut out = cells;

--- a/src/ui/markdown/table_boxed.rs
+++ b/src/ui/markdown/table_boxed.rs
@@ -47,23 +47,38 @@ pub(crate) fn render_table_boxed(
     let style = Style::default().fg(Color::Reset);
 
     let mut out = Vec::with_capacity(rows.len() * 2 + 3);
-    out.push(clip_line(border_cells(&inner, '\u{250c}', '\u{252c}', '\u{2510}', style), width));
+    out.push(clip_line(
+        border_cells(&inner, '\u{250c}', '\u{252c}', '\u{2510}', style),
+        width,
+    ));
     out.extend(render_row(headers, &inner, theme, style, width));
-    out.push(clip_line(border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style), width));
+    out.push(clip_line(
+        border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style),
+        width,
+    ));
     for (idx, row) in rows.iter().enumerate() {
         out.extend(render_row(row, &inner, theme, style, width));
         if idx + 1 < rows.len() {
-            out.push(clip_line(border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style), width));
+            out.push(clip_line(
+                border_cells(&inner, '\u{251c}', '\u{253c}', '\u{2524}', style),
+                width,
+            ));
         }
     }
-    out.push(clip_line(border_cells(&inner, '\u{2514}', '\u{2534}', '\u{2518}', style), width));
+    out.push(clip_line(
+        border_cells(&inner, '\u{2514}', '\u{2534}', '\u{2518}', style),
+        width,
+    ));
     out
 }
 
 /// 各列の自然な内側幅: ヘッダーとすべての本体セルにわたる
 /// max(セルの表示幅) + 2（左右に1列ずつのパディング）。
 fn natural_inner_widths(headers: &[String], rows: &[Vec<String>], theme: &Theme) -> Vec<usize> {
-    let mut w: Vec<usize> = headers.iter().map(|h| rendered_width(h, theme) + 2).collect();
+    let mut w: Vec<usize> = headers
+        .iter()
+        .map(|h| rendered_width(h, theme) + 2)
+        .collect();
     for row in rows {
         for (k, cell) in row.iter().enumerate() {
             if let Some(col) = w.get_mut(k) {
@@ -151,7 +166,12 @@ fn wrap_cell(text: &str, inner_w: usize, style: Style, theme: &Theme) -> Vec<Vec
         return vec![Vec::new()];
     }
     let content_w = inner_w.saturating_sub(2).max(1);
-    let cells = spans_to_cells(&inline_spans(text, style, theme, MarkdownFlavor::Transcript));
+    let cells = spans_to_cells(&inline_spans(
+        text,
+        style,
+        theme,
+        MarkdownFlavor::Transcript,
+    ));
     wrap_cells_raw(&cells, content_w, false)
         .into_iter()
         .map(|line| pad_left(line, inner_w, style))

--- a/src/ui/markdown/tests/mod.rs
+++ b/src/ui/markdown/tests/mod.rs
@@ -2,10 +2,10 @@
 //! parsing（ブロック/インライン/テーブルの解析）と rendering（折り返し・
 //! 堅牢性・コードブロック/transcript の描画・キャッシュ）に関心事ごとに分けてある。
 
-use super::*;
 use super::inline::inline_spans;
 use super::parse::{Align, split_table_row};
 use super::wrap::display_width;
+use super::*;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use syntect::highlighting::ThemeSet;

--- a/src/ui/markdown/tests/parsing.rs
+++ b/src/ui/markdown/tests/parsing.rs
@@ -39,8 +39,14 @@ fn headings_parse_with_level() {
     assert_eq!(
         parse_blocks("# Title\n### Sub"),
         vec![
-            MdBlock::Heading { level: 1, text: "Title".to_string() },
-            MdBlock::Heading { level: 3, text: "Sub".to_string() },
+            MdBlock::Heading {
+                level: 1,
+                text: "Title".to_string()
+            },
+            MdBlock::Heading {
+                level: 3,
+                text: "Sub".to_string()
+            },
         ]
     );
 }
@@ -50,10 +56,30 @@ fn list_items_bullet_and_ordered() {
     assert_eq!(
         parse_blocks("- a\n* b\n1. c\n2) d"),
         vec![
-            MdBlock::ListItem { ordered: None, checked: None, text: "a".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: None, checked: None, text: "b".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: Some("1".to_string()), checked: None, text: "c".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: Some("2".to_string()), checked: None, text: "d".to_string(), indent: 0 },
+            MdBlock::ListItem {
+                ordered: None,
+                checked: None,
+                text: "a".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: None,
+                checked: None,
+                text: "b".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: Some("1".to_string()),
+                checked: None,
+                text: "c".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: Some("2".to_string()),
+                checked: None,
+                text: "d".to_string(),
+                indent: 0
+            },
         ]
     );
     // マーカーの後にスペースがない → 普通の段落。
@@ -81,7 +107,10 @@ fn fence_without_lang_and_crlf() {
     assert_eq!(
         blocks,
         vec![
-            MdBlock::CodeBlock { lang: None, lines: vec!["code".to_string()] },
+            MdBlock::CodeBlock {
+                lang: None,
+                lines: vec!["code".to_string()]
+            },
             MdBlock::Blank,
         ]
     );
@@ -116,7 +145,12 @@ fn snake_case_and_bare_star_stay_literal() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
     // アンダースコアは強調にならない。
-    let spans = inline_spans("call set_change_summary here", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "call set_change_summary here",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert_eq!(joined(&spans), "call set_change_summary here");
     assert_eq!(spans.len(), 1, "no styled split for snake_case");
     // 2 * 3: 両側にスペースがあるアスタリスクはそのまま文字として扱われる。
@@ -163,7 +197,16 @@ fn unclosed_inline_delimiters_stay_literal() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
     for input in [
-        "a `b", "a *b", "a **b", "*", "`", "a ~~b", "~~", "~", "a ~ b", "~/foo",
+        "a `b",
+        "a *b",
+        "a **b",
+        "*",
+        "`",
+        "a ~~b",
+        "~~",
+        "~",
+        "a ~ b",
+        "~/foo",
         "a ~~ b ~~ c",
     ] {
         let spans = inline_spans(input, base, &theme, MarkdownFlavor::Rich);
@@ -188,7 +231,12 @@ fn strikethrough_does_not_nest_inner_markup() {
     // — ただし取り消し線の外側にあるインラインマークアップは引き続き機能する。
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
-    let spans = inline_spans("~~old **bold**~~ and **real**", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "~~old **bold**~~ and **real**",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert!(
         spans
             .iter()
@@ -220,10 +268,30 @@ fn task_checkboxes_parse() {
     assert_eq!(
         parse_blocks("- [ ] todo\n- [x] done\n- [X] also\n1. [ ] num"),
         vec![
-            MdBlock::ListItem { ordered: None, checked: Some(false), text: "todo".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: None, checked: Some(true), text: "done".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: None, checked: Some(true), text: "also".to_string(), indent: 0 },
-            MdBlock::ListItem { ordered: Some("1".to_string()), checked: Some(false), text: "num".to_string(), indent: 0 },
+            MdBlock::ListItem {
+                ordered: None,
+                checked: Some(false),
+                text: "todo".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: None,
+                checked: Some(true),
+                text: "done".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: None,
+                checked: Some(true),
+                text: "also".to_string(),
+                indent: 0
+            },
+            MdBlock::ListItem {
+                ordered: Some("1".to_string()),
+                checked: Some(false),
+                text: "num".to_string(),
+                indent: 0
+            },
         ]
     );
 }
@@ -348,7 +416,13 @@ fn wide_table_cells_wrap_instead_of_losing_content() {
         | toggle | switches a markdown file between raw source and rendered prose |\n\
         | scroll | independent of the raw view |";
     let words = [
-        "switches", "markdown", "between", "source", "rendered", "prose", "independent",
+        "switches",
+        "markdown",
+        "between",
+        "source",
+        "rendered",
+        "prose",
+        "independent",
     ];
     for width in [20usize, 30, 40, 60, 100] {
         let text: String = render(table, width)
@@ -437,7 +511,10 @@ fn table_alignment_does_not_change_cell_width() {
         .iter()
         .map(|d| display_width(&line_text(&mk(d)[2])))
         .collect();
-    assert!(full.iter().all(|&w| w == full[0]), "row widths differ: {full:?}");
+    assert!(
+        full.iter().all(|&w| w == full[0]),
+        "row widths differ: {full:?}"
+    );
     let _ = widths;
 }
 
@@ -457,7 +534,12 @@ fn links_render_text_and_url() {
     let base = Style::default().fg(theme.fg);
 
     // リンクテキストを表示し、URL は控えめな括弧書きで保持する。
-    let spans = inline_spans("see [the docs](https://example.com) now", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "see [the docs](https://example.com) now",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert_eq!(joined(&spans), "see the docs (https://example.com) now");
     assert!(
         spans.iter().any(|s| s.content == "the docs"
@@ -466,7 +548,12 @@ fn links_render_text_and_url() {
     );
 
     // リンクテキスト内のインラインマークアップにも引き続きスタイルが付く。
-    let spans = inline_spans("[**bold** link](https://x.io)", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "[**bold** link](https://x.io)",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert!(
         spans
             .iter()
@@ -481,11 +568,21 @@ fn self_titled_and_empty_links_show_url_once() {
     let (theme, _, _) = fixtures();
     let base = Style::default().fg(theme.fg);
 
-    let spans = inline_spans("[https://x.com](https://x.com)", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "[https://x.com](https://x.com)",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert_eq!(joined(&spans), "https://x.com");
 
     // 末尾のスラッシュや大文字小文字の違いがあっても1つにまとまる。
-    let spans = inline_spans("[https://x.com/](https://x.com)", base, &theme, MarkdownFlavor::Rich);
+    let spans = inline_spans(
+        "[https://x.com/](https://x.com)",
+        base,
+        &theme,
+        MarkdownFlavor::Rich,
+    );
     assert_eq!(joined(&spans), "https://x.com");
 
     let spans = inline_spans("[](https://x.com)", base, &theme, MarkdownFlavor::Rich);

--- a/src/ui/markdown/tests/rendering.rs
+++ b/src/ui/markdown/tests/rendering.rs
@@ -12,7 +12,16 @@ fn wraps_to_width_and_preserves_words() {
     for line in &lines {
         assert!(display_width(&line_text(line)) <= 9);
     }
-    assert_eq!(lines.iter().map(line_text).collect::<Vec<_>>().join(" ").replace("  ", " ").trim(), "the quick brown fox");
+    assert_eq!(
+        lines
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join(" ")
+            .replace("  ", " ")
+            .trim(),
+        "the quick brown fox"
+    );
 }
 
 #[test]
@@ -108,7 +117,12 @@ fn code_block_is_highlighted_and_carded() {
     // syntect が複数のスタイル付き span に分割する。
     let content = &lines[1];
     assert!(line_text(content).contains("let x = 1;"));
-    assert!(content.spans.iter().all(|s| s.style.bg == Some(theme.code_bg)));
+    assert!(
+        content
+            .spans
+            .iter()
+            .all(|s| s.style.bg == Some(theme.code_bg))
+    );
     assert!(content.spans.len() > 2);
     // カード全体が端から端まで幅を埋める。
     assert_eq!(display_width(&line_text(content)), 40);
@@ -216,21 +230,39 @@ fn transcript_h1_is_bold_italic_underlined_h2_h3_stay_bold_only() {
     let h1 = render_transcript("# Title", 30);
     let span = &h1[0].spans[0];
     assert!(span.style.add_modifier.contains(Modifier::BOLD), "H1 bold");
-    assert!(span.style.add_modifier.contains(Modifier::ITALIC), "H1 italic");
-    assert!(span.style.add_modifier.contains(Modifier::UNDERLINED), "H1 underlined");
+    assert!(
+        span.style.add_modifier.contains(Modifier::ITALIC),
+        "H1 italic"
+    );
+    assert!(
+        span.style.add_modifier.contains(Modifier::UNDERLINED),
+        "H1 underlined"
+    );
 
     for src in ["## Sub", "### Subsub"] {
         let lines = render_transcript(src, 30);
         let span = &lines[0].spans[0];
-        assert!(!span.style.add_modifier.contains(Modifier::ITALIC), "{src}: not italic");
-        assert!(!span.style.add_modifier.contains(Modifier::UNDERLINED), "{src}: not underlined");
+        assert!(
+            !span.style.add_modifier.contains(Modifier::ITALIC),
+            "{src}: not italic"
+        );
+        assert!(
+            !span.style.add_modifier.contains(Modifier::UNDERLINED),
+            "{src}: not underlined"
+        );
     }
 
     // Rich フレーバーの H1 は影響を受けない（太字のみ、斜体/下線なし）。
     let rich_h1 = render("# Title", 30);
     let rich_span = &rich_h1[0].spans[1]; // spans[0] はカラーバー
-    assert!(!rich_span.style.add_modifier.contains(Modifier::ITALIC), "Rich H1 stays bold-only");
-    assert!(!rich_span.style.add_modifier.contains(Modifier::UNDERLINED), "Rich H1 stays bold-only");
+    assert!(
+        !rich_span.style.add_modifier.contains(Modifier::ITALIC),
+        "Rich H1 stays bold-only"
+    );
+    assert!(
+        !rich_span.style.add_modifier.contains(Modifier::UNDERLINED),
+        "Rich H1 stays bold-only"
+    );
 }
 
 #[test]
@@ -239,11 +271,21 @@ fn transcript_task_checkbox_renders_literally_unstyled() {
     // チェックボックスのマーカーは本文テキストのまま、普通の箇条書き項目として残る。
     let (theme, _, _) = fixtures();
     let lines = render_transcript("- [ ] unchecked task\n- [x] checked task", 40);
-    assert_eq!(lines[0].spans[0].content.as_ref(), "- ", "ordinary dash bullet, not dropped");
-    let unchecked_text: String = lines[0].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(
+        lines[0].spans[0].content.as_ref(),
+        "- ",
+        "ordinary dash bullet, not dropped"
+    );
+    let unchecked_text: String = lines[0].spans[1..]
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
     assert_eq!(unchecked_text, "[ ] unchecked task");
     assert_eq!(lines[1].spans[0].content.as_ref(), "- ");
-    let checked_text: String = lines[1].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    let checked_text: String = lines[1].spans[1..]
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
     assert_eq!(checked_text, "[x] checked task");
     // 特別な色付けはなし: 箇条書きマーカーも本文も本文色のままで、
     // theme.success（「完了」を表す緑）や theme.muted（「後退」を表すグレー）には
@@ -258,7 +300,11 @@ fn transcript_task_checkbox_renders_literally_unstyled() {
     let rich = render("- [ ] todo\n- [x] done", 40);
     assert_eq!(rich[0].spans[0].content.as_ref(), "[ ] ");
     assert_eq!(rich[1].spans[0].content.as_ref(), "[x] ");
-    assert_eq!(rich[1].spans[0].style.fg, Some(theme.success), "Rich still colours [x] green");
+    assert_eq!(
+        rich[1].spans[0].style.fg,
+        Some(theme.success),
+        "Rich still colours [x] green"
+    );
 }
 
 #[test]
@@ -292,14 +338,27 @@ fn transcript_quote_uses_dim_glyph_and_default_colour_italic_body() {
     let lines = render_transcript("> quoted text", 40);
     let glyph = &lines[0].spans[0];
     assert_eq!(glyph.content.as_ref(), "\u{258e} ", "▎ glyph, not │");
-    assert!(glyph.style.add_modifier.contains(Modifier::DIM), "glyph is dim");
+    assert!(
+        glyph.style.add_modifier.contains(Modifier::DIM),
+        "glyph is dim"
+    );
     assert_eq!(glyph.style.fg, None, "glyph carries no explicit colour");
 
-    let body: String = lines[0].spans[1..].iter().map(|s| s.content.as_ref()).collect();
+    let body: String = lines[0].spans[1..]
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
     assert_eq!(body, "quoted text");
     for span in &lines[0].spans[1..] {
-        assert_eq!(span.style.fg, Some(theme.fg), "body is default colour, not muted");
-        assert!(span.style.add_modifier.contains(Modifier::ITALIC), "body stays italic");
+        assert_eq!(
+            span.style.fg,
+            Some(theme.fg),
+            "body is default colour, not muted"
+        );
+        assert!(
+            span.style.add_modifier.contains(Modifier::ITALIC),
+            "body stays italic"
+        );
     }
 
     // Rich フレーバーは muted 色の「│ 」バーと muted 斜体の本文を維持する
@@ -331,14 +390,19 @@ fn transcript_heading_does_not_stack_double_blank() {
     let texts: Vec<String> = lines.iter().map(line_text).collect();
     let h = texts.iter().position(|t| t == "Head").unwrap();
     assert_eq!(texts[h + 1], "", "one blank below");
-    assert_eq!(texts[h + 2], "body", "body immediately after the single blank");
+    assert_eq!(
+        texts[h + 2],
+        "body",
+        "body immediately after the single blank"
+    );
 }
 
 #[test]
 fn transcript_lines_stay_within_width() {
     // ダッシュの箇条書きと太字見出しは折り返し幅を決してはみ出さない。
     for width in [4usize, 8, 20, 40] {
-        for line in render_transcript("### 見出し\n- あいうえお item\n1. another one", width) {
+        for line in render_transcript("### 見出し\n- あいうえお item\n1. another one", width)
+        {
             assert!(display_width(&line_text(&line)) <= width);
         }
     }
@@ -371,7 +435,11 @@ fn transcript_table_renders_as_boxed_grid() {
     // テーブルのどこにも色や太字はない。
     for line in &lines {
         for span in &line.spans {
-            assert_eq!(span.style.fg, Some(Color::Reset), "table text carries no colour");
+            assert_eq!(
+                span.style.fg,
+                Some(Color::Reset),
+                "table text carries no colour"
+            );
             assert_eq!(span.style.bg, None, "table has no background");
             assert!(
                 !span.style.add_modifier.contains(Modifier::BOLD),
@@ -403,19 +471,34 @@ fn rich_table_stays_borderless_after_transcript_boxed_table_change() {
     let table = "| h1 | h2 |\n| --- | --- |\n| a | b |";
     let lines = render(table, 40);
     let joined: String = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
-    for boxed_char in ['\u{250c}', '\u{2510}', '\u{2514}', '\u{2518}', '\u{251c}', '\u{2524}', '\u{252c}', '\u{2534}', '\u{253c}'] {
-        assert!(!joined.contains(boxed_char), "Rich table must not use box-drawing borders");
+    for boxed_char in [
+        '\u{250c}', '\u{2510}', '\u{2514}', '\u{2518}', '\u{251c}', '\u{2524}', '\u{252c}',
+        '\u{2534}', '\u{253c}',
+    ] {
+        assert!(
+            !joined.contains(boxed_char),
+            "Rich table must not use box-drawing borders"
+        );
     }
     let (theme, _, _) = fixtures();
-    assert_eq!(lines[0].spans[0].style.fg, Some(theme.accent), "Rich header keeps its accent colour");
-    assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::BOLD), "Rich header stays bold");
+    assert_eq!(
+        lines[0].spans[0].style.fg,
+        Some(theme.accent),
+        "Rich header keeps its accent colour"
+    );
+    assert!(
+        lines[0].spans[0]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD),
+        "Rich header stays bold"
+    );
 }
 
 #[test]
 fn apply_background_fills_only_bare_spans() {
     let (theme, ss, st) = fixtures();
-    let mut lines =
-        render_markdown("text with `code`", 40, &theme, &ss, &st);
+    let mut lines = render_markdown("text with `code`", 40, &theme, &ss, &st);
     let bg = theme.comment_preview_bg;
     apply_background(&mut lines, bg);
     for line in &lines {

--- a/src/ui/markdown/tests/transcript_code_block_colors.rs
+++ b/src/ui/markdown/tests/transcript_code_block_colors.rs
@@ -27,13 +27,26 @@ fn span<'a>(lines: &'a [Line<'static>], text: &str) -> &'a Span<'static> {
 
 fn assert_fg(lines: &[Line<'static>], text: &str, color: Color) {
     let s = span(lines, text);
-    assert_eq!(s.style.fg, Some(color), "{text:?} expected fg {color:?}, got {:?}", s.style.fg);
+    assert_eq!(
+        s.style.fg,
+        Some(color),
+        "{text:?} expected fg {color:?}, got {:?}",
+        s.style.fg
+    );
 }
 
 fn assert_fg_dim(lines: &[Line<'static>], text: &str, color: Color) {
     let s = span(lines, text);
-    assert_eq!(s.style.fg, Some(color), "{text:?} expected fg {color:?}, got {:?}", s.style.fg);
-    assert!(s.style.add_modifier.contains(Modifier::DIM), "{text:?} expected DIM modifier");
+    assert_eq!(
+        s.style.fg,
+        Some(color),
+        "{text:?} expected fg {color:?}, got {:?}",
+        s.style.fg
+    );
+    assert!(
+        s.style.add_modifier.contains(Modifier::DIM),
+        "{text:?} expected DIM modifier"
+    );
 }
 
 /// word を単独の識別子として見たときの色を探す。周囲の句読点/空白と一緒に
@@ -51,8 +64,16 @@ fn assert_word_fg(lines: &[Line<'static>], word: &str, color: Color) {
     let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
     for line in lines {
         for s in &line.spans {
-            if s.content.split(|c: char| !is_word_char(c)).any(|tok| tok == word) {
-                assert_eq!(s.style.fg, Some(color), "{word:?} expected fg {color:?}, got {:?}", s.style.fg);
+            if s.content
+                .split(|c: char| !is_word_char(c))
+                .any(|tok| tok == word)
+            {
+                assert_eq!(
+                    s.style.fg,
+                    Some(color),
+                    "{word:?} expected fg {color:?}, got {:?}",
+                    s.style.fg
+                );
                 assert!(
                     !s.style.add_modifier.contains(Modifier::DIM),
                     "{word:?} unexpectedly carries DIM (Type vs Builtin mix-up?)"
@@ -73,7 +94,11 @@ fn transcript_code_block_has_no_card_chrome() {
     for span in &lines[0].spans {
         assert_eq!(span.style.bg, None, "no background colour");
     }
-    assert_eq!(lines[0].spans[0].content.as_ref(), "let", "content starts at column 0, no left inset");
+    assert_eq!(
+        lines[0].spans[0].content.as_ref(),
+        "let",
+        "content starts at column 0, no left inset"
+    );
 }
 
 #[test]
@@ -101,7 +126,9 @@ struct S { field: Vec<u8> }";
     assert_fg(&lines, "from", Color::Yellow);
     assert_fg(&lines, "Some", Color::Yellow);
 
-    for ty in ["str", "bool", "Option", "u32", "String", "usize", "Vec", "u8"] {
+    for ty in [
+        "str", "bool", "Option", "u32", "String", "usize", "Vec", "u8",
+    ] {
         assert_fg_dim(&lines, ty, Color::Cyan);
     }
 
@@ -129,7 +156,9 @@ class C(object):\n\
 
     assert_fg(&lines, "# python comment", Color::Green);
 
-    for kw in ["import", "def", "return", "for", "in", "if", "class", "object", "pass"] {
+    for kw in [
+        "import", "def", "return", "for", "in", "if", "class", "object", "pass",
+    ] {
         assert_fg(&lines, kw, Color::Blue);
     }
 

--- a/src/ui/markdown/wrap.rs
+++ b/src/ui/markdown/wrap.rs
@@ -201,7 +201,11 @@ pub(crate) fn with_prefix(
         .enumerate()
         .map(|(idx, line)| {
             let mut spans = Vec::with_capacity(line.spans.len() + 1);
-            spans.push(if idx == 0 { first.clone() } else { cont.clone() });
+            spans.push(if idx == 0 {
+                first.clone()
+            } else {
+                cont.clone()
+            });
             spans.extend(line.spans);
             Line::from(spans)
         })

--- a/src/ui/menu_bar.rs
+++ b/src/ui/menu_bar.rs
@@ -136,9 +136,7 @@ pub fn render_dropdown(frame: &mut Frame, frame_area: Rect, app: &mut App) {
                     .iter()
                     .find(|c| c.id == *id)
                     .and_then(|c| c.action)
-                    .and_then(|a| {
-                        crate::ui::common::representative_chord(&app.keymap, context, a)
-                    })
+                    .and_then(|a| crate::ui::common::representative_chord(&app.keymap, context, a))
                     .unwrap_or_default();
                 Row::Command {
                     label,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,7 +25,7 @@ pub mod grep_search;
 pub mod hover_info;
 pub mod panel_overlay;
 pub mod references;
-pub mod review;
 pub mod revidere_view;
+pub mod review;
 pub mod symbol_action;
 pub mod theme_picker;

--- a/src/ui/reflow_view/block_render.rs
+++ b/src/ui/reflow_view/block_render.rs
@@ -56,7 +56,9 @@ impl Default for TranscriptStyles {
             tools: ToolStyles {
                 marker: Style::default().fg(palette::SUCCESS),
                 marker_err: Style::default().fg(palette::ERROR),
-                name: Style::default().fg(palette::TEXT).add_modifier(Modifier::BOLD),
+                name: Style::default()
+                    .fg(palette::TEXT)
+                    .add_modifier(Modifier::BOLD),
                 // ツールの引数は本文と同じ色で、薄くしない。実測の画面では
                 // ⏺ Write(/tmp/out.txt) の (...) 部分が灰色ではなく本文と同色になっている。
                 arg: Style::default().fg(palette::TEXT),
@@ -294,7 +296,13 @@ fn render_teammate_message(
         return lines;
     }
     let body_width = width.saturating_sub(MARKER_COLS);
-    let md_lines = markdown(ctx, md_theme, &format!("{ei}:{bi}:teammate"), body, body_width);
+    let md_lines = markdown(
+        ctx,
+        md_theme,
+        &format!("{ei}:{bi}:teammate"),
+        body,
+        body_width,
+    );
     lines.extend(with_marker(md_lines, " ", styles.result));
     lines
 }

--- a/src/ui/reflow_view/build.rs
+++ b/src/ui/reflow_view/build.rs
@@ -3,7 +3,6 @@
 //! 変わったときだけ再構築する。App から独立しているので、App を構築せずに単体で
 //! 生成・テストできる。
 
-
 use ratatui::text::Line;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;

--- a/src/ui/reflow_view/build_tests.rs
+++ b/src/ui/reflow_view/build_tests.rs
@@ -98,10 +98,7 @@ fn teammate_message(id: &str, body: &str) -> DisplayBlock {
 }
 
 fn entry(role: Role, blocks: Vec<DisplayBlock>) -> LogEntry {
-    LogEntry {
-        role,
-        blocks,
-    }
+    LogEntry { role, blocks }
 }
 
 fn build(entries: &[LogEntry], expanded: bool) -> Vec<Line<'static>> {
@@ -141,7 +138,11 @@ fn only_visible_line<'a>(lines: &'a [Line<'a>]) -> &'a Line<'a> {
         .iter()
         .filter(|l| !line_text(l).trim().is_empty())
         .collect();
-    assert_eq!(visible.len(), 1, "expected exactly one visible line, got {visible:?}");
+    assert_eq!(
+        visible.len(),
+        1,
+        "expected exactly one visible line, got {visible:?}"
+    );
     visible[0]
 }
 
@@ -150,13 +151,37 @@ fn only_visible_line<'a>(lines: &'a [Line<'a>]) -> &'a Line<'a> {
 #[test]
 fn read_results_collapse_into_aggregated_count_line() {
     let entries = vec![
-        entry(Role::Assistant, vec![tool_use("Read", json!({"file_path": "/a"}))]),
+        entry(
+            Role::Assistant,
+            vec![tool_use("Read", json!({"file_path": "/a"}))],
+        ),
         entry(
             Role::User,
             vec![
-                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["a"], false),
-                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["b"], false),
-                tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["c"], false),
+                tool_result(
+                    ResultKind::Counted {
+                        bucket: CountedBucket::Read,
+                        from_bash: false,
+                    },
+                    &["a"],
+                    false,
+                ),
+                tool_result(
+                    ResultKind::Counted {
+                        bucket: CountedBucket::Read,
+                        from_bash: false,
+                    },
+                    &["b"],
+                    false,
+                ),
+                tool_result(
+                    ResultKind::Counted {
+                        bucket: CountedBucket::Read,
+                        from_bash: false,
+                    },
+                    &["c"],
+                    false,
+                ),
             ],
         ),
     ];
@@ -171,7 +196,14 @@ fn read_results_collapse_into_aggregated_count_line() {
 fn read_results_singular_count_uses_singular_noun() {
     let entries = vec![entry(
         Role::User,
-        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["a"], false)],
+        vec![tool_result(
+            ResultKind::Counted {
+                bucket: CountedBucket::Read,
+                from_bash: false,
+            },
+            &["a"],
+            false,
+        )],
     )];
     let lines = build(&entries, false);
     assert_eq!(
@@ -187,8 +219,22 @@ fn grep_and_glob_share_one_search_bucket_summary() {
     let entries = vec![entry(
         Role::User,
         vec![
-            tool_result(ResultKind::Counted { bucket: CountedBucket::Search, from_bash: false }, &["match1"], false),
-            tool_result(ResultKind::Counted { bucket: CountedBucket::Search, from_bash: false }, &["match2"], false),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::Search,
+                    from_bash: false,
+                },
+                &["match1"],
+                false,
+            ),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::Search,
+                    from_bash: false,
+                },
+                &["match2"],
+                false,
+            ),
         ],
     )];
     let lines = build(&entries, false);
@@ -203,8 +249,22 @@ fn bash_ls_collapses_to_listed_directories_summary() {
     let entries = vec![entry(
         Role::User,
         vec![
-            tool_result(ResultKind::Counted { bucket: CountedBucket::List, from_bash: true }, &["a"], false),
-            tool_result(ResultKind::Counted { bucket: CountedBucket::List, from_bash: true }, &["b"], false),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::List,
+                    from_bash: true,
+                },
+                &["a"],
+                false,
+            ),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::List,
+                    from_bash: true,
+                },
+                &["b"],
+                false,
+            ),
         ],
     )];
     let lines = build(&entries, false);
@@ -221,8 +281,22 @@ fn bash_cat_merges_with_read_bucket_summary() {
     let entries = vec![entry(
         Role::User,
         vec![
-            tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["file a contents"], false),
-            tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["file b contents"], false),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::Read,
+                    from_bash: false,
+                },
+                &["file a contents"],
+                false,
+            ),
+            tool_result(
+                ResultKind::Counted {
+                    bucket: CountedBucket::Read,
+                    from_bash: false,
+                },
+                &["file b contents"],
+                false,
+            ),
         ],
     )];
     let lines = build(&entries, false);
@@ -239,7 +313,14 @@ fn counted_result_ignores_is_error_and_still_aggregates_normally() {
     // 折り込まれる。
     let entries = vec![entry(
         Role::User,
-        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &["boom: file not found"], true)],
+        vec![tool_result(
+            ResultKind::Counted {
+                bucket: CountedBucket::Read,
+                from_bash: false,
+            },
+            &["boom: file not found"],
+            true,
+        )],
     )];
     let lines = build(&entries, false);
     let line = only_visible_line(&lines);
@@ -313,12 +394,18 @@ fn inline_tool_use_renders_bold_name_and_text_colored_arg_not_gray() {
     let lines = build(&entries, false);
     let line = only_visible_line(&lines);
 
-    assert_eq!(line.spans.len(), 3, "marker + name + arg spans, got {line:?}");
+    assert_eq!(
+        line.spans.len(),
+        3,
+        "marker + name + arg spans, got {line:?}"
+    );
     assert_eq!(line.spans[0].style, Style::default().fg(palette::SUCCESS));
     assert_eq!(line.spans[1].content.as_ref(), "Write");
     assert_eq!(
         line.spans[1].style,
-        Style::default().fg(palette::TEXT).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(palette::TEXT)
+            .add_modifier(Modifier::BOLD)
     );
     assert_eq!(line.spans[2].content.as_ref(), "(/tmp/out.txt)");
     // ネイティブのキャプチャでは引数は暗く表示されるのではなく本文テキストと
@@ -332,8 +419,14 @@ fn inline_tool_use_renders_bold_name_and_text_colored_arg_not_gray() {
 #[test]
 fn todowrite_renders_nothing_in_collapsed_mode() {
     let entries = vec![
-        entry(Role::Assistant, vec![tool_use("TodoWrite", json!({"todos": []}))]),
-        entry(Role::User, vec![tool_result(ResultKind::Inline, &["ok"], false)]),
+        entry(
+            Role::Assistant,
+            vec![tool_use("TodoWrite", json!({"todos": []}))],
+        ),
+        entry(
+            Role::User,
+            vec![tool_result(ResultKind::Inline, &["ok"], false)],
+        ),
     ];
     let lines = build(&entries, false);
     assert!(non_blank_texts(&lines).is_empty());
@@ -349,7 +442,8 @@ fn inline_error_result_draws_multiline_error_block() {
     // "Error: " のプレフィックスは最初の行にしか付かない。
     let entries = vec![entry(
         Role::User,
-        vec![tool_result(ResultKind::Inline,
+        vec![tool_result(
+            ResultKind::Inline,
             &[
                 "bash: command failed with exit code 1",
                 "second line of the error",
@@ -362,7 +456,11 @@ fn inline_error_result_draws_multiline_error_block() {
         .iter()
         .filter(|l| !line_text(l).trim().is_empty())
         .collect();
-    assert_eq!(visible.len(), 2, "first + continuation error line, got {visible:?}");
+    assert_eq!(
+        visible.len(),
+        2,
+        "first + continuation error line, got {visible:?}"
+    );
 
     let first = visible[0];
     assert_eq!(
@@ -503,7 +601,10 @@ fn teammate_message_collapsed_line_is_entirely_inactive() {
     let line = only_visible_line(&lines);
     for span in &line.spans {
         assert_eq!(span.style.fg, Some(palette::INACTIVE));
-        assert_eq!(span.style.bg, None, "spec: no background block, unlike user turns");
+        assert_eq!(
+            span.style.bg, None,
+            "spec: no background block, unlike user turns"
+        );
     }
 }
 
@@ -511,10 +612,7 @@ fn teammate_message_collapsed_line_is_entirely_inactive() {
 fn teammate_message_collapsed_ignores_the_body_entirely() {
     // 折り畳みモードでは id しかレンダリングされない — 本文テキストは短くても
     // サマリー行に漏れてはならない。
-    let entries = vec![entry(
-        Role::User,
-        vec![teammate_message("alice", "hi")],
-    )];
+    let entries = vec![entry(Role::User, vec![teammate_message("alice", "hi")])];
     let lines = build(&entries, false);
     let texts = non_blank_texts(&lines);
     assert_eq!(texts.len(), 1);
@@ -561,7 +659,10 @@ fn expanded_mode_shows_raw_tool_name_not_the_collapsed_alias() {
 
 #[test]
 fn user_text_renders_the_marker_glyph_not_the_assistant_bullet() {
-    let entries = vec![entry(Role::User, vec![DisplayBlock::Text("hi".to_string())])];
+    let entries = vec![entry(
+        Role::User,
+        vec![DisplayBlock::Text("hi".to_string())],
+    )];
     let lines = build(&entries, false);
     let line = only_visible_line(&lines);
     assert_eq!(line.spans[0].content, "\u{276f} ");
@@ -569,11 +670,18 @@ fn user_text_renders_the_marker_glyph_not_the_assistant_bullet() {
 
 #[test]
 fn user_text_marker_and_body_carry_the_background_fill_color() {
-    let entries = vec![entry(Role::User, vec![DisplayBlock::Text("hi".to_string())])];
+    let entries = vec![entry(
+        Role::User,
+        vec![DisplayBlock::Text("hi".to_string())],
+    )];
     let lines = build(&entries, false);
     let line = only_visible_line(&lines);
     for span in &line.spans {
-        assert_eq!(span.style.bg, Some(palette::USER_BG), "span {span:?} missing background fill");
+        assert_eq!(
+            span.style.bg,
+            Some(palette::USER_BG),
+            "span {span:?} missing background fill"
+        );
     }
     assert_eq!(line.spans[0].style.fg, Some(palette::USER_MARKER_FG));
     assert_eq!(line.spans[1].style.fg, Some(palette::USER_TEXT));
@@ -586,7 +694,9 @@ fn user_text_bypasses_markdown_rendering() {
     // テキストであるため。
     let entries = vec![entry(
         Role::User,
-        vec![DisplayBlock::Text("**not bold** # not a heading".to_string())],
+        vec![DisplayBlock::Text(
+            "**not bold** # not a heading".to_string(),
+        )],
     )];
     let lines = build(&entries, false);
     let texts = non_blank_texts(&lines);
@@ -679,12 +789,23 @@ fn expanded_mode_shows_every_result_line_with_no_cap() {
     let raw_refs: Vec<&str> = raw_lines.iter().map(String::as_str).collect();
     let entries = vec![entry(
         Role::User,
-        vec![tool_result(ResultKind::Counted { bucket: CountedBucket::Read, from_bash: false }, &raw_refs, false)],
+        vec![tool_result(
+            ResultKind::Counted {
+                bucket: CountedBucket::Read,
+                from_bash: false,
+            },
+            &raw_refs,
+            false,
+        )],
     )];
     let lines = build(&entries, true);
     let texts = non_blank_texts(&lines);
 
-    assert_eq!(texts.len(), 12, "no cap on expanded result lines: {texts:?}");
+    assert_eq!(
+        texts.len(),
+        12,
+        "no cap on expanded result lines: {texts:?}"
+    );
     for (i, text) in texts.iter().enumerate() {
         assert!(
             text.ends_with(&format!("line{i}")),
@@ -751,7 +872,10 @@ fn two_buckets_keep_the_measured_order_and_casing() {
 fn shell_cat_counts_only_when_the_read_tool_is_absent() {
     // Bash(cat ...) と Read の実測された5通りの組み合わせ。
     let cases: [(&[(ResultKind, bool)], &str); 5] = [
-        (&[(counted(CountedBucket::Read, true), false)], "Read 1 file"),
+        (
+            &[(counted(CountedBucket::Read, true), false)],
+            "Read 1 file",
+        ),
         (
             &[
                 (counted(CountedBucket::Read, true), false),
@@ -797,7 +921,10 @@ fn shell_cat_counts_only_when_the_read_tool_is_absent() {
 #[test]
 fn counted_result_ignores_is_error_entirely() {
     // 実測: 失敗した Read でも普通のサマリーへ折り込まれる。
-    let entries = vec![results_entry(&[(counted(CountedBucket::Read, false), true)])];
+    let entries = vec![results_entry(&[(
+        counted(CountedBucket::Read, false),
+        true,
+    )])];
     assert_eq!(
         non_blank_texts(&build(&entries, false)),
         vec!["Read 1 file (ctrl+o to expand)"]
@@ -826,10 +953,7 @@ fn compact_group_matches_the_native_layout() {
         ),
         entry(Role::User, vec![annotation("Read alpha.rs (42 lines)")]),
         entry(Role::User, vec![annotation("Referenced file beta.yml")]),
-        entry(
-            Role::Assistant,
-            vec![DisplayBlock::Text("done".into())],
-        ),
+        entry(Role::Assistant, vec![DisplayBlock::Text("done".into())]),
     ];
     let rendered: Vec<String> = build(&entries, false)
         .iter()
@@ -912,7 +1036,11 @@ fn long_annotations_and_notices_stay_inside_the_panel() {
         };
         for line in build_lines(&ctx, width).lines {
             let w = unicode_width::UnicodeWidthStr::width(line_text(&line).as_str());
-            assert!(w <= width, "{w} cols at width {width}: {:?}", line_text(&line));
+            assert!(
+                w <= width,
+                "{w} cols at width {width}: {:?}",
+                line_text(&line)
+            );
         }
     }
 }
@@ -951,7 +1079,10 @@ fn a_long_annotation_wraps_instead_of_being_elided() {
     // 何も省略されない: パスのすべての文字がどこかに残っている。
     let joined: String = texts.iter().map(|t| t.trim_start()).collect();
     assert!(joined.contains(&"x".repeat(120)), "path was cut: {joined}");
-    assert!(!joined.contains('\u{2026}'), "unexpected ellipsis: {joined}");
+    assert!(
+        !joined.contains('\u{2026}'),
+        "unexpected ellipsis: {joined}"
+    );
 }
 
 #[test]

--- a/src/ui/reflow_view/corpus_tests.rs
+++ b/src/ui/reflow_view/corpus_tests.rs
@@ -35,9 +35,7 @@ fn corpus_files() -> Option<Vec<PathBuf>> {
         .flatten()
         .map(|e| e.path())
         .filter(|p| p.extension().is_some_and(|e| e == "jsonl"))
-        .filter(|p| {
-            std::fs::metadata(p).is_ok_and(|m| m.is_file() && m.len() <= MAX_BYTES)
-        })
+        .filter(|p| std::fs::metadata(p).is_ok_and(|m| m.is_file() && m.len() <= MAX_BYTES))
         .collect();
     // readdir の順序に依存せず、失敗が再現可能になるようソートする。
     files.sort();
@@ -176,6 +174,11 @@ fn rebuilding_at_a_previous_width_reproduces_it() {
         let first = texts(&h.build(&cache, &entries, 80, false).lines);
         let _ = h.build(&cache, &entries, 40, false);
         let back = texts(&h.build(&cache, &entries, 80, false).lines);
-        assert_eq!(first, back, "{}: 80 -> 40 -> 80 was not idempotent", path.display());
+        assert_eq!(
+            first,
+            back,
+            "{}: 80 -> 40 -> 80 was not idempotent",
+            path.display()
+        );
     }
 }

--- a/src/ui/reflow_view/render.rs
+++ b/src/ui/reflow_view/render.rs
@@ -198,18 +198,11 @@ pub(super) fn render_jump_badge(frame: &mut Frame, area: Rect, following: bool) 
         .find(|l| UnicodeWidthStr::width(**l) < area.width as usize)?;
     let w = UnicodeWidthStr::width(*label) as u16;
 
-    let rect = Rect::new(
-        area.x + area.width - w,
-        area.y + area.height - 1,
-        w,
-        1,
-    );
+    let rect = Rect::new(area.x + area.width - w, area.y + area.height - 1, w, 1);
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
             *label,
-            Style::default()
-                .fg(palette::INACTIVE)
-                .bg(palette::USER_BG),
+            Style::default().fg(palette::INACTIVE).bg(palette::USER_BG),
         ))),
         rect,
     );

--- a/src/ui/reflow_view/render_tests.rs
+++ b/src/ui/reflow_view/render_tests.rs
@@ -114,10 +114,7 @@ fn build(entries: &[LogEntry], expanded: bool) -> Vec<Option<u16>> {
 }
 
 fn entry(role: Role, blocks: Vec<DisplayBlock>) -> LogEntry {
-    LogEntry {
-        role,
-        blocks,
-    }
+    LogEntry { role, blocks }
 }
 
 /// 穴はグリフがどこにあってもその直後に置かれる — グリフの位置は常にカラム0とは
@@ -164,7 +161,11 @@ fn user_turns_get_no_hole() {
 /// この対策は黙って効かなくなってしまう。
 #[test]
 fn every_ambiguous_gutter_glyph_is_registered() {
-    for glyph in [ASSISTANT_MARKER, TOOL_RESULT_GLYPH, super::glyphs::THINKING_GLYPH] {
+    for glyph in [
+        ASSISTANT_MARKER,
+        TOOL_RESULT_GLYPH,
+        super::glyphs::THINKING_GLYPH,
+    ] {
         let ch = glyph.chars().next().unwrap();
         assert!(
             super::glyphs::is_width_ambiguous(ch),
@@ -173,7 +174,10 @@ fn every_ambiguous_gutter_glyph_is_registered() {
         );
     }
     // ……そして意図的にそうでない2つ。
-    for glyph in [super::glyphs::USER_MARKER, super::glyphs::TEAMMATE_MESSAGE_GLYPH] {
+    for glyph in [
+        super::glyphs::USER_MARKER,
+        super::glyphs::TEAMMATE_MESSAGE_GLYPH,
+    ] {
         let ch = glyph.chars().next().unwrap();
         assert!(!super::glyphs::is_width_ambiguous(ch), "{glyph:?}");
     }
@@ -216,11 +220,11 @@ fn wide_and_multi_char_clusters_do_not_shift_the_hole() {
     // これらすべての本文について穴はカラム3にある。
     for body in [
         "plain",
-        "日本語の全角テキスト",                            // width-2 CJK
+        "日本語の全角テキスト", // width-2 CJK
         "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466} family", // ZWJ, 7 chars / 2 cols
-        "\u{26a0}\u{fe0f} warn",                          // emoji-presentation selector
-        "\u{1f44b}\u{1f3fd} wave",                        // skin-tone modifier
-        "e\u{0301}\u{0301} combining",                    // combining marks
+        "\u{26a0}\u{fe0f} warn",       // emoji-presentation selector
+        "\u{1f44b}\u{1f3fd} wave",     // skin-tone modifier
+        "e\u{0301}\u{0301} combining", // combining marks
     ] {
         let holes = build(
             &[entry(
@@ -337,11 +341,7 @@ fn screen_text(buf: &Buffer) -> String {
 fn no_badge_while_following() {
     let (hit, buf) = draw_badge(40, 6, true);
     assert_eq!(hit, None);
-    assert!(
-        !screen_text(&buf).contains("(G)"),
-        "{}",
-        screen_text(&buf)
-    );
+    assert!(!screen_text(&buf).contains("(G)"), "{}", screen_text(&buf));
 }
 
 #[test]
@@ -427,7 +427,11 @@ fn reflow_fixture() -> Vec<LogEntry> {
     (0..40)
         .map(|i| {
             entry(
-                if i % 2 == 0 { Role::Assistant } else { Role::User },
+                if i % 2 == 0 {
+                    Role::Assistant
+                } else {
+                    Role::User
+                },
                 vec![DisplayBlock::Text(format!(
                     "Turn {i}: {}",
                     "the quick brown fox jumps over the lazy dog ".repeat(4)

--- a/src/ui/reflow_view/tests.rs
+++ b/src/ui/reflow_view/tests.rs
@@ -69,10 +69,7 @@ fn gutter_markers_are_exactly_one_column() {
 #[test]
 fn with_marker_prepends_glyph_to_first_line() {
     let style = Style::default().fg(Color::Green);
-    let lines = vec![
-        Line::from("hello"),
-        Line::from("world"),
-    ];
+    let lines = vec![Line::from("hello"), Line::from("world")];
     let result = with_marker(lines, ">", style);
     assert_eq!(result.len(), 2);
     // 最初の行の最初の span がマーカー。

--- a/src/ui/reflow_view/tool_lines.rs
+++ b/src/ui/reflow_view/tool_lines.rs
@@ -101,8 +101,18 @@ pub(crate) fn render_tool_use(
             ToolCategory::Inline { display_name, arg } => (display_name, arg),
         }
     };
-    let marker_style = if errored { styles.marker_err } else { styles.marker };
-    Some(tool_use_line(&display_name, arg.as_deref(), width, marker_style, styles))
+    let marker_style = if errored {
+        styles.marker_err
+    } else {
+        styles.marker
+    };
+    Some(tool_use_line(
+        &display_name,
+        arg.as_deref(),
+        width,
+        marker_style,
+        styles,
+    ))
 }
 
 /// ⏺ {display_name}({arg}) — 先頭の丸（色は marker_style で指定）、太字の名前、
@@ -224,10 +234,7 @@ fn bucket_summary_line(
             format!(", {} ", lower_first(verb))
         };
         parts.push((lead, styles.result));
-        parts.push((
-            n.to_string(),
-            styles.result.add_modifier(Modifier::BOLD),
-        ));
+        parts.push((n.to_string(), styles.result.add_modifier(Modifier::BOLD)));
         parts.push((format!(" {noun}"), styles.result));
     }
     parts.push((EXPAND_HINT.to_string(), styles.result));
@@ -322,7 +329,11 @@ pub(crate) fn render_tool_result_expanded(
     let first_prefix = format!("  {TOOL_RESULT_GLYPH}  ");
     let prefix_cols = UnicodeWidthStr::width(first_prefix.as_str());
     let cont_indent = " ".repeat(prefix_cols);
-    let connector_style = if is_error { styles.result_err } else { body_style };
+    let connector_style = if is_error {
+        styles.result_err
+    } else {
+        body_style
+    };
 
     if lines.is_empty() {
         let s = truncate_to_width(&format!("{first_prefix}(no content)"), width);

--- a/src/ui/reflow_view/user_text_tests.rs
+++ b/src/ui/reflow_view/user_text_tests.rs
@@ -35,10 +35,7 @@ fn wrap_preserves_source_newlines_as_independent_lines() {
 
 #[test]
 fn wrap_preserves_blank_source_lines() {
-    assert_eq!(
-        wrap_plain_text("a\n\nb", 10),
-        vec!["a", "", "b"]
-    );
+    assert_eq!(wrap_plain_text("a\n\nb", 10), vec!["a", "", "b"]);
 }
 
 #[test]
@@ -65,7 +62,10 @@ fn wrap_hard_split_never_breaks_a_full_width_glyph() {
     // 予算5に2カラムのグリフ: 1行につき2文字、半分だけのグリフになる行は無い。
     let chunks = wrap_plain_text(&"あ".repeat(5), 5);
     for c in &chunks {
-        assert!(unicode_width::UnicodeWidthStr::width(c.as_str()) <= 5, "{c:?}");
+        assert!(
+            unicode_width::UnicodeWidthStr::width(c.as_str()) <= 5,
+            "{c:?}"
+        );
     }
     assert_eq!(chunks.concat(), "あ".repeat(5));
 }
@@ -92,7 +92,9 @@ fn pad_string_wider_than_target_unchanged() {
 // render_user_text
 
 fn marker_style() -> Style {
-    Style::default().fg(palette::USER_MARKER_FG).bg(palette::USER_BG)
+    Style::default()
+        .fg(palette::USER_MARKER_FG)
+        .bg(palette::USER_BG)
 }
 
 fn body_style() -> Style {
@@ -108,7 +110,10 @@ fn first_line_gets_the_marker_continuation_lines_get_blank_indent() {
         marker_style(),
         body_style(),
     );
-    assert!(lines.len() > 1, "expected the body to wrap onto multiple lines");
+    assert!(
+        lines.len() > 1,
+        "expected the body to wrap onto multiple lines"
+    );
     assert_eq!(lines[0].spans[0].content, "\u{276f} ");
     assert_eq!(lines[1].spans[0].content, "  ");
 }
@@ -123,7 +128,10 @@ fn every_line_is_padded_to_the_full_panel_width_for_the_background() {
             .iter()
             .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
             .sum();
-        assert_eq!(total, width, "line {line:?} must fill the full width for its background");
+        assert_eq!(
+            total, width,
+            "line {line:?} must fill the full width for its background"
+        );
     }
 }
 
@@ -137,7 +145,13 @@ fn marker_and_body_spans_carry_the_background_color() {
 
 #[test]
 fn source_newlines_survive_as_separate_lines_each_with_their_own_gutter_slot() {
-    let lines = render_user_text("first\nsecond", 20, "\u{276f}", marker_style(), body_style());
+    let lines = render_user_text(
+        "first\nsecond",
+        20,
+        "\u{276f}",
+        marker_style(),
+        body_style(),
+    );
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].spans[0].content, "\u{276f} ");
     assert_eq!(lines[1].spans[0].content, "  ");
@@ -146,8 +160,17 @@ fn source_newlines_survive_as_separate_lines_each_with_their_own_gutter_slot() {
 #[test]
 fn body_wraps_at_width_minus_marker_cols() {
     // width=10 なら body_width = 10 - MARKER_COLS(2) = テキスト用に8カラム残る。
-    let lines = render_user_text("abcdefgh ijkl", 10, "\u{276f}", marker_style(), body_style());
-    assert!(lines.len() >= 2, "8-col budget must force a wrap: {lines:?}");
+    let lines = render_user_text(
+        "abcdefgh ijkl",
+        10,
+        "\u{276f}",
+        marker_style(),
+        body_style(),
+    );
+    assert!(
+        lines.len() >= 2,
+        "8-col budget must force a wrap: {lines:?}"
+    );
     // このテストが依存する定数をガードしておく。MARKER_COLS が変わったとき、
     // 誤った予算のまま黙って通ってしまうのではなく、はっきり失敗させるため。
     assert_eq!(MARKER_COLS, 2);
@@ -185,6 +208,9 @@ fn zwj_sequence_is_never_split() {
     let wrapped = wrap_plain_text(&family.repeat(3), 4);
     assert_eq!(wrapped.concat(), family.repeat(3));
     for line in &wrapped {
-        assert!(unicode_width::UnicodeWidthStr::width(line.as_str()) <= 4, "{line:?}");
+        assert!(
+            unicode_width::UnicodeWidthStr::width(line.as_str()) <= 4,
+            "{line:?}"
+        );
     }
 }

--- a/src/ui/review.rs
+++ b/src/ui/review.rs
@@ -173,7 +173,9 @@ pub fn render_delete_confirm_overlay(frame: &mut Frame, area: Rect, app: &App) {
         Line::from(vec![
             Span::styled(
                 "y",
-                Style::default().fg(theme.error).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(": delete   ", Style::default().fg(theme.muted)),
             Span::styled(

--- a/src/ui/viewer_panel/code_line.rs
+++ b/src/ui/viewer_panel/code_line.rs
@@ -217,8 +217,9 @@ pub(super) fn render_code_line_rows(
 
     // コンテンツの span に水平スクロールを適用し、パネル幅（枠線＋マーカー列＋
     // ガター＋バッジ）でクリップする。
-    let content_max_w = (ctx.area_width as usize)
-        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4);
+    let content_max_w = (ctx.area_width as usize).saturating_sub(
+        crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4,
+    );
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
     // ジャンプ用の下線を適用する（ジャンプ可能なシンボル上でのホバーであれば

--- a/src/ui/viewer_panel/comment_thread.rs
+++ b/src/ui/viewer_panel/comment_thread.rs
@@ -39,7 +39,8 @@ pub(super) fn build_inline_thread_lines<'a>(
 
     use crate::viewer::ScreenRow;
     let mut out: Vec<(Line, ScreenRow)> = Vec::new();
-    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2; // マーカー + ガター + バッジ
+    let left_pad =
+        crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2; // マーカー + ガター + バッジ
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     // 執筆者ごとに面の色味を変え、「誰が書いたか」を一目でわかるようにする。Claude の
@@ -330,7 +331,8 @@ pub(super) fn build_inline_compose_lines<'a>(
 ) -> Vec<(Line<'a>, crate::viewer::ScreenRow)> {
     use crate::viewer::ScreenRow;
     let bg = theme.comment_user_bg;
-    let left_pad = crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2;
+    let left_pad =
+        crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 2;
     let gutter_pad: String = " ".repeat(left_pad);
     let border_style = Style::default().fg(theme.accent);
     let bg_style = Style::default().bg(bg);

--- a/src/ui/viewer_panel/diff_line.rs
+++ b/src/ui/viewer_panel/diff_line.rs
@@ -217,8 +217,9 @@ pub(super) fn render_diff_content_line(
     };
 
     // 水平スクロールを適用し、パネル幅（枠線 + マーカー列 + ガター + バッジ）でクリップする。
-    let content_max_w = (ctx.area_width as usize)
-        .saturating_sub(crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4);
+    let content_max_w = (ctx.area_width as usize).saturating_sub(
+        crate::viewer::COMMENT_MARKER_W as usize + gutter_width + crate::viewer::GUTTER_FIXED_W + 4,
+    );
     let content_spans = h_scroll_spans(content_spans, vs.content.h_scroll, content_max_w);
 
     let mut spans = vec![marker, gutter_span, badge];

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -22,8 +22,8 @@ use super::media_view::render_media_view;
 use super::search_box::render_search_box;
 use super::span_utils::digit_count;
 use super::summary_view::render_summary_view;
-use super::tab_row;
 use super::syntax::ensure_diff_annotations_cached;
+use super::tab_row;
 
 /// 与えられた area に Viewer（ファイル内容）パネルを描画する。
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -184,8 +184,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     // パンくずバーとタブ行の高さぶんを見込む（表示されているときは各1行）。
     let breadcrumb_height: u16 = if breadcrumb_visible.is_some() { 1 } else { 0 };
     let tab_row_height: u16 = if tab_row::is_visible(vs) { 1 } else { 0 };
-    let inner_height =
-        (area.height.saturating_sub(2 + breadcrumb_height + tab_row_height)) as usize;
+    let inner_height = (area
+        .height
+        .saturating_sub(2 + breadcrumb_height + tab_row_height)) as usize;
     let gutter_width = digit_count(vs.content.file_content.len());
 
     // diff 注釈は ViewerState にキャッシュされている（関数の入口で埋めた）。
@@ -357,8 +358,7 @@ pub(super) fn render_tab_row(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
     let row = Rect::new(area.x + 1, area.y + 1, area.width - 2, 1);
-    app.viewer_state.tab_row_hits =
-        tab_row::render(frame, row, &app.theme, &app.viewer_state);
+    app.viewer_state.tab_row_hits = tab_row::render(frame, row, &app.theme, &app.viewer_state);
 }
 
 /// Viewer のタイトルを max_w **表示カラム数**に収める。左側から省略し

--- a/src/viewer/fold.rs
+++ b/src/viewer/fold.rs
@@ -213,7 +213,10 @@ impl FoldState {
 
     /// line_1 が可視行の何番目か（0始まり）。スクロールバーのつまみの位置。
     pub fn visible_index(&self, line_1: usize, total: usize) -> usize {
-        (1..=line_1.min(total)).filter(|l| !self.is_hidden(*l)).count().saturating_sub(1)
+        (1..=line_1.min(total))
+            .filter(|l| !self.is_hidden(*l))
+            .count()
+            .saturating_sub(1)
     }
 
     /// line_1 から可視行を delta 行ぶん進める（負なら戻る）。端で止まる。
@@ -581,7 +584,10 @@ mod tests {
     #[test]
     fn hovering_a_marker_marks_its_whole_range() {
         let mut folds = FoldState::default();
-        folds.rebuild("fn outer() {\n    if cond {\n        inner();\n    }\n}\n", "a.rs");
+        folds.rebuild(
+            "fn outer() {\n    if cond {\n        inner();\n    }\n}\n",
+            "a.rs",
+        );
         folds.set_hover(Some(1));
         assert_eq!(folds.hover_rule(1), Some(FoldRule::Head));
         assert_eq!(folds.hover_rule(2), Some(FoldRule::Body));

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -12,9 +12,9 @@
 
 mod content;
 mod diff_view;
-mod fold;
 mod file_tree;
 mod file_view;
+mod fold;
 mod highlight;
 mod search;
 mod selection;

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -340,7 +340,6 @@ pub(in crate::viewer) struct TabView {
     pub(in crate::viewer) md_scroll: usize,
 }
 
-
 /// Viewer の最も左にあるコメントマーカー列の幅（列数） — 💬/│ の
 /// スレッドマーカーが存在する場所で、行番号の左側にある。「+」バッジ列
 /// （行番号の右側）とは別に保つことで、既存スレッドの開閉と新規コメントの


### PR DESCRIPTION
## Summary

リポジトリ全体を rustfmt clean にし、それが崩れないよう pre-commit フックで担保する。
あわせて clippy の警告を解消し、コンパイルが通る範囲で依存を最新化した。

### フォーマットと pre-commit フック

- `cargo fmt --all` を全体に適用 (111 ファイル)。差分は行の折り返しのみで、文字列リテラルの
  中身は変わっていない。
- `.githooks/pre-commit` を追加。commit 時に `cargo fmt --all -- --check` を走らせ、
  未フォーマットがあれば拒否する。
- pre-commit フレームワークは導入していない。このリポジトリに Python 資産が無く、
  `cargo fmt --check` 1 本のために全コントリビュータへ `pip install pre-commit` を
  要求するのが割に合わないため。
- 有効化は `make hooks` (= `git config core.hooksPath .githooks`) で clone ごとに一度だけ。
  ディレクトリ名を `scripts/` ではなく `.githooks/` にしたのは、`core.hooksPath` が
  指すディレクトリの中身はすべてフックとして扱われるので、将来そこへ置いた無関係な
  スクリプトが意図せず発火するのを避けるため。

### Lint

- clippy の警告 2 件を解消し、`cargo clippy --workspace --all-targets` の警告をゼロにした。
  いずれも doc コメントが意図せず Markdown のリスト/リンク参照定義として解釈されていたもの。

### 依存の更新

- semver 互換の 79 パッケージを更新。
- rusqlite 0.40 / similar 3 / image 0.25.10 を採用 (いずれもコード変更なしで通る)。
- MSRV を 1.85 から 1.88 へ引き上げ、ignore 0.4.33 ほか 16 パッケージを解禁した。
  ビルド要件の非互換変更なので 0.x の慣習に従い MINOR を上げている。
- 見送ったもの: crossterm 0.29 / ratatui 0.30 / git2 0.21 はコンパイルエラーが出る
  (それぞれ 4 / 10 / 16 件)。vt100 0.16 は ratatui 0.29 が `unicode-width = "=0.2.0"` を
  固定しているため依存解決自体が失敗し、ratatui とセットでしか動かせない。

### ドキュメントの整理

- README を 268 行から 160 行へ。設定の全項目を `docs/configuration.md`、PR レビューの
  詳細手順を `docs/reviewing-a-pr.md` に移した。情報の欠落はない。
- CLAUDE.md を 342 行から 236 行へ。実測値・設計に至った経緯・コードを読めば分かる操作の
  詳細を削った。SCIP の `signature_documentation` / `kind` の罠と索引の不変条件は、
  コードを読んでも気づけず黙ってバグを生む内容なので残している。
- Key Modules 表のうち、実際はディレクトリなのにファイルとして書かれていた 6 件
  (`git_engine.rs`, `diff_state.rs`, `review_store.rs`, `pty_manager.rs`, `config.rs`,
  `theme.rs`) を修正した。

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — 警告 0 件
- `cargo check --workspace` — 通過
- `cargo test --workspace` — 1319 件 pass / 0 fail
- pre-commit フックの動作確認:
  - 正常系: フォーマット済みの状態で commit が通ること
  - 異常系: `src/term_caps.rs` を意図的に崩して `git commit` し、フックがコミットを
    拒否すること (`git log` でコミットが作られていないことを確認) 、その後ファイルを復元
- CLAUDE.md / README が参照するパスとシンボル (`store::impl_pair`,
  `store::signature_text`, `store::fenced_declaration`, `kind::from_declaration`,
  `count_references_upto`, `execute_palette_command`, `src/ui/worktree_bar.rs` ほか) が
  実在することを確認
