### PR TITLE
fix: タブ帯のオーバーフローに手が届くようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "conductor"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "aa-media",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/revidere", "crates/revidere-fixtures", "crates/sheaf-core"]
 
 [package]
 name = "conductor"
-version = "0.115.0"
+version = "0.115.1"
 edition = "2024"
 
 [dependencies]

--- a/src/event/mouse/mod.rs
+++ b/src/event/mouse/mod.rs
@@ -36,6 +36,30 @@ use worktree_panel::handle_worktree_column_click;
 // スレッドフォーカスのロジックを共有できるよう再エクスポートしている。
 pub(in crate::event) use viewer_panel::toggle_inline_thread_at;
 
+/// Viewer のタブ行（ブロック内側の先頭行）の上か。タブ行を描いていない
+/// フレームではクリック領域が空なので false になり、ホイールは本文の
+/// スクロールへ落ちる。
+fn on_viewer_tab_row(app: &App, col: u16, row: u16, geom: &ClickGeometry) -> bool {
+    !app.viewer_state.tab_row_hits.is_empty()
+        && row == geom.main_area.y + 1
+        && matches!(geom.column_at(col), Column::Viewer)
+}
+
+/// Claude / Shell のタブ帯（各パネルの 1 行目）の上なら、Claude 側かどうかを
+/// 返す。
+fn terminal_tab_row_at(col: u16, row: u16, geom: &ClickGeometry) -> Option<bool> {
+    if !matches!(geom.column_at(col), Column::Terminal) {
+        return None;
+    }
+    if row == geom.terminal_claude_y {
+        Some(true)
+    } else if row == geom.terminal_split_y {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 /// 2回のクリックをダブルクリックとみなす最大間隔（ミリ秒）。
 const DOUBLE_CLICK_MS: u128 = 400;
 
@@ -501,6 +525,28 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
         terminal_split_y,
     };
 
+    // ターミナルのタブ帯の上のホイールは、本文ではなくタブを横へ送る
+    // （Viewer のタブ行・worktree ストリップと同じ）。この 1 行の上では
+    // スクロールバックを遡れなくなる。
+    if let Some(is_claude) = terminal_tab_row_at(col, row, &geom) {
+        let scroll = if is_claude {
+            &mut app.terminal.claude_tab_scroll
+        } else {
+            &mut app.terminal.shell_tab_scroll
+        };
+        match mouse.kind {
+            MouseEventKind::ScrollDown => {
+                *scroll += 1;
+                return;
+            }
+            MouseEventKind::ScrollUp => {
+                *scroll = scroll.saturating_sub(1);
+                return;
+            }
+            _ => {}
+        }
+    }
+
     match mouse.kind {
         MouseEventKind::ScrollDown if wtbar_area.height > 0 && row == wtbar_area.y => {
             // worktreeストリップ上でのホイールは、横方向に約1画面ぶん
@@ -510,6 +556,12 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, _frame_area: ratatui
         }
         MouseEventKind::ScrollUp if wtbar_area.height > 0 && row == wtbar_area.y => {
             app.wtbar.scroll = app.wtbar.scroll.saturating_sub(wtbar_page_step(app));
+        }
+        MouseEventKind::ScrollDown if on_viewer_tab_row(app, col, row, &geom) => {
+            app.viewer_state.tab_scroll += 1;
+        }
+        MouseEventKind::ScrollUp if on_viewer_tab_row(app, col, row, &geom) => {
+            app.viewer_state.tab_scroll = app.viewer_state.tab_scroll.saturating_sub(1);
         }
         MouseEventKind::ScrollDown => {
             handle_mouse_scroll(app, col, row, &geom, 3);

--- a/src/event/mouse/tests.rs
+++ b/src/event/mouse/tests.rs
@@ -5,7 +5,10 @@ use super::explorer_panel::{diff_list_row_at, explorer_tree_row_at};
 use super::viewer_panel::{
     MarginClickAction, MarginZone, classify_margin_click, thread_anchor_line,
 };
-use super::{ClickGeometry, Column, in_fold_zone, register_double_click, register_double_click_on};
+use super::{
+    ClickGeometry, Column, in_fold_zone, register_double_click, register_double_click_on,
+    terminal_tab_row_at,
+};
 use std::time::{Duration, Instant};
 
 /// 指定したカラム境界でClickGeometryを構築する。幅/高さは、[<=>] 展開ボタン
@@ -170,6 +173,18 @@ fn column_at_maps_columns_by_boundary() {
     assert_eq!(g.column_at(89), Column::Viewer);
     assert_eq!(g.column_at(90), Column::Terminal);
     assert_eq!(g.column_at(200), Column::Terminal);
+}
+
+/// ホイールでタブを送れるのは、ターミナル列の 2 本のタブ帯の行だけ。
+/// 本文の行まで拾うと、スクロールバックを遡れなくなる。
+#[test]
+fn terminal_tab_rows_are_only_the_two_strip_rows() {
+    let g = geom(20, 50, 90);
+    assert_eq!(terminal_tab_row_at(95, g.terminal_claude_y, &g), Some(true));
+    assert_eq!(terminal_tab_row_at(95, g.terminal_split_y, &g), Some(false));
+    assert_eq!(terminal_tab_row_at(95, g.terminal_split_y - 1, &g), None);
+    // 同じ行でも、ターミナル列の外は当たらない。
+    assert_eq!(terminal_tab_row_at(60, g.terminal_claude_y, &g), None);
 }
 
 #[test]

--- a/src/event/mouse/viewer_panel.rs
+++ b/src/event/mouse/viewer_panel.rs
@@ -110,6 +110,12 @@ pub(super) fn handle_viewer_column_click(
         match action {
             crate::ui::tab_bar::TabAction::Select(idx) => app.focus_viewer_tab(idx),
             crate::ui::tab_bar::TabAction::Close(idx) => app.close_viewer_tab(Some(idx)),
+            crate::ui::tab_bar::TabAction::ScrollLeft => {
+                app.viewer_state.tab_scroll = app.viewer_state.tab_scroll.saturating_sub(1);
+            }
+            crate::ui::tab_bar::TabAction::ScrollRight => {
+                app.viewer_state.tab_scroll += 1;
+            }
             _ => {}
         }
         return;

--- a/src/ui/viewer_panel/file_view.rs
+++ b/src/ui/viewer_panel/file_view.rs
@@ -358,7 +358,10 @@ pub(super) fn render_tab_row(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
     let row = Rect::new(area.x + 1, area.y + 1, area.width - 2, 1);
-    app.viewer_state.tab_row_hits = tab_row::render(frame, row, &app.theme, &app.viewer_state);
+    let (hits, scroll) = tab_row::render(frame, row, &app.theme, &app.viewer_state);
+    app.viewer_state.tab_row_hits = hits;
+    app.viewer_state.tab_scroll = scroll;
+    app.viewer_state.tab_reveal = false;
 }
 
 /// Viewer のタイトルを max_w **表示カラム数**に収める。左側から省略し

--- a/src/ui/viewer_panel/tab_row.rs
+++ b/src/ui/viewer_panel/tab_row.rs
@@ -7,7 +7,9 @@
 //! 消費するだけの価値が無い。
 //!
 //! クリック領域はターミナルのタブバーと同じ [TabHit] で表すので、マウス処理は
-//! 幅を計算し直さずこの描画結果をそのまま引ける。
+//! 幅を計算し直さずこの描画結果をそのまま引ける。オーバーフローヒント
+//! （‹N / N›）もクリックできる領域で、ターミナルのタブバーや worktree
+//! ストリップと同じく窓を横へずらす。
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -58,16 +60,17 @@ pub(crate) fn is_visible(vs: &ViewerState) -> bool {
     vs.tabs.len() >= 2
 }
 
-/// タブ行を area（高さ 1）に描き、クリック領域を返す。
+/// タブ行を area（高さ 1）に描き、クリック領域と解決後のスクロール位置
+/// （最初に表示したタブ。呼び出し側が state へ書き戻す）を返す。
 pub(crate) fn render(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
     vs: &ViewerState,
-) -> Vec<TabHit> {
+) -> (Vec<TabHit>, usize) {
     let mut hits: Vec<TabHit> = Vec::new();
     if area.width == 0 || area.height == 0 || !is_visible(vs) {
-        return hits;
+        return (hits, vs.tab_scroll);
     }
 
     let close_w = w(CLOSE);
@@ -93,11 +96,17 @@ pub(crate) fn render(
     } else {
         area.width.saturating_sub(hint_reserve * 2)
     };
-    // アクティブなタブは常に見えていなければならないので、窓はそこを基準に開く。
     let (start, end) = if all_fit {
         (0, total)
     } else {
-        visible_window(&slots, sep_w, avail, vs.active_tab, vs.active_tab, true)
+        visible_window(
+            &slots,
+            sep_w,
+            avail,
+            vs.tab_scroll,
+            vs.active_tab,
+            vs.tab_reveal,
+        )
     };
 
     let mut spans: Vec<Span> = Vec::new();
@@ -105,8 +114,14 @@ pub(crate) fn render(
 
     if start > 0 {
         let hint = format!("\u{2039}{start} ");
-        x += w(&hint);
+        let hint_w = w(&hint);
         spans.push(Span::styled(hint, Style::default().fg(theme.hint)));
+        hits.push(TabHit {
+            x0: x,
+            x1: x + hint_w,
+            action: TabAction::ScrollLeft,
+        });
+        x += hint_w;
     }
 
     for (idx, label) in labels.iter().enumerate().take(end).skip(start) {
@@ -143,14 +158,18 @@ pub(crate) fn render(
     }
 
     if end < total {
-        spans.push(Span::styled(
-            format!(" {}\u{203a}", total - end),
-            Style::default().fg(theme.hint),
-        ));
+        let hint = format!(" {}\u{203a}", total - end);
+        let hint_w = w(&hint);
+        spans.push(Span::styled(hint, Style::default().fg(theme.hint)));
+        hits.push(TabHit {
+            x0: x,
+            x1: x + hint_w,
+            action: TabAction::ScrollRight,
+        });
     }
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
-    hits
+    (hits, start)
 }
 
 #[cfg(test)]
@@ -166,18 +185,26 @@ mod tests {
             vs.tabs.push(crate::viewer::ViewerTab::for_test(path));
         }
         vs.active_tab = active;
+        // タブを切り替えた直後の状態。focus_tab が立てるのと同じ。
+        vs.tab_reveal = true;
         vs
     }
 
-    fn draw(width: u16, vs: &ViewerState) -> (ratatui::buffer::Buffer, Vec<TabHit>) {
+    /// [super::super::file_view::render_tab_row] と同じ書き戻しをする。
+    fn draw(width: u16, vs: &mut ViewerState) -> (ratatui::buffer::Buffer, Vec<TabHit>) {
         let theme = Theme::default();
         let mut terminal = Terminal::new(TestBackend::new(width, 1)).unwrap();
         let mut hits = Vec::new();
+        let mut scroll = 0;
         terminal
             .draw(|f| {
-                hits = render(f, f.area(), &theme, vs);
+                let (h, s) = render(f, f.area(), &theme, vs);
+                hits = h;
+                scroll = s;
             })
             .unwrap();
+        vs.tab_scroll = scroll;
+        vs.tab_reveal = false;
         (terminal.backend().buffer().clone(), hits)
     }
 
@@ -189,9 +216,9 @@ mod tests {
     /// 1 行を使う理由が無い。
     #[test]
     fn a_single_tab_does_not_take_a_row() {
-        let vs = state(&["src/main.rs"], 0);
+        let mut vs = state(&["src/main.rs"], 0);
         assert!(!is_visible(&vs));
-        let (_, hits) = draw(40, &vs);
+        let (_, hits) = draw(40, &mut vs);
         assert!(hits.is_empty());
     }
 
@@ -208,8 +235,8 @@ mod tests {
 
     #[test]
     fn every_visible_tab_is_selectable_and_closable() {
-        let vs = state(&["a.rs", "b.rs"], 0);
-        let (_, hits) = draw(60, &vs);
+        let mut vs = state(&["a.rs", "b.rs"], 0);
+        let (_, hits) = draw(60, &mut vs);
         for idx in 0..2 {
             assert!(hits.iter().any(|h| h.action == TabAction::Select(idx)));
             assert!(hits.iter().any(|h| h.action == TabAction::Close(idx)));
@@ -228,10 +255,75 @@ mod tests {
     fn the_active_tab_stays_visible_when_tabs_overflow() {
         let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
         let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
-        let vs = state(&refs, 11);
-        let (buf, hits) = draw(40, &vs);
+        let mut vs = state(&refs, 11);
+        let (buf, hits) = draw(40, &mut vs);
         assert!(hits.iter().any(|h| h.action == TabAction::Select(11)));
         assert!(text(&buf, 40).contains("file11.rs"));
+    }
+
+    /// はみ出したタブへはヒントのクリックで届く。ここが空だと、隠れたタブは
+    /// マウスからは一切触れない（それがこのヒントの唯一の役目）。
+    #[test]
+    fn clicking_the_overflow_hint_reaches_a_hidden_tab() {
+        let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let mut vs = state(&refs, 0);
+
+        let (_, hits) = draw(40, &mut vs);
+        let right = hits
+            .iter()
+            .find(|h| h.action == TabAction::ScrollRight)
+            .expect("右にはみ出しているのでヒントがある");
+        assert_eq!(hit_at(&hits, right.x0), Some(TabAction::ScrollRight));
+        let hidden = hits
+            .iter()
+            .filter_map(|h| match h.action {
+                TabAction::Select(idx) => Some(idx),
+                _ => None,
+            })
+            .max()
+            .unwrap()
+            + 1;
+
+        // クリック = マウス処理と同じ 1 つ右へ。
+        vs.tab_scroll += 1;
+        let (buf, hits) = draw(40, &mut vs);
+        assert!(
+            hits.iter().any(|h| h.action == TabAction::Select(hidden)),
+            "隠れていたタブ {hidden} が選べるようになる"
+        );
+        assert!(text(&buf, 40).contains(&paths[hidden]));
+
+        // 左にもはみ出したので、戻る側のヒントも出る。
+        let left = hits
+            .iter()
+            .find(|h| h.action == TabAction::ScrollLeft)
+            .expect("左にはみ出しているのでヒントがある");
+        vs.tab_scroll = vs.tab_scroll.saturating_sub(1);
+        assert_eq!(hit_at(&hits, left.x0), Some(TabAction::ScrollLeft));
+        let (_, hits) = draw(40, &mut vs);
+        assert!(hits.iter().any(|h| h.action == TabAction::Select(0)));
+    }
+
+    /// スクロールして覗いている間は、アクティブなタブへ引き戻されない。
+    #[test]
+    fn scrolling_is_not_undone_by_the_active_tab() {
+        let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let mut vs = state(&refs, 0);
+
+        draw(40, &mut vs);
+        vs.tab_scroll += 1;
+        let (_, hits) = draw(40, &mut vs);
+        assert!(
+            !hits.iter().any(|h| h.action == TabAction::Select(0)),
+            "アクティブなタブ 0 は窓の外へ出たまま"
+        );
+
+        // タブを切り替えれば戻ってくる。
+        vs.tab_reveal = true;
+        let (_, hits) = draw(40, &mut vs);
+        assert!(hits.iter().any(|h| h.action == TabAction::Select(0)));
     }
 
     /// はみ出した分は左右のヒントで数が分かる。
@@ -239,8 +331,8 @@ mod tests {
     fn overflow_is_announced_on_both_sides() {
         let paths: Vec<String> = (0..12).map(|i| format!("file{i:02}.rs")).collect();
         let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
-        let vs = state(&refs, 6);
-        let (buf, _) = draw(40, &vs);
+        let mut vs = state(&refs, 6);
+        let (buf, _) = draw(40, &mut vs);
         let rendered = text(&buf, 40);
         assert!(rendered.contains('\u{2039}'), "left hint: {rendered}");
         assert!(rendered.contains('\u{203a}'), "right hint: {rendered}");

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -383,6 +383,13 @@ pub struct ViewerState {
     /// タブ行のクリック領域（render 中に更新される）。マウス処理が幅を
     /// 計算し直さず、描画とまったく同じジオメトリを引けるようにする。
     pub tab_row_hits: Vec<crate::ui::tab_bar::TabHit>,
+    /// タブ行の横スクロール位置（最初に表示するタブ）。render が解決後の値を
+    /// 書き戻す。
+    pub tab_scroll: usize,
+    /// 次の描画で窓をアクティブなタブまで寄せるか。タブを切り替えた側が立て、
+    /// render が下ろす。常に立てておくと、オーバーフローヒントで隠れたタブを
+    /// 覗く操作がその場で巻き戻される。
+    pub tab_reveal: bool,
     /// 'g' が押されて2つ目のキー（gd, gi, gr）待ちかどうか。
     pub pending_g_key: bool,
     /// 'z' が押されて2つ目のキー（za, zc, zo, zR, zM）待ちかどうか。

--- a/src/viewer/tabs.rs
+++ b/src/viewer/tabs.rs
@@ -30,6 +30,7 @@ impl ViewerState {
         let Some(path) = self.tabs.get(idx).map(|t| t.path.clone()) else {
             return;
         };
+        self.tab_reveal = true;
         if idx != self.active_tab {
             self.stash_active_view();
             self.active_tab = idx;
@@ -68,6 +69,7 @@ impl ViewerState {
         if idx >= self.tabs.len() {
             return;
         }
+        self.tab_reveal = true;
         if idx != self.active_tab {
             self.tabs.remove(idx);
             if idx < self.active_tab {
@@ -103,6 +105,7 @@ impl ViewerState {
         if self.tabs.len() == before {
             return;
         }
+        self.tab_reveal = true;
         match active_path.and_then(|p| self.tabs.iter().position(|t| t.path == p)) {
             Some(idx) => self.active_tab = idx,
             None => {
@@ -121,6 +124,7 @@ impl ViewerState {
     /// relative_path のタブを用意してアクティブにする。既に開いていればそれを使う。
     /// 新しく作った場合だけ true を返す。
     pub(in crate::viewer) fn activate_tab_for(&mut self, relative_path: &str) -> bool {
+        self.tab_reveal = true;
         if let Some(idx) = self.tabs.iter().position(|t| t.path == relative_path) {
             if idx != self.active_tab {
                 self.stash_active_view();


### PR DESCRIPTION
## 直したもの

Viewer のタブ行 (`src/ui/viewer_panel/tab_row.rs`) はオーバーフローヒント `‹N` / `N›` を**描くだけ**で `TabHit` を積んでいなかった。そのためクリックしても `hit_at` が None を返し、幅に収まらないタブへはマウスから一切到達できなかった。

ターミナルのタブバー (`src/ui/tab_bar.rs`) と worktree ストリップは同じヒントに `ScrollLeft`/`ScrollRight` のヒットを積んでいる。Viewer だけ抜けていたので、同じ形に揃えた。

## 変更

- ヒントに `TabHit` を積む。窓の起点を `active_tab` 固定から `ViewerState::tab_scroll` へ移し、`render` は解決後の位置を返す
- `tab_reveal` はタブが動いたときだけ立てる (`focus_tab` / `close_tab` / `prune_tabs_to_root` / `activate_tab_for`)。常に立てておくと、隠れたタブを覗く操作がその場で巻き戻される
- タブ帯の上のホイールでタブを横へ送る。Viewer のタブ行と Claude/Shell のタブ帯を追加 (worktree ストリップは実装済み)。ターミナルは帯の 2 行だけを拾う — 本文の行まで拾うとスクロールバックを遡れなくなる

キーボードは既存の `next_viewer_tab` / `prev_viewer_tab` で全タブに届く。reveal のおかげで窓も追従するので、キーバインドの追加は無し。

## テスト

- `clicking_the_overflow_hint_reaches_a_hidden_tab` — ヒントを押すと、それまで `Select` に現れなかったタブが選べるようになる
- `scrolling_is_not_undone_by_the_active_tab` — 覗いている間はアクティブなタブへ引き戻されない
- `terminal_tab_rows_are_only_the_two_strip_rows` — ホイールが当たるのは帯の 2 行だけ

`cargo test --workspace` / `cargo clippy --workspace` / `make fmt` 通過。

実マウスのクリックとホイールだけは環境の都合で自分では試せていない (キー入力は注入できるがマウスは不可)。描画が積むヒット領域と `hit_at` までをテストで固めてあり、ディスパッチ側は既に動いている Select/Close と同じ行・列判定に分岐を足しただけ。